### PR TITLE
Add travel time estimate to G-code summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,17 @@ if(ORNLSLICER_BUILD_TESTS)
     target_link_libraries(${PROJECT_NAME}_gcode_settings_importer_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME gcode_settings_importer_tests COMMAND ${PROJECT_NAME}_gcode_settings_importer_tests)
 
+    add_executable(${PROJECT_NAME}_common_parser_tests tests/common_parser_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_common_parser_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_common_parser_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME common_parser_tests COMMAND ${PROJECT_NAME}_common_parser_tests)
+
     add_executable(${PROJECT_NAME}_arc_specialties_parser_tests tests/arc_specialties_parser_tests.cpp)
     target_include_directories(
         ${PROJECT_NAME}_arc_specialties_parser_tests

--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -516,6 +516,9 @@ class CommonParser : public ParserBase {
     //! \brief Returns whether feedrate scaling should be skipped for the parsed motion command.
     bool feedrateScalingDisabledForCommand(const GcodeCommand& command) const;
 
+    //! \brief Returns whether the current motion command deposits material.
+    bool currentMotionDepositsMaterial() const;
+
     //! \brief Records the authored modal feedrate for a parsed motion command.
     void recordModalFeedrateForCommand(const GcodeCommand& command);
 

--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -206,6 +206,10 @@ class CommonParser : public ParserBase {
     //! \return travel distance in gcode file
     Distance getTravelDistance();
 
+    //! \brief Returns the estimated total travel time for the gcode file
+    //! \return travel time in gcode file
+    Time getTravelTime();
+
     //! \brief Returns whether or not any lines were altered to enforce minimum layer times or expand/contract
     bool getWasModified();
 
@@ -515,6 +519,9 @@ class CommonParser : public ParserBase {
     //! \brief Records the authored modal feedrate for a parsed motion command.
     void recordModalFeedrateForCommand(const GcodeCommand& command);
 
+    //! \brief Records motion distance and non-deposition time after estimating a parsed command.
+    void recordMotionEstimate(Distance distance, Time time_delta);
+
     //! \brief Replaces an existing F token or inserts one before the command comment.
     void setCommandFeedrate(QString& line, double feedrate);
 
@@ -564,6 +571,9 @@ class CommonParser : public ParserBase {
 
     //! \brief layer "G1 F" lines feedrate modifier
     QList<double> m_layer_FR_modifiers;
+
+    //! \brief Estimated time spent on non-deposition motion.
+    Time m_travel_time;
 
     //! \brief layer time from "G1 F" lines
     QList<Time> m_layer_G1F_times;

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -92,6 +92,7 @@ CommonParser::CommonParser(GcodeMeta meta, bool allowLayerAlter, QStringList& li
     MotionEstimation::m_total_distance = 0;
     MotionEstimation::m_printing_distance = 0;
     MotionEstimation::m_travel_distance = 0;
+    m_travel_time = 0 * m_time_unit;
 }
 
 Distance CommonParser::getCurrentGXDistance() {
@@ -895,6 +896,7 @@ void CommonParser::reset() {
     m_purge_time = 0 * m_time_unit;
     m_wait_to_wipe_time = 0 * m_time_unit;
     m_wait_time_to_start_purge = 0 * m_time_unit;
+    m_travel_time = 0 * m_time_unit;
 
     m_deposition_active = false;
     m_dynamic_spindle_control = false;
@@ -973,6 +975,8 @@ Distance CommonParser::getPrintingDistance() { return MotionEstimation::m_printi
 
 Distance CommonParser::getTravelDistance() { return MotionEstimation::m_travel_distance; }
 
+Time CommonParser::getTravelTime() { return m_travel_time; }
+
 bool CommonParser::getWasModified() { return m_was_modified; }
 
 void CommonParser::cancelSlice() { m_should_cancel = true; }
@@ -984,6 +988,18 @@ int CommonParser::getCurrentLine() { return m_current_line; }
 void CommonParser::alterCurrentEndLine(int count) { m_current_end_line += count; }
 
 void CommonParser::setModified() { m_was_modified = true; }
+
+void CommonParser::recordMotionEstimate(Distance distance, Time time_delta) {
+    MotionEstimation::m_total_distance += distance;
+
+    if (m_deposition_active) {
+        MotionEstimation::m_printing_distance += distance;
+    }
+    else {
+        MotionEstimation::m_travel_distance += distance;
+        m_travel_time += time_delta;
+    }
+}
 
 void CommonParser::setXPos(NT value) { MotionEstimation::m_current_x = value; }
 
@@ -1101,13 +1117,9 @@ void CommonParser::G0Handler(QVector<QString> params) {
         m_motion_commands[m_current_layer].push_back(m_current_gcode_command);
     }
 
+    const Time layer_time_before = m_layer_times[m_current_layer];
     Distance temp = getCurrentGXDistance();
-    MotionEstimation::m_total_distance += temp;
-
-    if (m_deposition_active)
-        MotionEstimation::m_printing_distance += temp;
-    else
-        MotionEstimation::m_travel_distance += temp;
+    recordMotionEstimate(temp, m_layer_times[m_current_layer] - layer_time_before);
 }
 
 void CommonParser::G1Handler(QVector<QString> params) {
@@ -1300,12 +1312,9 @@ void CommonParser::G1Handler(QVector<QString> params) {
     m_with_F_value =
         is_motion_command && m_has_modal_feedrate && !feedrateScalingDisabledForCommand(m_current_gcode_command);
 
+    const Time layer_time_before = m_layer_times[m_current_layer];
     Distance temp = getCurrentGXDistance();
-    MotionEstimation::m_total_distance += temp;
-    if (m_deposition_active)
-        MotionEstimation::m_printing_distance += temp;
-    else
-        MotionEstimation::m_travel_distance += temp;
+    recordMotionEstimate(temp, m_layer_times[m_current_layer] - layer_time_before);
 }
 
 void CommonParser::G1HandlerHelper(QVector<QString> params, QVector<QString> optionalParams) {
@@ -1524,12 +1533,9 @@ void CommonParser::G2Handler(QVector<QString> params) {
 
     m_with_F_value = m_has_modal_feedrate && !feedrateScalingDisabledForCommand(m_current_gcode_command);
 
+    const Time layer_time_before = m_layer_times[m_current_layer];
     Distance temp = getCurrentArcDistance(start_x, start_y, start_z, !i_not_used, !j_not_used, !r_not_used, false);
-    MotionEstimation::m_total_distance += temp;
-    if (m_deposition_active)
-        MotionEstimation::m_printing_distance += temp;
-    else
-        MotionEstimation::m_travel_distance += temp;
+    recordMotionEstimate(temp, m_layer_times[m_current_layer] - layer_time_before);
 }
 
 void CommonParser::G3Handler(QVector<QString> params) {
@@ -1742,12 +1748,9 @@ void CommonParser::G3Handler(QVector<QString> params) {
 
     m_with_F_value = m_has_modal_feedrate && !feedrateScalingDisabledForCommand(m_current_gcode_command);
 
+    const Time layer_time_before = m_layer_times[m_current_layer];
     Distance temp = getCurrentArcDistance(start_x, start_y, start_z, !i_not_used, !j_not_used, !r_not_used, true);
-    MotionEstimation::m_total_distance += temp;
-    if (m_deposition_active)
-        MotionEstimation::m_printing_distance += temp;
-    else
-        MotionEstimation::m_travel_distance += temp;
+    recordMotionEstimate(temp, m_layer_times[m_current_layer] - layer_time_before);
 }
 
 void CommonParser::G4Handler(QVector<QString> params) {

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -107,7 +107,7 @@ Distance CommonParser::getCurrentGXDistance() {
     const Time adjustable_time_before = m_layer_G1F_times[m_current_layer];
     const Distance distance = MotionEstimation::calculateTimeAndVolume(
         m_current_layer, include_feedrate_adjustable_time, m_current_gcode_command.getCommandID() == 0,
-        m_deposition_active, m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer],
+        currentMotionDepositsMaterial(), m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer],
         m_layer_volumes[m_current_layer], uses_b);
 
     const Time command_adjustable_time = m_layer_G1F_times[m_current_layer] - adjustable_time_before;
@@ -139,7 +139,7 @@ Distance CommonParser::getCurrentArcDistance(Distance start_x, Distance start_y,
     const Time adjustable_time_before = m_layer_G1F_times[m_current_layer];
     const Distance distance = MotionEstimation::calculatePathTimeAndVolume(
         path_length, start_direction_x, start_direction_y, start_direction_z, end_direction_x, end_direction_y,
-        end_direction_z, include_feedrate_adjustable_time, false, m_deposition_active,
+        end_direction_z, include_feedrate_adjustable_time, false, currentMotionDepositsMaterial(),
         m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer], m_layer_volumes[m_current_layer]);
 
     const Time command_adjustable_time = m_layer_G1F_times[m_current_layer] - adjustable_time_before;
@@ -356,6 +356,11 @@ bool CommonParser::feedrateScalingDisabledForCommand(const GcodeCommand& command
 
     return fileBoolSetting(MS::SpiralLift::kDisableFeedrateScaling) &&
            comment.contains(Constants::PathModifierStrings::kSpiralLift);
+}
+
+bool CommonParser::currentMotionDepositsMaterial() const {
+    return m_deposition_active && !m_current_gcode_command.getComment().contains(Constants::RegionTypeStrings::kTravel,
+                                                                                 Qt::CaseInsensitive);
 }
 
 void CommonParser::recordModalFeedrateForCommand(const GcodeCommand& command) {
@@ -992,7 +997,7 @@ void CommonParser::setModified() { m_was_modified = true; }
 void CommonParser::recordMotionEstimate(Distance distance, Time time_delta) {
     MotionEstimation::m_total_distance += distance;
 
-    if (m_deposition_active) {
+    if (currentMotionDepositsMaterial()) {
         MotionEstimation::m_printing_distance += distance;
     }
     else {
@@ -1110,7 +1115,7 @@ void CommonParser::G0Handler(QVector<QString> params) {
                 break;
         }
     }
-    m_current_gcode_command.setDepositionActive(m_deposition_active);
+    m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (is_motion_command) {
@@ -1298,7 +1303,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
         }
         m_current_gcode_command.addParameter(current_parameter, current_value);
     }
-    m_current_gcode_command.setDepositionActive(m_deposition_active);
+    m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -1510,7 +1515,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                 throw IllegalParameterException(exceptionString);
         }
     }
-    m_current_gcode_command.setDepositionActive(m_deposition_active);
+    m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -1719,7 +1724,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                 throw IllegalParameterException(exceptionString);
         }
     }
-    m_current_gcode_command.setDepositionActive(m_deposition_active);
+    m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)
@@ -2011,7 +2016,7 @@ void CommonParser::G5Handler(QVector<QString> params) {
                 throw IllegalParameterException(exceptionString);
         }
     }
-    m_current_gcode_command.setDepositionActive(m_deposition_active);
+    m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
     if (!f_not_used)

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -339,7 +339,9 @@ void GCodeLoader::run() {
                       QString::number(printingDistanceValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" % "Travel Distance: " %
                       QString::number(travelDistanceValue) % " " %
-                      PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" % "Total Distance: " %
+                      PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" %
+                      "Total Travel Time Estimate: " % MathUtils::formattedTimeSpan(m_parser->getTravelTime()()) %
+                      "\n" % "Total Distance: " %
                       QString::number(distanceValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" % "Approximate Weight (" %
                       toString(m_material) % "): " % QString::number(massValue) % " " %

--- a/tests/common_parser_tests.cpp
+++ b/tests/common_parser_tests.cpp
@@ -16,14 +16,40 @@ bool expect(bool condition, const char* message) {
     return condition;
 }
 
+QStringList upperLines(const QStringList& lines) {
+    QStringList upper_lines;
+    for (const QString& line : lines) {
+        upper_lines.append(line.toUpper());
+    }
+
+    return upper_lines;
+}
+
 bool accumulatesTravelTimeForNonDepositionMove() {
     QStringList original_lines {"G1 F60 X1 ;TRAVEL"};
-    QStringList upper_lines {original_lines.first().toUpper()};
+    QStringList upper_lines = upperLines(original_lines);
     ORNL::CommonParser parser(ORNL::GcodeMetaList::MarlinMeta, false, original_lines, upper_lines);
 
     try {
         parser.parseLines();
         return parser.getTravelDistance() > 0.0 * ORNL::mm && parser.getTravelTime() > 0.0 * ORNL::s;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << '\n';
+        return false;
+    }
+}
+
+bool accumulatesTravelTimeForTravelCommentAfterDepositionMove() {
+    QStringList original_lines {"G1 F60 X1 E1 ;PERIMETER", "G1 F60 X2 ;TRAVEL"};
+    QStringList upper_lines = upperLines(original_lines);
+    ORNL::CommonParser parser(ORNL::GcodeMetaList::MarlinMeta, false, original_lines, upper_lines);
+
+    try {
+        const QList<QList<ORNL::GcodeCommand>> commands = parser.parseLines();
+        return commands.size() == 1 && commands.first().size() == 2 &&
+               commands.first().first().getDepositionActive() && !commands.first().last().getDepositionActive() &&
+               parser.getPrintingDistance() > 0.0 * ORNL::mm && parser.getTravelDistance() > 0.0 * ORNL::mm &&
+               parser.getTravelTime() > 0.0 * ORNL::s;
     } catch (const std::exception& ex) {
         std::cerr << ex.what() << '\n';
         return false;
@@ -37,6 +63,8 @@ int main(int argc, char* argv[]) {
     bool passed = true;
     passed &= expect(accumulatesTravelTimeForNonDepositionMove(),
                      "Common parser did not accumulate travel time for a travel move.");
+    passed &= expect(accumulatesTravelTimeForTravelCommentAfterDepositionMove(),
+                     "Common parser did not accumulate travel time for a travel comment after deposition.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/common_parser_tests.cpp
+++ b/tests/common_parser_tests.cpp
@@ -1,0 +1,42 @@
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+
+#include <QCoreApplication>
+#include <QStringList>
+
+#include "gcode/gcode_meta.h"
+#include "gcode/parsers/common_parser.h"
+#include "units/unit.h"
+
+namespace {
+bool expect(bool condition, const char* message) {
+    if (!condition)
+        std::cerr << message << '\n';
+    return condition;
+}
+
+bool accumulatesTravelTimeForNonDepositionMove() {
+    QStringList original_lines {"G1 F60 X1 ;TRAVEL"};
+    QStringList upper_lines {original_lines.first().toUpper()};
+    ORNL::CommonParser parser(ORNL::GcodeMetaList::MarlinMeta, false, original_lines, upper_lines);
+
+    try {
+        parser.parseLines();
+        return parser.getTravelDistance() > 0.0 * ORNL::mm && parser.getTravelTime() > 0.0 * ORNL::s;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << '\n';
+        return false;
+    }
+}
+} // namespace
+
+int main(int argc, char* argv[]) {
+    QCoreApplication app(argc, argv);
+
+    bool passed = true;
+    passed &= expect(accumulatesTravelTimeForNonDepositionMove(),
+                     "Common parser did not accumulate travel time for a travel move.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- Track estimated non-deposition motion time while parsing G-code.
- Expose the aggregate travel time from `CommonParser` and include it in the existing G-code summary output.
- Add a dedicated common parser regression test for travel-time accumulation.

## Validation
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer_common_parser_tests ornlslicer_arc_specialties_parser_tests`
- `nix develop --command ctest --test-dir build/generic-llvm-ninja -C Debug -R 'common_parser_tests|arc_specialties_parser_tests' --output-on-failure`