### PR TITLE
Improve spiral contour connection handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,17 @@ if(ORNLSLICER_BUILD_TESTS)
     target_link_libraries(${PROJECT_NAME}_path_modifier_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME path_modifier_tests COMMAND ${PROJECT_NAME}_path_modifier_tests)
 
+    add_executable(${PROJECT_NAME}_spiral_path_tests tests/spiral_path_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_spiral_path_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_spiral_path_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME spiral_path_tests COMMAND ${PROJECT_NAME}_spiral_path_tests)
+
     set(ORNLSLICER_NEW_IMPACT_PROJECT "/home/rhc/develop/new-impact.s2p" CACHE FILEPATH
         "Optional local project used for the new-impact planar slicing regression test.")
     if(EXISTS "${ORNLSLICER_NEW_IMPACT_PROJECT}")

--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <limits>
 
 #include <qcontainerfwd.h>
@@ -39,7 +40,8 @@ inline bool hasSmoothClosingSegment(const Polyline& line) {
         return false;
     }
 
-    return MathUtils::nearCollinear(line[line.size() - 2], line.back(), line.front(), 45 * deg);
+    const Angle closing_angle = MathUtils::internalAngle(line[line.size() - 2], line.back(), line.front());
+    return closing_angle >= (pi - (45 * deg));
 }
 
 inline Polyline reversePreservingStart(const Polyline& line) {
@@ -217,6 +219,43 @@ struct StitchLoop {
     Polyline loop;
     Distance width;
 };
+
+inline bool closedPolylineContainsAnyPoint(Polyline container, const Polyline& points) {
+    if (container.size() < 3 || points.isEmpty()) {
+        return false;
+    }
+
+    if (container.front() != container.back()) {
+        container.push_back(container.front());
+    }
+
+    for (const Point& point : points) {
+        if (container.inside(point, true)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+inline bool loopsAreNested(const Polyline& lhs, const Polyline& rhs) {
+    if (lhs.size() < 3 || rhs.size() < 3) {
+        return false;
+    }
+
+    return closedPolylineContainsAnyPoint(lhs, rhs) || closedPolylineContainsAnyPoint(rhs, lhs);
+}
+
+inline bool canConnectLoops(const StitchLoop& current_loop, const StitchLoop& next_loop, const Point& connector_start,
+                            Distance stop_distance) {
+    if (!loopsAreNested(current_loop.loop, next_loop.loop)) {
+        return false;
+    }
+
+    const Distance connector_length = connector_start.distance(next_loop.loop.front());
+    const double max_connector_length = std::max(stop_distance() * 2.0, 1.0e-6);
+    return connector_length() <= max_connector_length;
+}
 } // namespace detail
 
 /*!
@@ -235,6 +274,106 @@ inline Distance closedPolylineLength(const Polyline& line) {
  */
 inline Point transitionStartPoint(const Polyline& line, Distance distance_before_start) {
     return detail::stopPointOnClosingSegment(line, distance_before_start);
+}
+
+/*!
+ * \brief Links ordered closed loops into open spiral-style polyline groups.
+ *
+ * Adjacent loops are joined with an extruding connector. When the candidate connector would jump between unrelated or
+ * non-adjacent loops, the current group ends at the connector start so the caller can emit a travel to the next group.
+ *
+ * \param ordered_loops Closed loops without a repeated final point.
+ * \param loop_widths Bead widths for the ordered loops.
+ * \param fallback_width Width used when a per-loop width is not supplied.
+ * \return One or more polylines, each representing a connectable spiral group.
+ */
+inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& ordered_loops,
+                                                  const QVector<Distance>& loop_widths, Distance fallback_width) {
+    QVector<detail::StitchLoop> loops;
+    loops.reserve(ordered_loops.size());
+    for (int i = 0, end = ordered_loops.size(); i < end; ++i) {
+        loops.push_back({ordered_loops[i], i < loop_widths.size() ? loop_widths[i] : fallback_width});
+    }
+
+    bool has_reference_orientation = false;
+    bool reference_orientation = false;
+    for (const detail::StitchLoop& stitch_loop : loops) {
+        if (stitch_loop.loop.size() >= 3) {
+            reference_orientation = stitch_loop.loop.orientation();
+            has_reference_orientation = true;
+            break;
+        }
+    }
+    if (has_reference_orientation) {
+        for (detail::StitchLoop& stitch_loop : loops) {
+            detail::alignOrientation(stitch_loop.loop, reference_orientation);
+        }
+    }
+
+    QVector<Polyline> spiral_groups;
+    Polyline spiral;
+
+    while (!loops.isEmpty() && loops.front().loop.size() < 3) {
+        loops.removeFirst();
+    }
+
+    if (loops.isEmpty()) {
+        return spiral_groups;
+    }
+
+    detail::StitchLoop current_loop = loops.takeFirst();
+    while (true) {
+        spiral += current_loop.loop;
+
+        while (!loops.isEmpty() && loops.front().loop.size() < 3) {
+            loops.removeFirst();
+        }
+
+        if (!loops.isEmpty()) {
+            detail::StitchLoop next_loop = loops.takeFirst();
+            detail::StitchLoop prepared_next_loop = next_loop;
+            const Distance stop_distance =
+                detail::transitionDistance(current_loop.width, next_loop.width, fallback_width);
+            const Point connector_start =
+                detail::prepareConnector(current_loop.loop, prepared_next_loop.loop, stop_distance);
+
+            if (spiral.back() != connector_start) {
+                spiral += connector_start;
+            }
+
+            if (detail::canConnectLoops(current_loop, prepared_next_loop, connector_start, stop_distance)) {
+                current_loop = prepared_next_loop;
+            }
+            else {
+                spiral_groups.push_back(spiral);
+                spiral.clear();
+                current_loop = next_loop;
+            }
+        }
+        else {
+            const Point final_stop = detail::stopPointOnClosingSegment(
+                current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
+
+            if (spiral.back() != final_stop) {
+                spiral += final_stop;
+            }
+            spiral_groups.push_back(spiral);
+            break;
+        }
+    }
+
+    return spiral_groups;
+}
+
+inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& ordered_loops,
+                                                  Distance final_stop_distance) {
+    QVector<Distance> loop_widths;
+    loop_widths.reserve(ordered_loops.size());
+    for (int i = 0, end = ordered_loops.size(); i < end; ++i) {
+        loop_widths.push_back(final_stop_distance);
+    }
+
+    return linkClosedPolylineGroups(ordered_loops, loop_widths, final_stop_distance);
 }
 
 /*!

--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -337,14 +337,19 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
             const Point connector_start =
                 detail::prepareConnector(current_loop.loop, prepared_next_loop.loop, stop_distance);
 
-            if (spiral.back() != connector_start) {
-                spiral += connector_start;
-            }
-
             if (detail::canConnectLoops(current_loop, prepared_next_loop, connector_start, stop_distance)) {
+                if (spiral.back() != connector_start) {
+                    spiral += connector_start;
+                }
                 current_loop = prepared_next_loop;
             }
             else {
+                const Point final_stop = detail::stopPointOnClosingSegment(
+                    current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
+
+                if (spiral.back() != final_stop) {
+                    spiral += final_stop;
+                }
                 spiral_groups.push_back(spiral);
                 spiral.clear();
                 current_loop = next_loop;

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -458,6 +458,34 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         }
     }
 
+    auto appendSpiralPaths = [&](const QVector<Polyline>& spiral_groups, bool ccw, Distance min_path_length) {
+        for (const Polyline& spiral_group : spiral_groups) {
+            if (spiral_group.size() < 3) {
+                continue;
+            }
+
+            Path newPath = createPath(spiral_group);
+            newPath.setCCW(ccw);
+
+            if (newPath.size() > 0) {
+                newPath.getSegments().removeLast();
+            }
+
+            if (newPath.calculateLength() < min_path_length) {
+                continue;
+            }
+
+            if (newPath.size() > 0) {
+                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
+                PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                      m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                current_location = newPath.back()->end();
+                m_paths.push_back(newPath);
+            }
+        }
+    };
+
     if (m_sb->setting<bool>(PS::Inset::kEnableSpiralInset)) {
         if (!m_sb->setting<bool>(PS::Inset::kAdaptive)) {
             Point spiral_query_location = current_location;
@@ -510,31 +538,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
                 return;
             }
 
-            Polyline result = SpiralPath::linkClosedPolylines(ordered_insets, bead_width);
-
-            if (result.size() < 3) {
-                return;
-            }
-
-            Path newPath = createPath(result);
-            newPath.setCCW(ordered_insets.front().orientation());
-
-            if (newPath.size() > 0) {
-                newPath.getSegments().removeLast();
-            }
-
-            if (newPath.calculateLength() < min_path_length) {
-                return;
-            }
-
-            if (newPath.size() > 0) {
-                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
-                PathModifierGenerator::GenerateTravel(newPath, current_location,
-                                                      m_sb->setting<Velocity>(PS::Travel::kSpeed));
-
-                current_location = newPath.back()->end();
-                m_paths.push_back(newPath);
-            }
+            appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_insets, bead_width),
+                              ordered_insets.front().orientation(), min_path_length);
 
             return;
         }
@@ -610,31 +615,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         }
 
         const Distance nominal_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
-        Polyline result = SpiralPath::linkClosedPolylines(ordered_insets, ordered_inset_widths, nominal_width);
-
-        if (result.size() < 3) {
-            return;
-        }
-
-        Path newPath = createPath(result);
-        newPath.setCCW(ordered_insets.front().orientation());
-
-        if (newPath.size() > 0) {
-            newPath.getSegments().removeLast();
-        }
-
-        if (newPath.calculateLength() < min_path_length) {
-            return;
-        }
-
-        if (newPath.size() > 0) {
-            calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
-            PathModifierGenerator::GenerateTravel(newPath, current_location,
-                                                  m_sb->setting<Velocity>(PS::Travel::kSpeed));
-
-            current_location = newPath.back()->end();
-            m_paths.push_back(newPath);
-        }
+        appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_insets, ordered_inset_widths, nominal_width),
+                          ordered_insets.front().orientation(), min_path_length);
 
         return;
     }

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -565,6 +565,34 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 line = line.reverse();
             }
 
+        auto appendSpiralPaths = [&](const QVector<Polyline>& spiral_groups, bool ccw, Distance min_path_length) {
+            for (const Polyline& spiral_group : spiral_groups) {
+                if (spiral_group.size() < 3) {
+                    continue;
+                }
+
+                Path newPath = createPath(spiral_group);
+                newPath.setCCW(ccw);
+
+                if (newPath.size() > 0) {
+                    newPath.getSegments().removeLast();
+                }
+
+                if (newPath.calculateLength() < min_path_length) {
+                    continue;
+                }
+
+                if (newPath.size() > 0) {
+                    calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
+                    PathModifierGenerator::GenerateTravel(newPath, current_location,
+                                                          m_sb->setting<Velocity>(PS::Travel::kSpeed));
+
+                    current_location = newPath.back()->end();
+                    m_paths.push_back(newPath);
+                }
+            }
+        };
+
         if (m_sb->setting<bool>(PS::Perimeter::kEnableSpiralPerimeter)) {
             if (!m_sb->setting<bool>(PS::Perimeter::kAdaptive)) {
                 Point spiral_query_location = current_location;
@@ -618,31 +646,8 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                     return;
                 }
 
-                Polyline result = SpiralPath::linkClosedPolylines(ordered_perimeters, bead_width);
-
-                if (result.size() < 3) {
-                    return;
-                }
-
-                Path newPath = createPath(result);
-                newPath.setCCW(ordered_perimeters.front().orientation());
-
-                if (newPath.size() > 0) {
-                    newPath.getSegments().removeLast();
-                }
-
-                if (newPath.calculateLength() < min_path_length) {
-                    return;
-                }
-
-                if (newPath.size() > 0) {
-                    calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
-                    PathModifierGenerator::GenerateTravel(newPath, current_location,
-                                                          m_sb->setting<Velocity>(PS::Travel::kSpeed));
-
-                    current_location = newPath.back()->end();
-                    m_paths.push_back(newPath);
-                }
+                appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_perimeters, bead_width),
+                                  ordered_perimeters.front().orientation(), min_path_length);
 
                 return;
             }
@@ -718,32 +723,9 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             }
 
             const Distance nominal_width = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
-            Polyline result =
-                SpiralPath::linkClosedPolylines(ordered_perimeters, ordered_perimeter_widths, nominal_width);
-
-            if (result.size() < 3) {
-                return;
-            }
-
-            Path newPath = createPath(result);
-            newPath.setCCW(ordered_perimeters.front().orientation());
-
-            if (newPath.size() > 0) {
-                newPath.getSegments().removeLast();
-            }
-
-            if (newPath.calculateLength() < min_path_length) {
-                return;
-            }
-
-            if (newPath.size() > 0) {
-                calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
-                PathModifierGenerator::GenerateTravel(newPath, current_location,
-                                                      m_sb->setting<Velocity>(PS::Travel::kSpeed));
-
-                current_location = newPath.back()->end();
-                m_paths.push_back(newPath);
-            }
+            appendSpiralPaths(
+                SpiralPath::linkClosedPolylineGroups(ordered_perimeters, ordered_perimeter_widths, nominal_width),
+                ordered_perimeters.front().orientation(), min_path_length);
 
             return;
         }

--- a/tests/spiral_path_tests.cpp
+++ b/tests/spiral_path_tests.cpp
@@ -80,6 +80,10 @@ int main() {
 
     passed &= expect(nested_gap_groups.size() == 2,
                      "Expected nested loops separated by more than the transition width to be split.");
+    if (nested_gap_groups.size() == 2) {
+        passed &= expectPoint(nested_gap_groups.front().back(), 0.0, 1.0,
+                              "Expected rejected nested-gap group to end at the normal final stop.");
+    }
 
     QVector<ORNL::Polyline> separated_nested_loops;
     separated_nested_loops.push_back(square(0.0, 0.0, 12.0, 18.0));

--- a/tests/spiral_path_tests.cpp
+++ b/tests/spiral_path_tests.cpp
@@ -1,0 +1,113 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <QVector>
+
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "geometry/spiral_path.h"
+#include "units/unit.h"
+
+namespace {
+bool expect(bool condition, const std::string& message) {
+    if (condition)
+        return true;
+
+    std::cerr << message << '\n';
+    return false;
+}
+
+bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-4; }
+
+bool expectPoint(const ORNL::Point& point, double x, double y, const std::string& message) {
+    return expect(closeTo(point.x(), x) && closeTo(point.y(), y), message);
+}
+
+ORNL::Polyline square(double min_x, double min_y, double max_x, double max_y) {
+    ORNL::Polyline line;
+    line.push_back(ORNL::Point(min_x, min_y, 0.0f));
+    line.push_back(ORNL::Point(max_x, min_y, 0.0f));
+    line.push_back(ORNL::Point(max_x, max_y, 0.0f));
+    line.push_back(ORNL::Point(min_x, max_y, 0.0f));
+    return line;
+}
+
+ORNL::Polyline rectangleStartingOnLeftEdge(double min_x, double min_y, double max_x, double max_y, double start_y) {
+    ORNL::Polyline line;
+    line.push_back(ORNL::Point(min_x, start_y, 0.0f));
+    line.push_back(ORNL::Point(min_x, min_y, 0.0f));
+    line.push_back(ORNL::Point(max_x, min_y, 0.0f));
+    line.push_back(ORNL::Point(max_x, max_y, 0.0f));
+    line.push_back(ORNL::Point(min_x, max_y, 0.0f));
+    return line;
+}
+} // namespace
+
+int main() {
+    bool passed = true;
+
+    const ORNL::Distance bead_width(1.0);
+
+    QVector<ORNL::Polyline> adjacent_loops;
+    adjacent_loops.push_back(square(0.0, 0.0, 10.0, 10.0));
+    adjacent_loops.push_back(square(1.0, 1.0, 9.0, 9.0));
+    QVector<ORNL::Polyline> adjacent_groups = ORNL::SpiralPath::linkClosedPolylineGroups(adjacent_loops, bead_width);
+
+    passed &= expect(adjacent_groups.size() == 1, "Expected adjacent nested loops to remain in one spiral group.");
+
+    QVector<ORNL::Polyline> disjoint_loops;
+    disjoint_loops.push_back(square(0.0, 0.0, 10.0, 10.0));
+    disjoint_loops.push_back(square(30.0, 0.0, 40.0, 10.0));
+    QVector<ORNL::Polyline> disjoint_groups = ORNL::SpiralPath::linkClosedPolylineGroups(disjoint_loops, bead_width);
+
+    passed &= expect(disjoint_groups.size() == 2, "Expected disjoint loops to be split into separate spiral groups.");
+    if (disjoint_groups.size() == 2) {
+        passed &= expectPoint(disjoint_groups.front().back(), 0.0, 1.0,
+                              "Expected disjoint group to end at the rejected connector start.");
+        passed &= expectPoint(disjoint_groups.back().front(), 30.0, 0.0,
+                              "Expected next disjoint group to keep its existing start vertex.");
+        passed &= expect(disjoint_groups.front().back().distance(disjoint_groups.back().front()) > bead_width * 2.0,
+                         "Expected rejected connector to exceed the spiral adjacency threshold.");
+    }
+
+    QVector<ORNL::Polyline> nested_gap_loops;
+    nested_gap_loops.push_back(square(0.0, 0.0, 50.0, 50.0));
+    nested_gap_loops.push_back(square(20.0, 20.0, 30.0, 30.0));
+    QVector<ORNL::Polyline> nested_gap_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(nested_gap_loops, bead_width);
+
+    passed &= expect(nested_gap_groups.size() == 2,
+                     "Expected nested loops separated by more than the transition width to be split.");
+
+    QVector<ORNL::Polyline> separated_nested_loops;
+    separated_nested_loops.push_back(square(0.0, 0.0, 12.0, 18.0));
+    separated_nested_loops.push_back(square(1.0, 1.0, 11.0, 17.0));
+    separated_nested_loops.push_back(square(40.0, 0.0, 52.0, 18.0));
+    separated_nested_loops.push_back(square(41.0, 1.0, 51.0, 17.0));
+    QVector<ORNL::Polyline> separated_nested_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(separated_nested_loops, bead_width);
+
+    passed &= expect(separated_nested_groups.size() == 2,
+                     "Expected separated nested inset stacks to become two spiral groups.");
+    if (separated_nested_groups.size() == 2) {
+        passed &= expect(separated_nested_groups.front().size() > 6,
+                         "Expected the first inset stack to link into a multi-loop spiral group.");
+        passed &= expect(separated_nested_groups.back().size() > 6,
+                         "Expected the second inset stack to link into a multi-loop spiral group.");
+        passed &= expectPoint(separated_nested_groups.back().front(), 40.0, 0.0,
+                              "Expected the second inset stack to keep its existing start vertex.");
+    }
+
+    QVector<ORNL::Polyline> edge_start_loops;
+    edge_start_loops.push_back(rectangleStartingOnLeftEdge(0.0, 0.0, 12.0, 18.0, 3.06));
+    edge_start_loops.push_back(square(0.34, 0.34, 11.66, 17.66));
+    QVector<ORNL::Polyline> edge_start_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(edge_start_loops, ORNL::Distance(0.34));
+
+    passed &= expect(edge_start_groups.size() == 1,
+                     "Expected an inset stack with a mid-edge outer start point to stay spiralized.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- Split spiral perimeters and insets into separate spiral groups when a candidate connector would jump between non-adjacent or unrelated loops.
- Emit travel moves between those groups while preserving normal extruding spiral connectors for adjacent nested loops.
- Avoid carrying synthetic split points from rejected connector probes into the next spiral group.
- Add focused spiral path regression tests for adjacent loops, disjoint loops, separated nested stacks, and mid-edge start handling.

## Root Cause

The spiral linker always prepared the next loop for extrusion before deciding whether the connector was valid. When a cross-gap connector was rejected, the prepared loop could still retain a generated mid-segment start point, and the next group would inherit that synthetic point. The grouping logic now probes a copy and commits the prepared loop only when the connector is accepted.

## Validation

- `direnv exec . cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer_spiral_path_tests`
- `direnv exec . ctest --test-dir build/generic-llvm-ninja -C Debug -R spiral_path_tests --output-on-failure`
- `git diff --check`
- `direnv exec . cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer`
- `direnv exec . build/generic-llvm-ninja/Debug/ornlslicer --input_project_file /home/rhc/develop/Spiral-Test.s2p --output_location /tmp/spiral-test-output --single_slice_layer_number 0`