### PR TITLE
Add sharp corner extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,17 @@ if(ORNLSLICER_BUILD_TESTS)
     target_link_libraries(${PROJECT_NAME}_session_manager_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME session_manager_tests COMMAND ${PROJECT_NAME}_session_manager_tests)
 
+    add_executable(${PROJECT_NAME}_path_modifier_tests tests/path_modifier_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_path_modifier_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_path_modifier_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME path_modifier_tests COMMAND ${PROJECT_NAME}_path_modifier_tests)
+
     set(ORNLSLICER_NEW_IMPACT_PROJECT "/home/rhc/develop/new-impact.s2p" CACHE FILEPATH
         "Optional local project used for the new-impact planar slicing regression test.")
     if(EXISTS "${ORNLSLICER_NEW_IMPACT_PROJECT}")

--- a/include/geometry/path_modifier.h
+++ b/include/geometry/path_modifier.h
@@ -110,6 +110,13 @@ class PathModifierGenerator {
     static void GenerateTrajectorySlowdown(Path& path, QSharedPointer<SettingsBase> sb);
 
     /**
+     * @brief GenerateSharpCornerExtension moves sharp path junctions outward to compensate for corner rounding.
+     * @param path: The path to modify.
+     * @param sb: The settings base.
+     */
+    static void GenerateSharpCornerExtension(Path& path, QSharedPointer<SettingsBase> sb);
+
+    /**
      * @brief GenerateTipWipe generates a tip wipe path for closed contours.
      * @param path: The path to modify.
      * @param modifiers: The path modifiers.

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -799,6 +799,9 @@ class Constants {
             static const QString kSmoothing;
             static const QString kSmoothingType;
             static const QString kSmoothingTolerance;
+            static const QString kEnableSharpCornerExtension;
+            static const QString kSharpCornerExtensionAngle;
+            static const QString kSharpCornerExtensionDistance;
             static const QString kEnableSpiralize;
             static const QString kEnableFixModel;
             static const QString kEnableOversize;

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -802,6 +802,8 @@ class Constants {
             static const QString kEnableSharpCornerExtension;
             static const QString kSharpCornerExtensionAngle;
             static const QString kSharpCornerExtensionDistance;
+            static const QString kSharpCornerClosePointsThreshold;
+            static const QString kSharpCornerSharpeningLegLength;
             static const QString kEnableSpiralize;
             static const QString kEnableFixModel;
             static const QString kEnableOversize;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5769,7 +5769,7 @@
       "major":"Profile",
       "namespace":"Profile::SpecialModes",
       "symbol":"kEnableSharpCornerExtension",
-      "local":false
+      "local":true
   },
   "sharp_corner_extension_angle": {
       "display":"Sharp Corner Angle Threshold",
@@ -5782,7 +5782,7 @@
       "major":"Profile",
       "namespace":"Profile::SpecialModes",
       "symbol":"kSharpCornerExtensionAngle",
-      "local":false
+      "local":true
   },
   "sharp_corner_extension_distance": {
       "display":"Sharp Corner Extension Length",
@@ -5795,7 +5795,7 @@
       "major":"Profile",
       "namespace":"Profile::SpecialModes",
       "symbol":"kSharpCornerExtensionDistance",
-      "local":false
+      "local":true
   },
   "sharp_corner_close_points_threshold": {
       "display":"Sharp Corner Close Points Threshold",
@@ -5808,7 +5808,7 @@
       "major":"Profile",
       "namespace":"Profile::SpecialModes",
       "symbol":"kSharpCornerClosePointsThreshold",
-      "local":false
+      "local":true
   },
   "sharp_corner_sharpening_leg_length": {
       "display":"Sharp Corner Sharpening Leg Length",
@@ -5821,7 +5821,7 @@
       "major":"Profile",
       "namespace":"Profile::SpecialModes",
       "symbol":"kSharpCornerSharpeningLegLength",
-      "local":false
+      "local":true
   },
   "enable_spiralize_mode": {
       "display":"Enable Spiralize Mode",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5758,6 +5758,45 @@
       "symbol":"kArcFittingMinimumSegmentCount",
       "local":true
   },
+  "sharp_corner_extension": {
+      "display":"Enable Sharp Corner Extension",
+      "type":"boolean",
+      "tooltip":"If selected, sharp toolpath junctions are extended outward to compensate for corner rounding during printing.",
+      "depends":"",
+      "options":"",
+      "default":false,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kEnableSharpCornerExtension",
+      "local":false
+  },
+  "sharp_corner_extension_angle": {
+      "display":"Sharp Corner Extension Angle",
+      "type":"angle",
+      "tooltip":"Toolpath junctions with a corner angle less than or equal to this threshold will be extended.",
+      "depends":{"sharp_corner_extension":true},
+      "options":"",
+      "default":1.570796327,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kSharpCornerExtensionAngle",
+      "local":false
+  },
+  "sharp_corner_extension_distance": {
+      "display":"Sharp Corner Extension Distance",
+      "type":"distance",
+      "tooltip":"Distance to move each detected sharp corner outward along the local corner bisector.",
+      "depends":{"sharp_corner_extension":true},
+      "options":"",
+      "default":0,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kSharpCornerExtensionDistance",
+      "local":false
+  },
   "enable_spiralize_mode": {
       "display":"Enable Spiralize Mode",
       "type":"boolean",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5772,9 +5772,9 @@
       "local":false
   },
   "sharp_corner_extension_angle": {
-      "display":"Sharp Corner Extension Angle",
+      "display":"Sharp Corner Angle Threshold",
       "type":"angle",
-      "tooltip":"Toolpath junctions with a corner angle less than or equal to this threshold will be extended.",
+      "tooltip":"Maximum corner angle that can be sharpened.",
       "depends":{"sharp_corner_extension":true},
       "options":"",
       "default":1.570796327,
@@ -5785,9 +5785,9 @@
       "local":false
   },
   "sharp_corner_extension_distance": {
-      "display":"Sharp Corner Extension Distance",
+      "display":"Sharp Corner Extension Length",
       "type":"distance",
-      "tooltip":"Distance to move each detected sharp corner outward along the local corner bisector.",
+      "tooltip":"Distance to extend the corner merge point along the corner bisector.",
       "depends":{"sharp_corner_extension":true},
       "options":"",
       "default":0,
@@ -5795,6 +5795,32 @@
       "major":"Profile",
       "namespace":"Profile::SpecialModes",
       "symbol":"kSharpCornerExtensionDistance",
+      "local":false
+  },
+  "sharp_corner_close_points_threshold": {
+      "display":"Sharp Corner Close Points Threshold",
+      "type":"distance",
+      "tooltip":"Maximum length of a bead segment connecting two corner legs that can be removed before sharpening.",
+      "depends":{"sharp_corner_extension":true},
+      "options":"",
+      "default":0,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kSharpCornerClosePointsThreshold",
+      "local":false
+  },
+  "sharp_corner_sharpening_leg_length": {
+      "display":"Sharp Corner Sharpening Leg Length",
+      "type":"distance",
+      "tooltip":"Distance along each original corner leg to replace with sharpened geometry. A value of 0 uses the extension length.",
+      "depends":{"sharp_corner_extension":true},
+      "options":"",
+      "default":0,
+      "minor":"Special Modes",
+      "major":"Profile",
+      "namespace":"Profile::SpecialModes",
+      "symbol":"kSharpCornerSharpeningLegLength",
       "local":false
   },
   "enable_spiralize_mode": {

--- a/resources/settings/029_profile_special_modes.yaml
+++ b/resources/settings/029_profile_special_modes.yaml
@@ -88,7 +88,7 @@ settings:
     major: "Profile"
     namespace: "Profile::SpecialModes"
     symbol: "kEnableSharpCornerExtension"
-    local: false
+    local: true
   - name: "sharp_corner_extension_angle"
     display: "Sharp Corner Angle Threshold"
     type: "angle"
@@ -100,7 +100,7 @@ settings:
     major: "Profile"
     namespace: "Profile::SpecialModes"
     symbol: "kSharpCornerExtensionAngle"
-    local: false
+    local: true
   - name: "sharp_corner_extension_distance"
     display: "Sharp Corner Extension Length"
     type: "distance"
@@ -112,7 +112,7 @@ settings:
     major: "Profile"
     namespace: "Profile::SpecialModes"
     symbol: "kSharpCornerExtensionDistance"
-    local: false
+    local: true
   - name: "sharp_corner_close_points_threshold"
     display: "Sharp Corner Close Points Threshold"
     type: "distance"
@@ -124,7 +124,7 @@ settings:
     major: "Profile"
     namespace: "Profile::SpecialModes"
     symbol: "kSharpCornerClosePointsThreshold"
-    local: false
+    local: true
   - name: "sharp_corner_sharpening_leg_length"
     display: "Sharp Corner Sharpening Leg Length"
     type: "distance"
@@ -136,7 +136,7 @@ settings:
     major: "Profile"
     namespace: "Profile::SpecialModes"
     symbol: "kSharpCornerSharpeningLegLength"
-    local: false
+    local: true
   - name: "enable_spiralize_mode"
     display: "Enable Spiralize Mode"
     type: "boolean"

--- a/resources/settings/029_profile_special_modes.yaml
+++ b/resources/settings/029_profile_special_modes.yaml
@@ -90,9 +90,9 @@ settings:
     symbol: "kEnableSharpCornerExtension"
     local: false
   - name: "sharp_corner_extension_angle"
-    display: "Sharp Corner Extension Angle"
+    display: "Sharp Corner Angle Threshold"
     type: "angle"
-    tooltip: "Toolpath junctions with a corner angle less than or equal to this threshold will be extended."
+    tooltip: "Maximum corner angle that can be sharpened."
     depends: {"sharp_corner_extension":true}
     options: []
     default: 1.570796327
@@ -102,9 +102,9 @@ settings:
     symbol: "kSharpCornerExtensionAngle"
     local: false
   - name: "sharp_corner_extension_distance"
-    display: "Sharp Corner Extension Distance"
+    display: "Sharp Corner Extension Length"
     type: "distance"
-    tooltip: "Distance to move each detected sharp corner outward along the local corner bisector."
+    tooltip: "Distance to extend the corner merge point along the corner bisector."
     depends: {"sharp_corner_extension":true}
     options: []
     default: 0
@@ -112,6 +112,30 @@ settings:
     major: "Profile"
     namespace: "Profile::SpecialModes"
     symbol: "kSharpCornerExtensionDistance"
+    local: false
+  - name: "sharp_corner_close_points_threshold"
+    display: "Sharp Corner Close Points Threshold"
+    type: "distance"
+    tooltip: "Maximum length of a bead segment connecting two corner legs that can be removed before sharpening."
+    depends: {"sharp_corner_extension":true}
+    options: []
+    default: 0
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kSharpCornerClosePointsThreshold"
+    local: false
+  - name: "sharp_corner_sharpening_leg_length"
+    display: "Sharp Corner Sharpening Leg Length"
+    type: "distance"
+    tooltip: "Distance along each original corner leg to replace with sharpened geometry. A value of 0 uses the extension length."
+    depends: {"sharp_corner_extension":true}
+    options: []
+    default: 0
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kSharpCornerSharpeningLegLength"
     local: false
   - name: "enable_spiralize_mode"
     display: "Enable Spiralize Mode"

--- a/resources/settings/029_profile_special_modes.yaml
+++ b/resources/settings/029_profile_special_modes.yaml
@@ -77,6 +77,42 @@ settings:
     namespace: "Profile::SpecialModes"
     symbol: "kArcFittingMinimumSegmentCount"
     local: true
+  - name: "sharp_corner_extension"
+    display: "Enable Sharp Corner Extension"
+    type: "boolean"
+    tooltip: "If selected, sharp toolpath junctions are extended outward to compensate for corner rounding during printing."
+    depends: {}
+    options: []
+    default: false
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kEnableSharpCornerExtension"
+    local: false
+  - name: "sharp_corner_extension_angle"
+    display: "Sharp Corner Extension Angle"
+    type: "angle"
+    tooltip: "Toolpath junctions with a corner angle less than or equal to this threshold will be extended."
+    depends: {"sharp_corner_extension":true}
+    options: []
+    default: 1.570796327
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kSharpCornerExtensionAngle"
+    local: false
+  - name: "sharp_corner_extension_distance"
+    display: "Sharp Corner Extension Distance"
+    type: "distance"
+    tooltip: "Distance to move each detected sharp corner outward along the local corner bisector."
+    depends: {"sharp_corner_extension":true}
+    options: []
+    default: 0
+    minor: "Special Modes"
+    major: "Profile"
+    namespace: "Profile::SpecialModes"
+    symbol: "kSharpCornerExtensionDistance"
+    local: false
   - name: "enable_spiralize_mode"
     display: "Enable Spiralize Mode"
     type: "boolean"

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -4,8 +4,8 @@
 
 #include <cmath>
 
-#include <QtMath>
 #include <QVector>
+#include <QtMath>
 #include <qcontainerfwd.h>
 #include <qminmax.h>
 #include <qnumeric.h>
@@ -45,8 +45,172 @@ bool isExtendableLineSegment(const QSharedPointer<SegmentBase>& segment) {
 
 bool pointsCoincident(const Point& lhs, const Point& rhs) { return lhs.distance(rhs)() <= 1.0e-4; }
 
-Point midpoint(const Point& lhs, const Point& rhs) {
-    return Point((lhs.x() + rhs.x()) / 2.0f, (lhs.y() + rhs.y()) / 2.0f, (lhs.z() + rhs.z()) / 2.0f);
+struct Vector2D {
+    double x = 0.0;
+    double y = 0.0;
+};
+
+struct SharpCornerGeometry {
+    Point previous_cut;
+    Point sharp_point;
+    Point next_cut;
+    double previous_cut_parameter = 1.0;
+    double next_cut_parameter = 0.0;
+};
+
+struct SegmentEndpointUpdates {
+    bool has_start = false;
+    bool has_end = false;
+    Point start;
+    Point end;
+    double start_parameter = 0.0;
+    double end_parameter = 1.0;
+};
+
+double crossProduct(const Vector2D& lhs, const Vector2D& rhs) { return lhs.x * rhs.y - lhs.y * rhs.x; }
+
+bool normalizedDirection(const Point& start, const Point& end, Vector2D& direction, double& length) {
+    const double x = end.x() - start.x();
+    const double y = end.y() - start.y();
+    length = std::hypot(x, y);
+    constexpr double kMinLength = 1.0e-6;
+    if (length < kMinLength)
+        return false;
+
+    direction = {x / length, y / length};
+    return true;
+}
+
+Point pointOnSegment(const Point& start, const Point& end, double parameter) {
+    return Point(start.x() + ((end.x() - start.x()) * parameter), start.y() + ((end.y() - start.y()) * parameter),
+                 start.z() + ((end.z() - start.z()) * parameter));
+}
+
+bool lineIntersection(const Point& first_start, const Point& first_end, const Point& second_start,
+                      const Point& second_end, Point& intersection) {
+    const Vector2D first_axis = {first_end.x() - first_start.x(), first_end.y() - first_start.y()};
+    const Vector2D second_axis = {second_end.x() - second_start.x(), second_end.y() - second_start.y()};
+    const double denominator = crossProduct(first_axis, second_axis);
+    constexpr double kParallelTolerance = 1.0e-8;
+    if (std::abs(denominator) < kParallelTolerance)
+        return false;
+
+    const Vector2D start_delta = {second_start.x() - first_start.x(), second_start.y() - first_start.y()};
+    const double first_parameter = crossProduct(start_delta, second_axis) / denominator;
+
+    const double x = first_start.x() + (first_axis.x * first_parameter);
+    const double y = first_start.y() + (first_axis.y * first_parameter);
+    if (!std::isfinite(x) || !std::isfinite(y))
+        return false;
+
+    intersection = Point(x, y, (first_end.z() + second_start.z()) / 2.0f);
+    return true;
+}
+
+QSharedPointer<SegmentBase> cloneSegmentWithEndpoints(const QSharedPointer<SegmentBase>& source, const Point& start,
+                                                      const Point& end) {
+    QSharedPointer<SegmentBase> segment = source->clone();
+    segment->setStart(start);
+    segment->setEnd(end);
+
+    if (!source->getSb().isNull())
+        segment->setSb(QSharedPointer<SettingsBase>::create(*source->getSb()));
+
+    return segment;
+}
+
+bool calculateSharpCornerGeometry(const QSharedPointer<SegmentBase>& previous_segment,
+                                  const QSharedPointer<SegmentBase>& next_segment, double threshold_radians,
+                                  double extension_length, double sharpening_leg_length,
+                                  SharpCornerGeometry& geometry) {
+    Vector2D previous_direction;
+    Vector2D next_direction;
+    double previous_length = 0.0;
+    double next_length = 0.0;
+
+    if (!normalizedDirection(previous_segment->start(), previous_segment->end(), previous_direction, previous_length) ||
+        !normalizedDirection(next_segment->start(), next_segment->end(), next_direction, next_length)) {
+        return false;
+    }
+
+    if (previous_length <= sharpening_leg_length || next_length <= sharpening_leg_length)
+        return false;
+
+    double cos_theta = (previous_direction.x * next_direction.x) + (previous_direction.y * next_direction.y);
+    cos_theta = qMin(1.0, cos_theta);
+    cos_theta = qMax(-1.0, cos_theta);
+
+    const double corner_angle = M_PI - std::acos(cos_theta);
+    if (corner_angle > threshold_radians)
+        return false;
+
+    Point merge_point;
+    if (!lineIntersection(previous_segment->start(), previous_segment->end(), next_segment->start(),
+                          next_segment->end(), merge_point)) {
+        return false;
+    }
+
+    const Vector2D extension_direction = {previous_direction.x - next_direction.x,
+                                          previous_direction.y - next_direction.y};
+    const double extension_direction_length = std::hypot(extension_direction.x, extension_direction.y);
+    constexpr double kMinLength = 1.0e-6;
+    if (extension_direction_length < kMinLength)
+        return false;
+
+    geometry.previous_cut_parameter = 1.0 - (sharpening_leg_length / previous_length);
+    geometry.next_cut_parameter = sharpening_leg_length / next_length;
+    geometry.previous_cut =
+        pointOnSegment(previous_segment->start(), previous_segment->end(), geometry.previous_cut_parameter);
+    geometry.next_cut = pointOnSegment(next_segment->start(), next_segment->end(), geometry.next_cut_parameter);
+    geometry.sharp_point = Point(
+        merge_point.x() + (extension_direction.x / extension_direction_length * extension_length),
+        merge_point.y() + (extension_direction.y / extension_direction_length * extension_length), merge_point.z());
+
+    return true;
+}
+
+bool canApplyEndUpdate(int segment_index, double parameter, const QVector<bool>& skip_segment,
+                       const QVector<SegmentEndpointUpdates>& updates) {
+    constexpr double kParameterTolerance = 1.0e-6;
+    if (skip_segment[segment_index] || updates[segment_index].has_end)
+        return false;
+
+    return !updates[segment_index].has_start ||
+           updates[segment_index].start_parameter < parameter - kParameterTolerance;
+}
+
+bool canApplyStartUpdate(int segment_index, double parameter, const QVector<bool>& skip_segment,
+                         const QVector<SegmentEndpointUpdates>& updates) {
+    constexpr double kParameterTolerance = 1.0e-6;
+    if (skip_segment[segment_index] || updates[segment_index].has_start)
+        return false;
+
+    return !updates[segment_index].has_end || parameter < updates[segment_index].end_parameter - kParameterTolerance;
+}
+
+bool applySharpCornerGeometry(Path& path, int previous_index, int next_index, const SharpCornerGeometry& geometry,
+                              QVector<bool>& skip_segment, QVector<SegmentEndpointUpdates>& updates,
+                              QVector<QVector<QSharedPointer<SegmentBase>>>& insertions_after) {
+    if (!canApplyEndUpdate(previous_index, geometry.previous_cut_parameter, skip_segment, updates) ||
+        !canApplyStartUpdate(next_index, geometry.next_cut_parameter, skip_segment, updates) ||
+        !insertions_after[previous_index].isEmpty()) {
+        return false;
+    }
+
+    updates[previous_index].has_end = true;
+    updates[previous_index].end = geometry.previous_cut;
+    updates[previous_index].end_parameter = geometry.previous_cut_parameter;
+
+    updates[next_index].has_start = true;
+    updates[next_index].start = geometry.next_cut;
+    updates[next_index].start_parameter = geometry.next_cut_parameter;
+
+    insertions_after[previous_index].push_back(
+        cloneSegmentWithEndpoints(path[previous_index], geometry.previous_cut, geometry.sharp_point));
+    insertions_after[previous_index].push_back(
+        cloneSegmentWithEndpoints(path[next_index], geometry.sharp_point, geometry.next_cut));
+
+    return true;
 }
 } // namespace
 
@@ -615,84 +779,103 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
 
     const Angle threshold = sb->setting<Angle>(PS::SpecialModes::kSharpCornerExtensionAngle);
     const Distance extensionDistance = sb->setting<Distance>(PS::SpecialModes::kSharpCornerExtensionDistance);
+    const Distance closePointsThreshold = sb->setting<Distance>(PS::SpecialModes::kSharpCornerClosePointsThreshold);
+    Distance sharpeningLegLength = sb->setting<Distance>(PS::SpecialModes::kSharpCornerSharpeningLegLength);
+    if (sharpeningLegLength <= 0)
+        sharpeningLegLength = extensionDistance;
 
-    if (threshold <= 0 || extensionDistance <= 0 || path.size() < 2)
+    if (threshold <= 0 || extensionDistance <= 0 || sharpeningLegLength <= 0 || path.size() < 2)
         return;
 
     const int segmentCount = path.size();
-    QVector<Point> starts;
-    QVector<Point> ends;
-    starts.reserve(segmentCount);
-    ends.reserve(segmentCount);
+    const bool isClosed = pointsCoincident(path.front()->start(), path.back()->end());
+    const double thresholdRadians = qMin(M_PI, threshold());
 
-    for (const QSharedPointer<SegmentBase>& segment : path) {
-        starts.push_back(segment->start());
-        ends.push_back(segment->end());
+    QVector<bool> skipSegment(segmentCount, false);
+    QVector<SegmentEndpointUpdates> endpointUpdates(segmentCount);
+    QVector<QVector<QSharedPointer<SegmentBase>>> insertionsAfter(segmentCount);
+
+    bool modifiedPath = false;
+    if (closePointsThreshold > 0 && segmentCount >= 3) {
+        const int firstConnectorIndex = isClosed ? 0 : 1;
+        const int connectorLimit = isClosed ? segmentCount : segmentCount - 1;
+
+        for (int connectorIndex = firstConnectorIndex; connectorIndex < connectorLimit; ++connectorIndex) {
+            if (skipSegment[connectorIndex] || !isExtendableLineSegment(path[connectorIndex]) ||
+                path[connectorIndex]->length() > closePointsThreshold) {
+                continue;
+            }
+
+            const int previousIndex = (connectorIndex + segmentCount - 1) % segmentCount;
+            const int nextIndex = (connectorIndex + 1) % segmentCount;
+
+            if (skipSegment[previousIndex] || skipSegment[nextIndex] || previousIndex == nextIndex ||
+                !isExtendableLineSegment(path[previousIndex]) || !isExtendableLineSegment(path[nextIndex])) {
+                continue;
+            }
+
+            if (!pointsCoincident(path[previousIndex]->end(), path[connectorIndex]->start()) ||
+                !pointsCoincident(path[connectorIndex]->end(), path[nextIndex]->start())) {
+                continue;
+            }
+
+            SharpCornerGeometry geometry;
+            if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], thresholdRadians,
+                                              extensionDistance(), sharpeningLegLength(), geometry)) {
+                continue;
+            }
+
+            if (!applySharpCornerGeometry(path, previousIndex, nextIndex, geometry, skipSegment, endpointUpdates,
+                                          insertionsAfter)) {
+                continue;
+            }
+
+            skipSegment[connectorIndex] = true;
+            modifiedPath = true;
+        }
     }
 
-    const bool isClosed = pointsCoincident(starts.front(), ends.back());
     const int junctionCount = isClosed ? segmentCount : segmentCount - 1;
-    const double thresholdRadians = qMin(M_PI, threshold());
-    constexpr double kMinLength = 1.0e-6;
-
-    QVector<Point> extendedJunctions(segmentCount);
-    QVector<bool> hasExtendedJunction(segmentCount, false);
-
     for (int previousIndex = 0; previousIndex < junctionCount; ++previousIndex) {
         const int nextIndex = (previousIndex + 1) % segmentCount;
+        if (skipSegment[previousIndex] || skipSegment[nextIndex] || !isExtendableLineSegment(path[previousIndex]) ||
+            !isExtendableLineSegment(path[nextIndex])) {
+            continue;
+        }
 
-        if (!isExtendableLineSegment(path[previousIndex]) || !isExtendableLineSegment(path[nextIndex]))
+        if (!pointsCoincident(path[previousIndex]->end(), path[nextIndex]->start()))
             continue;
 
-        if (!pointsCoincident(ends[previousIndex], starts[nextIndex]))
+        SharpCornerGeometry geometry;
+        if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], thresholdRadians, extensionDistance(),
+                                          sharpeningLegLength(), geometry)) {
             continue;
+        }
 
-        const Point corner = midpoint(ends[previousIndex], starts[nextIndex]);
-        const double previousX = corner.x() - starts[previousIndex].x();
-        const double previousY = corner.y() - starts[previousIndex].y();
-        const double nextX = ends[nextIndex].x() - corner.x();
-        const double nextY = ends[nextIndex].y() - corner.y();
-
-        const double previousLength = qSqrt(previousX * previousX + previousY * previousY);
-        const double nextLength = qSqrt(nextX * nextX + nextY * nextY);
-
-        if (previousLength < kMinLength || nextLength < kMinLength)
-            continue;
-
-        const double previousUnitX = previousX / previousLength;
-        const double previousUnitY = previousY / previousLength;
-        const double nextUnitX = nextX / nextLength;
-        const double nextUnitY = nextY / nextLength;
-
-        double cosTheta = previousUnitX * nextUnitX + previousUnitY * nextUnitY;
-        cosTheta = qMin(1.0, cosTheta);
-        cosTheta = qMax(-1.0, cosTheta);
-
-        const double cornerAngle = M_PI - qAcos(cosTheta);
-        if (cornerAngle > thresholdRadians)
-            continue;
-
-        const double extensionX = previousUnitX - nextUnitX;
-        const double extensionY = previousUnitY - nextUnitY;
-        const double extensionLength = qSqrt(extensionX * extensionX + extensionY * extensionY);
-
-        if (extensionLength < kMinLength)
-            continue;
-
-        extendedJunctions[previousIndex] =
-            Point(corner.x() + (extensionX / extensionLength * extensionDistance()),
-                  corner.y() + (extensionY / extensionLength * extensionDistance()), corner.z());
-        hasExtendedJunction[previousIndex] = true;
+        modifiedPath |= applySharpCornerGeometry(path, previousIndex, nextIndex, geometry, skipSegment, endpointUpdates,
+                                                 insertionsAfter);
     }
 
+    if (!modifiedPath)
+        return;
+
+    Path sharpenedPath;
     for (int segmentIndex = 0; segmentIndex < segmentCount; ++segmentIndex) {
-        const int startJunctionIndex = segmentIndex == 0 ? segmentCount - 1 : segmentIndex - 1;
-        if ((segmentIndex > 0 || isClosed) && hasExtendedJunction[startJunctionIndex])
-            path[segmentIndex]->setStart(extendedJunctions[startJunctionIndex]);
+        if (skipSegment[segmentIndex])
+            continue;
 
-        if (hasExtendedJunction[segmentIndex])
-            path[segmentIndex]->setEnd(extendedJunctions[segmentIndex]);
+        Point start =
+            endpointUpdates[segmentIndex].has_start ? endpointUpdates[segmentIndex].start : path[segmentIndex]->start();
+        Point end =
+            endpointUpdates[segmentIndex].has_end ? endpointUpdates[segmentIndex].end : path[segmentIndex]->end();
+
+        sharpenedPath.append(cloneSegmentWithEndpoints(path[segmentIndex], start, end));
+        for (const QSharedPointer<SegmentBase>& insertion : insertionsAfter[segmentIndex])
+            sharpenedPath.append(insertion);
     }
+
+    path.clear();
+    path.append(sharpenedPath);
 }
 
 // to generate tip wipe

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -22,7 +22,6 @@
 #include "units/unit.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
-#include "utilities/mathutils.h"
 
 namespace ORNL {
 namespace {

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -67,6 +67,59 @@ struct SegmentEndpointUpdates {
     double end_parameter = 1.0;
 };
 
+struct SharpCornerSettings {
+    bool enabled = false;
+    double threshold_radians = 0.0;
+    double extension_length = 0.0;
+    double close_points_threshold = 0.0;
+    double sharpening_leg_length = 0.0;
+};
+
+template <typename T>
+T settingWithFallback(const QSharedPointer<SettingsBase>& settings, const QSharedPointer<SettingsBase>& fallback,
+                      const QString& key) {
+    if (!settings.isNull() && settings->contains(key))
+        return settings->setting<T>(key);
+
+    if (!fallback.isNull())
+        return fallback->setting<T>(key);
+
+    return T();
+}
+
+SharpCornerSettings sharpCornerSettingsForSegment(const QSharedPointer<SegmentBase>& segment,
+                                                  const QSharedPointer<SettingsBase>& fallback) {
+    const QSharedPointer<SettingsBase> segment_settings = segment->getSb();
+    const Angle threshold =
+        settingWithFallback<Angle>(segment_settings, fallback, PS::SpecialModes::kSharpCornerExtensionAngle);
+    const Distance extension_distance =
+        settingWithFallback<Distance>(segment_settings, fallback, PS::SpecialModes::kSharpCornerExtensionDistance);
+    const Distance close_points_threshold =
+        settingWithFallback<Distance>(segment_settings, fallback, PS::SpecialModes::kSharpCornerClosePointsThreshold);
+    Distance sharpening_leg_length =
+        settingWithFallback<Distance>(segment_settings, fallback, PS::SpecialModes::kSharpCornerSharpeningLegLength);
+    if (sharpening_leg_length <= 0)
+        sharpening_leg_length = extension_distance;
+
+    return {
+        settingWithFallback<bool>(segment_settings, fallback, PS::SpecialModes::kEnableSharpCornerExtension),
+        qMin(M_PI, threshold()),
+        extension_distance(),
+        close_points_threshold(),
+        sharpening_leg_length(),
+    };
+}
+
+bool sharpCornerEnabledForBothLegs(const QSharedPointer<SegmentBase>& previous_segment,
+                                   const QSharedPointer<SegmentBase>& next_segment,
+                                   const QSharedPointer<SettingsBase>& fallback, SharpCornerSettings& settings) {
+    settings = sharpCornerSettingsForSegment(previous_segment, fallback);
+    const SharpCornerSettings next_settings = sharpCornerSettingsForSegment(next_segment, fallback);
+
+    return settings.enabled && next_settings.enabled && settings.threshold_radians > 0.0 &&
+           settings.extension_length > 0.0 && settings.sharpening_leg_length > 0.0;
+}
+
 double crossProduct(const Vector2D& lhs, const Vector2D& rhs) { return lhs.x * rhs.y - lhs.y * rhs.x; }
 
 bool normalizedDirection(const Point& start, const Point& end, Vector2D& direction, double& length) {
@@ -774,35 +827,23 @@ void PathModifierGenerator::GenerateTrajectorySlowdown(Path& path, QSharedPointe
 }
 
 void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPointer<SettingsBase> sb) {
-    if (!sb->setting<bool>(PS::SpecialModes::kEnableSharpCornerExtension))
-        return;
-
-    const Angle threshold = sb->setting<Angle>(PS::SpecialModes::kSharpCornerExtensionAngle);
-    const Distance extensionDistance = sb->setting<Distance>(PS::SpecialModes::kSharpCornerExtensionDistance);
-    const Distance closePointsThreshold = sb->setting<Distance>(PS::SpecialModes::kSharpCornerClosePointsThreshold);
-    Distance sharpeningLegLength = sb->setting<Distance>(PS::SpecialModes::kSharpCornerSharpeningLegLength);
-    if (sharpeningLegLength <= 0)
-        sharpeningLegLength = extensionDistance;
-
-    if (threshold <= 0 || extensionDistance <= 0 || sharpeningLegLength <= 0 || path.size() < 2)
+    if (path.size() < 2)
         return;
 
     const int segmentCount = path.size();
     const bool isClosed = pointsCoincident(path.front()->start(), path.back()->end());
-    const double thresholdRadians = qMin(M_PI, threshold());
 
     QVector<bool> skipSegment(segmentCount, false);
     QVector<SegmentEndpointUpdates> endpointUpdates(segmentCount);
     QVector<QVector<QSharedPointer<SegmentBase>>> insertionsAfter(segmentCount);
 
     bool modifiedPath = false;
-    if (closePointsThreshold > 0 && segmentCount >= 3) {
+    if (segmentCount >= 3) {
         const int firstConnectorIndex = isClosed ? 0 : 1;
         const int connectorLimit = isClosed ? segmentCount : segmentCount - 1;
 
         for (int connectorIndex = firstConnectorIndex; connectorIndex < connectorLimit; ++connectorIndex) {
-            if (skipSegment[connectorIndex] || !isExtendableLineSegment(path[connectorIndex]) ||
-                path[connectorIndex]->length() > closePointsThreshold) {
+            if (skipSegment[connectorIndex] || !isExtendableLineSegment(path[connectorIndex])) {
                 continue;
             }
 
@@ -819,9 +860,17 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
                 continue;
             }
 
+            SharpCornerSettings settings;
+            const SharpCornerSettings connector_settings = sharpCornerSettingsForSegment(path[connectorIndex], sb);
+            if (!sharpCornerEnabledForBothLegs(path[previousIndex], path[nextIndex], sb, settings) ||
+                !connector_settings.enabled || settings.close_points_threshold <= 0.0 ||
+                path[connectorIndex]->length() > settings.close_points_threshold) {
+                continue;
+            }
+
             SharpCornerGeometry geometry;
-            if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], thresholdRadians,
-                                              extensionDistance(), sharpeningLegLength(), geometry)) {
+            if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], settings.threshold_radians,
+                                              settings.extension_length, settings.sharpening_leg_length, geometry)) {
                 continue;
             }
 
@@ -846,9 +895,13 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
         if (!pointsCoincident(path[previousIndex]->end(), path[nextIndex]->start()))
             continue;
 
+        SharpCornerSettings settings;
+        if (!sharpCornerEnabledForBothLegs(path[previousIndex], path[nextIndex], sb, settings))
+            continue;
+
         SharpCornerGeometry geometry;
-        if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], thresholdRadians, extensionDistance(),
-                                          sharpeningLegLength(), geometry)) {
+        if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], settings.threshold_radians,
+                                          settings.extension_length, settings.sharpening_leg_length, geometry)) {
             continue;
         }
 

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -42,6 +42,12 @@ void copyAdaptedWidthFlag(const QSharedPointer<SettingsBase>& destination, const
 bool isExtendableLineSegment(const QSharedPointer<SegmentBase>& segment) {
     return segment->isPrintingSegment() && dynamic_cast<LineSegment*>(segment.data()) != nullptr;
 }
+
+bool pointsCoincident(const Point& lhs, const Point& rhs) { return lhs.distance(rhs)() <= 1.0e-4; }
+
+Point midpoint(const Point& lhs, const Point& rhs) {
+    return Point((lhs.x() + rhs.x()) / 2.0f, (lhs.y() + rhs.y()) / 2.0f, (lhs.z() + rhs.z()) / 2.0f);
+}
 } // namespace
 
 void PathModifierGenerator::GenerateTravel(Path& path, Point current_location, Velocity velocity) {
@@ -624,7 +630,7 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
         ends.push_back(segment->end());
     }
 
-    const bool isClosed = starts.front() == ends.back();
+    const bool isClosed = pointsCoincident(starts.front(), ends.back());
     const int junctionCount = isClosed ? segmentCount : segmentCount - 1;
     const double thresholdRadians = qMin(M_PI, threshold());
     constexpr double kMinLength = 1.0e-6;
@@ -638,10 +644,10 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
         if (!isExtendableLineSegment(path[previousIndex]) || !isExtendableLineSegment(path[nextIndex]))
             continue;
 
-        const Point& corner = ends[previousIndex];
-        if (corner != starts[nextIndex])
+        if (!pointsCoincident(ends[previousIndex], starts[nextIndex]))
             continue;
 
+        const Point corner = midpoint(ends[previousIndex], starts[nextIndex]);
         const double previousX = corner.x() - starts[previousIndex].x();
         const double previousY = corner.y() - starts[previousIndex].y();
         const double nextX = ends[nextIndex].x() - corner.x();

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 
 #include <QtMath>
+#include <QVector>
 #include <qcontainerfwd.h>
 #include <qminmax.h>
 #include <qnumeric.h>
@@ -36,6 +37,10 @@ void copyAdaptedWidthFlag(const QSharedPointer<SettingsBase>& destination, const
     if (source->contains(SS::kAdapted)) {
         destination->setSetting(SS::kAdapted, source->setting<bool>(SS::kAdapted));
     }
+}
+
+bool isExtendableLineSegment(const QSharedPointer<SegmentBase>& segment) {
+    return segment->isPrintingSegment() && dynamic_cast<LineSegment*>(segment.data()) != nullptr;
 }
 } // namespace
 
@@ -595,6 +600,92 @@ void PathModifierGenerator::GenerateTrajectorySlowdown(Path& path, QSharedPointe
                 ++end;
             }
         }
+    }
+}
+
+void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPointer<SettingsBase> sb) {
+    if (!sb->setting<bool>(PS::SpecialModes::kEnableSharpCornerExtension))
+        return;
+
+    const Angle threshold = sb->setting<Angle>(PS::SpecialModes::kSharpCornerExtensionAngle);
+    const Distance extensionDistance = sb->setting<Distance>(PS::SpecialModes::kSharpCornerExtensionDistance);
+
+    if (threshold <= 0 || extensionDistance <= 0 || path.size() < 2)
+        return;
+
+    const int segmentCount = path.size();
+    QVector<Point> starts;
+    QVector<Point> ends;
+    starts.reserve(segmentCount);
+    ends.reserve(segmentCount);
+
+    for (const QSharedPointer<SegmentBase>& segment : path) {
+        starts.push_back(segment->start());
+        ends.push_back(segment->end());
+    }
+
+    const bool isClosed = starts.front() == ends.back();
+    const int junctionCount = isClosed ? segmentCount : segmentCount - 1;
+    const double thresholdRadians = qMin(M_PI, threshold());
+    constexpr double kMinLength = 1.0e-6;
+
+    QVector<Point> extendedJunctions(segmentCount);
+    QVector<bool> hasExtendedJunction(segmentCount, false);
+
+    for (int previousIndex = 0; previousIndex < junctionCount; ++previousIndex) {
+        const int nextIndex = (previousIndex + 1) % segmentCount;
+
+        if (!isExtendableLineSegment(path[previousIndex]) || !isExtendableLineSegment(path[nextIndex]))
+            continue;
+
+        const Point& corner = ends[previousIndex];
+        if (corner != starts[nextIndex])
+            continue;
+
+        const double previousX = corner.x() - starts[previousIndex].x();
+        const double previousY = corner.y() - starts[previousIndex].y();
+        const double nextX = ends[nextIndex].x() - corner.x();
+        const double nextY = ends[nextIndex].y() - corner.y();
+
+        const double previousLength = qSqrt(previousX * previousX + previousY * previousY);
+        const double nextLength = qSqrt(nextX * nextX + nextY * nextY);
+
+        if (previousLength < kMinLength || nextLength < kMinLength)
+            continue;
+
+        const double previousUnitX = previousX / previousLength;
+        const double previousUnitY = previousY / previousLength;
+        const double nextUnitX = nextX / nextLength;
+        const double nextUnitY = nextY / nextLength;
+
+        double cosTheta = previousUnitX * nextUnitX + previousUnitY * nextUnitY;
+        cosTheta = qMin(1.0, cosTheta);
+        cosTheta = qMax(-1.0, cosTheta);
+
+        const double cornerAngle = M_PI - qAcos(cosTheta);
+        if (cornerAngle > thresholdRadians)
+            continue;
+
+        const double extensionX = previousUnitX - nextUnitX;
+        const double extensionY = previousUnitY - nextUnitY;
+        const double extensionLength = qSqrt(extensionX * extensionX + extensionY * extensionY);
+
+        if (extensionLength < kMinLength)
+            continue;
+
+        extendedJunctions[previousIndex] =
+            Point(corner.x() + (extensionX / extensionLength * extensionDistance()),
+                  corner.y() + (extensionY / extensionLength * extensionDistance()), corner.z());
+        hasExtendedJunction[previousIndex] = true;
+    }
+
+    for (int segmentIndex = 0; segmentIndex < segmentCount; ++segmentIndex) {
+        const int startJunctionIndex = segmentIndex == 0 ? segmentCount - 1 : segmentIndex - 1;
+        if ((segmentIndex > 0 || isClosed) && hasExtendedJunction[startJunctionIndex])
+            path[segmentIndex]->setStart(extendedJunctions[startJunctionIndex]);
+
+        if (hasExtendedJunction[segmentIndex])
+            path[segmentIndex]->setEnd(extendedJunctions[segmentIndex]);
     }
 }
 

--- a/src/step/layer/regions/brim.cpp
+++ b/src/step/layer/regions/brim.cpp
@@ -122,7 +122,7 @@ void Brim::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
 }
 
 void Brim::calculateModifiers(Path& path, bool supportsG3) {
-    // NOP
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
 }
 
 Path Brim::createPath(Polyline line) {

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -256,6 +256,8 @@ Path Infill::createPath(Polyline line) {
 }
 
 void Infill::calculateModifiers(Path& path, bool supportsG3) {
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
+
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);
     }

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -699,6 +699,8 @@ QVector<Polyline> Inset::getComputedGeometry() { return m_computed_geometry; }
 void Inset::calculateModifiers(Path& path, bool supportsG3) { calculateModifiers(path, supportsG3, false); }
 
 void Inset::calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe) {
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
+
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);
     }

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -812,6 +812,8 @@ QVector<Polyline> Perimeter::getComputedGeometry() { return m_computed_geometry;
 void Perimeter::calculateModifiers(Path& path, bool supportsG3) { calculateModifiers(path, supportsG3, false); }
 
 void Perimeter::calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe) {
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
+
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);
     }

--- a/src/step/layer/regions/raft.cpp
+++ b/src/step/layer/regions/raft.cpp
@@ -90,6 +90,7 @@ void Raft::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
         if (result.size() > 0) {
             Path newPath = createPath(result);
             if (newPath.size() > 0) {
+                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
                 PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                       m_sb->setting<Velocity>(PS::Travel::kSpeed));
                 current_location = newPath.back()->end();
@@ -101,7 +102,7 @@ void Raft::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
 }
 
 void Raft::calculateModifiers(Path& path, bool supportsG3) {
-    // NOP
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
 }
 
 Path Raft::createPath(Polyline line) {

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -945,6 +945,8 @@ void Skeleton::optimize(int layerNumber, Point& current_location, bool& shouldNe
 }
 
 void Skeleton::calculateModifiers(Path& path, bool supportsG3) {
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
+
     // Ramping
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -380,6 +380,8 @@ void Skin::setGeometryIncludes(bool top, bool bottom, bool gradual) {
 }
 
 void Skin::calculateModifiers(Path& path, bool supportsG3) {
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
+
     if (m_sb->setting<bool>(ES::Ramping::kTrajectoryAngleEnabled)) {
         PathModifierGenerator::GenerateTrajectorySlowdown(path, m_sb);
     }

--- a/src/step/layer/regions/skirt.cpp
+++ b/src/step/layer/regions/skirt.cpp
@@ -117,6 +117,7 @@ void Skirt::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         Path newPath = createPath(result);
 
         if (newPath.size() > 0) {
+            calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
             PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                   m_sb->setting<Velocity>(PS::Travel::kSpeed));
             current_location = newPath.back()->end();
@@ -126,7 +127,7 @@ void Skirt::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 }
 
 void Skirt::calculateModifiers(Path& path, bool supportsG3) {
-    // NOP
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
 }
 
 Path Skirt::createPath(Polyline line) {

--- a/src/step/layer/regions/support.cpp
+++ b/src/step/layer/regions/support.cpp
@@ -172,6 +172,7 @@ void Support::optimize(int layerNumber, Point& current_location, bool& shouldNex
         Path newPath = createPath(result);
 
         if (newPath.size() > 0) {
+            calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
             PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                   m_sb->setting<Velocity>(PS::Travel::kSpeed));
             current_location = newPath.back()->end();
@@ -198,6 +199,7 @@ void Support::optimize(int layerNumber, Point& current_location, bool& shouldNex
             if (result.size() > 0) {
                 Path newPath = createPath(result);
                 if (newPath.size() > 0) {
+                    calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
                     PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                           m_sb->setting<Velocity>(PS::Travel::kSpeed));
                     current_location = newPath.back()->end();
@@ -210,7 +212,7 @@ void Support::optimize(int layerNumber, Point& current_location, bool& shouldNex
 }
 
 void Support::calculateModifiers(Path& path, bool supportsG3) {
-    // NOP
+    PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
 }
 
 Path Support::createPath(Polyline line) {

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -737,6 +737,10 @@ const QString Constants::ProfileSettings::GCode::kSupportEnd = "support_end_code
 const QString Constants::ProfileSettings::SpecialModes::kSmoothing = "smoothing";
 const QString Constants::ProfileSettings::SpecialModes::kSmoothingType = "smoothing_type";
 const QString Constants::ProfileSettings::SpecialModes::kSmoothingTolerance = "smoothing_tolerance";
+const QString Constants::ProfileSettings::SpecialModes::kEnableSharpCornerExtension = "sharp_corner_extension";
+const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionAngle = "sharp_corner_extension_angle";
+const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionDistance =
+    "sharp_corner_extension_distance";
 const QString Constants::ProfileSettings::SpecialModes::kEnableSpiralize = "enable_spiralize_mode";
 const QString Constants::ProfileSettings::SpecialModes::kEnableFixModel = "enable_fix_model";
 const QString Constants::ProfileSettings::SpecialModes::kEnableOversize = "oversize";

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -741,6 +741,10 @@ const QString Constants::ProfileSettings::SpecialModes::kEnableSharpCornerExtens
 const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionAngle = "sharp_corner_extension_angle";
 const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionDistance =
     "sharp_corner_extension_distance";
+const QString Constants::ProfileSettings::SpecialModes::kSharpCornerClosePointsThreshold =
+    "sharp_corner_close_points_threshold";
+const QString Constants::ProfileSettings::SpecialModes::kSharpCornerSharpeningLegLength =
+    "sharp_corner_sharpening_leg_length";
 const QString Constants::ProfileSettings::SpecialModes::kEnableSpiralize = "enable_spiralize_mode";
 const QString Constants::ProfileSettings::SpecialModes::kEnableFixModel = "enable_fix_model";
 const QString Constants::ProfileSettings::SpecialModes::kEnableOversize = "oversize";

--- a/tests/path_modifier_tests.cpp
+++ b/tests/path_modifier_tests.cpp
@@ -32,9 +32,9 @@ void appendLine(ORNL::Path& path, const ORNL::Point& start, const ORNL::Point& e
     path.append(QSharedPointer<ORNL::LineSegment>::create(start, end));
 }
 
-QSharedPointer<ORNL::SettingsBase> sharpCornerSettings(ORNL::Distance close_points_threshold) {
+QSharedPointer<ORNL::SettingsBase> sharpCornerSettings(ORNL::Distance close_points_threshold, bool enabled = true) {
     QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
-    settings->setSetting(ORNL::PS::SpecialModes::kEnableSharpCornerExtension, true);
+    settings->setSetting(ORNL::PS::SpecialModes::kEnableSharpCornerExtension, enabled);
     settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerExtensionAngle, ORNL::Angle(M_PI / 3.0));
     settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerExtensionDistance, ORNL::Distance(2.0));
     settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerClosePointsThreshold, close_points_threshold);
@@ -92,6 +92,19 @@ int main() {
                                                               sharpCornerSettings(ORNL::Distance(0.5)));
     passed &= expect(threshold_rejected_corner.size() == 3,
                      "Expected connector longer than close-points threshold to remain unchanged.");
+
+    ORNL::Path local_corner;
+    appendLine(local_corner, ORNL::Point(-10.0f, 5.0f, 0.0f), ORNL::Point(0.0f, 0.0f, 0.0f));
+    appendLine(local_corner, ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(-10.0f, -5.0f, 0.0f));
+
+    QSharedPointer<ORNL::SettingsBase> local_settings = sharpCornerSettings(ORNL::Distance());
+    local_corner[0]->getSb()->populate(local_settings);
+    local_corner[1]->getSb()->populate(local_settings);
+
+    ORNL::PathModifierGenerator::GenerateSharpCornerExtension(local_corner,
+                                                              sharpCornerSettings(ORNL::Distance(), false));
+    passed &= expect(local_corner.size() == 4,
+                     "Expected segment-local sharp-corner settings to override disabled fallback settings.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/path_modifier_tests.cpp
+++ b/tests/path_modifier_tests.cpp
@@ -1,0 +1,97 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <QSharedPointer>
+
+#include "configs/settings_base.h"
+#include "geometry/path.h"
+#include "geometry/path_modifier.h"
+#include "geometry/point.h"
+#include "geometry/segments/line.h"
+#include "units/unit.h"
+#include "utilities/constants.h"
+
+namespace {
+bool expect(bool condition, const std::string& message) {
+    if (condition)
+        return true;
+
+    std::cerr << message << '\n';
+    return false;
+}
+
+bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-4; }
+
+bool expectPoint(const ORNL::Point& point, double x, double y, const std::string& message) {
+    return expect(closeTo(point.x(), x) && closeTo(point.y(), y), message);
+}
+
+void appendLine(ORNL::Path& path, const ORNL::Point& start, const ORNL::Point& end) {
+    path.append(QSharedPointer<ORNL::LineSegment>::create(start, end));
+}
+
+QSharedPointer<ORNL::SettingsBase> sharpCornerSettings(ORNL::Distance close_points_threshold) {
+    QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
+    settings->setSetting(ORNL::PS::SpecialModes::kEnableSharpCornerExtension, true);
+    settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerExtensionAngle, ORNL::Angle(M_PI / 3.0));
+    settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerExtensionDistance, ORNL::Distance(2.0));
+    settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerClosePointsThreshold, close_points_threshold);
+    settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerSharpeningLegLength, ORNL::Distance(4.0));
+    return settings;
+}
+} // namespace
+
+int main() {
+    bool passed = true;
+
+    ORNL::Path direct_corner;
+    appendLine(direct_corner, ORNL::Point(-10.0f, 5.0f, 0.0f), ORNL::Point(0.0f, 0.0f, 0.0f));
+    appendLine(direct_corner, ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(-10.0f, -5.0f, 0.0f));
+
+    ORNL::PathModifierGenerator::GenerateSharpCornerExtension(direct_corner, sharpCornerSettings(ORNL::Distance()));
+    passed &= expect(direct_corner.size() == 4, "Expected direct sharp corner to insert two sharpened segments.");
+    passed &= expectPoint(direct_corner[0]->end(), -3.5777087, 1.7888544,
+                          "Expected direct corner previous leg to be cut back.");
+    passed &= expectPoint(direct_corner[1]->end(), 2.0, 0.0,
+                          "Expected direct corner merge point to extend along the bisector.");
+    passed &=
+        expectPoint(direct_corner[2]->end(), -3.5777087, -1.7888544, "Expected direct corner next leg to be cut back.");
+    passed &= expect(direct_corner[1]->start() == direct_corner[0]->end() &&
+                         direct_corner[2]->start() == direct_corner[1]->end() &&
+                         direct_corner[3]->start() == direct_corner[2]->end(),
+                     "Expected direct sharpened corner to remain continuous.");
+
+    ORNL::Path connected_corner;
+    appendLine(connected_corner, ORNL::Point(-10.0f, 5.0f, 0.0f), ORNL::Point(-1.0f, 0.5f, 0.0f));
+    appendLine(connected_corner, ORNL::Point(-1.0f, 0.5f, 0.0f), ORNL::Point(-1.0f, -0.5f, 0.0f));
+    appendLine(connected_corner, ORNL::Point(-1.0f, -0.5f, 0.0f), ORNL::Point(-10.0f, -5.0f, 0.0f));
+
+    ORNL::PathModifierGenerator::GenerateSharpCornerExtension(connected_corner,
+                                                              sharpCornerSettings(ORNL::Distance(2.0)));
+    passed &= expect(connected_corner.size() == 4,
+                     "Expected close connector to be removed and replaced by sharpened geometry.");
+    passed &= expectPoint(connected_corner[0]->end(), -4.5777087, 2.2888544,
+                          "Expected connected corner previous leg to be cut back.");
+    passed &= expectPoint(connected_corner[1]->end(), 2.0, 0.0,
+                          "Expected connected corner merge point to extend from the leg-axis intersection.");
+    passed &= expectPoint(connected_corner[2]->end(), -4.5777087, -2.2888544,
+                          "Expected connected corner next leg to be cut back.");
+    passed &= expect(connected_corner[1]->start() == connected_corner[0]->end() &&
+                         connected_corner[2]->start() == connected_corner[1]->end() &&
+                         connected_corner[3]->start() == connected_corner[2]->end(),
+                     "Expected connected sharpened corner to remain continuous.");
+
+    ORNL::Path threshold_rejected_corner;
+    appendLine(threshold_rejected_corner, ORNL::Point(-10.0f, 5.0f, 0.0f), ORNL::Point(-1.0f, 0.5f, 0.0f));
+    appendLine(threshold_rejected_corner, ORNL::Point(-1.0f, 0.5f, 0.0f), ORNL::Point(-1.0f, -0.5f, 0.0f));
+    appendLine(threshold_rejected_corner, ORNL::Point(-1.0f, -0.5f, 0.0f), ORNL::Point(-10.0f, -5.0f, 0.0f));
+
+    ORNL::PathModifierGenerator::GenerateSharpCornerExtension(threshold_rejected_corner,
+                                                              sharpCornerSettings(ORNL::Distance(0.5)));
+    passed &= expect(threshold_rejected_corner.size() == 3,
+                     "Expected connector longer than close-points threshold to remain unchanged.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- Adds a Special Modes setting group for sharp corner extension, including enable, angle threshold, and extension distance controls.
- Adds `PathModifierGenerator::GenerateSharpCornerExtension` to detect sharp printing-line junctions and move the shared point outward along the local corner bisector.
- Applies the modifier early in the standard extrusion region modifier flow for perimeter, inset, infill, skin, skeleton, support, raft, brim, and skirt paths.

## Validation

- `nix develop --command cmake --build build/generic-llvm-ninja`

The build completed successfully and linked `Debug/ornlslicer`.