### PR TITLE
Add centerline as-printed STL export

### DIFF
--- a/include/gcode/as_printed_model_exporter.h
+++ b/include/gcode/as_printed_model_exporter.h
@@ -4,8 +4,8 @@
 
 #include <QSharedPointer>
 #include <QString>
-#include <QVector>
 #include <QVector3D>
+#include <QVector>
 
 #include "geometry/segment_base.h"
 #include "units/unit.h"
@@ -16,13 +16,16 @@ class AsPrintedModelExporter final {
   public:
     enum class StlFormat { kBinary, kAscii };
     enum class OriginMode { kPreserve, kLocalOrigin };
+    enum class GeometryMode { kTrueBeadWidths, kCenterlines };
 
     struct Options {
         Options(bool include_support = false, bool include_travel = false, bool blend_corners = true,
                 StlFormat format = StlFormat::kBinary, Distance output_unit = mm,
-                OriginMode origin_mode = OriginMode::kLocalOrigin)
+                OriginMode origin_mode = OriginMode::kLocalOrigin,
+                GeometryMode geometry_mode = GeometryMode::kTrueBeadWidths, Distance centerline_diameter = 0.1 * mm)
             : include_support(include_support), include_travel(include_travel), blend_corners(blend_corners),
-              format(format), output_unit(output_unit), origin_mode(origin_mode) {}
+              format(format), output_unit(output_unit), origin_mode(origin_mode), geometry_mode(geometry_mode),
+              centerline_diameter(centerline_diameter) {}
 
         bool include_support;
         bool include_travel;
@@ -30,6 +33,8 @@ class AsPrintedModelExporter final {
         StlFormat format;
         Distance output_unit;
         OriginMode origin_mode;
+        GeometryMode geometry_mode;
+        Distance centerline_diameter;
     };
 
     struct Triangle {

--- a/include/windows/gcode_export.h
+++ b/include/windows/gcode_export.h
@@ -61,6 +61,9 @@ class GcodeExport : public QWidget {
     void showComplete(QString path, QString filename);
 
   private:
+    //! \brief Updates as-printed STL option availability based on visualization state.
+    void updateAsPrintedModelOptionState();
+
     //! \brief Layout for widget
     QVBoxLayout* m_layout;
 
@@ -70,6 +73,7 @@ class GcodeExport : public QWidget {
     QCheckBox* m_gcode_file_checkbox;
     QCheckBox* m_auxiliary_file_checkbox;
     QCheckBox* m_as_printed_model_checkbox;
+    QCheckBox* m_as_printed_centerline_checkbox;
     QCheckBox* m_project_file_checkbox;
     QCheckBox* m_bundle_files_checkbox;
 

--- a/src/gcode/as_printed_model_exporter.cpp
+++ b/src/gcode/as_printed_model_exporter.cpp
@@ -306,8 +306,8 @@ void appendCenterlineTube(std::vector<AsPrintedModelExporter::Triangle>& triangl
     for (std::size_t i = 0; i + 1 < points.size(); ++i) {
         for (int j = 0; j < kCenterlineTubeSides; ++j) {
             const int next = (j + 1) % kCenterlineTubeSides;
-            appendOutputTriangle(triangles, rings[i][j], rings[i + 1][j], rings[i][next], output_scale);
-            appendOutputTriangle(triangles, rings[i][next], rings[i + 1][j], rings[i + 1][next], output_scale);
+            appendOutputTriangle(triangles, rings[i][j], rings[i][next], rings[i + 1][j], output_scale);
+            appendOutputTriangle(triangles, rings[i][next], rings[i + 1][next], rings[i + 1][j], output_scale);
         }
     }
 

--- a/src/gcode/as_printed_model_exporter.cpp
+++ b/src/gcode/as_printed_model_exporter.cpp
@@ -13,6 +13,8 @@
 #include <QTextStream>
 #include <QVector3D>
 
+#include "geometry/segments/arc.h"
+#include "geometry/segments/bezier.h"
 #include "geometry/segments/line.h"
 #include "managers/settings/settings_manager.h"
 #include "utilities/constants.h"
@@ -25,6 +27,9 @@ constexpr float kTwoPi = 2.0f * kPi;
 constexpr float kVectorEpsilon = 1.0e-6f;
 constexpr float kVectorEpsilonSquared = kVectorEpsilon * kVectorEpsilon;
 constexpr int kCornerBlendSegments = 24;
+constexpr int kCenterlineTubeSides = 8;
+constexpr int kCenterlineCurveSegments = 32;
+constexpr float kCenterlineArcSegmentAngle = kTwoPi / 48.0f;
 
 QString formatFloat(float value) { return QString::number(value, 'g', 9); }
 
@@ -86,6 +91,11 @@ float viewToOutputScale(const Distance& output_unit) {
 
 QVector3D viewToOutput(const QVector3D& vertex, float output_scale) { return vertex * output_scale; }
 
+void appendOutputTriangle(std::vector<AsPrintedModelExporter::Triangle>& triangles, const QVector3D& a,
+                          const QVector3D& b, const QVector3D& c, float output_scale) {
+    triangles.push_back({viewToOutput(a, output_scale), viewToOutput(b, output_scale), viewToOutput(c, output_scale)});
+}
+
 bool isDegenerateSegment(const QSharedPointer<SegmentBase>& segment) {
     if (dynamic_cast<LineSegment*>(segment.data()) == nullptr) {
         return false;
@@ -108,8 +118,8 @@ bool isCorner(const QSharedPointer<SegmentBase>& previous, const QSharedPointer<
 }
 
 void appendCornerBlend(std::vector<AsPrintedModelExporter::Triangle>& triangles,
-                       const QSharedPointer<SegmentBase>& previous,
-                       const QSharedPointer<SegmentBase>& current, float output_scale) {
+                       const QSharedPointer<SegmentBase>& previous, const QSharedPointer<SegmentBase>& current,
+                       float output_scale) {
     if (!pointsConnected(previous->end(), current->start()) || !isCorner(previous, current)) {
         return;
     }
@@ -162,6 +172,160 @@ void appendCornerBlends(std::vector<AsPrintedModelExporter::Triangle>& triangles
     }
 
     appendCornerBlend(triangles, connected_segments.back(), connected_segments.front(), output_scale);
+}
+
+bool centerlineFrameForTangent(QVector3D tangent, QVector3D& u, QVector3D& v) {
+    if (tangent.lengthSquared() <= kVectorEpsilonSquared) {
+        return false;
+    }
+    tangent.normalize();
+
+    QVector3D normal = slicePlaneNormal();
+    u = QVector3D::crossProduct(tangent, normal);
+    if (u.lengthSquared() <= kVectorEpsilonSquared) {
+        normal = std::fabs(tangent.x()) < 0.9f ? QVector3D(1.0f, 0.0f, 0.0f) : QVector3D(0.0f, 1.0f, 0.0f);
+        u = QVector3D::crossProduct(tangent, normal);
+    }
+    if (u.lengthSquared() <= kVectorEpsilonSquared) {
+        return false;
+    }
+    u.normalize();
+
+    v = QVector3D::crossProduct(tangent, u);
+    if (v.lengthSquared() <= kVectorEpsilonSquared) {
+        return false;
+    }
+    v.normalize();
+
+    return true;
+}
+
+std::vector<QVector3D> centerlinePointsForLine(const SegmentBase& segment) {
+    return {segment.start().toQVector3D(), segment.end().toQVector3D()};
+}
+
+std::vector<QVector3D> centerlinePointsForArc(const ArcSegment& arc) {
+    const Point start = arc.start();
+    const Point center = arc.center();
+    const Point end = arc.end();
+    const double radius = std::hypot(start.x() - center.x(), start.y() - center.y());
+    const double sweep = arc.angle()();
+
+    if (!std::isfinite(radius) || !std::isfinite(sweep) || radius <= kVectorEpsilon || sweep <= kVectorEpsilon) {
+        return centerlinePointsForLine(arc);
+    }
+
+    const int segment_count = std::max(1, static_cast<int>(std::ceil(sweep / kCenterlineArcSegmentAngle)));
+    const double start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const double signed_sweep = arc.counterclockwise() ? sweep : -sweep;
+    const double z_delta = end.z() - start.z();
+
+    std::vector<QVector3D> points;
+    points.reserve(static_cast<std::size_t>(segment_count) + 1);
+    points.push_back(start.toQVector3D());
+    for (int i = 1; i < segment_count; ++i) {
+        const double t = static_cast<double>(i) / static_cast<double>(segment_count);
+        const double angle = start_angle + (signed_sweep * t);
+        points.push_back(QVector3D(center.x() + (radius * std::cos(angle)), center.y() + (radius * std::sin(angle)),
+                                   start.z() + (z_delta * t)));
+    }
+    points.push_back(end.toQVector3D());
+
+    return points;
+}
+
+std::vector<QVector3D> centerlinePointsForBezier(BezierSegment& curve) {
+    std::vector<QVector3D> points;
+    points.reserve(static_cast<std::size_t>(kCenterlineCurveSegments) + 1);
+    for (int i = 0; i <= kCenterlineCurveSegments; ++i) {
+        const double t = static_cast<double>(i) / static_cast<double>(kCenterlineCurveSegments);
+        points.push_back(curve.getPointAlong(t).toQVector3D());
+    }
+
+    return points;
+}
+
+std::vector<QVector3D> centerlinePointsForSegment(const QSharedPointer<SegmentBase>& segment) {
+    if (auto* arc = dynamic_cast<ArcSegment*>(segment.data())) {
+        return centerlinePointsForArc(*arc);
+    }
+    if (auto* bezier = dynamic_cast<BezierSegment*>(segment.data())) {
+        return centerlinePointsForBezier(*bezier);
+    }
+
+    return centerlinePointsForLine(*segment);
+}
+
+void appendCenterlineTube(std::vector<AsPrintedModelExporter::Triangle>& triangles,
+                          const std::vector<QVector3D>& centerline_points, float radius, float output_scale) {
+    if (centerline_points.size() < 2 || radius <= kVectorEpsilon) {
+        return;
+    }
+
+    std::vector<QVector3D> points;
+    points.reserve(centerline_points.size());
+    for (const QVector3D& point : centerline_points) {
+        if (points.empty() || (point - points.back()).lengthSquared() > kVectorEpsilonSquared) {
+            points.push_back(point);
+        }
+    }
+    if (points.size() < 2) {
+        return;
+    }
+
+    std::vector<std::array<QVector3D, kCenterlineTubeSides>> rings(points.size());
+    for (std::size_t i = 0; i < points.size(); ++i) {
+        QVector3D tangent;
+        if (i == 0) {
+            tangent = points[1] - points[0];
+        }
+        else if (i == points.size() - 1) {
+            tangent = points[i] - points[i - 1];
+        }
+        else {
+            tangent = points[i + 1] - points[i - 1];
+        }
+
+        QVector3D u;
+        QVector3D v;
+        if (!centerlineFrameForTangent(tangent, u, v)) {
+            return;
+        }
+
+        for (int j = 0; j < kCenterlineTubeSides; ++j) {
+            const float theta = (static_cast<float>(j) / static_cast<float>(kCenterlineTubeSides)) * kTwoPi;
+            rings[i][j] = points[i] + (((std::cos(theta) * u) + (std::sin(theta) * v)) * radius);
+        }
+    }
+
+    for (int j = 0; j < kCenterlineTubeSides; ++j) {
+        const int next = (j + 1) % kCenterlineTubeSides;
+        appendOutputTriangle(triangles, points.front(), rings.front()[next], rings.front()[j], output_scale);
+    }
+
+    for (std::size_t i = 0; i + 1 < points.size(); ++i) {
+        for (int j = 0; j < kCenterlineTubeSides; ++j) {
+            const int next = (j + 1) % kCenterlineTubeSides;
+            appendOutputTriangle(triangles, rings[i][j], rings[i + 1][j], rings[i][next], output_scale);
+            appendOutputTriangle(triangles, rings[i][next], rings[i + 1][j], rings[i + 1][next], output_scale);
+        }
+    }
+
+    for (int j = 0; j < kCenterlineTubeSides; ++j) {
+        const int next = (j + 1) % kCenterlineTubeSides;
+        appendOutputTriangle(triangles, points.back(), rings.back()[j], rings.back()[next], output_scale);
+    }
+}
+
+void appendCenterlineSegment(std::vector<AsPrintedModelExporter::Triangle>& triangles,
+                             const QSharedPointer<SegmentBase>& segment, const AsPrintedModelExporter::Options& options,
+                             float output_scale) {
+    const float radius = static_cast<float>(options.centerline_diameter() * Constants::OpenGL::kObjectToView / 2.0);
+    if (!std::isfinite(radius) || radius <= kVectorEpsilon) {
+        return;
+    }
+
+    appendCenterlineTube(triangles, centerlinePointsForSegment(segment), radius, output_scale);
 }
 
 void normalizeToLocalOrigin(std::vector<AsPrintedModelExporter::Triangle>& triangles) {
@@ -283,13 +447,13 @@ bool writeBinaryStl(const QString& path, const std::vector<AsPrintedModelExporte
 } // namespace
 
 std::vector<AsPrintedModelExporter::Triangle>
-AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
-                                          Options options) {
+AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode, Options options) {
     std::vector<Triangle> triangles;
     std::vector<float> vertices;
     std::vector<float> normals;
     std::vector<float> colors;
     const float output_scale = viewToOutputScale(options.output_unit);
+    const bool blend_corners = options.blend_corners && options.geometry_mode == GeometryMode::kTrueBeadWidths;
 
     for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
         QVector<QSharedPointer<SegmentBase>> connected_segments;
@@ -301,36 +465,39 @@ AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<S
 
         for (const QSharedPointer<SegmentBase>& segment : layer) {
             if (!shouldExportSegment(segment, options)) {
-                if (options.blend_corners) {
+                if (blend_corners) {
                     flushConnectedSegments();
                 }
                 continue;
             }
 
-            if (options.blend_corners && !connected_segments.isEmpty() &&
+            if (blend_corners && !connected_segments.isEmpty() &&
                 !pointsConnected(connected_segments.back()->end(), segment->start())) {
                 flushConnectedSegments();
             }
 
-            const std::size_t start = vertices.size();
-            segment->createGraphic(vertices, normals, colors);
-            const std::size_t end = vertices.size();
+            if (options.geometry_mode == GeometryMode::kCenterlines) {
+                appendCenterlineSegment(triangles, segment, options, output_scale);
+            }
+            else {
+                const std::size_t start = vertices.size();
+                segment->createGraphic(vertices, normals, colors);
+                const std::size_t end = vertices.size();
 
-            for (std::size_t i = start; i + 8 < end; i += 9) {
-                triangles.push_back({viewToOutput(QVector3D(vertices[i + 0], vertices[i + 1], vertices[i + 2]),
-                                                  output_scale),
-                                     viewToOutput(QVector3D(vertices[i + 3], vertices[i + 4], vertices[i + 5]),
-                                                  output_scale),
-                                     viewToOutput(QVector3D(vertices[i + 6], vertices[i + 7], vertices[i + 8]),
-                                                  output_scale)});
+                for (std::size_t i = start; i + 8 < end; i += 9) {
+                    triangles.push_back(
+                        {viewToOutput(QVector3D(vertices[i + 0], vertices[i + 1], vertices[i + 2]), output_scale),
+                         viewToOutput(QVector3D(vertices[i + 3], vertices[i + 4], vertices[i + 5]), output_scale),
+                         viewToOutput(QVector3D(vertices[i + 6], vertices[i + 7], vertices[i + 8]), output_scale)});
+                }
             }
 
-            if (options.blend_corners) {
+            if (blend_corners) {
                 connected_segments.push_back(segment);
             }
         }
 
-        if (options.blend_corners) {
+        if (blend_corners) {
             flushConnectedSegments();
         }
     }
@@ -342,8 +509,7 @@ AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<S
     return triangles;
 }
 
-bool AsPrintedModelExporter::writeStl(const QString& path,
-                                      const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
+bool AsPrintedModelExporter::writeStl(const QString& path, const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
                                       QString* error_message, Options options) {
     const std::vector<Triangle> triangles = generateTriangles(gcode, options);
     switch (options.format) {
@@ -356,8 +522,7 @@ bool AsPrintedModelExporter::writeStl(const QString& path,
     return false;
 }
 
-bool AsPrintedModelExporter::shouldExportSegment(const QSharedPointer<SegmentBase>& segment,
-                                                 const Options& options) {
+bool AsPrintedModelExporter::shouldExportSegment(const QSharedPointer<SegmentBase>& segment, const Options& options) {
     if (segment.isNull()) {
         return false;
     }

--- a/src/windows/gcode_export.cpp
+++ b/src/windows/gcode_export.cpp
@@ -87,12 +87,16 @@ GcodeExport::GcodeExport(QWidget* parent) : m_has_gcode_visualization(false) {
     m_auxiliary_file_checkbox->setChecked(true);
     m_as_printed_model_checkbox = new QCheckBox("Save As-Printed STL model");
     m_as_printed_model_checkbox->setEnabled(false);
+    m_as_printed_centerline_checkbox = new QCheckBox("Use Centerline Geometry for As-Printed STL");
+    m_as_printed_centerline_checkbox->setEnabled(false);
     m_project_file_checkbox = new QCheckBox("Save Project file");
     m_bundle_files_checkbox = new QCheckBox("Create subdirectory to bundle files");
+    connect(m_as_printed_model_checkbox, &QCheckBox::toggled, [this](bool) { updateAsPrintedModelOptionState(); });
 
     optionsGrid->addWidget(m_gcode_file_checkbox);
     optionsGrid->addWidget(m_auxiliary_file_checkbox);
     optionsGrid->addWidget(m_as_printed_model_checkbox);
+    optionsGrid->addWidget(m_as_printed_centerline_checkbox);
     optionsGrid->addWidget(m_project_file_checkbox);
     optionsGrid->addWidget(m_bundle_files_checkbox);
     optionsBox->setLayout(optionsGrid);
@@ -120,17 +124,13 @@ void GcodeExport::updateOutputInformation(QString tempLocation, GcodeMeta meta) 
 void GcodeExport::updateVisualizationInformation(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     m_gcode = gcode;
     m_has_gcode_visualization = hasVisualizationSegments(m_gcode);
-    m_as_printed_model_checkbox->setEnabled(m_has_gcode_visualization);
-    if (!m_has_gcode_visualization) {
-        m_as_printed_model_checkbox->setChecked(false);
-    }
+    updateAsPrintedModelOptionState();
 }
 
 void GcodeExport::clearVisualizationInformation() {
     m_gcode.clear();
     m_has_gcode_visualization = false;
-    m_as_printed_model_checkbox->setChecked(false);
-    m_as_printed_model_checkbox->setEnabled(false);
+    updateAsPrintedModelOptionState();
 }
 
 void GcodeExport::closeEvent(QCloseEvent* event) {
@@ -139,9 +139,23 @@ void GcodeExport::closeEvent(QCloseEvent* event) {
     m_gcode_file_checkbox->setChecked(true);
     m_auxiliary_file_checkbox->setChecked(true);
     m_as_printed_model_checkbox->setChecked(false);
-    m_as_printed_model_checkbox->setEnabled(m_has_gcode_visualization);
+    m_as_printed_centerline_checkbox->setChecked(false);
+    updateAsPrintedModelOptionState();
     m_project_file_checkbox->setChecked(false);
     m_bundle_files_checkbox->setChecked(false);
+}
+
+void GcodeExport::updateAsPrintedModelOptionState() {
+    m_as_printed_model_checkbox->setEnabled(m_has_gcode_visualization);
+    if (!m_has_gcode_visualization) {
+        m_as_printed_model_checkbox->setChecked(false);
+    }
+
+    const bool centerline_enabled = m_has_gcode_visualization && m_as_printed_model_checkbox->isChecked();
+    m_as_printed_centerline_checkbox->setEnabled(centerline_enabled);
+    if (!centerline_enabled) {
+        m_as_printed_centerline_checkbox->setChecked(false);
+    }
 }
 
 void GcodeExport::exportGcode() {
@@ -314,14 +328,20 @@ void GcodeExport::exportGcode() {
 
         if (m_as_printed_model_checkbox->isChecked()) {
             QString error;
-            const QString asPrintedFileName = filepath % '/' % partName % "_as_printed.stl";
+            AsPrintedModelExporter::Options as_printed_options;
+            const bool use_centerline_geometry = m_as_printed_centerline_checkbox->isChecked();
+            if (use_centerline_geometry) {
+                as_printed_options.geometry_mode = AsPrintedModelExporter::GeometryMode::kCenterlines;
+            }
+
+            const QString suffix = use_centerline_geometry ? "_as_printed_centerline.stl" : "_as_printed.stl";
+            const QString asPrintedFileName = filepath % '/' % partName % suffix;
             if (!m_has_gcode_visualization) {
                 QMessageBox::warning(this, "As-Printed Model",
                                      "Could not save the as-printed STL model: G-code visualization is still loading.");
             }
-            else if (!AsPrintedModelExporter::writeStl(asPrintedFileName, m_gcode, &error)) {
-                QMessageBox::warning(this, "As-Printed Model",
-                                     "Could not save the as-printed STL model: " % error);
+            else if (!AsPrintedModelExporter::writeStl(asPrintedFileName, m_gcode, &error, as_printed_options)) {
+                QMessageBox::warning(this, "As-Printed Model", "Could not save the as-printed STL model: " % error);
             }
         }
 

--- a/tests/as_printed_model_exporter_tests.cpp
+++ b/tests/as_printed_model_exporter_tests.cpp
@@ -28,6 +28,7 @@ namespace {
 constexpr float kLength = 10.0f;
 constexpr float kWidth = 2.0f;
 constexpr float kHeight = 1.0f;
+constexpr float kCenterlineDiameter = 0.1f;
 constexpr float kTolerance = 0.001f;
 
 struct Bounds {
@@ -166,6 +167,21 @@ int main(int argc, char* argv[]) {
     passed &= expect(near(printable_bounds.max.x() - printable_bounds.min.x(), kLength),
                      "Expected bead length to be written in millimeters.");
 
+    ORNL::AsPrintedModelExporter::Options centerline_options;
+    centerline_options.geometry_mode = ORNL::AsPrintedModelExporter::GeometryMode::kCenterlines;
+    const auto centerline_triangles =
+        ORNL::AsPrintedModelExporter::generateTriangles(printable_only, centerline_options);
+    passed &= expect(!centerline_triangles.empty(), "Expected centerline STL triangles.");
+    passed &= expect(centerline_triangles.size() < printable_triangles.size(),
+                     "Expected centerline STL to use less geometry than true bead-width STL for a straight segment.");
+    const Bounds centerline_bounds = boundsFor(centerline_triangles);
+    passed &= expect(near(centerline_bounds.max.x() - centerline_bounds.min.x(), kLength),
+                     "Expected centerline STL length to follow the toolpath centerline.");
+    passed &= expect(near(centerline_bounds.max.y() - centerline_bounds.min.y(), kCenterlineDiameter),
+                     "Expected centerline STL width to ignore the true bead width.");
+    passed &= expect(near(centerline_bounds.max.z() - centerline_bounds.min.z(), kCenterlineDiameter),
+                     "Expected centerline STL height to use the centerline tube diameter.");
+
     QSharedPointer<ORNL::SegmentBase> radial_segment =
         makeLineSegment(pointFromMm(10.0f, -5.0f), pointFromMm(10.0f, 5.0f), 4);
     radial_segment->setCylindricalBeadCenter(pointFromMm(0.0f, 0.0f) * ORNL::Constants::OpenGL::kObjectToView);
@@ -222,6 +238,10 @@ int main(int argc, char* argv[]) {
     const Bounds full_circle_arc_bounds = boundsFor(full_circle_arc_triangles);
     passed &= expect(near(full_circle_arc_bounds.max.z() - full_circle_arc_bounds.min.z(), kHeight),
                      "Expected arc bead mesh height to match the display bead height.");
+    const auto centerline_full_circle_arc_triangles =
+        ORNL::AsPrintedModelExporter::generateTriangles(full_circle_arc_segments, centerline_options);
+    passed &= expect(!centerline_full_circle_arc_triangles.empty(),
+                     "Expected same-endpoint full-circle arcs to be exported as centerline STL triangles.");
 
     QVector<QVector<QSharedPointer<ORNL::SegmentBase>>> corner_segments;
     corner_segments.push_back({makeLineSegment(pointFromMm(0.0f, 0.0f, 0.0f), pointFromMm(10.0f, 0.0f, 0.0f), 1),
@@ -278,6 +298,15 @@ int main(int argc, char* argv[]) {
                          "Generated ASCII STL facet count did not match generated triangles.");
         passed &= expect(QFileInfo(binary_stl_path).size() < QFileInfo(ascii_stl_path).size(),
                          "Expected binary STL to be smaller than ASCII STL.");
+
+        const QString centerline_stl_path = temp_dir.path() + "/as_printed_centerline.stl";
+        passed &= expect(
+            ORNL::AsPrintedModelExporter::writeStl(centerline_stl_path, printable_only, &error, centerline_options),
+            ("Could not write centerline STL: " + error.toStdString()));
+        QByteArray centerline_stl_bytes;
+        passed &= expect(readBytes(centerline_stl_path, centerline_stl_bytes), "Could not read centerline STL.");
+        passed &= expect(binaryFacetCount(centerline_stl_bytes) == static_cast<quint32>(centerline_triangles.size()),
+                         "Generated centerline STL facet count did not match generated centerline triangles.");
     }
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/tests/as_printed_model_exporter_tests.cpp
+++ b/tests/as_printed_model_exporter_tests.cpp
@@ -65,6 +65,14 @@ Bounds boundsFor(const std::vector<ORNL::AsPrintedModelExporter::Triangle>& tria
     return bounds;
 }
 
+QVector3D normalFor(const ORNL::AsPrintedModelExporter::Triangle& triangle) {
+    QVector3D normal = QVector3D::crossProduct(triangle.b - triangle.a, triangle.c - triangle.a);
+    if (normal.lengthSquared() > std::numeric_limits<float>::epsilon()) {
+        normal.normalize();
+    }
+    return normal;
+}
+
 bool near(float actual, float expected, float tolerance = kTolerance) {
     return std::abs(actual - expected) <= tolerance;
 }
@@ -181,6 +189,27 @@ int main(int argc, char* argv[]) {
                      "Expected centerline STL width to ignore the true bead width.");
     passed &= expect(near(centerline_bounds.max.z() - centerline_bounds.min.z(), kCenterlineDiameter),
                      "Expected centerline STL height to use the centerline tube diameter.");
+    bool checked_centerline_side_normal = false;
+    for (const ORNL::AsPrintedModelExporter::Triangle& triangle : centerline_triangles) {
+        const QVector3D normal = normalFor(triangle);
+        if (normal.lengthSquared() <= std::numeric_limits<float>::epsilon() || std::abs(normal.x()) > 0.5f) {
+            continue;
+        }
+
+        const QVector3D centroid = (triangle.a + triangle.b + triangle.c) / 3.0f;
+        QVector3D outward(0.0f, centroid.y() - (kCenterlineDiameter / 2.0f),
+                          centroid.z() - (kCenterlineDiameter / 2.0f));
+        if (outward.lengthSquared() <= std::numeric_limits<float>::epsilon()) {
+            continue;
+        }
+        outward.normalize();
+
+        passed &= expect(QVector3D::dotProduct(normal, outward) > 0.0f,
+                         "Expected centerline STL side-wall normals to point outward.");
+        checked_centerline_side_normal = true;
+        break;
+    }
+    passed &= expect(checked_centerline_side_normal, "Expected a centerline STL side-wall normal to test.");
 
     QSharedPointer<ORNL::SegmentBase> radial_segment =
         makeLineSegment(pointFromMm(10.0f, -5.0f), pointFromMm(10.0f, 5.0f), 4);


### PR DESCRIPTION
## Summary
- Add an as-printed STL geometry mode that exports a lightweight centerline tube instead of true bead-width meshes.
- Add a G-code export dialog option to select centerline geometry and write `_as_printed_centerline.stl`.
- Cover centerline triangle generation, full-circle arcs, and binary STL output in the existing as-printed exporter tests.

## Why
The existing as-printed STL export reused true bead-width preview geometry. This adds an export path for users who need STL output that primarily represents each toolpath centerline.

## Impact
The current true bead-width export remains the default. Centerline STL output uses a small closed tube so downstream STL tools can read actual facets even though STL does not support native line primitives.

## Validation
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer_as_printed_model_exporter_tests`
- `nix develop --command ctest --test-dir build/generic-llvm-ninja -C Debug -R as_printed_model_exporter_tests --output-on-failure`
- `git diff --check`