### PR TITLE
Add pre-commit formatting config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,38 +1,332 @@
 ﻿---
+# BasedOnStyle: Google
+AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: 'true'
-AlignOperands: 'true'
-AlignTrailingComments: 'true'
-AllowShortBlocksOnASingleLine: 'true'
-BreakBeforeBraces: Custom
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators: true
+AlignConsecutiveBitFields:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: true
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: false
+  PadOperators: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AllowShortNamespacesOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AttributeMacros:
+  - __capability
+  - absl_nonnull
+  - absl_nullable
+  - absl_nullability_unknown
+BinPackArguments: true
+BinPackLongBracedList: true
+BinPackParameters: BinPack
+BitFieldColonSpacing: Both
 BraceWrapping:
-    BeforeElse: 'true'
-ColumnLimit: '120'
-CompactNamespaces: 'false'
-ContinuationIndentWidth: '4'
-Cpp11BracedListStyle: 'true'
-FixNamespaceComments: 'true'
-IncludeBlocks: 'Regroup'
-IncludeIsMainRegex: '$'
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BracedInitializerIndentWidth: -1
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: None
+BreakArrays: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTemplateCloser: false
+BreakBeforeTernaryOperators: true
+BreakBinaryOperations: Never
+BreakConstructorInitializers: BeforeColon
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+ColumnLimit: 120
+CommentPragmas: "^ IWYU pragma:"
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+EnumTrailingComma: Leave
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^<((GL/gl|aio|arpa/inet|assert|complex|ctype|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|getopt|glob|grp|iconv|inttypes|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|net/if|netdb|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|string|strings|stropts|sys/ioctl|sys/ipc|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|syslog|tar|termios|tgmath|threads|time|uchar|unistd|utime|utmpx|wchar|wctype|wordexp)\.h)>$' # C, POSIX, and platform system headers only
     Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
   - Regex: '^<[a-z][a-z0-9_]*>$' # C++ standard library headers without extension
     Priority: 2
-    CaseSensitive: true
+    SortPriority: 0
+    CaseSensitive: false
   - Regex: '^<.*>$' # Other libraries
     Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
   - Regex: '^".*"' # Project headers
     Priority: 4
-IndentCaseLabels: 'true'
+    SortPriority: 0
+    CaseSensitive: false
+IncludeIsMainRegex: ([-_](test|unittest))?$
+IncludeIsMainSourceRegex: ""
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExportBlock: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
 IndentPPDirectives: BeforeHash
-IndentWidth: '4'
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertBraces: false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary: 0
+  BinaryMinDigits: 0
+  Decimal: 0
+  DecimalMinDigits: 0
+  Hex: 0
+  HexMinDigits: 0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: true
+KeepFormFeed: false
+LambdaBodyIndentation: Signature
+LineEnding: DeriveLF
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+OneLineFormatOffRegex: ""
+PPIndentWidth: -1
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakBeforeMemberAccess: 150
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-SortIncludes: 'true'
-SpaceBeforeAssignmentOperators: 'true'
-SpaceBeforeCpp11BracedList: 'true'
-SpaceBeforeInheritanceColon: 'true'
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - c++
+      - C++
+    CanonicalDelimiter: ""
+    BasedOnStyle: google
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle: google
+ReferenceAlignment: Pointer
+ReflowComments: Always
+RemoveBracesLLVM: false
+RemoveEmptyLinesInUnwrappedLines: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:
+  Enabled: true
+  IgnoreCase: false
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterOperatorKeyword: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
-TabWidth: '4'
-
-...
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterIfMacros: true
+  AfterNot: false
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 4
+TableGenBreakInsideDAGArg: DontBreak
+UseTab: Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+WrapNamespaceBodyWithEmptyLines: Leave

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+fail_fast: false
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v22.1.8'
+    hooks:
+      - id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+ci:
+  autofix_prs: true
+  autofix_commit_msg: |
+    [pre-commit.ci] auto format with clang-format
+
+    for more information, see https://pre-commit.ci
+
 fail_fast: false
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,11 @@
 {
-  "recommendations": [
-    "ms-vscode.cmake-tools",
-    "llvm-vs-code-extensions.lldb-dap",
-    "EditorConfig.EditorConfig",
-    "bbenoist.nix",
-    "llvm-vs-code-extensions.vscode-clangd",
-    "mkhl.direnv",
-    "xaver.clang-format"
-  ]
+    "recommendations": [
+        "ms-vscode.cmake-tools",
+        "llvm-vs-code-extensions.lldb-dap",
+        "EditorConfig.EditorConfig",
+        "bbenoist.nix",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "mkhl.direnv",
+        "xaver.clang-format"
+    ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This guide summarizes expectations for code style, formatting, documentation, an
 1. Create a branch using the conventional branch scheme (e.g. `feat/feature-name`).
 2. Implement changes following the style & formatting guides.
 3. Add/adjust Doxygen docs for public APIs.
-4. Run `clang-format` on changed files.
+4. Run `clang-format` or the configured `pre-commit` hook on changed files.
 5. Write commits using Conventional Commits.
 6. Rebase or update from `develop` if needed; resolve conflicts.
 7. Open a pull request with a clear summary and rationale.
@@ -39,7 +39,7 @@ Follow naming, layout, and structural conventions; favor clarity over cleverness
 
 ## [Formatting](docs/contributing/formatting.md)
 
-Use `clang-format` before committing; never hand-adjust whitespace.
+Use `clang-format` or the configured `pre-commit` hook before committing; pre-commit.ci automatically applies formatting fixes to pull requests when needed.
 
 ## [Documentation](docs/contributing/documentation.md)
 

--- a/cmake/presets/generic-llvm-ninja.json
+++ b/cmake/presets/generic-llvm-ninja.json
@@ -2,22 +2,22 @@
     "version": 6,
     "configurePresets": [
         {
-            "name":        "generic-llvm-ninja",
+            "name": "generic-llvm-ninja",
             "displayName": "Generic (llvm-ninja)",
             "description": "Basic configuration with the LLVM toolchain using Ninja generator.",
-            "generator":   "Ninja Multi-Config",
-            "binaryDir":   "${sourceDir}/build/${presetName}",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
-                "CMAKE_C_COMPILER":   "clang",
+                "CMAKE_C_COMPILER": "clang",
                 "CMAKE_CXX_COMPILER": "clang++"
             }
         },
         {
-            "name":        "generic-llvm-ninja-fast",
+            "name": "generic-llvm-ninja-fast",
             "displayName": "Generic Fast (llvm-ninja)",
             "description": "LLVM/Ninja configuration with unity builds enabled for faster clean builds.",
-            "inherits":    "generic-llvm-ninja",
-            "binaryDir":   "${sourceDir}/build/${presetName}",
+            "inherits": "generic-llvm-ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
             "cacheVariables": {
                 "ORNLSLICER_ENABLE_UNITY_BUILD": "ON"
             }

--- a/docs/contributing/formatting.md
+++ b/docs/contributing/formatting.md
@@ -6,6 +6,7 @@ We enforce a single C++ style using [clang-format](https://clang.llvm.org/docs/C
 
 - [Configuration](#configuration)
 - [How to Format Code](#how-to-format-code)
+- [Pre-Commit Hooks and CI](#pre-commit-hooks-and-ci)
 - [Best Practices](#best-practices)
 
 ---
@@ -13,6 +14,8 @@ We enforce a single C++ style using [clang-format](https://clang.llvm.org/docs/C
 ## Configuration
 
 Style rules live in the repository root `.clang-format` (Google-derived with project overrides: includes, spacing, braces, ordering).
+
+The repository root `.pre-commit-config.yaml` runs the matching `clang-format` hook. Install the `pre-commit` CLI with `pip install pre-commit`; pre-commit.ci pull request autofixes are enabled so PRs with formatting drift can receive an automatic formatting commit from pre-commit.ci.
 
 Updating style:
 1. Edit `.clang-format` (optionally test variants using an online configurator).
@@ -54,10 +57,31 @@ Enable editor format-on-save to avoid manual runs.
 
 ---
 
+## Pre-Commit Hooks and CI
+
+Install the local hook once per checkout:
+```bash
+pre-commit install
+```
+
+Run the configured formatter on all files:
+```bash
+pre-commit run --all-files
+```
+
+Run it on staged changes before committing:
+```bash
+pre-commit run
+```
+
+pre-commit.ci reads `.pre-commit-config.yaml` and runs the same hook on pull requests. If `clang-format` changes files, pre-commit.ci pushes an automatic formatting commit to the PR using the configured autofix message.
+
+---
+
 ## Best Practices
 
 - Format before commit (stage, format, re-stage if needed).
-- Use format-on-save / pre-commit hook to enforce style.
+- Use format-on-save / pre-commit hook to enforce style before pre-commit.ci has to fix the PR.
 - Never hand-tweak whitespace—fix `.clang-format` instead.
 - Separate pure formatting PRs from logic changes.
 - After style modifications, re-run full-project formatting to normalize.

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -25,7 +25,7 @@ Complete these before marking a PR ready for review:
 - Commits follow Conventional Commits; squash fixups locally before opening.
 - Code builds locally; no new warnings introduced intentionally.
 - Public APIs, structs, classes, and complex functions documented (see `documentation.md`).
-- Formatting applied: `clang-format` run on all modified C++ headers and sources.
+- Formatting applied: `clang-format` or `pre-commit run` run on all modified C++ headers and sources; pre-commit.ci may add an automatic formatting commit if drift remains.
 - No stray debug code, commented-out blocks, or unused includes.
 - Added/updated tests where feasible (logic, parsing, geometry, algorithms). If not applicable, state why.
 - Large assets or generated files are excluded from the diff.

--- a/flake.lock
+++ b/flake.lock
@@ -54,6 +54,22 @@
         "type": "github"
       }
     },
+    "llvmNixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1725103162,
@@ -91,6 +107,7 @@
     "root": {
       "inputs": {
         "appimage": "appimage",
+        "llvmNixpkgs": "llvmNixpkgs",
         "nixpkgs": "nixpkgs_2",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -17,15 +17,18 @@
         inherit system;
         inherit (import ./nix/nixpkgs/config.nix {}) overlays config;
       };
-      llvmPkgs = import inputs.llvmNixpkgs {
-        inherit system;
-      };
+      llvmToolingPackages =
+        if system == "x86_64-darwin"
+        then pkgs.llvmPackages_18
+        else (import inputs.llvmNixpkgs {
+          inherit system;
+        }).llvmPackages_22;
 
       stdenv = llvm.stdenv;
 
       llvm = rec {
         packages = pkgs.llvmPackages_18;
-        toolingPackages = llvmPkgs.llvmPackages_22;
+        toolingPackages = llvmToolingPackages;
         stdenv   = packages.stdenv;
 
         tooling = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     # Upstream still publishes this ref as `slicer2`; no `ornlslicer` ref exists yet.
     nixpkgs.url  = gitlab:mdf/nixpkgs/slicer2?host=code.ornl.gov;
+    llvmNixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
     utils.url    = github:numtide/flake-utils;
     appimage = {
       url = github:ralismark/nix-appimage;
@@ -16,16 +17,20 @@
         inherit system;
         inherit (import ./nix/nixpkgs/config.nix {}) overlays config;
       };
+      llvmPkgs = import inputs.llvmNixpkgs {
+        inherit system;
+      };
 
       stdenv = llvm.stdenv;
 
       llvm = rec {
         packages = pkgs.llvmPackages_18;
+        toolingPackages = llvmPkgs.llvmPackages_22;
         stdenv   = packages.stdenv;
 
         tooling = rec {
-          lldb = packages.lldb;
-          clang-tools = packages.clang-tools;
+          lldb = toolingPackages.lldb;
+          clang-tools = toolingPackages.clang-tools;
           clang-tools-libcxx = clang-tools.override {
               enableLibcxx = true;
           };

--- a/include/algorithms/knn.h
+++ b/include/algorithms/knn.h
@@ -14,7 +14,7 @@ namespace ORNL {
  * \note Points are compared in 3D space.
  */
 class kNN {
-  public:
+   public:
     //! \brief Computes the kNN for a set of query points.
     kNN(const QVector<Point>& referencePoints, const QVector<Point>& queryPoints, int kNeighbors);
 
@@ -30,7 +30,7 @@ class kNN {
     //! \brief Returns the K nearest distances for each query point
     QVector<Distance> getNearestDistances();
 
-  protected:
+   protected:
     //! \brief A pointer to our array of reference points.
     float* m_referencePoints;
 
@@ -66,4 +66,4 @@ class kNN {
     bool knn_c(const float* ref, int ref_nb, const float* query, int query_nb, int dim, int k, float* knn_dist,
                int* knn_index);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/algorithms/tsp_brute.h
+++ b/include/algorithms/tsp_brute.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QVector>
+
 #include <qsharedpointer.h>
 
 #include "step/layer/island/island_base.h"
@@ -16,7 +17,7 @@ namespace ORNL {
  * fixed and the path does not need to return to it, the search space is reduced from N! to (N-1)! permutations.
  */
 class TspBrute {
-  public:
+   public:
     //! \brief Computes the optimal path(shortest or longest) to visit all islands in a list.
     //! \note IslandBases are represented by their center of mass
     //! \note Can compute either shortest of longest path
@@ -32,7 +33,7 @@ class TspBrute {
     //! \brief Returns an order list of optimized islands
     QVector<QSharedPointer<IslandBase>> getOptimizedIslandBases();
 
-  protected:
+   protected:
     //! \brief The number of islands to order
     int m_number_of_islands;
 
@@ -80,4 +81,4 @@ class TspBrute {
     //! \brief Remove the element with specified value from a vector
     void removeValue(QVector<int>& index_list, int value);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/configs/settings_base.h
+++ b/include/configs/settings_base.h
@@ -2,6 +2,7 @@
 
 #include <QSharedPointer>
 #include <QString>
+
 #include <nlohmann/json.hpp>
 
 #include "utilities/qt_json_conversion.h"
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 
 class SettingsBase {
-  public:
+   public:
     //! \brief Default Constructor
     SettingsBase();
 
@@ -22,7 +23,8 @@ class SettingsBase {
      *
      * \note This function is templated and needs to stay in the header (best option)
      */
-    template <typename T> void setSetting(QString key, T value, int extruder_index = 0) {
+    template <typename T>
+    void setSetting(QString key, T value, int extruder_index = 0) {
         m_json[extruder_index][key.toStdString()] = value;
     }
 
@@ -31,7 +33,8 @@ class SettingsBase {
      *
      * \note This function is templated and needs to stay in the header (best option)
      */
-    template <typename T> T setting(QString key_root, int extruder_index = 0) const {
+    template <typename T>
+    T setting(QString key_root, int extruder_index = 0) const {
         // If this sb contains the key, return it.
         T return_value;
         // No longer use suffixing so full key is same as root
@@ -41,7 +44,7 @@ class SettingsBase {
             return_value = m_json[extruder_index][key_full.toStdString()].get<T>();
         }
         else {
-            return_value = T(); // Found nothing, return default value.
+            return_value = T();  // Found nothing, return default value.
         }
         return return_value;
     }
@@ -82,8 +85,8 @@ class SettingsBase {
     //! \param the layer number to adjust for
     void makeLocalAdjustments(int layer_number = 0);
 
-  protected:
+   protected:
     // Json array.
     fifojson m_json = fifojson::array({});
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/configs/settings_range.h
+++ b/include/configs/settings_range.h
@@ -11,7 +11,7 @@ namespace ORNL {
  *  \brief A layer range of settings
  */
 class SettingsRange {
-  public:
+   public:
     //! \brief creates a new settings range
     //! \param low the lower layer number to start at
     //! \param high the upper layer number to end at
@@ -58,7 +58,7 @@ class SettingsRange {
     //! \param group the name of the group
     void setGroup(QString group);
 
-  private:
+   private:
     // Layer number locations
     int m_low;
     int m_high;
@@ -69,4 +69,4 @@ class SettingsRange {
     // Settings
     QSharedPointer<SettingsBase> m_sb;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/console/command_line_processor.h
+++ b/include/console/command_line_processor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QCommandLineParser>
+
 #include <qdir.h>
 #include <qsharedpointer.h>
 
@@ -13,8 +14,7 @@ namespace ORNL {
  * \brief Handles setup of QCommandLineParser and conversion to appropriate data structs.
  */
 class CommandLineConverter {
-
-  public:
+   public:
     //! \brief Constructor
     CommandLineConverter();
 
@@ -27,7 +27,7 @@ class CommandLineConverter {
     //! \param options: valid command line options
     bool convertOptions(QCommandLineParser& parser, QSharedPointer<SettingsBase> options);
 
-  private:
+   private:
     //! \brief Convert/Check options that are required for processing
     //! These include either a project file or STL/GlobalSettings pair and an output location.
     //! \param parser: parser with values
@@ -63,4 +63,4 @@ class CommandLineConverter {
     //! \brief Copy of master json for access to individual settings
     QSharedPointer<SettingsBase> m_master;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/console/main_control.h
+++ b/include/console/main_control.h
@@ -18,19 +18,19 @@ namespace ORNL {
 class MainControl : public QObject {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor
     //! \param options: command line options that were successfully processed
     MainControl(QSharedPointer<SettingsBase> options);
 
-  signals:
+   signals:
     //! \brief Preprocessing is done.  STL's have been loaded.
     void preProcess();
 
     //! \brief Thread has complete. Signal for main to exit message handler.
     void finished();
 
-  public slots:
+   public slots:
 
     //! \brief Starts slicing
     void run();
@@ -38,7 +38,7 @@ class MainControl : public QObject {
     //! \brief Continue with process once security has been checked.
     void continueStartup();
 
-  private slots:
+   private slots:
     //! \brief Notification as to the number of parts contained in project file
     //! \param total: part total
     void partsInProject(int total);
@@ -64,7 +64,7 @@ class MainControl : public QObject {
     //! \brief Parsing of gcode is complete.  Must still parse to allow layer time adjustments.
     void gcodeParseComplete();
 
-  private:
+   private:
     //! \brief path's to input, output, and temporary locations
     QString m_input_path, m_output_path, m_temp_location;
 
@@ -80,4 +80,4 @@ class MainControl : public QObject {
     //! \brief Number of parts remaining to load if more than one specified.
     int m_parts_to_load;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/close_polygon_result.h
+++ b/include/cross_section/close_polygon_result.h
@@ -13,11 +13,11 @@ namespace ORNL {
  * point_idx.
  */
 class ClosePolygonResult {
-  public:
+   public:
     ClosePolygonResult();
 
     Point intersection_point;
     int polygon_idx;
     uint point_idx;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/cross_section.h
+++ b/include/cross_section/cross_section.h
@@ -40,6 +40,6 @@ Point findSlicingPlaneMidPoint(QSharedPointer<MeshBase> mesh, Plane& slicing_pla
 //! \return the intersection point
 Point findIntersection(Point& vertex0, Point& vertex1, Plane& slicing_plane);
 
-} // namespace CrossSection
+}  // namespace CrossSection
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/cross_section_object.h
+++ b/include/cross_section/cross_section_object.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <QSharedPointer>
+#include <QVector>
 #include <cstdint>
 #include <queue>
 
-#include <QSharedPointer>
-#include <QVector>
 #include <qcontainerfwd.h>
 #include <qmap.h>
 #include <qtypes.h>
@@ -23,7 +23,7 @@ class ClosePolygonResult;
 class PossibleStitch;
 
 class CrossSectionObject {
-  public:
+   public:
     /*!
      * \brief Default Constructor
      *
@@ -75,7 +75,7 @@ class CrossSectionObject {
      */
     PolygonList& getPolygonList();
 
-  private:
+   private:
     /*!
      * \brief Connect the segment into loops
      */
@@ -229,8 +229,8 @@ class CrossSectionObject {
     QVector<Polyline> m_open_polylines;
     QVector<Polygon> m_closeable_polygons;
     QVector<CrossSectionSegment> m_segments;
-    QMap<int, int> m_face_idx_to_segment_idx; // topology
+    QMap<int, int> m_face_idx_to_segment_idx;  // topology
 
     bool shorterThan(const Point& p0, int32_t len);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/cross_section_segment.h
+++ b/include/cross_section/cross_section_segment.h
@@ -14,7 +14,7 @@ class MeshVertex;
  * Based on the Cura Engine by Ultimaker
  */
 class CrossSectionSegment {
-  public:
+   public:
     CrossSectionSegment();
 
     //! \brief Start and end points
@@ -35,4 +35,4 @@ class CrossSectionSegment {
     //! \brief Face normal
     QVector3D normal;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/gap_closer_result.h
+++ b/include/cross_section/gap_closer_result.h
@@ -6,7 +6,7 @@
 
 namespace ORNL {
 class GapCloserResult {
-  public:
+   public:
     GapCloserResult();
     Distance length;
     int polygon_idx;
@@ -14,4 +14,4 @@ class GapCloserResult {
     uint point_idx_b;
     bool a_to_b;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/possible_stitch.h
+++ b/include/cross_section/possible_stitch.h
@@ -23,7 +23,7 @@ namespace ORNL {
  * the stitch.
  */
 class PossibleStitch {
-  public:
+   public:
     PossibleStitch();
 
     /*!
@@ -43,10 +43,10 @@ class PossibleStitch {
      */
     bool operator<(const PossibleStitch& other) const;
 
-    Area distance_2;     //!< The squared distance from terminus_0 to terminus_1
-    Terminus terminus_0; //!< The Terminus representing the end of polyline_0
-                         //! where the join would happen
-    Terminus terminus_1; //!< The Terminus representing the end of polyline_1
-                         //! where the join would happen
+    Area distance_2;      //!< The squared distance from terminus_0 to terminus_1
+    Terminus terminus_0;  //!< The Terminus representing the end of polyline_0
+                          //! where the join would happen
+    Terminus terminus_1;  //!< The Terminus representing the end of polyline_1
+                          //! where the join would happen
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/sparse_grid.h
+++ b/include/cross_section/sparse_grid.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <QVector>
 #include <cstddef>
 #include <functional>
 #include <unordered_map>
 #include <utility>
 
-#include <QVector>
 #include <qassert.h>
 #include <qcontainerfwd.h>
 #include <qtypes.h>
@@ -23,8 +23,9 @@ namespace ORNL {
  * \note This is an abstract template class which doesn't have any functions
  * to insert elements. \see SparsePointGrid
  */
-template <class T> class SparseGrid {
-  public:
+template <class T>
+class SparseGrid {
+   public:
     //! \brief Constructs a sparse grid with the specified cell size.
     SparseGrid(qlonglong cell_size, size_t element_reserve = 0U, float max_load_factor = 1.0f);
 
@@ -53,7 +54,9 @@ template <class T> class SparseGrid {
     // TODO
     // defined here to fix declaration problems,
     // take a look at this commit to understand why
-    static const std::function<bool(const T&)> no_precondition() { return true; };
+    static const std::function<bool(const T&)> no_precondition() {
+        return true;
+    };
 
     //! \brief Find the nearest element to a given \p query_pt within \p
     //! radius.
@@ -84,10 +87,10 @@ template <class T> class SparseGrid {
 
     long long getCellSize() const;
 
-  protected:
-    using GridPoint = Point;
+   protected:
+    using GridPoint    = Point;
     using grid_coord_t = qlonglong;
-    using GridMap = std::unordered_multimap<GridPoint, T>;
+    using GridMap      = std::unordered_multimap<GridPoint, T>;
 
     //! \brief Process elements from the cell indicated by \p grid_pt
     bool processFromCell(const GridPoint& grid_pt, const std::function<bool(const T&)>& process_func) const;
@@ -115,8 +118,8 @@ template <class T> class SparseGrid {
      */
     long long toLowerCoord(const grid_coord_t& grid_coord) const;
 
-    GridMap m_grid;        //!< Map from grid locations (GridPoint) to elements (T).
-    qlonglong m_cell_size; //!< The cell (square) size.
+    GridMap m_grid;         //!< Map from grid locations (GridPoint) to elements (T).
+    qlonglong m_cell_size;  //!< The cell (square) size.
     grid_coord_t nonzero_sign(const grid_coord_t z) const;
 };
 
@@ -131,9 +134,7 @@ SGI_THIS::SparseGrid(qlonglong cell_size, size_t element_reserve, float max_load
 
     // Must be before the reserve call
     m_grid.max_load_factor(max_load_factor);
-    if (element_reserve != 0U) {
-        m_grid.reserve(element_reserve);
-    }
+    if (element_reserve != 0U) { m_grid.reserve(element_reserve); }
 }
 
 SGI_TEMPLATE
@@ -172,9 +173,7 @@ SGI_TEMPLATE
 bool SGI_THIS::processFromCell(const GridPoint& grid_pt, const std::function<bool(const T&)>& process_func) const {
     auto grid_range = m_grid.equal_range(grid_pt);
     for (auto iter = grid_range.first; iter != grid_range.second; iter++) {
-        if (!process_func(iter->second)) {
-            return false;
-        }
+        if (!process_func(iter->second)) { return false; }
     }
     return true;
 }
@@ -183,7 +182,7 @@ SGI_TEMPLATE
 void SGI_THIS::processLineCells(const QPair<Point, Point> line,
                                 const std::function<bool(GridPoint)>& process_cell_func) {
     Point start = line.first;
-    Point end = line.second;
+    Point end   = line.second;
 
     if (end.x() < start.x()) {
         // make sure X increases between start and end
@@ -191,9 +190,9 @@ void SGI_THIS::processLineCells(const QPair<Point, Point> line,
     }
 
     const GridPoint start_cell = toGridPoint(start);
-    const GridPoint end_cell = toGridPoint(end);
-    const qlonglong y_diff = end.y() - start.y();
-    const grid_coord_t y_dir = nonzero_sign(y_diff);
+    const GridPoint end_cell   = toGridPoint(end);
+    const qlonglong y_diff     = end.y() - start.y();
+    const grid_coord_t y_dir   = nonzero_sign(y_diff);
 
     grid_coord_t x_cell_start = start_cell.x();
 
@@ -202,15 +201,13 @@ void SGI_THIS::processLineCells(const QPair<Point, Point> line,
         // nearest y coordinate of the cells in the next row
         grid_coord_t nearest_next_y =
             toLowerCoord(cell_y + ((nonzero_sign(cell_y) == y_dir || cell_y == 0) ? y_dir : qlonglong(0)));
-        grid_coord_t x_cell_end; // The x coord of the last cell to include
-                                 // from this row
-        if (y_diff == 0) {
-            x_cell_end = end_cell.x();
-        }
+        grid_coord_t x_cell_end;  // The x coord of the last cell to include
+                                  // from this row
+        if (y_diff == 0) { x_cell_end = end_cell.x(); }
         else {
-            qlonglong area = (end.x() - start.x()) * (nearest_next_y - start.y());
-            qlonglong corresponding_x = start.x() + area / y_diff; //!< the x coordinate correspinding to
-                                                                   //!< nearest_next_y
+            qlonglong area            = (end.x() - start.x()) * (nearest_next_y - start.y());
+            qlonglong corresponding_x = start.x() + area / y_diff;  //!< the x coordinate correspinding to
+                                                                    //!< nearest_next_y
             x_cell_end = toGridCoord(corresponding_x + ((corresponding_x < 0) && ((area % y_diff) != 0)));
             if (x_cell_end < start_cell.x()) {
                 // process at least one cell!
@@ -221,12 +218,8 @@ void SGI_THIS::processLineCells(const QPair<Point, Point> line,
         for (grid_coord_t cell_x = x_cell_start; cell_x <= x_cell_end; cell_x++) {
             GridPoint grid_loc(cell_x, cell_y);
             bool continue_ = process_cell_func(grid_loc);
-            if (!continue_) {
-                return;
-            }
-            if (grid_loc == end_cell) {
-                return;
-            }
+            if (!continue_) { return; }
+            if (grid_loc == end_cell) { return; }
 
             // TODO: this causes at least a one cell overlap for each row,
             // which include extra cells when crossing precisely on the
@@ -252,9 +245,7 @@ void SGI_THIS::processNearby(const Point& query_pt, Distance radius,
         for (qlonglong grid_x = min_grid.x(); grid_x <= max_grid.x(); grid_x++) {
             GridPoint grid_pt(grid_x, grid_y);
             bool continue_ = processFromCell(grid_pt, process_func);
-            if (!continue_) {
-                return;
-            }
+            if (!continue_) { return; }
         }
     }
 }
@@ -296,18 +287,16 @@ query_pt, Distance radius) const
 SGI_TEMPLATE
 bool SGI_THIS::getNearest(const Point& query_pt, Distance radius, T& element_nearest,
                           const std::function<bool(const T& t)> precondition) const {
-    bool found = false;
-    Area best_dist2 = radius * radius;
+    bool found                                       = false;
+    Area best_dist2                                  = radius * radius;
     const std::function<bool(const T&)> process_func = [&query_pt, &element_nearest, &found, &best_dist2,
                                                         &precondition](const T& t) {
-        if (!precondition(t)) {
-            return true;
-        }
+        if (!precondition(t)) { return true; }
         Area dist2 = qPow((t.point - query_pt).distance()(), 2);
         if (dist2 < best_dist2) {
-            found = true;
+            found           = true;
             element_nearest = t;
-            best_dist2 = dist2;
+            best_dist2      = dist2;
         }
         return true;
     };
@@ -316,8 +305,12 @@ bool SGI_THIS::getNearest(const Point& query_pt, Distance radius, T& element_nea
 }
 
 SGI_TEMPLATE
-qlonglong SGI_THIS::getCellSize() const { return m_cell_size; }
+qlonglong SGI_THIS::getCellSize() const {
+    return m_cell_size;
+}
 
 SGI_TEMPLATE
-typename SGI_THIS::grid_coord_t SGI_THIS::nonzero_sign(const grid_coord_t z) const { return (z >= 0) - (z - 0); }
-} // namespace ORNL
+typename SGI_THIS::grid_coord_t SGI_THIS::nonzero_sign(const grid_coord_t z) const {
+    return (z >= 0) - (z - 0);
+}
+}  // namespace ORNL

--- a/include/cross_section/sparse_point_grid.h
+++ b/include/cross_section/sparse_point_grid.h
@@ -19,28 +19,30 @@ namespace ORNL {
  *      have: Point operator()(const T &t) const
  *      which returns the location associated with val.
  */
-template <class T, class Locator> class SparsePointGrid : public SparseGrid<T> {
-  public:
+template <class T, class Locator>
+class SparsePointGrid : public SparseGrid<T> {
+   public:
     //! \brief Constructs a sparse grid with the specified cell size.
     SparsePointGrid(qlonglong cell_size, size_t element_reserve = 0U, float max_load_factor = 1.0f);
 
     //! \brief Inserts t into the sparse grid
     void insert(const T& t);
 
-  protected:
+   protected:
     using GridPoint = typename SparseGrid<T>::GridPoint;
 
-    Locator m_locator; //!< Accessor for getting locations from elements
+    Locator m_locator;  //!< Accessor for getting locations from elements
 };
 
 template <class T, class Locator>
 SparsePointGrid<T, Locator>::SparsePointGrid(qlonglong cell_size, size_t element_reserve, float max_load_factor)
     : SparseGrid<T>(cell_size, element_reserve, max_load_factor) {}
 
-template <class T, class Locator> void SparsePointGrid<T, Locator>::insert(const T& t) {
-    Point loc = m_locator(t);
+template <class T, class Locator>
+void SparsePointGrid<T, Locator>::insert(const T& t) {
+    Point loc          = m_locator(t);
     GridPoint grid_loc = SparseGrid<T>::toGridPoint(loc);
 
     SparseGrid<T>::m_grid.emplace(grid_loc, t);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/terminus.h
+++ b/include/cross_section/terminus.h
@@ -15,7 +15,7 @@ namespace ORNL {
  * vertex at the end.
  */
 class Terminus {
-  public:
+   public:
     /*! A representation of Terminus that can be used as an array index.
      *
      * See \ref asIndex() for more information.
@@ -91,7 +91,7 @@ class Terminus {
     //! \brief Test for inequality
     bool operator!=(const Terminus& other);
 
-  private:
+   private:
     /*!
      * \brief The index representation of the Terminus
      *
@@ -99,4 +99,4 @@ class Terminus {
      */
     Index m_idx;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/cross_section/terminus_tracking_map.h
+++ b/include/cross_section/terminus_tracking_map.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QVector>
 #include <cstddef>
 
-#include <QVector>
 #include <qcontainerfwd.h>
 
 #include "terminus.h"
@@ -18,7 +18,7 @@ namespace ORNL {
  * form polygons.
  */
 class TerminusTrackingMap {
-  public:
+   public:
     //! \brief Initializes the TerminusTrackingMap with the size indicated.
     TerminusTrackingMap(Terminus::Index end_idx);
 
@@ -68,8 +68,8 @@ class TerminusTrackingMap {
     void updateMap(size_t num_terminuses, const Terminus* current_terminus, const Terminus* next_terminus,
                    size_t num_removed_terminuses, const Terminus* removed_current_terminuses);
 
-  private:
+   private:
     QVector<Terminus> m_terminus_old_to_current_map;
     QVector<Terminus> m_terminus_current_to_old_map;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/exceptions/exceptions.h
+++ b/include/exceptions/exceptions.h
@@ -1,24 +1,25 @@
 #pragma once
 
+#include <QString>
 #include <exception>
 #include <string>
 
-#include <QString>
-
-#define NEW_EX(name)                                                                                                   \
-    class name : public ORNL::ExceptionBase {                                                                          \
-      public:                                                                                                          \
-        name(QString message = "") : ExceptionBase(#name ": " + message) {}                                            \
+#define NEW_EX(name)                                                        \
+    class name : public ORNL::ExceptionBase {                               \
+       public:                                                              \
+        name(QString message = "") : ExceptionBase(#name ": " + message) {} \
     };
 
 namespace ORNL {
 class ExceptionBase : public std::exception {
-  public:
+   public:
     ExceptionBase(QString message) : m_message(message.toStdString()) {}
 
-    const char* what() const throw() { return m_message.c_str(); }
+    const char* what() const throw() {
+        return m_message.c_str();
+    }
 
-  protected:
+   protected:
     std::string m_message;
 };
 
@@ -49,4 +50,4 @@ NEW_EX(IncorrectPathSegmentType)
 NEW_EX(UnknownUnitException)
 
 NEW_EX(BadLayerRange)
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/arc_specialties_axis_inference.h
+++ b/include/gcode/arc_specialties_axis_inference.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <QVector3D>
 #include <cmath>
 #include <limits>
 #include <optional>
 
-#include <QVector3D>
 #include <qmath.h>
 
 #include "geometry/point.h"
@@ -12,12 +12,8 @@
 namespace ORNL::ArcSpecialtiesAxisInference {
 inline double signedShortestDeltaDegrees(double start_degrees, double end_degrees) {
     double delta_degrees = end_degrees - start_degrees;
-    while (delta_degrees > 180.0) {
-        delta_degrees -= 360.0;
-    }
-    while (delta_degrees < -180.0) {
-        delta_degrees += 360.0;
-    }
+    while (delta_degrees > 180.0) { delta_degrees -= 360.0; }
+    while (delta_degrees < -180.0) { delta_degrees += 360.0; }
 
     return delta_degrees;
 }
@@ -31,28 +27,22 @@ inline double planarDistanceSquared(const Point& a, const Point& b) {
 inline bool cylindricalAxisFromCpDelta(const QVector3D& start_pos, const QVector3D& end_pos, double start_cp_degrees,
                                        double end_cp_degrees, bool reverse_cp_delta,
                                        const std::optional<Point>& reference_axis, Point& center) {
-    const double dx = end_pos.x() - start_pos.x();
-    const double dy = end_pos.y() - start_pos.y();
+    const double dx           = end_pos.x() - start_pos.x();
+    const double dy           = end_pos.y() - start_pos.y();
     const double chord_length = std::hypot(dx, dy);
-    if (chord_length <= std::numeric_limits<double>::epsilon()) {
-        return false;
-    }
+    if (chord_length <= std::numeric_limits<double>::epsilon()) { return false; }
 
     double delta_degrees = signedShortestDeltaDegrees(start_cp_degrees, end_cp_degrees);
-    if (reverse_cp_delta) {
-        delta_degrees *= -1.0;
-    }
+    if (reverse_cp_delta) { delta_degrees *= -1.0; }
 
-    const double delta_radians = qDegreesToRadians(delta_degrees);
-    const double half_delta = std::abs(delta_radians) / 2.0;
+    const double delta_radians  = qDegreesToRadians(delta_degrees);
+    const double half_delta     = std::abs(delta_radians) / 2.0;
     const double tan_half_delta = std::tan(half_delta);
-    if (std::abs(tan_half_delta) <= std::numeric_limits<double>::epsilon()) {
-        return false;
-    }
+    if (std::abs(tan_half_delta) <= std::numeric_limits<double>::epsilon()) { return false; }
 
     const double center_offset = chord_length / (2.0 * tan_half_delta);
-    const double mid_x = (start_pos.x() + end_pos.x()) / 2.0;
-    const double mid_y = (start_pos.y() + end_pos.y()) / 2.0;
+    const double mid_x         = (start_pos.x() + end_pos.x()) / 2.0;
+    const double mid_y         = (start_pos.y() + end_pos.y()) / 2.0;
     const double left_normal_x = -dy / chord_length;
     const double left_normal_y = dx / chord_length;
 
@@ -65,10 +55,8 @@ inline bool cylindricalAxisFromCpDelta(const QVector3D& start_pos, const QVector
                      ? positive_center
                      : negative_center;
     }
-    else {
-        center = delta_radians >= 0.0 ? positive_center : negative_center;
-    }
+    else { center = delta_radians >= 0.0 ? positive_center : negative_center; }
 
     return true;
 }
-} // namespace ORNL::ArcSpecialtiesAxisInference
+}  // namespace ORNL::ArcSpecialtiesAxisInference

--- a/include/gcode/as_printed_model_exporter.h
+++ b/include/gcode/as_printed_model_exporter.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <vector>
-
 #include <QSharedPointer>
 #include <QString>
 #include <QVector3D>
 #include <QVector>
+#include <vector>
 
 #include "geometry/segment_base.h"
 #include "units/unit.h"
@@ -13,7 +12,7 @@
 namespace ORNL {
 //! \brief Generates and saves an STL representation of deposited G-code beads.
 class AsPrintedModelExporter final {
-  public:
+   public:
     enum class StlFormat { kBinary, kAscii };
     enum class OriginMode { kPreserve, kLocalOrigin };
     enum class GeometryMode { kTrueBeadWidths, kCenterlines };
@@ -21,10 +20,15 @@ class AsPrintedModelExporter final {
     struct Options {
         Options(bool include_support = false, bool include_travel = false, bool blend_corners = true,
                 StlFormat format = StlFormat::kBinary, Distance output_unit = mm,
-                OriginMode origin_mode = OriginMode::kLocalOrigin,
+                OriginMode origin_mode     = OriginMode::kLocalOrigin,
                 GeometryMode geometry_mode = GeometryMode::kTrueBeadWidths, Distance centerline_diameter = 0.1 * mm)
-            : include_support(include_support), include_travel(include_travel), blend_corners(blend_corners),
-              format(format), output_unit(output_unit), origin_mode(origin_mode), geometry_mode(geometry_mode),
+            : include_support(include_support),
+              include_travel(include_travel),
+              blend_corners(blend_corners),
+              format(format),
+              output_unit(output_unit),
+              origin_mode(origin_mode),
+              geometry_mode(geometry_mode),
               centerline_diameter(centerline_diameter) {}
 
         bool include_support;
@@ -53,7 +57,7 @@ class AsPrintedModelExporter final {
     static bool writeStl(const QString& path, const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
                          QString* error_message = nullptr, Options options = Options());
 
-  private:
+   private:
     static bool shouldExportSegment(const QSharedPointer<SegmentBase>& segment, const Options& options);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/gcode_command.h
+++ b/include/gcode/gcode_command.h
@@ -3,6 +3,7 @@
 #include <QMap>
 #include <QObject>
 #include <QString>
+
 #include <qcontainerfwd.h>
 #include <qtmetamacros.h>
 
@@ -12,7 +13,7 @@ namespace ORNL {
 //! \brief A plain old data structure class for a GCode command.
 class GcodeCommand : public QObject {
     Q_OBJECT
-  public:
+   public:
     GcodeCommand();
 
     GcodeCommand(const GcodeCommand& other);
@@ -129,7 +130,7 @@ class GcodeCommand : public QObject {
 
     GcodeCommand& operator=(const GcodeCommand& other);
 
-  private:
+   private:
     int m_line_number;
     char m_command;
     int m_command_id;
@@ -142,4 +143,4 @@ class GcodeCommand : public QObject {
     bool m_is_motion_command;
     bool m_is_end_of_layer;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/gcode_meta.h
+++ b/include/gcode/gcode_meta.h
@@ -19,9 +19,9 @@ struct GcodeMeta {
     Acceleration m_acceleration_unit;
     AngularVelocity m_angular_velocity_unit;
     QString m_file_suffix;
-    bool hasTravels = true;
+    bool hasTravels                 = true;
     QString m_layer_count_delimiter = "LAYER COUNT";
-    QString m_layer_delimiter = "BEGINNING LAYER";
+    QString m_layer_delimiter       = "BEGINNING LAYER";
 
     bool operator==(const GcodeMeta& rhs) const = default;
 };
@@ -30,273 +30,273 @@ struct GcodeMeta {
 //! possible name clashing
 namespace GcodeMetaList {
 
-static GcodeMeta BeamMeta = {GcodeSyntax::kBeam, QString("("), QString(")"), in,    s, degree, lbm,
-                             in / minute,        in / s / s,   rev / minute, ".mpf"};
-static GcodeMeta CincinnatiMeta = {GcodeSyntax::kCincinnati,
-                                   QString("("),
-                                   QString(")"),
-                                   in,
-                                   s,
-                                   degree,
-                                   lbm,
-                                   in / minute,
-                                   in / s / s,
-                                   rev / minute,
-                                   ".nc"};
-static GcodeMeta MarlinMeta = {GcodeSyntax::kMarlin,
-                               QString(";"), // starting_delim
-                               QString(),    // ending_delim
-                               mm,           // distance
-                               ms,           // time
-                               degree,       // angle
-                               g,            // mass
-                               mm / minute,  // velocity
-                               mm / s / s,   // acceleration
-                               rev / minute, // angular velocity
-                               ".gcode"};
-static GcodeMeta SiemensMeta = {GcodeSyntax::kSiemens,
-                                QString(";"), // starting_delim
-                                QString(),    // ending_delim
-                                in,           // distance
-                                s,            // time
-                                degree,       // angle
-                                lbm,          // mass
-                                in / minute,  // velocity
-                                in / s / s,   // acceleration
-                                rev / minute, // angular velocity
-                                ".mpf"};
-static GcodeMeta WolfMeta = {GcodeSyntax::kWolf,
-                             QString(";"), // starting_delim
-                             QString(),    // ending_delim
-                             mm,           // distance
-                             s,            // time
-                             degree,       // angle
-                             g,            // mass
-                             mm / minute,  // velocity
-                             mm / s / s,   // acceleration
-                             rev / minute, // angular velocity
-                             ".gcode"};
-static GcodeMeta HaasInchMeta = {GcodeSyntax::kHaasInch,
-                                 QString("("), // starting_delim
-                                 QString(")"), // ending_delim
-                                 in,           // distance
-                                 s,            // time
-                                 degree,       // angle
-                                 lbm,          // mass
-                                 in / minute,  // velocity
-                                 in / s / s,   // acceleration
-                                 rev / minute, // angular velocity
-                                 ".nc"};
-static GcodeMeta HaasMetricMeta = {GcodeSyntax::kHaasMetric,
-                                   QString("("), // starting_delim
-                                   QString(")"), // ending_delim
-                                   mm,           // distance
-                                   s,            // time
-                                   degree,       // angle
-                                   g,            // mass
-                                   mm / minute,  // velocity
-                                   mm / s / s,   // acceleration
-                                   rev / minute, // angular velocity
-                                   ".nc"};
-static GcodeMeta RomiFanucMeta = {GcodeSyntax::kRomiFanuc,
-                                  QString("("), // starting_delim
-                                  QString(")"), // ending_delim
-                                  mm,           // distance
-                                  ms,           // time
-                                  degree,       // angle
-                                  g,            // mass
-                                  mm / minute,  // velocity
-                                  mm / s / s,   // acceleration
-                                  rev / minute, // angular velocity
-                                  ".txt"};
-static GcodeMeta DmgDmuAndBeamMeta = {GcodeSyntax::kDmgDmu,
-                                      QString(";"), // starting_delim
-                                      QString(),    // ending_delim
-                                      mm,           // distance
-                                      s,            // time
-                                      degree,       // angle
-                                      g,            // mass
-                                      mm / minute,  // velocity
-                                      mm / s / s,   // acceleration
-                                      rev / minute, // angular velocity
+static GcodeMeta BeamMeta          = {GcodeSyntax::kBeam, QString("("), QString(")"), in,    s, degree, lbm,
+                                      in / minute,        in / s / s,   rev / minute, ".mpf"};
+static GcodeMeta CincinnatiMeta    = {GcodeSyntax::kCincinnati,
+                                      QString("("),
+                                      QString(")"),
+                                      in,
+                                      s,
+                                      degree,
+                                      lbm,
+                                      in / minute,
+                                      in / s / s,
+                                      rev / minute,
+                                      ".nc"};
+static GcodeMeta MarlinMeta        = {GcodeSyntax::kMarlin,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      mm,            // distance
+                                      ms,            // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".gcode"};
+static GcodeMeta SiemensMeta       = {GcodeSyntax::kSiemens,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      in,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      lbm,           // mass
+                                      in / minute,   // velocity
+                                      in / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
                                       ".mpf"};
-static GcodeMeta GudelMeta = {GcodeSyntax::kGudel,
-                              QString(";"), // starting_delim
-                              QString(),    // ending_delim
-                              mm,           // distance
-                              s,            // time
-                              degree,       // angle
-                              g,            // mass
-                              mm / minute,  // velocity
-                              mm / s / s,   // acceleration
-                              rev / minute, // angular velocity
-                              ".mpf"};
-static GcodeMeta IngersollMeta = {GcodeSyntax::kIngersoll,
-                                  QString(";"), // starting_delim
-                                  QString(),    // ending_delim
-                                  mm,           // distance
-                                  s,            // time
-                                  degree,       // angle
-                                  g,            // mass
-                                  mm / minute,  // velocity
-                                  mm / s / s,   // acceleration
-                                  rev / minute, // angular velocity
-                                  ".gcode"};
-static GcodeMeta MVPMeta = {GcodeSyntax::kMVP,
-                            QString(";"), // starting_delim
-                            QString(),    // ending_delim
-                            mm,           // distance
-                            s,            // time
-                            degree,       // angle
-                            g,            // mass
-                            mm / minute,  // velocity
-                            mm / s / s,   // acceleration
-                            rev / minute, // angular velocity
-                            ".mpf"};
-static GcodeMeta MazakMeta = {GcodeSyntax::kMazak,
-                              QString("("), // starting_delim
-                              QString(")"), // ending_delim
-                              mm,           // distance
-                              s,            // time
-                              degree,       // angle
-                              g,            // mass
-                              mm / minute,  // velocity
-                              mm / s / s,   // acceleration
-                              rev / minute, // angular velocity
-                              ".eia"};
-static GcodeMeta MeldMeta = {GcodeSyntax::kMeld,
-                             QString("("), // starting_delim
-                             QString(")"), // ending_delim
-                             in,           // distance
-                             ms,           // time
-                             degree,       // angle
-                             lbm,          // mass
-                             in / minute,  // velocity
-                             in / s / s,   // acceleration
-                             rev / minute, // angular velocity
-                             ".nc"};
-static GcodeMeta HurcoMeta = {GcodeSyntax::kHurco,
-                              QString("("), // starting_delim
-                              QString(")"), // ending_delim
-                              mm,           // distance
-                              ms,           // time
-                              degree,       // angle
-                              g,            // mass
-                              mm / minute,  // velocity
-                              mm / s / s,   // acceleration
-                              rev / minute, // angular velocity
-                              ".nc"};
-static GcodeMeta RepRapMeta = {
+static GcodeMeta WolfMeta          = {GcodeSyntax::kWolf,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".gcode"};
+static GcodeMeta HaasInchMeta      = {GcodeSyntax::kHaasInch,
+                                      QString("("),  // starting_delim
+                                      QString(")"),  // ending_delim
+                                      in,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      lbm,           // mass
+                                      in / minute,   // velocity
+                                      in / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".nc"};
+static GcodeMeta HaasMetricMeta    = {GcodeSyntax::kHaasMetric,
+                                      QString("("),  // starting_delim
+                                      QString(")"),  // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".nc"};
+static GcodeMeta RomiFanucMeta     = {GcodeSyntax::kRomiFanuc,
+                                      QString("("),  // starting_delim
+                                      QString(")"),  // ending_delim
+                                      mm,            // distance
+                                      ms,            // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".txt"};
+static GcodeMeta DmgDmuAndBeamMeta = {GcodeSyntax::kDmgDmu,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".mpf"};
+static GcodeMeta GudelMeta         = {GcodeSyntax::kGudel,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".mpf"};
+static GcodeMeta IngersollMeta     = {GcodeSyntax::kIngersoll,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".gcode"};
+static GcodeMeta MVPMeta           = {GcodeSyntax::kMVP,
+                                      QString(";"),  // starting_delim
+                                      QString(),     // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".mpf"};
+static GcodeMeta MazakMeta         = {GcodeSyntax::kMazak,
+                                      QString("("),  // starting_delim
+                                      QString(")"),  // ending_delim
+                                      mm,            // distance
+                                      s,             // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".eia"};
+static GcodeMeta MeldMeta          = {GcodeSyntax::kMeld,
+                                      QString("("),  // starting_delim
+                                      QString(")"),  // ending_delim
+                                      in,            // distance
+                                      ms,            // time
+                                      degree,        // angle
+                                      lbm,           // mass
+                                      in / minute,   // velocity
+                                      in / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".nc"};
+static GcodeMeta HurcoMeta         = {GcodeSyntax::kHurco,
+                                      QString("("),  // starting_delim
+                                      QString(")"),  // ending_delim
+                                      mm,            // distance
+                                      ms,            // time
+                                      degree,        // angle
+                                      g,             // mass
+                                      mm / minute,   // velocity
+                                      mm / s / s,    // acceleration
+                                      rev / minute,  // angular velocity
+                                      ".nc"};
+static GcodeMeta RepRapMeta        = {
     GcodeSyntax::kRepRap,
-    QString(";"), // starting_delim
-    QString(),    // ending_delim
-    mm,           // distance
-    ms,           // time
-    degree,       // angle
-    g,            // mass
-    mm / minute,  // velocity
-    mm / s / s,   // acceleration
-    rev / minute, // angular velocity
-    ".gcode"      // suffix
+    QString(";"),  // starting_delim
+    QString(),     // ending_delim
+    mm,            // distance
+    ms,            // time
+    degree,        // angle
+    g,             // mass
+    mm / minute,   // velocity
+    mm / s / s,    // acceleration
+    rev / minute,  // angular velocity
+    ".gcode"       // suffix
 };
 
 static GcodeMeta AeroBasicMeta = {GcodeSyntax::kAeroBasic,
-                                  QString("'"), // starting_delim
-                                  QString(),    // ending_delim
-                                  mm,           // distance
-                                  s,            // time
-                                  degree,       // angle
-                                  g,            // mass
-                                  mm / s,       // velocity
-                                  mm / s / s,   // acceleration
-                                  rev / s,      // angular velocity
+                                  QString("'"),  // starting_delim
+                                  QString(),     // ending_delim
+                                  mm,            // distance
+                                  s,             // time
+                                  degree,        // angle
+                                  g,             // mass
+                                  mm / s,        // velocity
+                                  mm / s / s,    // acceleration
+                                  rev / s,       // angular velocity
                                   ".gcode"};
 
-static GcodeMeta ORNLMeta = {GcodeSyntax::kORNL,
-                             QString("("), // starting_delim
-                             QString(")"), // ending_delim
-                             in,
-                             s,
-                             degree,
-                             lbm,
-                             in / minute,
-                             in / s / s,
-                             rev / minute,
-                             ".gcode"};
-static GcodeMeta ORNLMetricMeta = {GcodeSyntax::kORNLMetric,
-                                   QString("("), // starting_delim
-                                   QString(")"), // ending_delim
-                                   mm,
-                                   s,
-                                   degree,
-                                   g,
-                                   mm / minute,
-                                   mm / s / s,
-                                   rev / minute,
-                                   ".gcode"};
-static GcodeMeta TormachMeta = {GcodeSyntax::kTormach,
-                                QString(";"), // starting_delim
-                                QString(""),  // ending_delim
-                                mm,
-                                s,
-                                degree,
-                                g,
-                                mm / minute,
-                                mm / s / s,
-                                rev / minute,
-                                ".nc"};
-static GcodeMeta AML3DMeta = {GcodeSyntax::kAML3D,
-                              QString("("), // starting_delim
-                              QString(")"), // ending_delim
-                              mm,
-                              s,
-                              degree,
-                              g,
-                              mm / s,
-                              mm / s / s,
-                              rev / minute,
-                              ".gcode"};
-static GcodeMeta KraussMaffeiMeta = {GcodeSyntax::kKraussMaffei,
-                                     QString(";"), // starting_delim
-                                     QString(),    // ending_delim
-                                     mm,           // distance
-                                     ms,           // time
-                                     degree,       // angle
-                                     g,            // mass
-                                     mm / minute,  // velocity
-                                     mm / s / s,   // acceleration
-                                     rev / minute, // angular velocity
+static GcodeMeta ORNLMeta         = {GcodeSyntax::kORNL,
+                                     QString("("),  // starting_delim
+                                     QString(")"),  // ending_delim
+                                     in,
+                                     s,
+                                     degree,
+                                     lbm,
+                                     in / minute,
+                                     in / s / s,
+                                     rev / minute,
                                      ".gcode"};
-static GcodeMeta SandiaMeta = {GcodeSyntax::kSandia,
-                               QString(";"), // starting_delim
-                               QString(),    // ending_delim
-                               mm,           // distance
-                               ms,           // time
-                               degree,       // angle
-                               g,            // mass
-                               m / s,        // velocity
-                               mm / s / s,   // acceleration
-                               rev / minute, // angular velocity
-                               ".gcode"};
-static GcodeMeta MeltioMeta = {GcodeSyntax::kMarlin,
-                               QString("("), // starting_delim
-                               QString(")"), // ending_delim
-                               mm,           // distance
-                               ms,           // time
-                               degree,       // angle
-                               g,            // mass
-                               mm / minute,  // velocity
-                               mm / s / s,   // acceleration
-                               rev / minute, // angular velocity
-                               ".nc"};
+static GcodeMeta ORNLMetricMeta   = {GcodeSyntax::kORNLMetric,
+                                     QString("("),  // starting_delim
+                                     QString(")"),  // ending_delim
+                                     mm,
+                                     s,
+                                     degree,
+                                     g,
+                                     mm / minute,
+                                     mm / s / s,
+                                     rev / minute,
+                                     ".gcode"};
+static GcodeMeta TormachMeta      = {GcodeSyntax::kTormach,
+                                     QString(";"),  // starting_delim
+                                     QString(""),   // ending_delim
+                                     mm,
+                                     s,
+                                     degree,
+                                     g,
+                                     mm / minute,
+                                     mm / s / s,
+                                     rev / minute,
+                                     ".nc"};
+static GcodeMeta AML3DMeta        = {GcodeSyntax::kAML3D,
+                                     QString("("),  // starting_delim
+                                     QString(")"),  // ending_delim
+                                     mm,
+                                     s,
+                                     degree,
+                                     g,
+                                     mm / s,
+                                     mm / s / s,
+                                     rev / minute,
+                                     ".gcode"};
+static GcodeMeta KraussMaffeiMeta = {GcodeSyntax::kKraussMaffei,
+                                     QString(";"),  // starting_delim
+                                     QString(),     // ending_delim
+                                     mm,            // distance
+                                     ms,            // time
+                                     degree,        // angle
+                                     g,             // mass
+                                     mm / minute,   // velocity
+                                     mm / s / s,    // acceleration
+                                     rev / minute,  // angular velocity
+                                     ".gcode"};
+static GcodeMeta SandiaMeta       = {GcodeSyntax::kSandia,
+                                     QString(";"),  // starting_delim
+                                     QString(),     // ending_delim
+                                     mm,            // distance
+                                     ms,            // time
+                                     degree,        // angle
+                                     g,             // mass
+                                     m / s,         // velocity
+                                     mm / s / s,    // acceleration
+                                     rev / minute,  // angular velocity
+                                     ".gcode"};
+static GcodeMeta MeltioMeta       = {GcodeSyntax::kMarlin,
+                                     QString("("),  // starting_delim
+                                     QString(")"),  // ending_delim
+                                     mm,            // distance
+                                     ms,            // time
+                                     degree,        // angle
+                                     g,             // mass
+                                     mm / minute,   // velocity
+                                     mm / s / s,    // acceleration
+                                     rev / minute,  // angular velocity
+                                     ".nc"};
 
 static GcodeMeta AdamantineMeta = {
     GcodeSyntax::kAdamantine, QString("("), QString(")"), m, s, degree, lbm, m / s, m / s / s, rev / s, ".txt"};
 
 //! @brief Metadata for Arc Specialties gcode.
 static GcodeMeta ArcSpecialtiesMeta = {GcodeSyntax::kArcSpecialties,
-                                       QString(";"), // starting_delim
-                                       QString(),    // ending_delim
+                                       QString(";"),  // starting_delim
+                                       QString(),     // ending_delim
                                        mm,
                                        s,
                                        degree,
@@ -342,5 +342,5 @@ static QHash<int, GcodeMeta> createMapping() {
 }
 
 static QHash<int, GcodeMeta> SyntaxToMetaHash = createMapping();
-} // namespace GcodeMetaList
-} // namespace ORNL
+}  // namespace GcodeMetaList
+}  // namespace ORNL

--- a/include/gcode/gcode_motion_estimate.h
+++ b/include/gcode/gcode_motion_estimate.h
@@ -6,7 +6,7 @@
 
 namespace ORNL {
 class MotionEstimation {
-  public:
+   public:
     //! \brief Initilizes the neccesary parameters and sets to default values
     static void Init();
 
@@ -80,7 +80,7 @@ class MotionEstimation {
     static Velocity m_current_speed;
     static Velocity m_incomingV;
 
-  private:
+   private:
     //! \brief Set direction vector from last motion
     //! \param vx Direction vector x component
     //! \param vy Direction vector y component
@@ -126,10 +126,10 @@ class MotionEstimation {
 
     static void setPreviousVelocityVector(Velocity velocity, Distance dx, Distance dy, Distance dz);
 
-    static bool m_previous_vertical; // Z or W move
+    static bool m_previous_vertical;  // Z or W move
 
     // Actual velocty vectors considering acceleration and parabolic blend
     static QVector3D m_previous_vv;
     static QVector3D m_current_vv;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/gcode_settings_importer.h
+++ b/include/gcode/gcode_settings_importer.h
@@ -1,17 +1,16 @@
 #pragma once
 
-#include <functional>
-#include <optional>
-
 #include <QString>
 #include <QStringList>
+#include <functional>
+#include <optional>
 
 #include "utilities/qt_json_conversion.h"
 
 namespace ORNL {
 
 class GcodeSettingsImporter {
-  public:
+   public:
     struct ImportResult {
         fifojson settings_file;
         QStringList errors;
@@ -36,4 +35,4 @@ class GcodeSettingsImporter {
     static QStringList settingOptions(const fifojson& master_entry);
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/adamantine_parser.h
+++ b/include/gcode/parsers/adamantine_parser.h
@@ -18,7 +18,7 @@ namespace ORNL {
  *              - M83
  */
 class AdamantineParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -32,7 +32,7 @@ class AdamantineParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Handler for 'G28' command for homing
     //! \param params Accepted by function for formatting check, but are not
     //! used for the command
@@ -47,11 +47,11 @@ class AdamantineParser : public CommonParser {
     //! used for the command
     virtual void M83Handler(QVector<QString> params);
 
-  private:
+   private:
     //! \brief Predefined string for home command
     QString m_home_string;
 
     //! \brief Predefined parameters referencing home command
     QVector<QString> m_home_parameters;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/aerobasic_parser.h
+++ b/include/gcode/parsers/aerobasic_parser.h
@@ -13,7 +13,7 @@ namespace ORNL {
  * AeroBasic 3D printer(s).
  */
 class AeroBasicParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -47,4 +47,4 @@ class AeroBasicParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/arc_specialties_parser.h
+++ b/include/gcode/parsers/arc_specialties_parser.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * format, and delegates motion estimation and visualization command creation to CommonParser.
  */
 class ArcSpecialtiesParser : public CommonParser {
-  public:
+   public:
     /*!
      * @brief Constructs an Arc Specialties gcode parser.
      * @param meta Gcode syntax metadata for units and comments.
@@ -37,7 +37,7 @@ class ArcSpecialtiesParser : public CommonParser {
     //! @brief Registers Arc Specialties command handlers and modal arc-center commands.
     void config() override;
 
-  protected:
+   protected:
     /*!
      * @brief Handles Arc Specialties travel moves after validating and stripping orientation axes.
      * @param params Raw G0/G00 parameters.
@@ -77,7 +77,7 @@ class ArcSpecialtiesParser : public CommonParser {
     //! @brief Marks Arc Specialties welder output as inactive deposition.
     void G83Handler(QVector<QString> params);
 
-  private:
+   private:
     /*!
      * @brief Validates Arc Specialties parameters and returns common-parser-compatible linear parameters.
      * @param params Raw gcode parameters for a motion command.
@@ -157,4 +157,4 @@ class ArcSpecialtiesParser : public CommonParser {
     //! @brief Tracks whether G161 absolute-center mode is active while parsing Arc Specialties G-code.
     bool m_use_absolute_arc_centers = false;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/beam_parser.h
+++ b/include/gcode/parsers/beam_parser.h
@@ -16,7 +16,7 @@ namespace ORNL {
  *              - M110, M111
  */
 class BeamParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -30,7 +30,7 @@ class BeamParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Handler for 'M110' command for turning on extruder
     //! \param params Accepted by function for formatting check, but are not
     //! used for the command
@@ -41,4 +41,4 @@ class BeamParser : public CommonParser {
     //! used for the command
     virtual void M111Handler(QVector<QString> params);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/cincinnati_parser.h
+++ b/include/gcode/parsers/cincinnati_parser.h
@@ -29,7 +29,7 @@ namespace ORNL {
  *
  */
 class CincinnatiParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -42,7 +42,7 @@ class CincinnatiParser : public CommonParser {
 
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Function handler for the 'M0' command for waiting for user
     //! input to continue runnning.
     //!        This function handler accepts no parameters but takes them
@@ -236,8 +236,8 @@ class CincinnatiParser : public CommonParser {
     //! a placeholder function.
     virtual void ToolChangeHandler(QVector<QString> params);
 
-  private:
+   private:
     bool m_voltage_control = true;
     double m_voltage_control_value;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -2,6 +2,7 @@
 
 #include <QScopedPointer>
 #include <QVector>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qhashfunctions.h>
@@ -37,7 +38,7 @@ namespace ORNL {
  */
 class CommonParser : public ParserBase {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor that allows for unit type selection
     //! \param meta Meta to use for units and command styles
     //! \param allowLayerAlter Whether or not the layers can be altered to adhere to the min layer time
@@ -220,7 +221,7 @@ class CommonParser : public ParserBase {
     //! \return List of start lines for each layer
     QList<int> getLayerStartLines();
 
-  signals:
+   signals:
 
     //! \brief Send status updates to slice dialog of progress
     //! \param type Current step process type
@@ -232,7 +233,7 @@ class CommonParser : public ParserBase {
     //!  main_window's status window.  Info includes: time, volume, weight, and material info.
     void forwardInfoToMainWindow(QString parsingInfo);
 
-  protected:
+   protected:
     //! \brief Returns the current line to the child parser
     //! \return Current line index
     int getCurrentLine();
@@ -471,8 +472,8 @@ class CommonParser : public ParserBase {
     //! \brief Tracks whether the parsed command stream is actively depositing material.
     bool m_deposition_active = false;
 
-    bool m_dynamic_spindle_control; // true if on, false if off.
-    bool m_park;                    // true if parking, false if not.
+    bool m_dynamic_spindle_control;  // true if on, false if off.
+    bool m_park;                     // true if parking, false if not.
 
     // Purging variables
     bool m_return_to_prev_location;
@@ -487,7 +488,7 @@ class CommonParser : public ParserBase {
     //! \brief Constant used for time adjustment and child parsers
     QChar m_space;
 
-  private:
+   private:
     //! \brief calculates distance for the current motion segment
     Distance getCurrentGXDistance();
 
@@ -664,6 +665,6 @@ class CommonParser : public ParserBase {
     //! \brief Line at which each layer start (used for visualization)
     QList<int> m_layer_start_lines;
 
-}; // class CommonParser
+};  // class CommonParser
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/marlin_parser.h
+++ b/include/gcode/parsers/marlin_parser.h
@@ -18,7 +18,7 @@ namespace ORNL {
  *              - M83
  */
 class MarlinParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -32,7 +32,7 @@ class MarlinParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Handler for 'G28' command for homing
     //! \param params Accepted by function for formatting check, but are not
     //! used for the command
@@ -47,11 +47,11 @@ class MarlinParser : public CommonParser {
     //! used for the command
     virtual void M83Handler(QVector<QString> params);
 
-  private:
+   private:
     //! \brief Predefined string for home command
     QString m_home_string;
 
     //! \brief Predefined parameters referencing home command
     QVector<QString> m_home_parameters;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/mazak_parser.h
+++ b/include/gcode/parsers/mazak_parser.h
@@ -18,7 +18,7 @@ namespace ORNL {
  *              - Feedrate
  */
 class MazakParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -32,7 +32,7 @@ class MazakParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config() override;
 
-  protected:
+   protected:
     //! \brief Handler for 'G1' command for motion
     //! G1 must be overridden due to unique format, formatting is adjusted and then
     //! referred to base G1 handler
@@ -54,7 +54,7 @@ class MazakParser : public CommonParser {
     //! \param params Should be single param containing speed
     virtual void FeedRateHandler(QVector<QString> params);
 
-  private:
+   private:
     //! \brief Feedrate replacement'#981' command.  Used as F variable.
     QString m_feedrate;
 
@@ -64,4 +64,4 @@ class MazakParser : public CommonParser {
     //! \brief Predefined variable for '#981' command.  Used for lookup.
     QString m_feedrate_reference;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/mvp_parser.h
+++ b/include/gcode/parsers/mvp_parser.h
@@ -16,7 +16,7 @@ namespace ORNL {
  *              - M124
  */
 class MVPParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -30,10 +30,10 @@ class MVPParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Handler for 'M124' command for turning off extruder
     //! \param params Accepted by function for formatting check, but are not
     //! used for the command
     virtual void M124Handler(QVector<QString> params);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/parser_base.h
+++ b/include/gcode/parsers/parser_base.h
@@ -20,7 +20,7 @@ namespace ORNL {
  */
 class ParserBase : public QObject {
     Q_OBJECT
-  public:
+   public:
     //! \brief Parses the command that is passed from the command string,
     //!        and sends the command to its corresponding handler.
     //! \param command_string Gcode command string
@@ -43,7 +43,7 @@ class ParserBase : public QObject {
     //! \return bool true if starts with delimiter
     bool startsWithDelimiter(QString& str);
 
-  protected:
+   protected:
     //! \brief Default Constructor
     ParserBase();
 
@@ -114,10 +114,10 @@ class ParserBase : public QObject {
     //! \brief Maps a GCode command to a function handlerm
     //! \brief This function throws a multiple parameter exception.
     QHash<QString, std::function<void(QVector<QString>)>>
-        m_command_mapping; //!< Mappings of GCode command strings
-                           //!< to function handlers which take parameters
+        m_command_mapping;  //!< Mappings of GCode command strings
+                            //!< to function handlers which take parameters
 
-  private:
+   private:
     //! \brief Current line comment
     QString m_line_comment;
     //! \brief Current starting delimiter
@@ -137,5 +137,5 @@ class ParserBase : public QObject {
     //! \brief Matcher for identifying new layers for quicker string comparison
     QStringMatcher m_beginning_layer_matcher;
 
-}; // class ParserBase
-} // namespace ORNL
+};  // class ParserBase
+}  // namespace ORNL

--- a/include/gcode/parsers/siemens_parser.h
+++ b/include/gcode/parsers/siemens_parser.h
@@ -16,7 +16,7 @@ namespace ORNL {
  *              - Bead Area, Extruder Off
  */
 class SiemensParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -30,7 +30,7 @@ class SiemensParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Handler for 'BEAD_AREA' command for turning on extruder
     //! \param params Accepted by function for formatting check, but are not
     //! used for the command
@@ -41,4 +41,4 @@ class SiemensParser : public CommonParser {
     //! used for the command
     virtual void ExtruderOffHandler(QVector<QString> params);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/parsers/tormach_parser.h
+++ b/include/gcode/parsers/tormach_parser.h
@@ -16,7 +16,7 @@ namespace ORNL {
  *              - M64, M65
  */
 class TormachParser : public CommonParser {
-  public:
+   public:
     //! \brief Standard constructor that specifies meta type and whether or not
     //! to alter layers for minimal layer time
     //! \param meta GcodeMeta struct that includes information about units and
@@ -30,7 +30,7 @@ class TormachParser : public CommonParser {
     //! \brief Function to initialize syntax specific handlers
     virtual void config();
 
-  protected:
+   protected:
     //! \brief Handler for 'M64' command for turning on extruder
     //! \param params Accepted by function for formatting check, but are not
     //! used for the command
@@ -41,4 +41,4 @@ class TormachParser : public CommonParser {
     //! used for the command
     virtual void M65Handler(QVector<QString> params);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/writers/adamantine_writer.h
+++ b/include/gcode/writers/adamantine_writer.h
@@ -18,7 +18,7 @@ namespace ORNL {
  */
 class AdamantineWriter : public WriterBase {
     // WriterBase interface
-  public:
+   public:
     //! \brief Constructor
     AdamantineWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
     // Required functions
@@ -41,9 +41,9 @@ class AdamantineWriter : public WriterBase {
     QString writeShutdown() override;
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief State variables
     RegionType m_region_type;
     int counter;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/writers/aerobasic_writer.h
+++ b/include/gcode/writers/aerobasic_writer.h
@@ -17,7 +17,7 @@ namespace ORNL {
  * \brief The gcode writer for the AeroBasic syntax
  */
 class AeroBasicWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     AeroBasicWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -81,7 +81,7 @@ class AeroBasicWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes g-code coordinates WXYZ for a move or travel to the destination point
     QString writeCoordinates(Point destination);
     //! \brief Writes g-code for retraction moves
@@ -98,5 +98,5 @@ class AeroBasicWriter : public WriterBase {
     //! \brief tracks the current amount of filament output for the E command
     Distance m_filament_location;
 
-}; // class AeroBasicWriter
-} // namespace ORNL
+};  // class AeroBasicWriter
+}  // namespace ORNL

--- a/include/gcode/writers/aml3d_writer.h
+++ b/include/gcode/writers/aml3d_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Tormach syntax
  */
 class AML3DWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     AML3DWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -87,7 +87,7 @@ class AML3DWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the tamper
     QString writeTamperOn();
     //! \brief Writes G-Code to disable the tamper
@@ -114,5 +114,5 @@ class AML3DWriter : public WriterBase {
     //! \brief true if wiping tip and no travel has been initiated
     bool m_tip_wipe;
 
-}; // class AML3DWriter
-} // namespace ORNL
+};  // class AML3DWriter
+}  // namespace ORNL

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -2,6 +2,7 @@
 
 #include <QPair>
 #include <QVector>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -29,7 +30,7 @@ namespace ORNL {
  * Revolution.
  */
 class ArcSpecialtiesWriter : public WriterBase {
-  public:
+   public:
     /*!
      * @brief Constructs an Arc Specialties writer.
      * @param meta Gcode syntax metadata for output units and comments.
@@ -156,7 +157,7 @@ class ArcSpecialtiesWriter : public WriterBase {
      */
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the welder
     QString writeWelderOn();
     /*!
@@ -322,4 +323,4 @@ class ArcSpecialtiesWriter : public WriterBase {
     //! @brief Effective part-local handedness values reported in helical G-code headers.
     QVector<QPair<QString, HelicalPathHandedness>> m_helical_path_handedness;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/gcode/writers/cincinnati_writer.h
+++ b/include/gcode/writers/cincinnati_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Cincinnati Inc. syntax
  */
 class CincinnatiWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     CincinnatiWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -84,7 +84,7 @@ class CincinnatiWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the tamper
     QString writeTamperOn();
     //! \brief Writes G-Code to disable the tamper
@@ -133,5 +133,5 @@ class CincinnatiWriter : public WriterBase {
     QString m_M10, m_M11, m_M64, m_M65;
     int m_material_number;
 
-}; // class CincinnatiWriter
-} // namespace ORNL
+};  // class CincinnatiWriter
+}  // namespace ORNL

--- a/include/gcode/writers/dmg_dmu_writer.h
+++ b/include/gcode/writers/dmg_dmu_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the DMG DMU syntax
  */
 class DMGDMUWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     DMGDMUWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class DMGDMUWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class DMGDMUWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class DMGDMUWriter
-} // namespace ORNL
+};  // class DMGDMUWriter
+}  // namespace ORNL

--- a/include/gcode/writers/gudel_writer.h
+++ b/include/gcode/writers/gudel_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Gudel syntax
  */
 class GudelWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     GudelWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class GudelWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class GudelWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class GudelWriter
-} // namespace ORNL
+};  // class GudelWriter
+}  // namespace ORNL

--- a/include/gcode/writers/haas_metric_no_comments_writer.h
+++ b/include/gcode/writers/haas_metric_no_comments_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Haas metric syntax without comments
  */
 class HaasMetricNoCommentsWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     HaasMetricNoCommentsWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class HaasMetricNoCommentsWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class HaasMetricNoCommentsWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class HaasMetricNoCommentsWriter
-} // namespace ORNL
+};  // class HaasMetricNoCommentsWriter
+}  // namespace ORNL

--- a/include/gcode/writers/haas_writer.h
+++ b/include/gcode/writers/haas_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Haas syntax
  */
 class HaasWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     HaasWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class HaasWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
 
@@ -102,5 +102,5 @@ class HaasWriter : public WriterBase {
     //! @brief The tool number to use for the current operation
     int m_tool_number;
 
-}; // class HaasWriter
-} // namespace ORNL
+};  // class HaasWriter
+}  // namespace ORNL

--- a/include/gcode/writers/hurco_writer.h
+++ b/include/gcode/writers/hurco_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Hurco syntax
  */
 class HurcoWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     HurcoWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class HurcoWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class HurcoWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class HurcoWriter
-} // namespace ORNL
+};  // class HurcoWriter
+}  // namespace ORNL

--- a/include/gcode/writers/ingersoll_writer.h
+++ b/include/gcode/writers/ingersoll_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Ingersoll syntax
  */
 class IngersollWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     IngersollWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -84,7 +84,7 @@ class IngersollWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, float rpm, int extruder_number,
                             const QSharedPointer<SettingsBase>& params = nullptr);
@@ -112,5 +112,5 @@ class IngersollWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class IngersollWriter
-} // namespace ORNL
+};  // class IngersollWriter
+}  // namespace ORNL

--- a/include/gcode/writers/juggerbot_writer.h
+++ b/include/gcode/writers/juggerbot_writer.h
@@ -17,7 +17,7 @@ namespace ORNL {
  * \brief The gcode writer for the JuggerBot syntax
  */
 class JuggerBotWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     JuggerBotWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -76,7 +76,7 @@ class JuggerBotWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, Distance bead_width, Distance bead_height,
                             const QSharedPointer<SettingsBase>& params = nullptr);
@@ -99,5 +99,5 @@ class JuggerBotWriter : public WriterBase {
     AngularVelocity m_current_rpm;
     Area m_current_bead_area;
 
-}; // class JuggerBotWriter
-} // namespace ORNL
+};  // class JuggerBotWriter
+}  // namespace ORNL

--- a/include/gcode/writers/kraussmaffei_writer.h
+++ b/include/gcode/writers/kraussmaffei_writer.h
@@ -17,7 +17,7 @@ namespace ORNL {
  * \brief The gcode writer for the KraussMaffei syntax
  */
 class KraussMaffeiWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     KraussMaffeiWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -76,7 +76,7 @@ class KraussMaffeiWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes g-code coordinates WXYZ for a move or travel to the destination point
     QString writeCoordinates(Point destination);
 
@@ -91,5 +91,5 @@ class KraussMaffeiWriter : public WriterBase {
     //! \brief true is first print motion of the layer
     bool m_layer_start;
 
-}; // class KraussMaffeiWriter
-} // namespace ORNL
+};  // class KraussMaffeiWriter
+}  // namespace ORNL

--- a/include/gcode/writers/mach4_writer.h
+++ b/include/gcode/writers/mach4_writer.h
@@ -17,7 +17,7 @@ namespace ORNL {
  * \brief The gcode writer for the Mach4 syntax
  */
 class Mach4Writer : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     Mach4Writer(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -76,7 +76,7 @@ class Mach4Writer : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes g-code coordinates WXYZ for a move or travel to the destination point
     QString writeCoordinates(Point destination);
     //! \brief Writes g-code for retraction moves
@@ -95,5 +95,5 @@ class Mach4Writer : public WriterBase {
     //! \brief tracks the current amount of filament output for the E command
     Distance m_filament_location;
 
-}; // class Mach4Writer
-} // namespace ORNL
+};  // class Mach4Writer
+}  // namespace ORNL

--- a/include/gcode/writers/marlin_writer.h
+++ b/include/gcode/writers/marlin_writer.h
@@ -17,7 +17,7 @@ namespace ORNL {
  * \brief The gcode writer for the Marlin syntax
  */
 class MarlinWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     MarlinWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -76,7 +76,7 @@ class MarlinWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes g-code coordinates WXYZ for a move or travel to the destination point
     QString writeCoordinates(Point destination);
     //! \brief Writes g-code for retraction moves
@@ -95,5 +95,5 @@ class MarlinWriter : public WriterBase {
     //! \brief tracks the current amount of filament output for the E command
     Distance m_filament_location;
 
-}; // class MarlinWriter
-} // namespace ORNL
+};  // class MarlinWriter
+}  // namespace ORNL

--- a/include/gcode/writers/mazak_writer.h
+++ b/include/gcode/writers/mazak_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Mazak syntax
  */
 class MazakWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     MazakWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class MazakWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class MazakWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class MazakWriter
-} // namespace ORNL
+};  // class MazakWriter
+}  // namespace ORNL

--- a/include/gcode/writers/meld_writer.h
+++ b/include/gcode/writers/meld_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Meld syntax
  */
 class MeldWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     MeldWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class MeldWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class MeldWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class MeldWriter
-} // namespace ORNL
+};  // class MeldWriter
+}  // namespace ORNL

--- a/include/gcode/writers/meltio_writer.h
+++ b/include/gcode/writers/meltio_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Meltio syntax
  */
 class MeltioWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     MeltioWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -78,7 +78,7 @@ class MeltioWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, int extruder_number);
     //! \brief Writes G-Code to disable the extruder
@@ -94,5 +94,5 @@ class MeltioWriter : public WriterBase {
     //! \brief true is first print motion of the layer
     bool m_layer_start;
 
-}; // class MeltioWriter
-} // namespace ORNL
+};  // class MeltioWriter
+}  // namespace ORNL

--- a/include/gcode/writers/mvp_writer.h
+++ b/include/gcode/writers/mvp_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Cincinnati Inc. syntax
  */
 class MVPWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     MVPWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -74,7 +74,7 @@ class MVPWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -93,5 +93,5 @@ class MVPWriter : public WriterBase {
 
     AngularVelocity m_current_rpm;
 
-}; // class MVPWriter
-} // namespace ORNL
+};  // class MVPWriter
+}  // namespace ORNL

--- a/include/gcode/writers/okuma_writer.h
+++ b/include/gcode/writers/okuma_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Haas syntax
  */
 class OkumaWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     OkumaWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class OkumaWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class OkumaWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class OkumaWriter
-} // namespace ORNL
+};  // class OkumaWriter
+}  // namespace ORNL

--- a/include/gcode/writers/ornl_writer.h
+++ b/include/gcode/writers/ornl_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the ORNL syntax
  */
 class ORNLWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     ORNLWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -78,7 +78,7 @@ class ORNLWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private: //! \brief Defines the machine type - used to differentiate between polymer extrusion and wire-arc
+   private:  //! \brief Defines the machine type - used to differentiate between polymer extrusion and wire-arc
     MachineType m_machine_type;
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType region_type, int rpm, int extruder_number,
@@ -107,5 +107,5 @@ class ORNLWriter : public WriterBase {
     //! \brief Defines the current region type - useful for determining how to enable/disable deposition
     RegionType m_current_type;
 
-}; // class ORNLWriter
-} // namespace ORNL
+};  // class ORNLWriter
+}  // namespace ORNL

--- a/include/gcode/writers/reprap_writer.h
+++ b/include/gcode/writers/reprap_writer.h
@@ -18,7 +18,7 @@ namespace ORNL {
  * \brief The gcode writer for the RapRapWriter syntax (a Marlin-like syntax for desktop printers)
  */
 class RepRapWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     RepRapWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -82,7 +82,7 @@ class RepRapWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes g-code coordinates WXYZ for a move or travel to the destination point
     QString writeCoordinates(Point destination);
     //! \brief Writes g-code for retraction moves
@@ -101,5 +101,5 @@ class RepRapWriter : public WriterBase {
     //! \brief tracks the current amount of filament output for the E command
     Distance m_filament_location;
 
-}; // class RapRapWriter
-} // namespace ORNL
+};  // class RapRapWriter
+}  // namespace ORNL

--- a/include/gcode/writers/romi_fanuc_writer.h
+++ b/include/gcode/writers/romi_fanuc_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Romi Fanuc syntax
  */
 class RomiFanucWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     RomiFanucWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class RomiFanucWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -96,5 +96,5 @@ class RomiFanucWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class RomiFanucWriter
-} // namespace ORNL
+};  // class RomiFanucWriter
+}  // namespace ORNL

--- a/include/gcode/writers/sandia_writer.h
+++ b/include/gcode/writers/sandia_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Sandia syntax
  */
 class SandiaWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     SandiaWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -87,7 +87,7 @@ class SandiaWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the tamper
     QString writeTamperOn();
     //! \brief Writes G-Code to disable the tamper
@@ -112,5 +112,5 @@ class SandiaWriter : public WriterBase {
     //! \brief true is first print motion of the layer
     bool m_layer_start;
 
-}; // class SANDIAWriter
-} // namespace ORNL
+};  // class SANDIAWriter
+}  // namespace ORNL

--- a/include/gcode/writers/siemens_writer.h
+++ b/include/gcode/writers/siemens_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Cincinnati Inc. syntax
  */
 class SiemensWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     SiemensWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class SiemensWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the tamper
     QString writeTamperOn();
     //! \brief Writes G-Code to disable the tamper
@@ -101,5 +101,5 @@ class SiemensWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     QString m_M64, m_M65;
 
-}; // class SiemensWriter
-} // namespace ORNL
+};  // class SiemensWriter
+}  // namespace ORNL

--- a/include/gcode/writers/thermwood_writer.h
+++ b/include/gcode/writers/thermwood_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Thermwood syntax
  */
 class ThermwoodWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     ThermwoodWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -75,7 +75,7 @@ class ThermwoodWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params = nullptr);
     //! \brief Writes G-Code to disable the extruder
@@ -98,5 +98,5 @@ class ThermwoodWriter : public WriterBase {
     //! \brief preallocated prefixs commonly used in this syntax
     int m_material_number;
 
-}; // class ThermwoodWriter
-} // namespace ORNL
+};  // class ThermwoodWriter
+}  // namespace ORNL

--- a/include/gcode/writers/tormach_writer.h
+++ b/include/gcode/writers/tormach_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Tormach syntax
  */
 class TormachWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     TormachWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -87,7 +87,7 @@ class TormachWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private:
+   private:
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType type, int rpm, int extruder_number);
     //! \brief Writes G-Code to disable the extruder
@@ -119,5 +119,5 @@ class TormachWriter : public WriterBase {
     //! \brief maximum yvalue used for travel pause
     Distance m_maximum_y;
 
-}; // class TORMACHWriter
-} // namespace ORNL
+};  // class TORMACHWriter
+}  // namespace ORNL

--- a/include/gcode/writers/wolf_writer.h
+++ b/include/gcode/writers/wolf_writer.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief The gcode writer for the Wolf syntax
  */
 class WolfWriter : public WriterBase {
-  public:
+   public:
     //! \brief Constructor
     WolfWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -78,7 +78,7 @@ class WolfWriter : public WriterBase {
     //! \brief Writes G-Code for a pause, G4
     QString writeDwell(Time time) override;
 
-  private: //! \brief Defines the machine type - used to differentiate between polymer extrusion and wire-arc
+   private:  //! \brief Defines the machine type - used to differentiate between polymer extrusion and wire-arc
     MachineType m_machine_type;
     //! \brief Writes G-Code to enable the extruder
     QString writeExtruderOn(RegionType region_type, int rpm, int extruder_number);
@@ -112,5 +112,5 @@ class WolfWriter : public WriterBase {
     //! \brief Integer identifier for path type: 1 = perimeter, 2 = inset, 8 = skeleton, 5 = infill, 6 = tip wipe
     int m_wolf_path_type;
 
-}; // class WolfWriter
-} // namespace ORNL
+};  // class WolfWriter
+}  // namespace ORNL

--- a/include/gcode/writers/writer_base.h
+++ b/include/gcode/writers/writer_base.h
@@ -5,6 +5,7 @@
 #include <QStringBuilder>
 #include <QTextStream>
 #include <QVector3D>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -20,7 +21,7 @@ namespace ORNL {
 class PathSegment;
 
 class WriterBase {
-  public:
+   public:
     //! \brief Default Constructor
     WriterBase(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb);
 
@@ -58,7 +59,9 @@ class WriterBase {
     virtual QString writeBeforePath(RegionType type) = 0;
 
     //! \brief Writes G-Code for travel lift between paths; only used for syntaxes that can't use defined slicing plane
-    virtual QString writeTravelLift(bool lift) { return QString(); }
+    virtual QString writeTravelLift(bool lift) {
+        return QString();
+    }
 
     //! \brief Writes G-Code for traveling between paths
     virtual QString writeTravel(Point start_location, Point target_location, TravelLiftType lType,
@@ -69,7 +72,9 @@ class WriterBase {
                               const QSharedPointer<SettingsBase> params) = 0;
 
     //! \brief Writes G-Code for scan segment
-    virtual QString writeScan(Point target_point, Velocity speed, bool on_off) { return QString(); }
+    virtual QString writeScan(Point target_point, Velocity speed, bool on_off) {
+        return QString();
+    }
 
     //! \brief Writes G-Code for arc segment
     virtual QString writeArc(const Point& start_point, const Point& end_point, const Point& center_point,
@@ -89,7 +94,9 @@ class WriterBase {
     }
 
     //! \brief Writes G-Code to be executed once all scans are complete
-    virtual QString writeAfterAllScans() { return QString(); }
+    virtual QString writeAfterAllScans() {
+        return QString();
+    }
 
     //! \brief Writes G-Code to be executed at the end of each island
     virtual QString writeAfterIsland() = 0;
@@ -131,7 +138,9 @@ class WriterBase {
     Point getCurrentPosition() const;
 
     //! \brief Write purge command
-    virtual QString writePurge(int RPM, int duration, int delay) { return QString(); }
+    virtual QString writePurge(int RPM, int duration, int delay) {
+        return QString();
+    }
 
     //! \brief Writes G-Code for a pause, G4
     virtual QString writeDwell(Time time) = 0;
@@ -142,7 +151,7 @@ class WriterBase {
     //! \brief writes the string param as a comment on its own line
     QString writeCommentLine(QString comment);
 
-  protected:
+   protected:
     //! \brief Writes a comment
     QString comment(const QString& text);
     //! \brief Writes a comment and ends the line
@@ -157,15 +166,14 @@ class WriterBase {
     QVector3D getLiftVector(Distance lift_height) const;
 
     //! \brief emits a final lift move for point-based writers when configured
-    template <typename MoveEmitter> QString writeFinalTravelLift(MoveEmitter&& emit_move, const QString& comment) {
+    template <typename MoveEmitter>
+    QString writeFinalTravelLift(MoveEmitter&& emit_move, const QString& comment) {
         const Distance final_lift = m_sb->setting<Distance>(PS::Travel::kFinalLiftDistance);
-        if (final_lift <= 0 || !m_has_current_position)
-            return QString();
+        if (final_lift <= 0 || !m_has_current_position) return QString();
 
         const Point lift_destination = m_current_position + getLiftVector(final_lift);
-        QString rv = emit_move(lift_destination);
-        if (rv.isEmpty())
-            return rv;
+        QString rv                   = emit_move(lift_destination);
+        if (rv.isEmpty()) return rv;
 
         if (comment.isEmpty())
             rv += m_newline;
@@ -224,6 +232,6 @@ class WriterBase {
     //! \brief whether or not the build maximum Z value has been recorded
     bool m_has_build_maximum_z;
 
-  private:
-}; // class WriterBase
-} // namespace ORNL
+   private:
+};  // class WriterBase
+}  // namespace ORNL

--- a/include/geometry/b_spline.h
+++ b/include/geometry/b_spline.h
@@ -12,7 +12,7 @@ namespace ORNL {
  *  \brief Geometry type for BSplines.
  */
 class BSpline {
-  public:
+   public:
     //! \brief Constructor
     //! \param start the first point on the spline
     explicit BSpline(const Point& start);
@@ -34,7 +34,7 @@ class BSpline {
     //! \return a list of bezier segments that comprise this spline
     QVector<QSharedPointer<BezierSegment>> toBezierSegments();
 
-  private:
+   private:
     //! \brief knots and controls that define curves
     QVector<Point> m_control_points;
     QVector<Point> m_knot_points;
@@ -42,4 +42,4 @@ class BSpline {
     //! \brief if this spline is a closed loop
     bool m_is_closed = false;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/geometry_debug.h
+++ b/include/geometry/geometry_debug.h
@@ -2,6 +2,7 @@
 
 #include <QPair>
 #include <QString>
+
 #include <qcontainerfwd.h>
 
 #include "geometry/point.h"
@@ -51,5 +52,5 @@ void printDesmos(const PolygonList& polygon_list, QString label = "");
 /// @param label An optional label to prepend to the output for identification purposes.
 void printDesmos(const EdgeList& edge_list, QString label = "");
 
-} // namespace GeometryDebug
-} // namespace ORNL
+}  // namespace GeometryDebug
+}  // namespace ORNL

--- a/include/geometry/mesh/advanced/mesh_types.h
+++ b/include/geometry/mesh/advanced/mesh_types.h
@@ -121,6 +121,6 @@ typedef boost::graph_traits<SurfaceMesh>::vertex_descriptor SM_VertexDescriptor;
 
 //! \brief Face of a surface mesh
 typedef boost::graph_traits<SurfaceMesh>::face_descriptor SM_FaceDescriptor;
-} // namespace SimpleCartesian
-} // namespace MeshTypes
-} // namespace ORNL
+}  // namespace SimpleCartesian
+}  // namespace MeshTypes
+}  // namespace ORNL

--- a/include/geometry/mesh/closed_mesh.h
+++ b/include/geometry/mesh/closed_mesh.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <QString>
 #include <utility>
 
 #include <CGAL/Modifier_base.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
-#include <QString>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -26,7 +26,7 @@ namespace ORNL {
 //! \class ClosedMesh
 //! \brief A class that represents a closed 3D volume
 class ClosedMesh : public MeshBase {
-  public:
+   public:
     enum class RepairResult {
         kSuccess,
         kSkippedLargeBoundary,
@@ -161,8 +161,8 @@ class ClosedMesh : public MeshBase {
     //! \pre Must be a triangulated and closed mesh
     //! \param mesh: the CGAL mesh polyhedron to be converted
     //! \return a list of vertices and faces that represent the object as a pair
-    static std::pair<QVector<MeshVertex>, QVector<MeshFace>>
-    FacesAndVerticesFromPolyhedron(MeshTypes::Polyhedron& mesh);
+    static std::pair<QVector<MeshVertex>, QVector<MeshFace>> FacesAndVerticesFromPolyhedron(
+        MeshTypes::Polyhedron& mesh);
 
     //! \brief Attempts to clean a supplied polyhedron for closed-mesh import.
     //! \param polyhedron Candidate polyhedron to clean in place.
@@ -182,7 +182,7 @@ class ClosedMesh : public MeshBase {
 
     MeshTypes::SurfaceMesh extractUpwardFaces() override;
 
-  private:
+   private:
     //! \brief converts vertices and faces into polyhedron, used to keep the two in sync
     void convert() override;
 
@@ -193,8 +193,9 @@ class ClosedMesh : public MeshBase {
     static bool CheckIntersectingCurves(Plane& plane, QVector<Polygon> boundary_curves);
 
     //! \brief Instructs CGAL how to build a polyhedron mesh from vertices and faces
-    template <class HDS> class MeshBuilder : public CGAL::Modifier_base<HDS> {
-      public:
+    template <class HDS>
+    class MeshBuilder : public CGAL::Modifier_base<HDS> {
+       public:
         //! \brief Builds a polyhedron incrementally using faces
         //! \param vertices: the mesh's vertices
         //! \param faces: the mesh's faces
@@ -205,9 +206,7 @@ class ClosedMesh : public MeshBase {
             builder.begin_surface(m_vertices.length(), m_faces.length());
 
             // Add all vertices
-            for (MeshVertex v : m_vertices) {
-                builder.add_vertex(v.toPoint3());
-            }
+            for (MeshVertex v : m_vertices) { builder.add_vertex(v.toPoint3()); }
 
             // Add all faces and connect to vertices
             for (MeshFace f : m_faces) {
@@ -221,7 +220,7 @@ class ClosedMesh : public MeshBase {
             builder.end_surface();
         }
 
-      private:
+       private:
         QVector<MeshVertex> m_vertices;
         QVector<MeshFace> m_faces;
     };
@@ -232,4 +231,4 @@ class ClosedMesh : public MeshBase {
     //! \brief the original CGAL representation of this mesh
     MeshTypes::Polyhedron m_original_representation;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/mesh/mesh_base.h
+++ b/include/geometry/mesh/mesh_base.h
@@ -28,7 +28,7 @@ namespace ORNL {
 //! \class MeshBase
 //! \brief A base type for 3D objects
 class MeshBase {
-  public:
+   public:
     //! \brief Default constructor
     MeshBase();
 
@@ -211,13 +211,15 @@ class MeshBase {
         typedef value_type& reference;
         typedef boost::lvalue_property_map_tag category;
         FacetPropMap(std::vector<ValueType>& internal_vector) : m_internal_vector(internal_vector) {}
-        reference operator[](key_type key) const { return m_internal_vector[key->id()]; }
+        reference operator[](key_type key) const {
+            return m_internal_vector[key->id()];
+        }
 
-      private:
+       private:
         std::vector<ValueType>& m_internal_vector;
     };
 
-  protected:
+   protected:
     //! \brief instructs child class to update it's underlying CGAL representation from the faces and vertices
     //! \note this is called by setTransformation()
     virtual void convert() = 0;
@@ -286,9 +288,9 @@ class MeshBase {
     //! \brief if this mesh is closed or not
     bool m_is_closed = false;
 
-  private:
+   private:
     //! \brief check if transformation is rotation
     //! \param matrix: a translation matrix
     bool isRotationalTransform(const QMatrix4x4& matrix, QQuaternion& rotation);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/mesh/mesh_face.h
+++ b/include/geometry/mesh/mesh_face.h
@@ -29,7 +29,7 @@ namespace ORNL {
  * \endverbatim
  */
 class MeshFace {
-  public:
+   public:
     //! \brief Constructor
     MeshFace();
 
@@ -44,10 +44,10 @@ class MeshFace {
     int vertex_index[3];
 
     //! \brief faces that are connected to this one
-    int connected_face_index[3]; //!< same ordering as vertex_index
-                                 //!(connected_face is connected via vertex
-                                 //! 0 and
-                                 //! 1, etc)
+    int connected_face_index[3];  //!< same ordering as vertex_index
+                                  //!(connected_face is connected via vertex
+                                  //! 0 and
+                                  //! 1, etc)
 
     //! \brief the normal of this face
     QVector3D normal;
@@ -55,4 +55,4 @@ class MeshFace {
     //! \brief a flag to ignore this face when cross-sectioning
     bool ignore = false;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/mesh/mesh_factory.h
+++ b/include/geometry/mesh/mesh_factory.h
@@ -9,7 +9,7 @@ namespace ORNL {
  * \brief Static class the provides various functions to generate meshes
  */
 class MeshFactory {
-  public:
+   public:
     //! \brief Constructor
     MeshFactory();
 
@@ -52,4 +52,4 @@ class MeshFactory {
     //! \return a new mesh
     static ClosedMesh CreateConeMesh(const Distance& radius, const Distance& height, const int resolution = 50);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/mesh/mesh_vertex.h
+++ b/include/geometry/mesh/mesh_vertex.h
@@ -2,6 +2,7 @@
 
 #include <QVector3D>
 #include <QVector>
+
 #include <qcontainerfwd.h>
 
 #include "geometry/mesh/advanced/mesh_types.h"
@@ -15,7 +16,7 @@ namespace ORNL {
  * Keeps track of which faces connect to it.
  */
 class MeshVertex {
-  public:
+   public:
     /*!
      * \brief Constructor
      *
@@ -30,8 +31,8 @@ class MeshVertex {
     //! \brief Converts the mesh vertex to a CGAL cartesian point
     MeshTypes::Point_3 toPoint3() const;
 
-    QVector3D location; //!< Location of the vertex
+    QVector3D location;  //!< Location of the vertex
     QVector3D normal;
-    QVector<int> connected_faces; //!< list of the indices of connected faces
+    QVector<int> connected_faces;  //!< list of the indices of connected faces
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/mesh/open_mesh.h
+++ b/include/geometry/mesh/open_mesh.h
@@ -24,7 +24,7 @@ namespace ORNL {
 //! \class OpenMesh
 //! \brief A class that represents an open 3D volume
 class OpenMesh : public MeshBase {
-  public:
+   public:
     //! \brief Default constructor
     OpenMesh();
 
@@ -93,15 +93,15 @@ class OpenMesh : public MeshBase {
     //! \brief converts a surface mesh into vertices and faces
     //! \param sm the surface mesh
     //! \return a pair of vertices and faces
-    static std::pair<QVector<MeshVertex>, QVector<MeshFace>>
-    VerticesAndFacesFromSurfaceMesh(MeshTypes::SurfaceMesh& sm);
+    static std::pair<QVector<MeshVertex>, QVector<MeshFace>> VerticesAndFacesFromSurfaceMesh(
+        MeshTypes::SurfaceMesh& sm);
 
     //! \brief Builds and returns a surface mesh from a point cloud
     //! \param file_path the file to build the cloud from
     //! \return a pointer to the new mesh if it could be loaded
     static QSharedPointer<OpenMesh> BuildMeshFromPointCloud(const QString& file_path);
 
-  private:
+   private:
     //! \brief converts vertices and faces into polyhedron, used to keep the two in sync
     void convert() override;
 
@@ -123,7 +123,7 @@ class OpenMesh : public MeshBase {
         ConstructPointCloud(MeshTypes::SurfaceMesh& mesh, PointIterator b, PointIterator e) : mesh(mesh) {
             for (; b != e; ++b) {
                 boost::graph_traits<MeshTypes::SurfaceMesh>::vertex_descriptor v;
-                v = add_vertex(mesh);
+                v             = add_vertex(mesh);
                 mesh.point(v) = *b;
             }
         }
@@ -135,9 +135,15 @@ class OpenMesh : public MeshBase {
                           vertex_descriptor(static_cast<size_type>(f[2])));
             return *this;
         }
-        ConstructPointCloud& operator*() { return *this; }
-        ConstructPointCloud& operator++() { return *this; }
-        ConstructPointCloud operator++(int) { return *this; }
+        ConstructPointCloud& operator*() {
+            return *this;
+        }
+        ConstructPointCloud& operator++() {
+            return *this;
+        }
+        ConstructPointCloud operator++(int) {
+            return *this;
+        }
     };
 
     //! \brief the CGAL representation of this mesh
@@ -146,4 +152,4 @@ class OpenMesh : public MeshBase {
     //! \brief the original CGAL representation of this mesh
     MeshTypes::SurfaceMesh m_original_representation;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/path.h
+++ b/include/geometry/path.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QList>
+
 #include <qquaternion.h>
 #include <qsharedpointer.h>
 
@@ -19,7 +20,7 @@ class SettingsBase;
  * \brief A list of path segments.
  */
 class Path {
-  public:
+   public:
     //! \brief Add a segment to the end of the path.
     //! \param ps: Segment to add
     void add(const QSharedPointer<SegmentBase>& ps);
@@ -124,11 +125,11 @@ class Path {
     //! \return whether or not path is ccw
     bool getCCW();
 
-  private:
+   private:
     //! \brief Segments that compose this path.
     QList<QSharedPointer<SegmentBase>> m_segments;
 
     //! \brief Bools for whether or not path is counter-clockwise or contains origin
     bool m_ccw;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/path_modifier.h
+++ b/include/geometry/path_modifier.h
@@ -14,7 +14,7 @@ namespace ORNL {
  * @brief The PathModifierGenerator class provides functions for modifying paths.
  */
 class PathModifierGenerator {
-  public:
+   public:
     static void GenerateTravel(Path& path, Point current_location, Velocity velocity);
 
     /**
@@ -158,7 +158,7 @@ class PathModifierGenerator {
     static void GenerateSpiralLift(Path& path, Distance spiralWidth, Distance spiralHeight, int spiralPoints,
                                    Velocity spiralLiftVelocity, bool supportsG3);
 
-  private:
+   private:
     /**
      * @brief writeSegment writes a segment to the path.
      * @param path: The path to modify.
@@ -221,4 +221,4 @@ class PathModifierGenerator {
     //! \brief track the distance already covered
     static Distance tipWipeDistanceCovered;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/pattern_generator.h
+++ b/include/geometry/pattern_generator.h
@@ -20,7 +20,7 @@ namespace ORNL {
  * Radial Hatch
  */
 class PatternGenerator {
-  public:
+   public:
     /*!
      * \brief Creates parallel lines as paths.
      * \param geometry: The bounds of the geometry under consideration
@@ -109,4 +109,4 @@ class PatternGenerator {
     static QVector<Polyline> GenerateRadialHatch(PolygonList geometry, Point center, Distance lineSpacing,
                                                  Angle sector_rotation, Angle infill_rotation);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/plane.h
+++ b/include/geometry/plane.h
@@ -9,7 +9,7 @@
 namespace ORNL {
 //! \brief an object for the point, normal representation of a plane
 class Plane {
-  public:
+   public:
     //! \brief Default Constructor for point/normal representation
     Plane();
 
@@ -88,7 +88,7 @@ class Plane {
     //! \brief Checks if two planes are equivalent
     bool operator==(const Plane& rhs);
 
-  private:
+   private:
     Point m_point;
     QVector3D m_normal_vector;
 
@@ -96,4 +96,4 @@ class Plane {
     double m_epsilon = .01;
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/point.h
+++ b/include/geometry/point.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <cstddef>
-#include <functional>
-
 #include <QMatrix4x4>
 #include <QPoint>
 #include <QPointF>
 #include <QVector2D>
 #include <QVector3D>
 #include <QVector4D>
+#include <cstddef>
+#include <functional>
+
 #include <clipper.hpp>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
@@ -25,7 +25,7 @@ namespace ORNL {
  * \brief Point class that converts to variable other 2d objects
  */
 class Point {
-  public:
+   public:
     //! \brief Constructor
     Point();
 
@@ -229,7 +229,7 @@ class Point {
     //! \return a string
     QString toCSVString();
 
-  private:
+   private:
     float m_x;
 
     float m_y;
@@ -239,7 +239,7 @@ class Point {
     //! \brief settings to apply at this point. Used in settings polygons/ regions
     QSharedPointer<SettingsBase> m_sb;
 
-}; // class Point
+};  // class Point
 
 Point operator*(const double lhs, const Point& rhs);
 Point operator*(const QMatrix4x4& lhs, const Point& rhs);
@@ -248,16 +248,17 @@ Point operator-(const Point& lhs, const Point& rhs);
 bool operator==(const Point& lhs, const Point& rhs);
 bool operator!=(const Point& lhs, const Point& rhs);
 bool operator<(const Point& lhs, const Point& rhs);
-} // namespace ORNL
+}  // namespace ORNL
 
 namespace std {
-template <> struct hash<ORNL::Point> {
+template <>
+struct hash<ORNL::Point> {
     size_t operator()(const ORNL::Point& pp) const {
         static int prime = 31;
-        int result = 89;
-        result = result * prime + pp.x();
-        result = result * prime + pp.y();
+        int result       = 89;
+        result           = result * prime + pp.x();
+        result           = result * prime + pp.y();
         return result;
     }
 };
-} // namespace std
+}  // namespace std

--- a/include/geometry/polygon.h
+++ b/include/geometry/polygon.h
@@ -22,7 +22,7 @@ class Polyline;
  * An individual polygon represented as a vector of points
  */
 class Polygon : public QVector<Point> {
-  public:
+   public:
     // QVector constructors
     using QVector<Point>::QVector;
 
@@ -179,5 +179,5 @@ class Polygon : public QVector<Point> {
     //! \brief operator for use with ClipperLib2
     ClipperLib2::Path operator()() const;
 
-}; // Class Polygon
-} // namespace ORNL
+};  // Class Polygon
+}  // namespace ORNL

--- a/include/geometry/polygon_list.h
+++ b/include/geometry/polygon_list.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QVector>
 #include <cstdint>
 
-#include <QVector>
 #include <clipper.hpp>
 #include <qcontainerfwd.h>
 #include <qpolygon.h>
@@ -27,7 +27,7 @@ const static int clipper_init = (0);
  * Ultimaker](https://github.com/Ultimaker/CuraEngine/blob/master/src/utils/polygon.h)
  */
 class PolygonList : public QVector<Polygon> {
-  public:
+   public:
     using QVector<Polygon>::QVector;
 
     PolygonList();
@@ -112,10 +112,10 @@ class PolygonList : public QVector<Polygon> {
      */
     QVector<PolygonList> splitIntoParts(bool unionAll = false) const;
 
-  private:
+   private:
     void splitIntoParts_processPolyTreeNode(ClipperLib2::PolyNode* node, QVector<PolygonList>& ret) const;
 
-  public:
+   public:
     //! \brief Removes overlapping consecutive line segments which don't
     //! delimit a positive area.
     PolygonList removeDegenerateVertices();
@@ -221,11 +221,11 @@ class PolygonList : public QVector<Polygon> {
     //! \brief Tracks geometry that is lost as a result of inward offsetting
     QVector<Polygon> lost_geometry;
 
-  protected:
+   protected:
     //! \brief Private operator for use with internal clipper functions
     ClipperLib2::Paths operator()() const;
 
-  private:
+   private:
     //! \brief Private constructor for use with internal clipper functions
     PolygonList(const ClipperLib2::Paths& paths);
 
@@ -321,6 +321,6 @@ class PolygonList : public QVector<Polygon> {
     using QVector<Polygon>::push_front;
     using QVector<Polygon>::insert;
 
-}; // class PolygonList
+};  // class PolygonList
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/polyline.h
+++ b/include/geometry/polyline.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
-
 #include <QVector3D>
 #include <QVector>
+#include <vector>
+
 #include <clipper.hpp>
 #include <qcontainerfwd.h>
 
@@ -21,7 +21,7 @@ class PolygonList;
  * \brief List of line segments that form an open path
  */
 class Polyline : public QVector<Point> {
-  public:
+   public:
     // QVector constructors.
     using QVector<Point>::QVector;
 
@@ -218,9 +218,9 @@ class Polyline : public QVector<Point> {
     friend class Polygon;
     friend class PolygonList;
 
-  private:
+   private:
     //! \brief Internal function used for Clipper to get a Clipper::Path
     //! from the current polyline
     ClipperLib2::Path operator()() const;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/segment_base.h
+++ b/include/geometry/segment_base.h
@@ -24,7 +24,7 @@ class WriterBase;
  * \brief Base class for all movements.
  */
 class SegmentBase {
-  public:
+   public:
     //! \brief Constructor
     SegmentBase(Point start, Point end);
 
@@ -167,10 +167,14 @@ class SegmentBase {
         SegmentInfoMeta() {}
 
         //! \brief Check if motion is in XY plane
-        bool isXYmove() { return start.x() != end.x() || start.y() != end.y(); }
+        bool isXYmove() {
+            return start.x() != end.x() || start.y() != end.y();
+        }
 
         //! \brief Compute Z motion change
-        float getZChange() { return end.z() - start.z(); }
+        float getZChange() {
+            return end.z() - start.z();
+        }
 
         //! \brief Compute the 2d angle along X axis (couter clock wise)
         float getCCWXAngle() {
@@ -180,12 +184,8 @@ class SegmentBase {
             float angle = 360;
             if (x != 0 || y != 0) {
                 float delta = 0;
-                if ((y >= 0 && x < 0) || (y < 0 && x < 0)) {
-                    delta = 180;
-                }
-                else if (y < 0 && x >= 0) {
-                    delta = 360;
-                }
+                if ((y >= 0 && x < 0) || (y < 0 && x < 0)) { delta = 180; }
+                else if (y < 0 && x >= 0) { delta = 360; }
 
                 angle = delta + atan(y / x) * 180 / 3.14159265358979323846;
             }
@@ -194,7 +194,7 @@ class SegmentBase {
         }
     } m_segment_info_meta;
 
-  protected:
+   protected:
     //! \brief  Start point for segment.
     Point m_start;
 
@@ -237,4 +237,4 @@ class SegmentBase {
     //! \brief Cylindrical axis used to orient true-width bead geometry.
     Point m_cylindrical_bead_center;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/segments/arc.h
+++ b/include/geometry/segments/arc.h
@@ -16,7 +16,7 @@ namespace ORNL {
  *  \brief Segment type for arc movements.
  */
 class ArcSegment : public SegmentBase {
-  public:
+   public:
     //! \brief Constructor
     ArcSegment(Point start, Point end, Point center, Angle angle, bool ccw);
 
@@ -106,7 +106,7 @@ class ArcSegment : public SegmentBase {
     //! \param shift: amount to shift by
     virtual void shift(Point shift) override;
 
-  private:
+   private:
     //! \brief recalculates angles based on points
     void updateAngle();
 
@@ -117,4 +117,4 @@ class ArcSegment : public SegmentBase {
     // CCW
     bool m_ccw;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/segments/bezier.h
+++ b/include/geometry/segments/bezier.h
@@ -16,7 +16,7 @@ namespace ORNL {
 //! \class BezierSegment
 //! \brief A segment type for a cubic bezier curve
 class BezierSegment : public SegmentBase {
-  public:
+   public:
     //! \brief Default Constructor
     BezierSegment();
 
@@ -89,9 +89,9 @@ class BezierSegment : public SegmentBase {
     //! \param shift: amount to shift by
     virtual void shift(Point shift) override;
 
-  private:
+   private:
     //! \brief Control points used to draw the curve
     Point m_control_a;
     Point m_control_b;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/segments/line.h
+++ b/include/geometry/segments/line.h
@@ -15,7 +15,7 @@ namespace ORNL {
  *  \brief Segment type for linear movements.
  */
 class LineSegment : public SegmentBase {
-  public:
+   public:
     //! \brief Constructor.
     LineSegment(Point start, Point end);
 
@@ -36,6 +36,6 @@ class LineSegment : public SegmentBase {
 };
 
 // Type definitions for shared pointers and lists of LineSegment
-using LSegmentPtr = QSharedPointer<LineSegment>;
+using LSegmentPtr  = QSharedPointer<LineSegment>;
 using LSegmentList = QVector<LSegmentPtr>;
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/segments/scan.h
+++ b/include/geometry/segments/scan.h
@@ -13,7 +13,7 @@ namespace ORNL {
  *  \brief Segment for scan movements.
  */
 class ScanSegment : public SegmentBase {
-  public:
+   public:
     //! \brief Constructor
     ScanSegment(Point start, Point end);
 
@@ -30,8 +30,8 @@ class ScanSegment : public SegmentBase {
     //! \brief must be implemented from segment_base, don't acutally need it
     float getMinZ() override;
 
-  private:
+   private:
     //! \brief boolean to track whether or not to trigger laser scanner
     bool m_on_off;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/segments/travel.h
+++ b/include/geometry/segments/travel.h
@@ -14,7 +14,7 @@ namespace ORNL {
  *  \brief Segment for travel movements.
  */
 class TravelSegment : public SegmentBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param start point
     //! \param end point
@@ -34,8 +34,8 @@ class TravelSegment : public SegmentBase {
     //! \brief returns minimum z-coordinate of the travel
     float getMinZ() override;
 
-  private:
+   private:
     //! private type to track what type of lift to apply to this particular travel
     TravelLiftType m_lift_type;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/settings_polygon.h
+++ b/include/geometry/settings_polygon.h
@@ -13,7 +13,7 @@ namespace ORNL {
  * \brief is a polygon that contains a settings. It is a cross-section of a settings mesh with part range info
  */
 class SettingsPolygon : public PolygonList {
-  public:
+   public:
     //! \brief Constructor
     SettingsPolygon() = default;
 
@@ -38,8 +38,8 @@ class SettingsPolygon : public PolygonList {
      */
     QSharedPointer<SettingsBase> getSettings() const;
 
-  private:
+   private:
     //! \brief the settings
     QSharedPointer<SettingsBase> m_sb;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -19,172 +19,136 @@ inline Point pointAlongSegment(const Point& start, const Point& end, double rati
 }
 
 inline Point stopPointOnClosingSegment(const Polyline& line, Distance distance_before_start) {
-    if (line.isEmpty()) {
-        return Point();
-    }
+    if (line.isEmpty()) { return Point(); }
 
-    const Point segment_start = line.back();
-    const Point segment_end = line.front();
+    const Point segment_start     = line.back();
+    const Point segment_end       = line.front();
     const Distance segment_length = segment_start.distance(segment_end);
 
-    if (segment_length <= distance_before_start) {
-        return segment_start;
-    }
+    if (segment_length <= distance_before_start) { return segment_start; }
 
     const double ratio = (segment_length() - distance_before_start()) / segment_length();
     return pointAlongSegment(segment_start, segment_end, ratio);
 }
 
 inline bool hasSmoothClosingSegment(const Polyline& line) {
-    if (line.size() < 3) {
-        return false;
-    }
+    if (line.size() < 3) { return false; }
 
     const Angle closing_angle = MathUtils::internalAngle(line[line.size() - 2], line.back(), line.front());
     return closing_angle >= (pi - (45 * deg));
 }
 
 inline Polyline reversePreservingStart(const Polyline& line) {
-    if (line.size() < 2) {
-        return line;
-    }
+    if (line.size() < 2) { return line; }
 
     Polyline reversed;
     reversed.reserve(line.size());
     reversed.push_back(line.front());
-    for (int i = line.size() - 1; i > 0; --i) {
-        reversed.push_back(line[i]);
-    }
+    for (int i = line.size() - 1; i > 0; --i) { reversed.push_back(line[i]); }
 
     return reversed;
 }
 
 inline void alignOrientation(Polyline& line, bool ccw) {
-    if (line.size() >= 3 && line.orientation() != ccw) {
-        line = reversePreservingStart(line);
-    }
+    if (line.size() >= 3 && line.orientation() != ccw) { line = reversePreservingStart(line); }
 }
 
 inline void rotateToClosestPoint(Polyline& line, const Point& query_point) {
-    if (line.size() < 2) {
-        return;
-    }
+    if (line.size() < 2) { return; }
 
     double closest_distance = std::numeric_limits<double>::max();
-    int rotation_index = 0;
+    int rotation_index      = 0;
     bool insert_split_point = false;
     Point split_point;
     int insertion_index = 0;
 
     for (int i = 0, end = line.size(); i < end; ++i) {
-        const int next_index = (i + 1) % line.size();
+        const int next_index           = (i + 1) % line.size();
         auto [closest_point, distance] = MathUtils::nearestPointOnSegment(line[i], line[next_index], query_point);
 
         if (distance < closest_distance) {
-            closest_distance = distance;
+            closest_distance   = distance;
             insert_split_point = false;
 
-            if (closest_point == line[i]) {
-                rotation_index = i;
-            }
-            else if (closest_point == line[next_index]) {
-                rotation_index = next_index;
-            }
+            if (closest_point == line[i]) { rotation_index = i; }
+            else if (closest_point == line[next_index]) { rotation_index = next_index; }
             else {
-                rotation_index = next_index;
+                rotation_index     = next_index;
                 insert_split_point = true;
-                split_point = closest_point;
-                insertion_index = next_index;
+                split_point        = closest_point;
+                insertion_index    = next_index;
             }
         }
     }
 
     if (insert_split_point) {
         const int previous_index = insertion_index == 0 ? line.size() - 1 : insertion_index - 1;
-        const int next_index = insertion_index % line.size();
+        const int next_index     = insertion_index % line.size();
 
-        if (split_point == line[previous_index]) {
-            rotation_index = previous_index;
-        }
-        else if (split_point == line[next_index]) {
-            rotation_index = next_index;
-        }
-        else {
-            line.insert(insertion_index, split_point);
-        }
+        if (split_point == line[previous_index]) { rotation_index = previous_index; }
+        else if (split_point == line[next_index]) { rotation_index = next_index; }
+        else { line.insert(insertion_index, split_point); }
     }
 
-    for (int i = 0; i < rotation_index; ++i) {
-        line.move(0, line.size() - 1);
-    }
+    for (int i = 0; i < rotation_index; ++i) { line.move(0, line.size() - 1); }
 }
 
 inline void rotateToClosestExistingPoint(Polyline& line, const Point& query_point) {
-    if (line.size() < 2) {
-        return;
-    }
+    if (line.size() < 2) { return; }
 
     double closest_distance = std::numeric_limits<double>::max();
-    int rotation_index = 0;
+    int rotation_index      = 0;
 
     for (int i = 0, end = line.size(); i < end; ++i) {
         const double distance = line[i].distance(query_point)();
         if (distance < closest_distance) {
             closest_distance = distance;
-            rotation_index = i;
+            rotation_index   = i;
         }
     }
 
-    for (int i = 0; i < rotation_index; ++i) {
-        line.move(0, line.size() - 1);
-    }
+    for (int i = 0; i < rotation_index; ++i) { line.move(0, line.size() - 1); }
 }
 
 inline void rotateToClosestForwardExistingPoint(Polyline& line, const Point& query_point, const Point& direction_start,
                                                 const Point& direction_end) {
-    if (line.size() < 2) {
-        return;
-    }
+    if (line.size() < 2) { return; }
 
-    const double direction_x = direction_end.x() - direction_start.x();
-    const double direction_y = direction_end.y() - direction_start.y();
+    const double direction_x         = direction_end.x() - direction_start.x();
+    const double direction_y         = direction_end.y() - direction_start.y();
     const double direction_length_sq = (direction_x * direction_x) + (direction_y * direction_y);
     if (direction_length_sq <= std::numeric_limits<double>::epsilon()) {
         rotateToClosestExistingPoint(line, query_point);
         return;
     }
 
-    double closest_distance = std::numeric_limits<double>::max();
+    double closest_distance          = std::numeric_limits<double>::max();
     double closest_fallback_distance = std::numeric_limits<double>::max();
-    int rotation_index = 0;
-    int fallback_index = 0;
-    bool found_forward_point = false;
+    int rotation_index               = 0;
+    int fallback_index               = 0;
+    bool found_forward_point         = false;
 
     for (int i = 0, end = line.size(); i < end; ++i) {
         const double candidate_x = line[i].x() - query_point.x();
         const double candidate_y = line[i].y() - query_point.y();
-        const double projection = (candidate_x * direction_x) + (candidate_y * direction_y);
-        const double distance = line[i].distance(query_point)();
+        const double projection  = (candidate_x * direction_x) + (candidate_y * direction_y);
+        const double distance    = line[i].distance(query_point)();
 
         if (distance < closest_fallback_distance) {
             closest_fallback_distance = distance;
-            fallback_index = i;
+            fallback_index            = i;
         }
 
         if (projection >= -std::numeric_limits<double>::epsilon() && distance < closest_distance) {
-            closest_distance = distance;
-            rotation_index = i;
+            closest_distance    = distance;
+            rotation_index      = i;
             found_forward_point = true;
         }
     }
 
-    if (!found_forward_point) {
-        rotation_index = fallback_index;
-    }
+    if (!found_forward_point) { rotation_index = fallback_index; }
 
-    for (int i = 0; i < rotation_index; ++i) {
-        line.move(0, line.size() - 1);
-    }
+    for (int i = 0; i < rotation_index; ++i) { line.move(0, line.size() - 1); }
 }
 
 inline Distance validWidthOrFallback(Distance width, Distance fallback_width) {
@@ -203,14 +167,10 @@ inline Point prepareConnector(const Polyline& current_loop, Polyline& next_loop,
             rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, current_loop.back(),
                                                 current_loop.front());
         }
-        else {
-            rotateToClosestPoint(next_loop, rough_connector_start);
-        }
+        else { rotateToClosestPoint(next_loop, rough_connector_start); }
     }
 
-    if (smooth_closing_segment || next_loop.isEmpty()) {
-        return rough_connector_start;
-    }
+    if (smooth_closing_segment || next_loop.isEmpty()) { return rough_connector_start; }
 
     return MathUtils::nearestPointOnSegment(current_loop.back(), current_loop.front(), next_loop.front()).first;
 }
@@ -221,50 +181,38 @@ struct StitchLoop {
 };
 
 inline bool closedPolylineContainsAnyPoint(Polyline container, const Polyline& points) {
-    if (container.size() < 3 || points.isEmpty()) {
-        return false;
-    }
+    if (container.size() < 3 || points.isEmpty()) { return false; }
 
-    if (container.front() != container.back()) {
-        container.push_back(container.front());
-    }
+    if (container.front() != container.back()) { container.push_back(container.front()); }
 
     for (const Point& point : points) {
-        if (container.inside(point, true)) {
-            return true;
-        }
+        if (container.inside(point, true)) { return true; }
     }
 
     return false;
 }
 
 inline bool loopsAreNested(const Polyline& lhs, const Polyline& rhs) {
-    if (lhs.size() < 3 || rhs.size() < 3) {
-        return false;
-    }
+    if (lhs.size() < 3 || rhs.size() < 3) { return false; }
 
     return closedPolylineContainsAnyPoint(lhs, rhs) || closedPolylineContainsAnyPoint(rhs, lhs);
 }
 
 inline bool canConnectLoops(const StitchLoop& current_loop, const StitchLoop& next_loop, const Point& connector_start,
                             Distance stop_distance) {
-    if (!loopsAreNested(current_loop.loop, next_loop.loop)) {
-        return false;
-    }
+    if (!loopsAreNested(current_loop.loop, next_loop.loop)) { return false; }
 
-    const Distance connector_length = connector_start.distance(next_loop.loop.front());
+    const Distance connector_length   = connector_start.distance(next_loop.loop.front());
     const double max_connector_length = std::max(stop_distance() * 2.0, 1.0e-6);
     return connector_length() <= max_connector_length;
 }
-} // namespace detail
+}  // namespace detail
 
 /*!
  * \brief Returns the length of a polyline treated as a closed loop.
  */
 inline Distance closedPolylineLength(const Polyline& line) {
-    if (line.size() < 2) {
-        return 0;
-    }
+    if (line.size() < 2) { return 0; }
 
     return line.length() + line.back().distance(line.front());
 }
@@ -296,10 +244,10 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
     }
 
     bool has_reference_orientation = false;
-    bool reference_orientation = false;
+    bool reference_orientation     = false;
     for (const detail::StitchLoop& stitch_loop : loops) {
         if (stitch_loop.loop.size() >= 3) {
-            reference_orientation = stitch_loop.loop.orientation();
+            reference_orientation     = stitch_loop.loop.orientation();
             has_reference_orientation = true;
             break;
         }
@@ -313,24 +261,18 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
     QVector<Polyline> spiral_groups;
     Polyline spiral;
 
-    while (!loops.isEmpty() && loops.front().loop.size() < 3) {
-        loops.removeFirst();
-    }
+    while (!loops.isEmpty() && loops.front().loop.size() < 3) { loops.removeFirst(); }
 
-    if (loops.isEmpty()) {
-        return spiral_groups;
-    }
+    if (loops.isEmpty()) { return spiral_groups; }
 
     detail::StitchLoop current_loop = loops.takeFirst();
     while (true) {
         spiral += current_loop.loop;
 
-        while (!loops.isEmpty() && loops.front().loop.size() < 3) {
-            loops.removeFirst();
-        }
+        while (!loops.isEmpty() && loops.front().loop.size() < 3) { loops.removeFirst(); }
 
         if (!loops.isEmpty()) {
-            detail::StitchLoop next_loop = loops.takeFirst();
+            detail::StitchLoop next_loop          = loops.takeFirst();
             detail::StitchLoop prepared_next_loop = next_loop;
             const Distance stop_distance =
                 detail::transitionDistance(current_loop.width, next_loop.width, fallback_width);
@@ -338,18 +280,14 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
                 detail::prepareConnector(current_loop.loop, prepared_next_loop.loop, stop_distance);
 
             if (detail::canConnectLoops(current_loop, prepared_next_loop, connector_start, stop_distance)) {
-                if (spiral.back() != connector_start) {
-                    spiral += connector_start;
-                }
+                if (spiral.back() != connector_start) { spiral += connector_start; }
                 current_loop = prepared_next_loop;
             }
             else {
                 const Point final_stop = detail::stopPointOnClosingSegment(
                     current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
 
-                if (spiral.back() != final_stop) {
-                    spiral += final_stop;
-                }
+                if (spiral.back() != final_stop) { spiral += final_stop; }
                 spiral_groups.push_back(spiral);
                 spiral.clear();
                 current_loop = next_loop;
@@ -359,9 +297,7 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
             const Point final_stop = detail::stopPointOnClosingSegment(
                 current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
 
-            if (spiral.back() != final_stop) {
-                spiral += final_stop;
-            }
+            if (spiral.back() != final_stop) { spiral += final_stop; }
             spiral_groups.push_back(spiral);
             break;
         }
@@ -374,9 +310,7 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
                                                   Distance final_stop_distance) {
     QVector<Distance> loop_widths;
     loop_widths.reserve(ordered_loops.size());
-    for (int i = 0, end = ordered_loops.size(); i < end; ++i) {
-        loop_widths.push_back(final_stop_distance);
-    }
+    for (int i = 0, end = ordered_loops.size(); i < end; ++i) { loop_widths.push_back(final_stop_distance); }
 
     return linkClosedPolylineGroups(ordered_loops, loop_widths, final_stop_distance);
 }
@@ -398,10 +332,10 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, cons
     }
 
     bool has_reference_orientation = false;
-    bool reference_orientation = false;
+    bool reference_orientation     = false;
     for (const detail::StitchLoop& stitch_loop : loops) {
         if (stitch_loop.loop.size() >= 3) {
-            reference_orientation = stitch_loop.loop.orientation();
+            reference_orientation     = stitch_loop.loop.orientation();
             has_reference_orientation = true;
             break;
         }
@@ -414,21 +348,15 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, cons
 
     Polyline spiral;
 
-    while (!loops.isEmpty() && loops.front().loop.size() < 3) {
-        loops.removeFirst();
-    }
+    while (!loops.isEmpty() && loops.front().loop.size() < 3) { loops.removeFirst(); }
 
-    if (loops.isEmpty()) {
-        return spiral;
-    }
+    if (loops.isEmpty()) { return spiral; }
 
     detail::StitchLoop current_loop = loops.takeFirst();
     while (true) {
         spiral += current_loop.loop;
 
-        while (!loops.isEmpty() && loops.front().loop.size() < 3) {
-            loops.removeFirst();
-        }
+        while (!loops.isEmpty() && loops.front().loop.size() < 3) { loops.removeFirst(); }
 
         if (!loops.isEmpty()) {
             detail::StitchLoop next_loop = loops.takeFirst();
@@ -436,9 +364,7 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, cons
                 detail::transitionDistance(current_loop.width, next_loop.width, fallback_width);
             const Point connector_start = detail::prepareConnector(current_loop.loop, next_loop.loop, stop_distance);
 
-            if (spiral.back() != connector_start) {
-                spiral += connector_start;
-            }
+            if (spiral.back() != connector_start) { spiral += connector_start; }
 
             current_loop = next_loop;
         }
@@ -446,9 +372,7 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, cons
             const Point final_stop = detail::stopPointOnClosingSegment(
                 current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
 
-            if (spiral.back() != final_stop) {
-                spiral += final_stop;
-            }
+            if (spiral.back() != final_stop) { spiral += final_stop; }
             break;
         }
     }
@@ -462,49 +386,37 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Dist
 
     for (int loop_index = 0, end = loops.size(); loop_index < end; ++loop_index) {
         const Polyline& loop = loops[loop_index];
-        if (loop.size() < 3) {
-            continue;
-        }
+        if (loop.size() < 3) { continue; }
 
         spiral += loop;
 
         if (loop_index + 1 < end) {
-            Polyline next_loop = loops[loop_index + 1];
-            Point rough_connector_start = detail::stopPointOnClosingSegment(loop, final_stop_distance);
+            Polyline next_loop                = loops[loop_index + 1];
+            Point rough_connector_start       = detail::stopPointOnClosingSegment(loop, final_stop_distance);
             const bool smooth_closing_segment = detail::hasSmoothClosingSegment(loop);
             if (smooth_closing_segment) {
                 detail::rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, loop.back(),
                                                             loop.front());
             }
-            else {
-                detail::rotateToClosestPoint(next_loop, rough_connector_start);
-            }
+            else { detail::rotateToClosestPoint(next_loop, rough_connector_start); }
             const Point next_start = next_loop.front();
             Point connector_start;
-            if (smooth_closing_segment) {
-                connector_start = rough_connector_start;
-            }
-            else {
-                connector_start = MathUtils::nearestPointOnSegment(loop.back(), loop.front(), next_start).first;
-            }
+            if (smooth_closing_segment) { connector_start = rough_connector_start; }
+            else { connector_start = MathUtils::nearestPointOnSegment(loop.back(), loop.front(), next_start).first; }
 
-            if (spiral.back() != connector_start) {
-                spiral += connector_start;
-            }
+            if (spiral.back() != connector_start) { spiral += connector_start; }
 
             loops[loop_index + 1] = next_loop;
         }
         else {
             const Point final_stop = detail::stopPointOnClosingSegment(loop, final_stop_distance);
 
-            if (spiral.back() != final_stop) {
-                spiral += final_stop;
-            }
+            if (spiral.back() != final_stop) { spiral += final_stop; }
         }
     }
 
     return spiral;
 }
 
-} // namespace SpiralPath
-} // namespace ORNL
+}  // namespace SpiralPath
+}  // namespace ORNL

--- a/include/graphics/base_view.h
+++ b/include/graphics/base_view.h
@@ -4,6 +4,7 @@
 #include <QOpenGLFunctions_3_3_Core>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLWidget>
+
 #include <qevent.h>
 #include <qlist.h>
 #include <qmatrix4x4.h>
@@ -32,7 +33,7 @@ class GCodeObject;
  */
 class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     Q_OBJECT
-  public:
+   public:
     //! \brief Initialize printer OpenGL buffers, projection and view matrices, part picker, and shader program
     //! \param parent QWidget that has to be passed to superclass constructor
     BaseView(QWidget* parent = nullptr);
@@ -101,7 +102,7 @@ class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     //! \return The camera object.
     QSharedPointer<CameraManager> camera();
 
-  protected:
+   protected:
     /*!
      * \title Object Methods
      * \brief The following functions relate to the addition and remove of objects.
@@ -215,7 +216,7 @@ class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     //! \brief Shows camera focus.
     QSharedPointer<AxesObject> m_focus;
 
-  private:
+   private:
     //! \brief OpenGL setup.
     void initializeGL() override;
 
@@ -251,4 +252,4 @@ class BaseView : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core {
     QList<QSharedPointer<GraphicsObject>> m_render_objects;
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/graphics_object.h
+++ b/include/graphics/graphics_object.h
@@ -2,14 +2,14 @@
 
 #include <GL/gl.h>
 
-#include <vector>
-
 #include <QMatrix4x4>
 #include <QOpenGLBuffer>
 #include <QOpenGLTexture>
 #include <QOpenGLVertexArrayObject>
 #include <QPointer>
 #include <QQueue>
+#include <vector>
+
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qimage.h>
@@ -48,7 +48,9 @@ struct Triangle {
     QVector3D c;
 
     // Allows access to struct members with index.
-    inline QVector3D& operator[](uint index) { return *((QVector3D*)(this) + index); }
+    inline QVector3D& operator[](uint index) {
+        return *((QVector3D*)(this) + index);
+    }
 };
 
 /*!
@@ -72,12 +74,12 @@ struct Triangle {
  * and translated to allow for this motion.
  */
 class GraphicsObject : public QEnableSharedFromThis<GraphicsObject> {
-  public:
+   public:
     //! \brief Construct object from GL data.
     GraphicsObject(BaseView* view, const std::vector<float>& vertices, const std::vector<float>& normals,
                    const std::vector<float>& colors, const ushort render_mode = GL_TRIANGLES,
                    const std::vector<float>& uv = std::vector<float>(),
-                   const QImage texture = QImage(":/textures/blank_texture.png"));
+                   const QImage texture         = QImage(":/textures/blank_texture.png"));
 
     //! \brief Destructor.
     ~GraphicsObject();
@@ -203,7 +205,7 @@ class GraphicsObject : public QEnableSharedFromThis<GraphicsObject> {
     //! \brief Gets object transparency.
     uint transparency();
 
-  protected:
+   protected:
     //! \brief Empty constructor. Only for derived classes.
     GraphicsObject();
 
@@ -211,7 +213,7 @@ class GraphicsObject : public QEnableSharedFromThis<GraphicsObject> {
     void populateGL(BaseView* view, const std::vector<float>& vertices, const std::vector<float>& normals,
                     const std::vector<float>& colors, const ushort render_mode = GL_TRIANGLES,
                     const std::vector<float>& uv = std::vector<float>(),
-                    const QImage texture = QImage(":/textures/blank_texture.png"));
+                    const QImage texture         = QImage(":/textures/blank_texture.png"));
 
     //! \brief The actual call to OpenGL to draw the object.
     //! \note This function is virtual to permit objects to render as they see fit. The default proceedure
@@ -319,7 +321,7 @@ class GraphicsObject : public QEnableSharedFromThis<GraphicsObject> {
     //! \brief If this object is selected or not.
     bool m_selected = false;
 
-  private:
+   private:
     //! \brief Set the global transformation. This is an internal function to enforce updating of
     //!        transform components.
     void setTransformationInternal(QMatrix4x4 mtrx, bool propagate = true);
@@ -357,4 +359,4 @@ class GraphicsObject : public QEnableSharedFromThis<GraphicsObject> {
     QVector<QVector3D> m_transformed_mbb;
 };
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/graphics/objects/arrow_object.h
+++ b/include/graphics/objects/arrow_object.h
@@ -15,7 +15,7 @@ namespace ORNL {
  * \brief A arrow drawn using GL_LINES. Mostly used to draw parenting relationships between parts.
  */
 class ArrowObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param view: View to render to.
     //! \param begin: Beginning point.
@@ -39,7 +39,7 @@ class ArrowObject : public GraphicsObject {
     //! \brief If tracking, update the arrow to the object center locations.
     void updateEndpoints();
 
-  private:
+   private:
     //! \brief Initalizes arrow.
     void initArrow(BaseView* view);
     //! \brief Finds a transform for the arrow between the beginning and end.
@@ -61,4 +61,4 @@ class ArrowObject : public GraphicsObject {
     //! \brief Color
     QColor m_color;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/axes_object.h
+++ b/include/graphics/objects/axes_object.h
@@ -7,7 +7,7 @@ namespace ORNL {
  * \brief Object that draws a set of coordinate arrows in the XYZ directions. A very commonly used object.
  */
 class AxesObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param view: View to render to.
     //! \param axis_length: GL length of the axes.
@@ -17,8 +17,8 @@ class AxesObject : public GraphicsObject {
     //! \param axis_length: GL length of the axes.
     void updateDimensions(float axis_length);
 
-  private:
+   private:
     //! \brief Length that object starts with. For scaling.
     float m_starting_length;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/cube/plane_object.h
+++ b/include/graphics/objects/cube/plane_object.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QColor>
+
 #include <qquaternion.h>
 
 #include "graphics/graphics_object.h"
@@ -13,7 +14,7 @@ namespace ORNL {
  * The plane object is another commonly used object. It has the ability to lock itself to a specific rotation.
  */
 class PlaneObject : public CubeObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param length: Plane length.
     //! \param width: Plane width.
@@ -40,11 +41,11 @@ class PlaneObject : public CubeObject {
     //! \brief Scales the plane to a new length/width/thickness.
     void updateDimensions(float length, float width, float height);
 
-  protected:
+   protected:
     //! \brief Handles plane rotation locking.
     void transformationCallback();
 
-  private:
+   private:
     //! \brief Starting dims.
     float m_starting_length;
     float m_starting_width;
@@ -58,4 +59,4 @@ class PlaneObject : public CubeObject {
     //! \brief If locked or not.
     bool m_rotation_toggle = false;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/cube_object.h
+++ b/include/graphics/objects/cube_object.h
@@ -28,7 +28,7 @@ namespace ORNL {
  *  auto goc = QSharedPointer<CubeObject>::create(this, 20, 10, 7, Constants::Colors::kWhite, GL_TRIANGLES, text);
  */
 class CubeObject : public GraphicsObject {
-  public:
+   public:
     /*!
      * \brief Constructor for object.
      * \param view: View this object is drawn on.
@@ -44,7 +44,7 @@ class CubeObject : public GraphicsObject {
     CubeObject(BaseView* view, float length, float width, float height, QColor color, ushort render_mode = GL_TRIANGLES,
                const QVector<QImage>& textures = QVector<QImage>());
 
-  protected:
+   protected:
     //! \brief Dims
     float m_length;
     float m_width;
@@ -53,4 +53,4 @@ class CubeObject : public GraphicsObject {
     //! \brief Cube texture.
     QVector<QImage> m_textures;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/cylinder/cylinder_plane_object.h
+++ b/include/graphics/objects/cylinder/cylinder_plane_object.h
@@ -10,7 +10,7 @@ namespace ORNL {
  * \brief A plane object that is a circle.
  */
 class CylinderPlaneObject : public CylinderObject {
-  public:
+   public:
     //! \brief Constructor.
     //! \param view: View to render to.
     //! \param radius: Plane radius.
@@ -33,10 +33,10 @@ class CylinderPlaneObject : public CylinderObject {
     //! \todo Inner radius is currently unused.
     void updateDimensions(float outer_radius, float inner_radius = -1);
 
-  private:
+   private:
     //! \brief Radius
     float m_starting_outer_radius;
     //! \brief Color
     QColor m_color;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/cylinder_object.h
+++ b/include/graphics/objects/cylinder_object.h
@@ -11,7 +11,7 @@ namespace ORNL {
  * This class is a base object type that can be used as primative for other objects.
  */
 class CylinderObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor.
     //! \param view: View to render to.
     //! \param radius: GL radius of cylinder.
@@ -27,10 +27,10 @@ class CylinderObject : public GraphicsObject {
     //! \todo Shape factory needs support for inner radius for this constructor to be useful.
     CylinderObject(BaseView* view, float outer_radius, float inner_radius, float height, QColor color);
 
-  private:
+   private:
     //! \brief Dims
     float m_inner_radius;
     float m_outer_radius;
     float m_height;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/gcode_object.h
+++ b/include/graphics/objects/gcode_object.h
@@ -29,7 +29,7 @@ namespace ORNL {
  * This unfortunately increases complexity of the object by a significant amount.
  */
 class GCodeObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor.
     //! \param view: View to render to.
     //! \param gcode: GCode segments to visualize.
@@ -40,7 +40,7 @@ class GCodeObject : public GraphicsObject {
     //! \param update_segment_info: If true, this object owns the segment info control's backing g-code.
     GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentBase>>> gcode,
                 QSharedPointer<GCodeInfoControl> segmentInfoControl, bool use_true_widths,
-                GCodePreviewMode preview_mode = GCodePreviewMode::kAuto,
+                GCodePreviewMode preview_mode         = GCodePreviewMode::kAuto,
                 qsizetype true_width_vertex_threshold = 5000000, bool update_segment_info = true);
 
     //! \brief Destructor.
@@ -108,11 +108,11 @@ class GCodeObject : public GraphicsObject {
     //! \brief Returns true when this object renders printable segments as lightweight lines.
     bool isLightweight() const;
 
-  protected:
+   protected:
     //! \brief Overridden draw call to allow segment hiding.
     void draw();
 
-  private:
+   private:
     //! \brief Render buffer that contains a segment's vertices.
     enum class SegmentRenderBuffer { kPrimary, kTravelLine };
 
@@ -209,4 +209,4 @@ class GCodeObject : public GraphicsObject {
     //! \brief Segment / Bead info display control
     QSharedPointer<GCodeInfoControl> m_segment_info_control;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/grid_object.h
+++ b/include/graphics/objects/grid_object.h
@@ -12,7 +12,7 @@ namespace ORNL {
  * \brief Displays a grid on a plane.
  */
 class GridObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor.
     //! \param length: Plane length.
     //! \param width: Plane width.
@@ -33,7 +33,7 @@ class GridObject : public GraphicsObject {
     //! grid.
     std::vector<Triangle> triangles();
 
-  private:
+   private:
     //! \brief Grid dims.
     float m_length;
     float m_width;
@@ -46,4 +46,4 @@ class GridObject : public GraphicsObject {
     //! \brief Vertices used to check for cast rays.
     std::vector<float> m_collision_vertices;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/part_object.h
+++ b/include/graphics/objects/part_object.h
@@ -3,6 +3,7 @@
 #include <GL/gl.h>
 
 #include <QColor>
+
 #include <qhashfunctions.h>
 #include <qset.h>
 #include <qsharedpointer.h>
@@ -30,7 +31,7 @@ class TextObject;
  * mesh types, and transparency.
  */
 class PartObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor.
     //! \param view: View to render object to.
     //! \param p: Part to extract geometry from.
@@ -85,7 +86,7 @@ class PartObject : public GraphicsObject {
     //! \brief Gets the mesh part pointer.
     QSharedPointer<Part> part();
 
-  protected:
+   protected:
     void draw() override;
     //! \brief Updates the overhang coloring. Called after rotations/translations.
     void overhangUpdate();
@@ -101,7 +102,7 @@ class PartObject : public GraphicsObject {
     //! \brief Paints a color while taking transparency/overhangs into account.
     void paint(QColor color) override;
 
-  private:
+   private:
     //! \brief Sorts triangle vertex, normal, and color buffers from back to front for transparent rendering.
     //!
     //! Transparent triangle blending is order-dependent. Sorting by view-space depth before drawing reduces dark
@@ -134,4 +135,4 @@ class PartObject : public GraphicsObject {
     //! \brief If overhang angles are shown or not.
     bool m_overhang_shown = false;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/graphics/objects/printer/cartesian_printer_object.h
+++ b/include/graphics/objects/printer/cartesian_printer_object.h
@@ -17,7 +17,7 @@ class PlaneObject;
  * \brief Printer that uses cartesian coordinates.
  */
 class CartesianPrinterObject : public PrinterObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param view: View to render to.
     //! \param sb: Settings to use.
@@ -31,13 +31,13 @@ class CartesianPrinterObject : public PrinterObject {
     //! \brief List of parts that are external to the build volume.
     QList<QSharedPointer<PartObject>> externalParts();
 
-  protected:
+   protected:
     //! \brief Hook for updating member variables.
     void updateMembers();
     //! \brief Hook for updating printer geometry.
     void updateGeometry();
 
-  private:
+   private:
     //! \brief Dims
     QVector3D m_min;
     QVector3D m_max;
@@ -54,4 +54,4 @@ class CartesianPrinterObject : public PrinterObject {
     //! \brief Reflective floor surface.
     QSharedPointer<PlaneObject> m_floor_plane;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/printer/cylindrical_printer_object.h
+++ b/include/graphics/objects/printer/cylindrical_printer_object.h
@@ -17,7 +17,7 @@ class CylinderPlaneObject;
  * \brief Printer that uses cylindrical coordinates.
  */
 class CylindricalPrinterObject : public PrinterObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param view: View to render to.
     //! \param sb: Settings to use.
@@ -31,13 +31,13 @@ class CylindricalPrinterObject : public PrinterObject {
     //! \brief List of parts that are external to the build volume.
     QList<QSharedPointer<PartObject>> externalParts();
 
-  protected:
+   protected:
     //! \brief Hook for updating member variables.
     void updateMembers();
     //! \brief Hook for updating printer geometry.
     void updateGeometry();
 
-  private:
+   private:
     //! \brief Dims
     float m_radius;
     float m_height;
@@ -52,4 +52,4 @@ class CylindricalPrinterObject : public PrinterObject {
     //! \brief Reflective floor surface.
     QSharedPointer<CylinderPlaneObject> m_floor_plane;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/printer/printer_object.h
+++ b/include/graphics/objects/printer/printer_object.h
@@ -3,6 +3,7 @@
 #include <QMatrix4x4>
 #include <QPointF>
 #include <QString>
+
 #include <qlist.h>
 #include <qsharedpointer.h>
 #include <qvectornd.h>
@@ -22,14 +23,16 @@ class SeamObject;
  * the derived classes.
  */
 class PrinterObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Pick result for draggable optimization point graphics.
     struct OptimizationPointPick {
         QSharedPointer<SeamObject> object;
         QString x_setting;
         QString y_setting;
 
-        bool isValid() const { return !object.isNull(); }
+        bool isValid() const {
+            return !object.isNull();
+        }
     };
 
     //! \brief Update this printer using new settings.
@@ -68,7 +71,7 @@ class PrinterObject : public GraphicsObject {
     //! \return the default zoom in OpenGL space
     float getDefaultZoom();
 
-  protected:
+   protected:
     //! \brief Empty constructor (for derived classes).
     PrinterObject(bool is_true_volume);
 
@@ -94,7 +97,7 @@ class PrinterObject : public GraphicsObject {
     //! \brief the max dim of the printer
     QVector3D m_printer_max_dims;
 
-  private:
+   private:
     //! \brief If seams are shown.
     bool m_seams_shown = false;
 
@@ -116,4 +119,4 @@ class PrinterObject : public GraphicsObject {
         QSharedPointer<GraphicsObject> custom_point_second_guide;
     } m_seams;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/sphere/seam_object.h
+++ b/include/graphics/objects/sphere/seam_object.h
@@ -12,10 +12,10 @@ namespace ORNL {
  * For use as a seam graphic.
  */
 class SeamObject : public SphereObject {
-  public:
+   public:
     //! \brief Constructor.
     //! \param view: View to render to.
     //! \param color: Color of the object.
     SeamObject(BaseView* view, QColor color);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/sphere_object.h
+++ b/include/graphics/objects/sphere_object.h
@@ -14,7 +14,7 @@ namespace ORNL {
  * This class is a base object type that can be used as primative for other objects.
  */
 class SphereObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param view: View to render to.
     //! \param radius: OpenGL radius.
@@ -22,8 +22,8 @@ class SphereObject : public GraphicsObject {
     //! \param render_mode: OpenGL render mode. Use GL_TRIANGLES, GL_LINES, etc.
     SphereObject(BaseView* view, float radius, QColor color, ushort render_mode = GL_TRIANGLES);
 
-  private:
+   private:
     //! \brief Radius
     float m_radius;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/objects/text_object.h
+++ b/include/graphics/objects/text_object.h
@@ -9,7 +9,7 @@ namespace ORNL {
  * \brief A graphic that renders a cube with a text texture. The object billboards to the camera if enabled.
  */
 class TextObject : public GraphicsObject {
-  public:
+   public:
     //! \brief Constructor
     //! \param view: The view this object renders to.
     //! \param str: String to display.
@@ -21,8 +21,8 @@ class TextObject : public GraphicsObject {
     //! \param str: String to display.
     void setText(QString str);
 
-  private:
+   private:
     //! \brief String
     QString m_str;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/support/camera_manager.h
+++ b/include/graphics/support/camera_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMatrix4x4>
+
 #include <qpoint.h>
 #include <qvectornd.h>
 
@@ -12,7 +13,7 @@ namespace ORNL {
  * \brief Manages the camera for an OpenGL widget
  */
 class CameraManager {
-  public:
+   public:
     //! \brief Constructor
     CameraManager();
 
@@ -78,7 +79,7 @@ class CameraManager {
     //! \return the default zoom
     float getDefaultZoom();
 
-  private:
+   private:
     //! \brief Update the view matrix after new data is available.
     void updateViewMatrix();
 
@@ -88,10 +89,10 @@ class CameraManager {
     QVector3D m_pan;
 
     float m_default_zoom = Constants::OpenGL::kZoomDefault;
-    float m_max_zoom = Constants::OpenGL::kZoomMax;
+    float m_max_zoom     = Constants::OpenGL::kZoomMax;
 
     float m_pitch = 0;
-    float m_yaw = 0;
+    float m_yaw   = 0;
 
     QPointF m_drag_start;
 
@@ -103,6 +104,6 @@ class CameraManager {
     //! \brief View matrix that represents the translation and rotation of the camera
     QMatrix4x4 m_view;
 
-}; // class CameraManager
+};  // class CameraManager
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/support/part_picker.h
+++ b/include/graphics/support/part_picker.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <tuple>
-#include <vector>
-
 #include <QMatrix4x4>
 #include <QPointF>
 #include <QVector3D>
+#include <tuple>
+#include <vector>
 
 #include "graphics/graphics_object.h"
 
@@ -29,9 +28,11 @@ std::tuple<float, Triangle> pickDistanceAndTriangle(const QMatrix4x4& projection
                                                     bool ortho = false);
 
 //! \brief Returns the distance to the nearest triangle, the nearest triangle iself, and the point of intersection.
-std::tuple<float, Triangle, QVector3D>
-pickDistanceTriangleAndIntersection(const QMatrix4x4& projection, const QMatrix4x4& view, QPointF ndc_mouse_pos,
-                                    const std::vector<Triangle>& triangles, bool ortho = false);
+std::tuple<float, Triangle, QVector3D> pickDistanceTriangleAndIntersection(const QMatrix4x4& projection,
+                                                                           const QMatrix4x4& view,
+                                                                           QPointF ndc_mouse_pos,
+                                                                           const std::vector<Triangle>& triangles,
+                                                                           bool ortho = false);
 
 //! \brief Calculate distance from nearest triangle in the vector to the mouse point
 float pickDistance(const QMatrix4x4& projection, const QMatrix4x4& view, QPointF ndc_mouse_pos,
@@ -58,5 +59,5 @@ float findDistanceToTriangle(const QVector3D& ray_start, const QVector3D& ray_di
  */
 std::tuple<QVector3D, QVector3D> getDirectionAndStart(const QMatrix4x4& projection, QPointF ndc_mouse_pos,
                                                       const QMatrix4x4& view, bool ortho);
-} // namespace PartPicker
-} // namespace ORNL
+}  // namespace PartPicker
+}  // namespace ORNL

--- a/include/graphics/support/shape_factory.h
+++ b/include/graphics/support/shape_factory.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <vector>
-
 #include <QColor>
 #include <QMatrix4x4>
 #include <QVector3D>
+#include <vector>
 
 #include "geometry/point.h"
 
@@ -14,7 +13,7 @@ namespace ORNL {
 //! All creation functions append to the supplied vectors so callers can build combined meshes without intermediate
 //! allocations.
 class ShapeFactory final {
-  public:
+   public:
     ShapeFactory() = delete;
 
     //! @name Closed Triangle Meshes
@@ -255,7 +254,7 @@ class ShapeFactory final {
 
     //! @}
 
-  private:
+   private:
     /*! @brief Computes the transform that places a local +Z bead mesh between two endpoints.
      *  @param start Segment start point.
      *  @param end Segment end point.
@@ -272,4 +271,4 @@ class ShapeFactory final {
     static QMatrix4x4 computeLinearBeadTransform(const QVector3D& start, const QVector3D& end,
                                                  const QVector3D& normal_hint);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/view/gcode_view.h
+++ b/include/graphics/view/gcode_view.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QVector>
 #include <limits>
 
-#include <QVector>
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qmap.h>
@@ -34,7 +34,7 @@ class SeamObject;
  */
 class GCodeView : public BaseView {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: Settings to use.
     //! \param segmentInfoControl: Segment info display control
@@ -58,7 +58,7 @@ class GCodeView : public BaseView {
     //! \brief Set camera to view from an isometric direction.
     void setIsoView();
 
-  public slots:
+   public slots:
     //! \brief Changes the view to use an orthographic projection instead of the normal perspective view.
     void useOrthographic(bool ortho);
 
@@ -116,7 +116,7 @@ class GCodeView : public BaseView {
     //! \brief Moves the camera to its default zoom and orientation.
     virtual void resetCamera() override;
 
-  signals:
+   signals:
     //! \brief Notification that a draggable optimization point setting edit has started.
     void optimizationPointDragStarted(QString x_setting, QString y_setting);
 
@@ -135,7 +135,7 @@ class GCodeView : public BaseView {
     //! \param max: new max segments
     void maxSegmentChanged(uint max);
 
-  protected:
+   protected:
     //! \brief Initalizes the view with the printer and the associated objects.
     void initView() override;
 
@@ -178,7 +178,7 @@ class GCodeView : public BaseView {
     //! \brief Handles the following: Orthographic out zoom
     void handleWheelBackward(QPointF mouse_ndc_pos, float delta) override;
 
-  private:
+   private:
     //! \brief Enables hover tracking only when the visible segment count is small enough for interactive picking.
     void updateHoverTracking();
 
@@ -286,13 +286,13 @@ class GCodeView : public BaseView {
 
     //! \brief Cache key for the visible-range true-width overlay.
     struct TrueWidthOverlayKey {
-        uint low_layer = 0;
-        uint high_layer = 0;
-        uint low_segment = 0;
-        uint high_segment = 0;
+        uint low_layer                = 0;
+        uint high_layer               = 0;
+        uint low_segment              = 0;
+        uint high_segment             = 0;
         GCodePreviewMode preview_mode = GCodePreviewMode::kAuto;
-        int vertex_threshold = 0;
-        bool use_true_widths = false;
+        int vertex_threshold          = 0;
+        bool use_true_widths          = false;
 
         bool operator==(const TrueWidthOverlayKey& other) const {
             return low_layer == other.low_layer && high_layer == other.high_layer && low_segment == other.low_segment &&
@@ -307,4 +307,4 @@ class GCodeView : public BaseView {
     //! \brief Segment / Bead info display control
     QSharedPointer<GCodeInfoControl> m_segment_info_control;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/graphics/view/part_view.h
+++ b/include/graphics/view/part_view.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QElapsedTimer>
+
 #include <qhashfunctions.h>
 #include <qlist.h>
 #include <qmap.h>
@@ -40,7 +41,7 @@ class RightClickMenu;
  */
 class PartView : public BaseView {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor for the view.
     //! \param sb: Settings to use for the print volume and other affected elements.
     PartView(QSharedPointer<SettingsBase> sb);
@@ -55,7 +56,7 @@ class PartView : public BaseView {
     //! \brief Returns the list of parts that are outside the build volume.
     QList<QSharedPointer<Part>> externalParts();
 
-  public slots:
+   public slots:
     //! \brief Shows or hides part labels.
     void showLabels(bool show);
 
@@ -117,7 +118,7 @@ class PartView : public BaseView {
     //! \brief Moves the camera to its default zoom and orientation.
     virtual void resetCamera() override;
 
-  signals:
+   signals:
     //! \brief Notification of parts that are outside and/or not aligned. Emitted after translations.
     void positioningIssues(QList<QSharedPointer<Part>> opl, QList<QSharedPointer<Part>> fpl);
 
@@ -136,7 +137,7 @@ class PartView : public BaseView {
     //! \brief Emitted when a measurement is committed by choosing the second point.
     void measurementCompleted(QString readout);
 
-  protected:
+   protected:
     //! \brief Initalizes the view with the printer and the associated objects.
     void initView() override;
 
@@ -200,7 +201,7 @@ class PartView : public BaseView {
     //! \brief Finishes an active optimization point drag.
     void finishOptimizationPointDrag(QPointF mouse_ndc_pos);
 
-  private slots:
+   private slots:
     //! \brief Recieves updates from model about selections.
     //! \param pm: The item that was just updated.
     void modelSelectionUpdate(QSharedPointer<PartMetaItem> pm);
@@ -233,7 +234,7 @@ class PartView : public BaseView {
     //!        to broadcast potential issues with the objects.
     void postTransformCheck();
 
-  private:
+   private:
     //! \brief Current view state.
     struct {
         //! \brief World space start of a translation event.
@@ -433,4 +434,4 @@ class PartView : public BaseView {
     //! \brief Current settings for visualization.
     QSharedPointer<SettingsBase> m_sb;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/managers/preferences_manager.h
+++ b/include/managers/preferences_manager.h
@@ -1,14 +1,14 @@
 #pragma once
 
+#include <QApplication>
+#include <QObject>
+#include <QPair>
+#include <QStyle>
 #include <list>
 #include <map>
 #include <string>
 #include <unordered_map>
 
-#include <QApplication>
-#include <QObject>
-#include <QPair>
-#include <QStyle>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qcoreapplication.h>
@@ -31,7 +31,7 @@ namespace ORNL {
 class PreferencesManager : public QObject {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Returns the singleton
     static QSharedPointer<PreferencesManager> getInstance();
 
@@ -227,7 +227,7 @@ class PreferencesManager : public QObject {
     //! \return visualization color map of name and color as hex string
     std::map<std::string, std::string> getVisualizationHexColors();
 
-  signals:
+   signals:
     //! \brief Signal emitted when the import unit is changed
     void importUnitChanged(Distance new_value, Distance old_value);
 
@@ -270,7 +270,7 @@ class PreferencesManager : public QObject {
     //! \brief Signal emitted when dependency-disabled setting visibility is changed
     void disabledSettingVisibilityChanged();
 
-  public slots:
+   public slots:
     //! \brief sets the unit used to scale when importing models
     //! \param du the unit text
     void setImportUnit(QString du);
@@ -412,7 +412,7 @@ class PreferencesManager : public QObject {
     //! \param lag: time to lag in milliseconds
     void setSegmentLag(int lag);
 
-  private:
+   private:
     //! \brief Constructor
     PreferencesManager();
 
@@ -487,5 +487,5 @@ class PreferencesManager : public QObject {
     //! \brief visualization color's preferences QColors
     std::unordered_map<std::string, QColor> m_visualization_qcolors;
 
-}; // class PreferencesManager
-} // namespace ORNL
+};  // class PreferencesManager
+}  // namespace ORNL

--- a/include/managers/session_manager.h
+++ b/include/managers/session_manager.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
-
 #include <QDir>
 #include <QFile>
 #include <QQueue>
 #include <QStandardPaths>
+#include <cstddef>
+#include <cstdint>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qmap.h>
@@ -40,7 +40,7 @@ class AbstractSlicingThread;
  */
 class SessionManager : public QObject {
     Q_OBJECT
-  public:
+   public:
     //! \brief Destructor.
     ~SessionManager();
 
@@ -56,16 +56,24 @@ class SessionManager : public QObject {
     };
 
     //! \brief Retuns a map of filename to model_data structures.
-    inline QMap<QString, model_data>& models() { return m_models; }
+    inline QMap<QString, model_data>& models() {
+        return m_models;
+    }
 
     //! \brief Returns a map of part name to Part class.
-    inline QMap<QString, QSharedPointer<Part>>& parts() { return m_parts; }
+    inline QMap<QString, QSharedPointer<Part>>& parts() {
+        return m_parts;
+    }
 
     //! \brief Returns a Part class associated with a name.
-    inline QSharedPointer<Part> getPart(QString name) { return m_parts.value(name, nullptr); }
+    inline QSharedPointer<Part> getPart(QString name) {
+        return m_parts.value(name, nullptr);
+    }
 
     //! \brief Retuns the number of parts in the session.
-    inline int count() { return m_parts.size(); }
+    inline int count() {
+        return m_parts.size();
+    }
 
     //! \brief Retuns the file last used to save the session.
     //! \todo This function will always return the autosave path since it is saved after the current session.
@@ -126,7 +134,7 @@ class SessionManager : public QObject {
     //! there are 1000s of files)
     void setDefaultGcodeDir(QString dir);
 
-  public slots:
+   public slots:
     //! \brief loads a model into the session
     //! \param filename the path to the file
     //! \param saveLocation the location to save to
@@ -214,7 +222,7 @@ class SessionManager : public QObject {
     //! \brief Paste previously copied part
     void pastePart();
 
-  signals:
+   signals:
 
     //! \brief Signal to the slice dialog with status update information
     //! \param type The current section of the step being completed
@@ -254,7 +262,7 @@ class SessionManager : public QObject {
     //! \brief Signal for total number of parts expected to load from project
     void totalPartsInProject(int total);
 
-  private:
+   private:
     //! \brief Constructor
     SessionManager();
 
@@ -316,4 +324,4 @@ class SessionManager : public QObject {
     //! \brief pointer to part to potentially paste
     QSharedPointer<Part> m_copied_part;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/managers/settings/settings_manager.h
+++ b/include/managers/settings/settings_manager.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QSharedPointer>
 #include <QVector>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qtmetamacros.h>
@@ -34,7 +35,7 @@ enum class SettingsVersionUpdateMode {
  */
 class SettingsManager : public QObject {
     Q_OBJECT
-  public:
+   public:
     //! \brief Get the singleton instance of this object.
     static QSharedPointer<SettingsManager> getInstance();
 
@@ -173,7 +174,7 @@ class SettingsManager : public QObject {
     //! \param sb: Settings provided to console
     void setConsoleSettings(QSharedPointer<SettingsBase> sb);
 
-  signals:
+   signals:
     //! \brief Signal that something was loaded into the global.
     //! \param name Name of new settings file to use
     void globalLoaded(QString name);
@@ -184,7 +185,7 @@ class SettingsManager : public QObject {
     //! \brief Signal that new layer bar tempalate was saved.
     void newLayerBarTemplateSaved();
 
-  private:
+   private:
     //! \brief Constructor
     SettingsManager();
 
@@ -230,4 +231,4 @@ class SettingsManager : public QObject {
     //! \brief Displayed file names and their corresponding layer bar templates
     QMap<QString, QVector<SettingsRange>> m_all_layer_bar_templates;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/managers/settings/settings_version_control.h
+++ b/include/managers/settings/settings_version_control.h
@@ -9,7 +9,7 @@ namespace ORNL {
  *         if/when existing settings are altered.
  */
 class SettingsVersionControl {
-  public:
+   public:
     //! \brief Public interface: receives current version and settings for alteration
     //! \param version: current version in settings file
     //! \param settings: settings to alter
@@ -24,7 +24,7 @@ class SettingsVersionControl {
     //! \param settings_group: a single settings object to modify
     static void migrateLegacySettingKeys(fifojson& settings_group);
 
-  private:
+   private:
     //! \brief Rolls initial settings templates without a version to version 1.0
     //! \param version: current version in settings file
     //! \param settings: settings to alter
@@ -75,4 +75,4 @@ class SettingsVersionControl {
     //! \param settings: settings to alter
     static void pre_10_0To10_0(double& version, fifojson& settings);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/optimizers/island_order_optimizer.h
+++ b/include/optimizers/island_order_optimizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QUuid>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -15,7 +16,7 @@
 
 namespace ORNL {
 class IslandBaseOrderOptimizer {
-  public:
+   public:
     //! \brief (Mode 1) Used to order islands in an order according to an optimization method
     //! \param current_position Point that represents current position, altered interally
     //! \param island_list List of islands to consider
@@ -60,7 +61,7 @@ class IslandBaseOrderOptimizer {
     //! \return Index for last island visited
     int getFirstIndexSelected();
 
-  private:
+   private:
     //! \brief Optimization information about last island visited in previous layers. Used only in the
     //! least recently used optimization mode.
     int m_last_island_visited;
@@ -189,4 +190,4 @@ class IslandBaseOrderOptimizer {
     int minDistanceLastPoint(QHash<QSet<int>, QMap<int, Distance>> DP_Distance_Map, QSet<int> point_set,
                              int ending_point_index);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/optimizers/layer_order_optimizer.h
+++ b/include/optimizers/layer_order_optimizer.h
@@ -14,11 +14,11 @@ namespace ORNL {
  * \brief Creates and orders global layers according to the user-selected schema
  */
 class LayerOrderOptimizer {
-  public:
+   public:
     //! \brief Creates and orders global layers
     //! \param global_sb: global settings base
     //! \param build_parts: list of build parts to access steps
     static QList<QSharedPointer<GlobalLayer>> populateSteps(QSharedPointer<SettingsBase> global_sb,
                                                             QVector<QSharedPointer<Part>> build_parts);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/optimizers/optimization_anchor.h
+++ b/include/optimizers/optimization_anchor.h
@@ -20,5 +20,5 @@ Point customPathOrderPoint(const QSharedPointer<SettingsBase>& sb, const Plane& 
 //! \brief Returns the custom point-order anchor in the flattened optimization frame.
 Point customPointOrderPoint(const QSharedPointer<SettingsBase>& sb, const Plane& slicing_plane,
                             const Point& optimization_shift);
-} // namespace OptimizationAnchor
-} // namespace ORNL
+}  // namespace OptimizationAnchor
+}  // namespace ORNL

--- a/include/optimizers/path_order_optimizer.h
+++ b/include/optimizers/path_order_optimizer.h
@@ -27,7 +27,7 @@ class TravelSegment;
  * \list kRandom: links to a random vertex each time
  */
 class PathOrderOptimizer {
-  public:
+   public:
     //! \brief Constructor
     //! \note Layer number is only needed if kConsecutive linking is used
     PathOrderOptimizer(Point& start, uint layer_number, const QSharedPointer<SettingsBase>& sb);
@@ -80,7 +80,7 @@ class PathOrderOptimizer {
     //! \param pt: Seam point
     void setStartPointOverride(Point pt);
 
-  private:
+   private:
     //! \brief Node to hold topological data
     //! \param m_poly: Polygon representing current path. Used for inside/outside comparison.
     //! \param m_path_index: Path index in m_paths that node represents.
@@ -93,7 +93,7 @@ class PathOrderOptimizer {
         TopologicalNode() {}
         TopologicalNode(int index, Polygon poly) {
             m_path_index = index;
-            m_poly = poly;
+            m_poly       = poly;
         }
     };
 
@@ -249,4 +249,4 @@ class PathOrderOptimizer {
     //! subsequent path.
     bool m_has_computed_heirarchy;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/optimizers/point_order_optimizer.h
+++ b/include/optimizers/point_order_optimizer.h
@@ -27,9 +27,9 @@ namespace ORNL {
  * farthest from the defined point.
  */
 class PointOrderOptimizer {
-  public:
+   public:
     struct PointOrderSelection {
-        int rotation_index = 0;
+        int rotation_index      = 0;
         bool insert_split_point = false;
         Point split_point;
         int insertion_index = 0;
@@ -46,7 +46,7 @@ class PointOrderOptimizer {
                                            PointOrderOptimization pointOptimization, bool min_dist_enabled,
                                            Distance min_dist_threshold, Distance consecutive_dist_threshold,
                                            bool local_randomness_enable, Distance randomness_radius,
-                                           bool allow_segment_breaking = false,
+                                           bool allow_segment_breaking                       = false,
                                            const std::optional<Point>& consecutive_reference = std::nullopt);
 
     //! \brief Constructor
@@ -58,7 +58,7 @@ class PointOrderOptimizer {
                                        PointOrderOptimization pointOptimization, bool min_dist_enabled,
                                        Distance min_dist_threshold);
 
-  private:
+   private:
     //! \brief Finds the shortest or longest distance between the current location and the points in the polyline
     //! \param polyline: The polyline to find the shortest or longest distance in
     //! \param startPoint: The current location
@@ -118,4 +118,4 @@ class PointOrderOptimizer {
     static int computePerturbation(const Polyline& polyline, const Point& current_start, Distance radius);
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/optimizers/polyline_order_optimizer.h
+++ b/include/optimizers/polyline_order_optimizer.h
@@ -32,7 +32,7 @@ namespace ORNL {
  * \list kRandom: links to a random vertex each time
  */
 class PolylineOrderOptimizer {
-  public:
+   public:
     //! \brief Constructor
     //! \note Layer number is only needed if kConsecutive linking is used
     PolylineOrderOptimizer(Point& start, uint layer_number);
@@ -88,7 +88,7 @@ class PolylineOrderOptimizer {
     //! \param pt: Seam point
     void setStartPointOverride(Point pt);
 
-  private:
+   private:
     //! \brief Node to hold topological data
     //! \param m_poly: Polygon representing current Polyline. Used for inside/outside comparison.
     //! \param m_Polyline_index: Polyline index in m_Polylines that node represents.
@@ -101,7 +101,7 @@ class PolylineOrderOptimizer {
         TopologicalNode() {}
         TopologicalNode(int index, Polyline poly) {
             m_Polyline_index = index;
-            m_poly = poly;
+            m_poly           = poly;
         }
     };
 
@@ -255,6 +255,6 @@ class PolylineOrderOptimizer {
 
     /// @brief Selection state used to alternate the two exterior edges when ordering open lines outside-in
     int m_open_path_selection_count = 0;
-    bool m_outside_in_from_front = true;
+    bool m_outside_in_from_front    = true;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/part/part.h
+++ b/include/part/part.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QUuid>
+
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qmap.h>
@@ -26,12 +27,11 @@ class Step;
  *        sub-meshes. Additionally, this class also has a parenting system between parts.
  */
 class Part : public QEnableSharedFromThis<Part> {
-
-  public:
+   public:
     //! \brief a step pair links a scan layer with its corresponding
     //!        printing layer
     struct StepPair {
-        QSharedPointer<Layer> printing_layer; // can be either raft or layer type
+        QSharedPointer<Layer> printing_layer;  // can be either raft or layer type
         QSharedPointer<ScanLayer> scan_layer;
     };
 
@@ -48,22 +48,34 @@ class Part : public QEnableSharedFromThis<Part> {
     //! \param Mesh type mode, defaults to build
     Part(QSharedPointer<MeshBase> root_mesh, QString file_name = "", MeshType mt = MeshType::kBuild);
 
-    void setSourceFile(QString file_name) { m_file_name = file_name; }
+    void setSourceFile(QString file_name) {
+        m_file_name = file_name;
+    }
 
     //! \brief Source file for part
-    QString sourceFilePath() { return m_file_name; }
+    QString sourceFilePath() {
+        return m_file_name;
+    }
 
     //! \brief Mesh type mode, defaults to build
-    MeshType getMeshType() { return m_mesh_type; }
+    MeshType getMeshType() {
+        return m_mesh_type;
+    }
 
     //! \brief Set Mesh type mode
-    void setMeshType(MeshType mt) { m_mesh_type = mt; }
+    void setMeshType(MeshType mt) {
+        m_mesh_type = mt;
+    }
 
     //! \brief Get name of this part.
-    inline QString name() { return m_name; }
+    inline QString name() {
+        return m_name;
+    }
 
     //! \brief Set name of this part.
-    inline void setName(QString name) { m_name = name; }
+    inline void setName(QString name) {
+        m_name = name;
+    }
 
     //! \brief Get the SettingsBase.
     //! \return pointer to SettingsBase
@@ -287,7 +299,7 @@ class Part : public QEnableSharedFromThis<Part> {
     //! \returns universally unique identifier for this part
     QUuid getId();
 
-  private:
+   private:
     //! \brief a unique identifier for the part
     QUuid m_uuid;
 
@@ -330,4 +342,4 @@ class Part : public QEnableSharedFromThis<Part> {
     //! \brief Mesh type mode, defaults to build
     MeshType m_mesh_type = MeshType::kBuild;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/slicing/buffered_slicer.h
+++ b/include/slicing/buffered_slicer.h
@@ -26,7 +26,7 @@ namespace ORNL {
 //! called, it actually computes the Nth next slice, however returns whatever the front of the buffer is.
 //! \note when the previous or future buffers cannot be filled with valid slices, they are instead filled with nullptr
 class BufferedSlicer {
-  public:
+   public:
     //! \struct SliceMeta
     //! \brief Contains a snapshot of various variables when taking a slice
     struct SliceMeta {
@@ -81,7 +81,7 @@ class BufferedSlicer {
     //! \return the number of slices taken
     int getSliceCount();
 
-  private:
+   private:
     //! \brief processes a single slice (cross-sections)
     //! \return a cross-section (SliceMeta) object
     QSharedPointer<BufferedSlicer::SliceMeta> processSingleSlice();
@@ -134,4 +134,4 @@ class BufferedSlicer {
     //! \brief list of settings parts being tracked
     QVector<QSharedPointer<Part>> m_settings_parts;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/slicing/layer_additions.h
+++ b/include/slicing/layer_additions.h
@@ -34,5 +34,5 @@ void addThermalScan(QSharedPointer<Layer> layer);
 //! \param output_path: the ouput dir of the scan file
 void addLaserScan(QSharedPointer<Part> part, int layer_index, double running_total, QSharedPointer<Step> build_layer,
                   QDir output_path);
-} // namespace LayerAdditions
-} // namespace ORNL
+}  // namespace LayerAdditions
+}  // namespace ORNL

--- a/include/slicing/preprocessor.h
+++ b/include/slicing/preprocessor.h
@@ -33,7 +33,7 @@ namespace ORNL {
 //!                 7. Final Processing: provides access to all parts/ global settings after all steps are created
 //!
 class Preprocessor {
-  public:
+   public:
     //! \struct Parts
     //! \brief provides access to all parts, sorted by type
     struct Parts {
@@ -47,16 +47,16 @@ class Preprocessor {
     struct ActivePartMeta {
         ActivePartMeta(QSharedPointer<Part> _part = nullptr, QSharedPointer<SettingsBase> _part_sb = nullptr,
                        int _steps_processed = 0, int _part_start = 0) {
-            part = _part;
-            part_sb = _part_sb;
+            part            = _part;
+            part_sb         = _part_sb;
             steps_processed = _steps_processed;
-            part_start = _part_start;
+            part_start      = _part_start;
         }
 
         QSharedPointer<Part> part;
         QSharedPointer<SettingsBase> part_sb;
         int steps_processed = 0;
-        int part_start = 0;
+        int part_start      = 0;
         int last_step_count = 0;
     };
 
@@ -139,7 +139,7 @@ class Preprocessor {
     //! \return Sorted Parts struct
     Parts getParts();
 
-  private:
+   private:
     //! \brief Callable functions used by the preprocessor
     StepBuilder m_step_builder;
     Processing m_initial_processing;
@@ -149,10 +149,10 @@ class Preprocessor {
     CrossSectionProcessing m_cross_section_processing;
     StatusUpdate m_status_update;
 
-    bool m_use_cgal_cross_section = false;
+    bool m_use_cgal_cross_section  = false;
     bool m_include_build_plate_gap = false;
 
     //! \brief Sorted parts
     Parts m_parts;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/slicing/slicing_utilities.h
+++ b/include/slicing/slicing_utilities.h
@@ -24,7 +24,7 @@ class Polyline;
  * \brief Provides access to methods used with polymer slicing
  */
 class SlicingUtilities {
-  public:
+   public:
     /*!
      * \brief Resamples a retained cylindrical path at G2/G3 arc boundaries.
      * \param polyline: densely sampled radial or helical path in the selected angular direction
@@ -131,4 +131,4 @@ class SlicingUtilities {
      */
     static bool doPartsOverlap(QVector<QSharedPointer<Part>> parts, Plane slicing_plane);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/global_layer.h
+++ b/include/step/global_layer.h
@@ -23,7 +23,7 @@ namespace ORNL {
  *        as one layer
  */
 class GlobalLayer {
-  public:
+   public:
     //! \brief Constructor
     //! \param layer_number - the # in sequence the global layer should be printed
     GlobalLayer(int layer_number);
@@ -71,11 +71,11 @@ class GlobalLayer {
     //! \note used for writeBeforeLayer() function
     Distance getLayerHeight();
 
-  private:
+   private:
     //! \brief Creates tree-like structure if brims exist, otherwise, sorts islands into precendence order;
     //!        helper function for connectPaths()
-    QList<QMap<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>>
-    createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children);
+    QList<QMap<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>> createSequence(
+        QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children);
 
     //! \brief returns true if this global layer contains scan layers
     bool containsScanLayers();
@@ -95,4 +95,4 @@ class GlobalLayer {
     //! \note order determined in connectPaths and saved for use again in writeGcode
     QList<QUuid> m_part_order;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/helical_layer.h
+++ b/include/step/layer/helical_layer.h
@@ -20,7 +20,7 @@ namespace ORNL {
  * the normal polymer island and region generation stack.
  */
 class HelicalLayer : public Layer {
-  public:
+   public:
     /*!
      * @brief Constructs a helical layer.
      * @param layer_nr One-based layer number used in generated gcode comments.
@@ -74,8 +74,8 @@ class HelicalLayer : public Layer {
      */
     bool hasPaths() const;
 
-  private:
+   private:
     //! @brief Precomputed travel and print paths for this helical layer.
     QVector<Path> m_paths;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/brim_island.h
+++ b/include/step/layer/island/brim_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island that polymer builds use.
  */
 class BrimIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -29,4 +29,4 @@ class BrimIsland : public IslandBase {
     void optimize(int layerNumber, Point& currentLocation,
                   QVector<QSharedPointer<RegionBase>>& previousRegions) override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/island_base.h
+++ b/include/step/layer/island/island_base.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QLinkedList>
+
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qtypes.h>
@@ -21,7 +22,7 @@ namespace ORNL {
  * \note For more information about the abstract slicing architecture, see the documentation.
  */
 class IslandBase {
-  public:
+   public:
     //! \brief Constructor.
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -98,7 +99,7 @@ class IslandBase {
     //! \brief Fits eligible planar line segments in this island to G2/G3 arcs.
     void fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb);
 
-  protected:
+   protected:
     //! \brief Prepares a region for optimization with layer metadata and previous-layer seam context.
     void prepareRegionForOptimization(const QSharedPointer<RegionBase>& region, int layerNumber,
                                       QVector<QSharedPointer<RegionBase>>& previousRegions);
@@ -118,4 +119,4 @@ class IslandBase {
     //! \brief Enum value of island type
     IslandType m_island_type;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/laser_scan_island.h
+++ b/include/step/layer/island/laser_scan_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island that laser scans are composed of.
  */
 class LaserScanIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -29,4 +29,4 @@ class LaserScanIsland : public IslandBase {
     void optimize(int layerNumber, Point& currentLocation,
                   QVector<QSharedPointer<RegionBase>>& previousRegions) override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/polymer_island.h
+++ b/include/step/layer/island/polymer_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island that polymer builds use.
  */
 class PolymerIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -32,4 +32,4 @@ class PolymerIsland : public IslandBase {
     //! \brief Reorder regions based on previously identified order
     void reorderRegions();
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/raft_island.h
+++ b/include/step/layer/island/raft_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island type for rafts.
  */
 class RaftIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -29,4 +29,4 @@ class RaftIsland : public IslandBase {
     void optimize(int layerNumber, Point& currentLocation,
                   QVector<QSharedPointer<RegionBase>>& previousRegions) override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/skirt_island.h
+++ b/include/step/layer/island/skirt_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island that skirt builds use.
  */
 class SkirtIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -29,4 +29,4 @@ class SkirtIsland : public IslandBase {
     void optimize(int layerNumber, Point& currentLocation,
                   QVector<QSharedPointer<RegionBase>>& previousRegions) override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/support_island.h
+++ b/include/step/layer/island/support_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island that supports are composed of.
  */
 class SupportIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -30,4 +30,4 @@ class SupportIsland : public IslandBase {
                   QVector<QSharedPointer<RegionBase>>& previousRegions) override;
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/island/thermal_scan_island.h
+++ b/include/step/layer/island/thermal_scan_island.h
@@ -16,7 +16,7 @@ namespace ORNL {
  * \brief Island that thermal scans are composed of.
  */
 class ThermalScanIsland : public IslandBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param geometry: the outlines
     //! \param sb: the settings
@@ -29,4 +29,4 @@ class ThermalScanIsland : public IslandBase {
     void optimize(int layerNumber, Point& currentLocation,
                   QVector<QSharedPointer<RegionBase>>& previousRegions) override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/layer.h
+++ b/include/step/layer/layer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QLinkedList>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -17,7 +18,7 @@ namespace ORNL {
 class IslandBase;
 
 class Layer : public Step {
-  public:
+   public:
     //! \brief Constructor
     Layer(uint layer_nr, const QSharedPointer<SettingsBase>& sb);
 
@@ -79,14 +80,14 @@ class Layer : public Step {
     //! \return a list of settings polygons
     QVector<SettingsPolygon> getSettingsPolygons();
 
-  protected:
+   protected:
     //! \brief Layer number.
     uint m_layer_nr;
 
     //! \brief Precendence list based on geometry and settings to define order for traveling and gcode.
     QList<QSharedPointer<IslandBase>> m_island_order;
 
-  private:
+   private:
     //! \brief Builds the translation used to move paths between the flattened slicing frame and printer coordinates.
     Point getOrientationShift() const;
 
@@ -103,8 +104,8 @@ class Layer : public Step {
     void redirectClearanceMoves();
 
     //! \brief Creates tree-like structure if brims exist, otherwise, sorts islands into precendence order
-    QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>>
-    createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children);
+    QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>> createSequence(
+        QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children);
 
     //! \brief Vertical shift applied to keep printing paths above the build surface.
     Distance m_minimum_z_shift;
@@ -112,4 +113,4 @@ class Layer : public Step {
     //! \brief a collection of polygons on this layer that contain setting overrides
     QVector<SettingsPolygon> m_settings_polygons;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/radial_layer.h
+++ b/include/step/layer/radial_layer.h
@@ -20,7 +20,7 @@ namespace ORNL {
  * paths against the model and skips the normal polymer path-generation stack.
  */
 class RadialLayer : public Layer {
-  public:
+   public:
     /*!
      * @brief Constructs a radial layer.
      * @param layer_nr One-based layer number used in generated gcode comments.
@@ -74,8 +74,8 @@ class RadialLayer : public Layer {
      */
     bool hasPaths() const;
 
-  private:
+   private:
     //! @brief Precomputed travel and print paths for this radial layer.
     QVector<Path> m_paths;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/brim.h
+++ b/include/step/layer/regions/brim.h
@@ -15,7 +15,7 @@
 
 namespace ORNL {
 class Brim : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
@@ -39,7 +39,7 @@ class Brim : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -48,4 +48,4 @@ class Brim : public RegionBase {
     //! \brief Holds the computed geometry before it is converted into paths
     QVector<Polyline> m_computed_geometry;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/infill.h
+++ b/include/step/layer/regions/infill.h
@@ -16,7 +16,7 @@
 
 namespace ORNL {
 class Infill : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param index: index for region order
@@ -41,7 +41,7 @@ class Infill : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -67,4 +67,4 @@ class Infill : public RegionBase {
     //! \brief Contains the layer that we are currently on
     uint m_layer_num;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/inset.h
+++ b/include/step/layer/regions/inset.h
@@ -15,7 +15,7 @@
 
 namespace ORNL {
 class Inset : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param index: index for region order
@@ -44,7 +44,7 @@ class Inset : public RegionBase {
     //! \return the computed geometry
     QVector<Polyline> getComputedGeometry();
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -95,4 +95,4 @@ class Inset : public RegionBase {
     //! \brief Holds the bead width associated with each computed contour in m_computed_geometry
     QVector<Distance> m_computed_widths;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/laser_scan.h
+++ b/include/step/layer/regions/laser_scan.h
@@ -15,7 +15,7 @@
 
 namespace ORNL {
 class LaserScan : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
@@ -39,7 +39,7 @@ class LaserScan : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -48,4 +48,4 @@ class LaserScan : public RegionBase {
     //! \brief Holds the computed geometry before it is converted into paths
     QVector<Polyline> m_computed_geometry;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/perimeter.h
+++ b/include/step/layer/regions/perimeter.h
@@ -16,7 +16,7 @@
 
 namespace ORNL {
 class Perimeter : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param index: index for region order
@@ -47,7 +47,7 @@ class Perimeter : public RegionBase {
     //! \return the computed geometry
     QVector<Polyline> getComputedGeometry();
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -101,4 +101,4 @@ class Perimeter : public RegionBase {
     //! \brief Holds the layer number that we are currently on
     uint m_layer_num;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/raft.h
+++ b/include/step/layer/regions/raft.h
@@ -15,7 +15,7 @@
 
 namespace ORNL {
 class Raft : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
@@ -39,7 +39,7 @@ class Raft : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -49,4 +49,4 @@ class Raft : public RegionBase {
     //! \brief Holds the computed geometry before it is converted into paths
     QVector<Polyline> m_computed_geometry;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/region_base.h
+++ b/include/step/layer/regions/region_base.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QObject>
 #include <optional>
 
-#include <QObject>
 #include <qcontainerfwd.h>
 #include <qtypes.h>
 
@@ -24,7 +24,7 @@ class PathOrderOptimizer;
  * \note For more information about the abstract slicing architecture, see the documentation.
  */
 class RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param index: index for region order
@@ -131,7 +131,7 @@ class RegionBase {
     //! \param spiral: whether or not last region was spiralized
     void setLastSpiral(bool spiral);
 
-  protected:
+   protected:
     //! \brief Generates paths for the region.
     //! \param line: polyline representing path
     //! \return Polyline converted to path
@@ -192,4 +192,4 @@ class RegionBase {
     Plane m_optimization_slicing_plane;
     Point m_optimization_shift;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/skeleton.h
+++ b/include/step/layer/regions/skeleton.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QStack>
+
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
 #include <boost/graph/filtered_graph.hpp>
@@ -24,9 +25,9 @@
 #include "units/unit.h"
 
 namespace ORNL {
-using SkeletonGraph = boost::adjacency_list<boost::listS, boost::listS, boost::undirectedS, Point, Polyline>;
+using SkeletonGraph  = boost::adjacency_list<boost::listS, boost::listS, boost::undirectedS, Point, Polyline>;
 using SkeletonVertex = boost::graph_traits<SkeletonGraph>::vertex_descriptor;
-using SkeletonEdge = boost::graph_traits<SkeletonGraph>::edge_descriptor;
+using SkeletonEdge   = boost::graph_traits<SkeletonGraph>::edge_descriptor;
 
 struct SkeletonSubgraphFilter {
     SkeletonSubgraphFilter() = default;
@@ -34,7 +35,9 @@ struct SkeletonSubgraphFilter {
     SkeletonSubgraphFilter(QMap<SkeletonVertex, int> vertex_subgraph_map_)
         : vertex_subgraph_map(vertex_subgraph_map_) {}
 
-    bool operator()(const SkeletonVertex& v) const { return vertex_subgraph_map[v] == 0; }
+    bool operator()(const SkeletonVertex& v) const {
+        return vertex_subgraph_map[v] == 0;
+    }
 
     QMap<SkeletonVertex, int> vertex_subgraph_map;
 };
@@ -42,7 +45,7 @@ struct SkeletonSubgraphFilter {
 using SkeletonSubgraph = boost::filtered_graph<SkeletonGraph, boost::keep_all, SkeletonSubgraphFilter>;
 
 class Skeleton : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param index: index for region order
@@ -155,7 +158,7 @@ class Skeleton : public RegionBase {
      */
     QVector<Path> filterPath(const Path& path);
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -173,4 +176,4 @@ class Skeleton : public RegionBase {
     //! @brief The current layer number being processed
     uint m_layer_num;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/skin.h
+++ b/include/step/layer/regions/skin.h
@@ -19,7 +19,7 @@
 
 namespace ORNL {
 class Skin : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param index: index for region order
@@ -65,7 +65,7 @@ class Skin : public RegionBase {
     //! \param poly_list geometry to add
     void addGradualGeometry(const PolygonList& poly_list);
 
-  private:
+   private:
     //! \brief Helper function to create pattern for skin and gradual areas
     //! \param pattern Selected pattern
     //! \param geometry Geometric bounds to apply pattern to
@@ -131,4 +131,4 @@ class Skin : public RegionBase {
     //! \brief Holds paths created by gradual areas as these paths may be different patterns
     // QVector<QVector<Path>> m_gradual_paths;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/skirt.h
+++ b/include/step/layer/regions/skirt.h
@@ -15,7 +15,7 @@
 
 namespace ORNL {
 class Skirt : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
@@ -39,7 +39,7 @@ class Skirt : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -48,4 +48,4 @@ class Skirt : public RegionBase {
     //! \brief Holds the computed geometry before it is converted into paths
     QVector<Polyline> m_computed_geometry;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/support.h
+++ b/include/step/layer/regions/support.h
@@ -16,7 +16,7 @@
 
 namespace ORNL {
 class Support : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
@@ -40,7 +40,7 @@ class Support : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -58,4 +58,4 @@ class Support : public RegionBase {
     //! blocking safe serpentine connectors.
     QVector<QVector<Polyline>> m_computed_infill_geometry;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/regions/thermal_scan.h
+++ b/include/step/layer/regions/thermal_scan.h
@@ -15,7 +15,7 @@
 
 namespace ORNL {
 class ThermalScan : public RegionBase {
-  public:
+   public:
     //! \brief Constructor
     //! \param sb: the settings
     //! \param settings_polygons: a vector of settings polygons to apply
@@ -39,7 +39,7 @@ class ThermalScan : public RegionBase {
     //! \return Polyline converted to path
     Path createPath(Polyline line) override;
 
-  private:
+   private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
     //! \param supportsG3 Whether or not G2/G3 is supported for spiral lift
@@ -48,4 +48,4 @@ class ThermalScan : public RegionBase {
     //! \brief Holds the computed geometry before it is converted into paths
     Polyline m_computed_geometry;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/layer/scan_layer.h
+++ b/include/step/layer/scan_layer.h
@@ -17,7 +17,7 @@ class IslandBase;
  *  \brief Step that generates pathing for a laser or thermal scan.
  */
 class ScanLayer : public Step {
-  public:
+   public:
     //! \brief Constructor
     ScanLayer(int layer, const QSharedPointer<SettingsBase>& sb);
 
@@ -56,11 +56,11 @@ class ScanLayer : public Step {
     //! \brief Sets scan as first
     void setFirst();
 
-  private:
+   private:
     //! \brief Layer number
     int m_layer_num;
 
     //! \brief First travel connection.  Potentially requires a unique case.
     bool m_first_connect;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/step/step.h
+++ b/include/step/step.h
@@ -2,6 +2,7 @@
 
 #include <QDir>
 #include <QObject>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -19,7 +20,7 @@ namespace ORNL {
  * \brief Abstract implementation of a step in the slicer process.
  */
 class Step {
-  public:
+   public:
     //! \brief Constructor
     Step(const QSharedPointer<SettingsBase>& sb = QSharedPointer<SettingsBase>::create());
     //! \brief Destructor
@@ -127,7 +128,7 @@ class Step {
     //! \return distance to shift
     QVector3D getRaftShift();
 
-  protected:
+   protected:
     //! \brief Settings for the step.
     QSharedPointer<SettingsBase> m_sb;
 
@@ -152,8 +153,8 @@ class Step {
     //! \brief The geometry on the layer.
     PolygonList m_geometry;
 
-  private:
+   private:
     //! \brief bool that holds dirty status
     bool m_dirty_bit;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/abs_slicing_thread.h
+++ b/include/threading/abs_slicing_thread.h
@@ -3,6 +3,7 @@
 #include <QElapsedTimer>
 #include <QQueue>
 #include <QThread>
+
 #include <nlohmann/json_fwd.hpp>
 #include <qdir.h>
 #include <qhashfunctions.h>
@@ -25,7 +26,7 @@ class Part;
  */
 class AbstractSlicingThread : public QObject {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     AbstractSlicingThread(QString outputLocation, bool skipGcode = false);
 
@@ -47,7 +48,7 @@ class AbstractSlicingThread : public QObject {
     //! \brief Get the time it took to slice
     qint64 getTimeElapsed();
 
-  public slots:
+   public slots:
     //! \brief Main function that starts slice.
     virtual void doSlice() = 0;
 
@@ -56,7 +57,7 @@ class AbstractSlicingThread : public QObject {
     //! \param completedPercentage: The percentage complete of the current step process
     void forwardStatus(StatusUpdateStepType type, int completedPercentage);
 
-  signals:
+   signals:
     //! \brief Signal to the active steps to begin computation.
     void stepStart();
 
@@ -72,7 +73,7 @@ class AbstractSlicingThread : public QObject {
     //! \brief Signal to session manager that slicing is complete
     void sliceComplete();
 
-  protected:
+   protected:
     //! \brief Pure virtual for preprocess step. This is always run first.
     //! \param opt_data optional sensor data
     virtual void preProcess(nlohmann::json opt_data = nlohmann::json()) = 0;
@@ -142,16 +143,16 @@ class AbstractSlicingThread : public QObject {
     QElapsedTimer m_timer;
     qint64 m_elapsed_time = 0;
 
-  protected slots:
+   protected slots:
     //! \brief Upon completion of thread running step object, this slot will clean up the thread.
     //!        If more objects are on the queue, then this will run the thread
     virtual void cleanThread() = 0;
 
-  private:
+   private:
     //! \brief Internal thread.
     QThread m_internal_thread;
 
     //! \brief Cancel flag set by session manager if user clicks on cancel button
     bool m_should_cancel;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/gcode_adamantine_saver.h
+++ b/include/threading/gcode_adamantine_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -14,7 +15,7 @@ namespace ORNL {
  */
 class GCodeAdamantineSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -27,7 +28,7 @@ class GCodeAdamantineSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
@@ -41,5 +42,5 @@ class GCodeAdamantineSaver : public QThread {
 
     Angle m_sector_width;
 
-}; // class GCodeAdamantineSaver
-} // namespace ORNL
+};  // class GCodeAdamantineSaver
+}  // namespace ORNL

--- a/include/threading/gcode_amcm_saver.h
+++ b/include/threading/gcode_amcm_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 class GCodeAMCMSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -25,12 +26,12 @@ class GCodeAMCMSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeAMCMSaver
-} // namespace ORNL
+};  // class GCodeAMCMSaver
+}  // namespace ORNL

--- a/include/threading/gcode_aml3d_saver.h
+++ b/include/threading/gcode_aml3d_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 class GCodeAML3DSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -25,12 +26,12 @@ class GCodeAML3DSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeAML3DSaver
-} // namespace ORNL
+};  // class GCodeAML3DSaver
+}  // namespace ORNL

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -2,6 +2,7 @@
 
 #include <QTextCharFormat>
 #include <QThread>
+
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qhash.h>
@@ -29,7 +30,7 @@ namespace ORNL {
  */
 class GCodeLoader : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param filename: Name of file to load
     //! \param conversion ratio to convert from model space to view space for
@@ -41,7 +42,7 @@ class GCodeLoader : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  signals:
+   signals:
 
     //! \brief signal to view with info for visualization
     //! \param layers: vector of graphics layers for visualization.  Information is
@@ -80,7 +81,7 @@ class GCodeLoader : public QThread {
     //! \param percentComplete: Current completion percentage
     void updateDialog(StatusUpdateStepType type, int percentComplete);
 
-  public slots:
+   public slots:
 
     //! \brief Set cancel flag as received from slice dialog
     void cancelSlice();
@@ -90,7 +91,7 @@ class GCodeLoader : public QThread {
     //! \param percentComplete: Current completion percentage
     void forwardDialogUpdate(StatusUpdateStepType type, int percentComplete);
 
-  private:
+   private:
     //! \brief parse header looking for syntax info and base offset
     //! \param originalLines: Original lines from gcode file
     //! \param lines Uppercase: lines used for ease of parsing/comparison
@@ -156,11 +157,10 @@ class GCodeLoader : public QThread {
     //! \param include_non_deposition_moves: if true, generates visual segments when deposition is inactive
     //! \param optional_parameters: Parameters of gcodecommand for start (x, y, z, w)
     //! \return List of generated visual segments.
-    QVector<QSharedPointer<SegmentBase>>
-    generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
-                          const QMap<char, double>& parameters, bool deposition_active, double extruder_speed,
-                          bool include_non_deposition_moves, const QString comment,
-                          const QMap<char, double>& optional_parameters = QMap<char, double>());
+    QVector<QSharedPointer<SegmentBase>> generateVisualSegment(
+        int line_num, int layer_num, const QColor& color, int command_id, const QMap<char, double>& parameters,
+        bool deposition_active, double extruder_speed, bool include_non_deposition_moves, const QString comment,
+        const QMap<char, double>& optional_parameters = QMap<char, double>());
 
     //! \brief Filename.
     QString m_filename;
@@ -243,5 +243,5 @@ class GCodeLoader : public QThread {
 
     //! \brief Current settings for gcode loader
     QSharedPointer<SettingsBase> m_sb;
-}; // class GCodeLoader
-} // namespace ORNL
+};  // class GCodeLoader
+}  // namespace ORNL

--- a/include/threading/gcode_marlin_saver.h
+++ b/include/threading/gcode_marlin_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 class GCodeMarlinSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -25,12 +26,12 @@ class GCodeMarlinSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeMarlinSaver
-} // namespace ORNL
+};  // class GCodeMarlinSaver
+}  // namespace ORNL

--- a/include/threading/gcode_meld_saver.h
+++ b/include/threading/gcode_meld_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 class GCodeMeldSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -25,12 +26,12 @@ class GCodeMeldSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeMeldSaver
-} // namespace ORNL
+};  // class GCodeMeldSaver
+}  // namespace ORNL

--- a/include/threading/gcode_sandia_saver.h
+++ b/include/threading/gcode_sandia_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 class GCodeSandiaSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -25,12 +26,12 @@ class GCodeSandiaSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeSandiaSaver
-} // namespace ORNL
+};  // class GCodeSandiaSaver
+}  // namespace ORNL

--- a/include/threading/gcode_simulation_output.h
+++ b/include/threading/gcode_simulation_output.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -14,7 +15,7 @@ namespace ORNL {
  */
 class GCodeSimulationOutput : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param temp_location location of gcode file
     //! \param path path to output
@@ -35,7 +36,7 @@ class GCodeSimulationOutput : public QThread {
     //! \param f the new velocity command
     void calculateTime(const QString& x, const QString& y, const QString& z, const QString& w, const QString& f);
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
@@ -54,5 +55,5 @@ class GCodeSimulationOutput : public QThread {
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeSimulationOutput
-} // namespace ORNL
+};  // class GCodeSimulationOutput
+}  // namespace ORNL

--- a/include/threading/gcode_tormach_saver.h
+++ b/include/threading/gcode_tormach_saver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -13,7 +14,7 @@ namespace ORNL {
  */
 class GCodeTormachSaver : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param tempLocation: location of gcode file
     //! \param path: path to output
@@ -25,12 +26,12 @@ class GCodeTormachSaver : public QThread {
     //! \brief Function that is run when start is called on this thread.
     void run() override;
 
-  private:
+   private:
     //! \brief Temporary file location, output path, output filename, and text to output
     QString m_temp_location, m_path, m_filename, m_text;
 
     //! \brief Meta info determined from file
     GcodeMeta m_selected_meta;
 
-}; // class GCodeTormachSaver
-} // namespace ORNL
+};  // class GCodeTormachSaver
+}  // namespace ORNL

--- a/include/threading/mesh_loader.h
+++ b/include/threading/mesh_loader.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <QFileInfo>
+#include <QThread>
 #include <cstddef>
 #include <utility>
 
 #include <CGAL/Modifier_base.h>
 #include <CGAL/Polyhedron_incremental_builder_3.h>
-#include <QFileInfo>
-#include <QThread>
 #include <assimp/mesh.h>
 #include <assimp/scene.h>
 #include <qcontainerfwd.h>
@@ -31,13 +31,13 @@ class MeshFace;
  */
 class MeshLoader : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \struct MeshData
     //! \brief Holds a pointer to a mesh and the raw data/ size
     struct MeshData {
         QSharedPointer<MeshBase> mesh = nullptr;
-        void* raw_data = nullptr;
-        size_t size = 0;
+        void* raw_data                = nullptr;
+        size_t size                   = 0;
     };
 
     //! \brief Constructor for thread
@@ -60,14 +60,14 @@ class MeshLoader : public QThread {
                                         QMatrix4x4 transform = QMatrix4x4(), Distance unit = Distance(mm),
                                         void* raw_data = nullptr, size_t file_size = 0);
 
-  signals:
+   signals:
     //! \brief Sends the model to the project manager
     void newMesh(MeshData data);
 
     //! \brief Emits error signal
     void error(QString msg);
 
-  private:
+   private:
     //! \brief loads raw data from a path
     //! \param file_path the path to load from
     //! \return a pair containing the raw data as a void ptr and the size in bytes
@@ -80,8 +80,9 @@ class MeshLoader : public QThread {
 
     //! \class MeshBuilderAssimp
     //! \brief CGAL builder to convert an assimp mesh into a CGAL polyhedron
-    template <class HDS> class MeshBuilderAssimp : public CGAL::Modifier_base<HDS> {
-      public:
+    template <class HDS>
+    class MeshBuilderAssimp : public CGAL::Modifier_base<HDS> {
+       public:
         //! \brief Builds a polyhedron incrementally using faces
         //! \param vertices: the mesh's vertices
         //! \param faces: the mesh's faces
@@ -94,7 +95,7 @@ class MeshLoader : public QThread {
 
             // Add all vertices
             for (unsigned int i = 0; i < m_mesh->mNumVertices; i++) {
-                builder.add_vertex(MeshTypes::Point_3(m_mesh->mVertices[i].x * 1000, // Scale from mm to micron
+                builder.add_vertex(MeshTypes::Point_3(m_mesh->mVertices[i].x * 1000,  // Scale from mm to micron
                                                       m_mesh->mVertices[i].y * 1000, m_mesh->mVertices[i].z * 1000));
             }
 
@@ -121,13 +122,14 @@ class MeshLoader : public QThread {
 
             builder.end_surface();
 
-            if (builder.check_unconnected_vertices())
-                builder.remove_unconnected_vertices();
+            if (builder.check_unconnected_vertices()) builder.remove_unconnected_vertices();
         }
 
-        bool wasError() { return m_error; }
+        bool wasError() {
+            return m_error;
+        }
 
-      private:
+       private:
         aiMesh* m_mesh;
         bool m_error = false;
     };
@@ -147,5 +149,5 @@ class MeshLoader : public QThread {
     //! \brief the default unit scaling to apply
     Distance m_unit;
 
-}; // class MeshLoader
-} // namespace ORNL
+};  // class MeshLoader
+}  // namespace ORNL

--- a/include/threading/session_loader.h
+++ b/include/threading/session_loader.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QThread>
 #include <string>
 
-#include <QThread>
 #include <qobject.h>
 #include <qtmetamacros.h>
 #include <zip/zip.h>
@@ -17,7 +17,7 @@ namespace ORNL {
  */
 class SessionLoader : public QThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor.
     //! \param filename: Filename for either loading or saving.
     //! \param save:     If true, the current session will be saved. If false, the current session will be loaded.
@@ -35,7 +35,7 @@ class SessionLoader : public QThread {
     //! \brief Start the thread.
     void run() override;
 
-  signals:
+   signals:
     //! \brief Signal that an error has occured.
     void error(QString error);
 
@@ -45,7 +45,7 @@ class SessionLoader : public QThread {
     //! \brief Signal that a session file has been loaded successfully.
     void loadSucceeded();
 
-  private:
+   private:
     //! \brief Saves a session.
     void saveSession();
 
@@ -72,5 +72,5 @@ class SessionLoader : public QThread {
     //! \brief If enabled, m_new_json is also written back into the project file.
     bool m_should_write_new_json;
 
-}; // class SessionLoader
-} // namespace ORNL
+};  // class SessionLoader
+}  // namespace ORNL

--- a/include/threading/slicers/helical_slicer.h
+++ b/include/threading/slicers/helical_slicer.h
@@ -32,7 +32,7 @@ class SettingsBase;
  * it intentionally bypasses polymer perimeter/infill/skin/support processing.
  */
 class HelicalSlicer : public TraditionalAST {
-  public:
+   public:
     /*!
      * @brief Constructs a helical slicer using the selected cylindrical G-code syntax.
      * @param gcodeLocation Temporary gcode output path used by the slicing thread.
@@ -47,7 +47,7 @@ class HelicalSlicer : public TraditionalAST {
      */
     void doSlice() override;
 
-  protected:
+   protected:
     /*!
      * @brief Builds helical layers by clipping helix candidates against each model cross section.
      * @param opt_data Optional process data.  Currently unused by helical slicing.
@@ -65,7 +65,7 @@ class HelicalSlicer : public TraditionalAST {
      */
     void writeGCode() override;
 
-  private:
+   private:
     /*!
      * @brief Copies a mesh so clipping can be applied without mutating the loaded model.
      * @param mesh Mesh to copy.
@@ -131,4 +131,4 @@ class HelicalSlicer : public TraditionalAST {
     //! @brief Ordered helical layers generated during helical path computation.
     QList<QSharedPointer<HelicalLayer>> m_helical_layers;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/slicers/image_slicer.h
+++ b/include/threading/slicers/image_slicer.h
@@ -21,10 +21,10 @@ namespace ORNL {
  * \brief Implementation of SlicingThread for Image slices.
  */
 class ImageSlicer : public TraditionalAST {
-  public:
+   public:
     ImageSlicer(QString gcodeLocation);
 
-  protected:
+   protected:
     //! \brief Creates images from cross-sections.
     //! \param opt_data: optional sensor data
     void preProcess(nlohmann::json opt_data = nlohmann::json()) override;
@@ -35,7 +35,7 @@ class ImageSlicer : public TraditionalAST {
     //! \brief NOP
     void writeGCode() override;
 
-  private:
+   private:
     //! \brief Struct to group meshes with their bounds and ids
     //! \param m_mesh: Mesh from each part
     //! \param m_min: minimum of mesh bounding cube
@@ -55,7 +55,7 @@ class ImageSlicer : public TraditionalAST {
     struct PolygonListAndColor {
         PolygonListAndColor(PolygonList pL, ushort c) {
             m_cross_section = pL;
-            m_color = c;
+            m_color         = c;
         }
         PolygonList m_cross_section;
         ushort m_color;
@@ -66,7 +66,7 @@ class ImageSlicer : public TraditionalAST {
     //! m_slicing_plane: current slicing plane for given id
     struct SlicingPlaneWithLayer {
         SlicingPlaneWithLayer(int layer, Plane slicing_plane) {
-            m_layer = layer;
+            m_layer         = layer;
             m_slicing_plane = slicing_plane;
         }
         int m_layer;
@@ -93,4 +93,4 @@ class ImageSlicer : public TraditionalAST {
     //!\brief Number of digits for image file name to allow sequencing of layers
     int m_total_digits = 7;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/slicers/planar_slicer.h
+++ b/include/threading/slicers/planar_slicer.h
@@ -18,10 +18,10 @@ namespace ORNL {
  * \brief Implementation of SlicingThread for planar slices.
  */
 class PlanarSlicer : public TraditionalAST {
-  public:
+   public:
     PlanarSlicer(QString gcodeLocation);
 
-  protected:
+   protected:
     //! \brief Creates layer steps by performing cross-sections.
     //! \param opt_data: optional sensor data
     void preProcess(nlohmann::json opt_data = nlohmann::json()) override;
@@ -35,7 +35,7 @@ class PlanarSlicer : public TraditionalAST {
     //! \param base: WriterBase that creates actual gcode output
     void writeGCode() override;
 
-  private:
+   private:
     //! \brief Creates layer steps for support structure
     //! \param part: Part to create supports for
     //! \param layer_count: Total number of layers
@@ -89,4 +89,4 @@ class PlanarSlicer : public TraditionalAST {
     //! \brief cached layer settings
     QList<QSharedPointer<SettingsBase>> m_saved_layer_settings;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/slicers/radial_slicer.h
+++ b/include/threading/slicers/radial_slicer.h
@@ -32,7 +32,7 @@ class SettingsBase;
  * it intentionally bypasses polymer perimeter/infill/skin/support processing.
  */
 class RadialSlicer : public TraditionalAST {
-  public:
+   public:
     /*!
      * @brief Constructs a radial slicer that emits the selected radial-capable gcode syntax.
      * @param gcodeLocation Temporary gcode output path used by the slicing thread.
@@ -47,7 +47,7 @@ class RadialSlicer : public TraditionalAST {
      */
     void doSlice() override;
 
-  protected:
+   protected:
     /*!
      * @brief Builds radial layers by clipping cylindrical ring candidates against each model cross section.
      * @param opt_data Optional process data.  Currently unused by radial slicing.
@@ -65,7 +65,7 @@ class RadialSlicer : public TraditionalAST {
      */
     void writeGCode() override;
 
-  private:
+   private:
     /*!
      * @brief Copies a mesh so clipping can be applied without mutating the loaded model.
      * @param mesh Mesh to copy.
@@ -127,4 +127,4 @@ class RadialSlicer : public TraditionalAST {
     //! @brief Ordered radial layers generated during radial path computation.
     QList<QSharedPointer<RadialLayer>> m_radial_layers;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/step_thread.h
+++ b/include/threading/step_thread.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QThread>
+
 #include <qobject.h>
 #include <qsharedpointer.h>
 #include <qtmetamacros.h>
@@ -14,7 +15,7 @@ namespace ORNL {
  */
 class StepThread : public QObject {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     StepThread();
 
@@ -27,15 +28,15 @@ class StepThread : public QObject {
     //! \brief Stops the internal worker thread after any active step callback has returned.
     void stop();
 
-  public slots:
+   public slots:
     //! \brief Perfom the computation for the step in this thread.
     void doStep();
 
-  signals:
+   signals:
     //! \brief Signal that computation has concluded.
     void completed();
 
-  private:
+   private:
     // Internal thread.
     QThread m_internal_thread;
 
@@ -43,4 +44,4 @@ class StepThread : public QObject {
     QSharedPointer<Step> m_step;
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/threading/traditional_ast.h
+++ b/include/threading/traditional_ast.h
@@ -17,24 +17,24 @@ namespace ORNL {
  */
 class TraditionalAST : public AbstractSlicingThread {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     TraditionalAST(QString outputLocation, bool skipGcode = false);
 
-  public slots:
+   public slots:
     //! \brief Main function that starts slice.
     void doSlice() override;
 
-  signals:
+   signals:
     //! \brief Signal to the active steps to begin computation.
     void stepStart();
 
-  protected slots:
+   protected slots:
     //! \brief Upon completion of thread running step object, this slot will clean up the thread.
     //!        If more objects are on the queue, then this will run the thread
     void cleanThread() override;
 
-  private:
+   private:
     //! \brief Queue of steps to be processed.
     QQueue<QSharedPointer<Step>> m_step_queue;
 
@@ -44,4 +44,4 @@ class TraditionalAST : public AbstractSlicingThread {
     //! \brief Start size of processing queue.  Used to avoid evaluting .size repeatedly
     int m_queue_start_size;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/units/derivative_units.h
+++ b/include/units/derivative_units.h
@@ -10,63 +10,75 @@ namespace ORNL {
  * \brief Two dimensional distance
  */
 class Distance2D {
-  public:
+   public:
     Distance2D() : x(0), y(0) {}
     Distance2D(Distance x, Distance y) : x(x), y(y) {}
 
     Distance x, y;
 
-    bool operator==(const Distance2D& other) { return x == other.x && y == other.y; }
+    bool operator==(const Distance2D& other) {
+        return x == other.x && y == other.y;
+    }
 
-    bool operator!=(const Distance2D& other) { return x != other.x || y != other.y; }
-}; // class Distance2D
+    bool operator!=(const Distance2D& other) {
+        return x != other.x || y != other.y;
+    }
+};  // class Distance2D
 
 /*!
  * \class Distance3D
  * \brief Three dimensional distance
  */
 class Distance3D {
-  public:
+   public:
     Distance3D() : x(0), y(0), z(0) {}
     Distance3D(Distance x, Distance y, Distance z) : x(x), y(y), z(z) {}
 
     Distance x, y, z;
 
-    bool operator==(const Distance3D& other) { return x == other.x && y == other.y && z == other.z; }
+    bool operator==(const Distance3D& other) {
+        return x == other.x && y == other.y && z == other.z;
+    }
 
-    bool operator!=(const Distance3D& other) { return x != other.x || y != other.y || z != other.z; }
-}; // class Distance3D
+    bool operator!=(const Distance3D& other) {
+        return x != other.x || y != other.y || z != other.z;
+    }
+};  // class Distance3D
 
 /*!
  * \class Distance4D
  * \brief Four dimensional distance
  */
 class Distance4D {
-  public:
+   public:
     Distance4D() : x(0), y(0), z(0), w(0) {}
     Distance4D(Distance x, Distance y, Distance z, Distance w) : x(x), y(y), z(z), w(w) {}
 
     Distance x, y, z, w;
 
-    bool operator==(const Distance4D& other) { return x == other.x && y == other.y && z == other.z && w == other.w; }
+    bool operator==(const Distance4D& other) {
+        return x == other.x && y == other.y && z == other.z && w == other.w;
+    }
 
-    bool operator!=(const Distance4D& other) { return x != other.x || y != other.y || z != other.z || w == other.w; }
-}; // class Distance4D
+    bool operator!=(const Distance4D& other) {
+        return x != other.x || y != other.y || z != other.z || w == other.w;
+    }
+};  // class Distance4D
 
 /*!
  * \class Angle3D
  * \brief Three dimensional angle
  */
 class Angle3D {
-  public:
+   public:
     Angle3D() : theta(0), phi(0), rho(0) {}
     Angle3D(Angle x, Angle y, Angle z) : theta(x), phi(y), rho(z) {}
 
     Angle theta, phi, rho;
 
-}; // class Angle3D
+};  // class Angle3D
 
-} // namespace ORNL
+}  // namespace ORNL
 
 Q_DECLARE_METATYPE(ORNL::Distance2D)
 Q_DECLARE_METATYPE(ORNL::Distance3D)

--- a/include/units/unit.h
+++ b/include/units/unit.h
@@ -2,29 +2,29 @@
 
 #include <math.h>
 
+#include <QMetaType>
+#include <QString>
+#include <QtMath>
 #include <limits>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <type_traits>
 
-#include <QMetaType>
-#include <QString>
-#include <QtMath>
-
 #include "utilities/qt_json_conversion.h"
 
 using json = fifojson;
 
 namespace ORNL {
-using NT = double; //!< \typedef Number Type
+using NT = double;  //!< \typedef Number Type
 
 /*!
  * \class Unit
  * \brief Unit aware variable
  */
-template <int U1, int U2, int U3, int U4, int U5, int U6> class Unit {
-  public:
+template <int U1, int U2, int U3, int U4, int U5, int U6>
+class Unit {
+   public:
     Unit(NT value_ = NT(0)) : m_value(value_) {}
 
     /*!
@@ -33,7 +33,7 @@ template <int U1, int U2, int U3, int U4, int U5, int U6> class Unit {
      */
     NT operator()() const {
 #if UNITS_FUNC
-    #warning("This function returns the internal value for the units class. Only use if this is exactly what you want.")
+    #warning ("This function returns the internal value for the units class. Only use if this is exactly what you want.")
 #endif
         return m_value;
     }
@@ -53,7 +53,7 @@ template <int U1, int U2, int U3, int U4, int U5, int U6> class Unit {
     virtual NT to(const Unit& u) const {
         // round conversion factors to deal with numerical imprecision
         double retValue = m_value / u.m_value;
-        retValue = QString::number(retValue, 'g', 6).toDouble();
+        retValue        = QString::number(retValue, 'g', 6).toDouble();
         return retValue;
     }
 
@@ -89,9 +89,9 @@ template <int U1, int U2, int U3, int U4, int U5, int U6> class Unit {
         return *this;
     }
 
-  protected:
+   protected:
     NT m_value;
-}; // class Unit
+};  // class Unit
 
 // Addition
 template <int U1, int U2, int U3, int U4, int U5, int U6>
@@ -162,8 +162,8 @@ const Unit<U1, U2, U3, U4, U5, U6> operator*(const Unit<U1, U2, U3, U4, U5, U6>&
 }
 
 template <int U1a, int U2a, int U3a, int U4a, int U5a, int U6a, int U1b, int U2b, int U3b, int U4b, int U5b, int U6b>
-const Unit<U1a + U1b, U2a + U2b, U3a + U3b, U4a + U4b, U5a + U5b, U6a + U6b>
-operator*(const Unit<U1a, U2a, U3a, U4a, U5a, U6a>& lhs, const Unit<U1b, U2b, U3b, U4b, U5b, U6b>& rhs) {
+const Unit<U1a + U1b, U2a + U2b, U3a + U3b, U4a + U4b, U5a + U5b, U6a + U6b> operator*(
+    const Unit<U1a, U2a, U3a, U4a, U5a, U6a>& lhs, const Unit<U1b, U2b, U3b, U4b, U5b, U6b>& rhs) {
     return Unit<U1a + U1b, U2a + U2b, U3a + U3b, U4a + U4b, U5a + U5b, U6a + U6b>(lhs() * rhs());
 }
 
@@ -179,8 +179,8 @@ const Unit<-U1, -U2, -U3, -U4, -U5, -U6> operator/(const NT& lhs, const Unit<U1,
 }
 
 template <int U1a, int U2a, int U3a, int U4a, int U5a, int U6a, int U1b, int U2b, int U3b, int U4b, int U5b, int U6b>
-const Unit<U1a - U1b, U2a - U2b, U3a - U3b, U4a - U4b, U5a - U5b, U6a - U6b>
-operator/(const Unit<U1a, U2a, U3a, U4a, U5a, U6a>& lhs, const Unit<U1b, U2b, U3b, U4b, U5b, U6b>& rhs) {
+const Unit<U1a - U1b, U2a - U2b, U3a - U3b, U4a - U4b, U5a - U5b, U6a - U6b> operator/(
+    const Unit<U1a, U2a, U3a, U4a, U5a, U6a>& lhs, const Unit<U1b, U2b, U3b, U4b, U5b, U6b>& rhs) {
     return Unit<U1a - U1b, U2a - U2b, U3a - U3b, U4a - U4b, U5a - U5b, U6a - U6b>(lhs() / rhs());
 }
 
@@ -294,8 +294,8 @@ Unit<U1, U2, U3, U4, U5, U6> max(const Unit<U1, U2, U3, U4, U5, U6>& lhs, const 
 }
 
 template <int U1, int U2, int U3, int U4, int U5, int U6, typename... Args>
-typename std::enable_if<1 < sizeof...(Args), Unit<U1, U2, U3, U4, U5, U6>>::type
-max(const Unit<U1, U2, U3, U4, U5, U6>& lhs, Args... rhs) {
+typename std::enable_if<1 < sizeof...(Args), Unit<U1, U2, U3, U4, U5, U6>>::type max(
+    const Unit<U1, U2, U3, U4, U5, U6>& lhs, Args... rhs) {
     return ORNL::max(lhs, ORNL::max(rhs...));
 }
 
@@ -305,8 +305,8 @@ Unit<U1, U2, U3, U4, U5, U6> min(const Unit<U1, U2, U3, U4, U5, U6>& lhs, const 
 }
 
 template <int U1, int U2, int U3, int U4, int U5, int U6, typename... Args>
-typename std::enable_if<1 < sizeof...(Args), Unit<U1, U2, U3, U4, U5, U6>>::type
-min(const Unit<U1, U2, U3, U4, U5, U6>& lhs, Args... rhs) {
+typename std::enable_if<1 < sizeof...(Args), Unit<U1, U2, U3, U4, U5, U6>>::type min(
+    const Unit<U1, U2, U3, U4, U5, U6>& lhs, Args... rhs) {
     return ORNL::min(lhs, ORNL::min(rhs...));
 }
 
@@ -316,8 +316,8 @@ Unit<U1 / 2, U2 / 2, U3 / 2, U4 / 2, U5 / 2, U6 / 2> sqrt(const Unit<U1, U2, U3,
 }
 
 template <int exponent, int U1, int U2, int U3, int U4, int U5, int U6>
-Unit<U1 * exponent, U2 * exponent, U3 * exponent, U4 * exponent, U5 * exponent, U6 * exponent>
-pow(const Unit<U1, U2, U3, U4, U5, U6>& base) {
+Unit<U1 * exponent, U2 * exponent, U3 * exponent, U4 * exponent, U5 * exponent, U6 * exponent> pow(
+    const Unit<U1, U2, U3, U4, U5, U6>& base) {
     return std::pow(base(), exponent);
 }
 
@@ -332,7 +332,7 @@ Unit<U1, U2, U3, U4, U5, U6> abs(const Unit<U1, U2, U3, U4, U5, U6>& lhs) {
  * \brief Unit class for distance
  */
 class Distance : public Unit<1, 0, 0, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Distance() = default;
 
@@ -359,7 +359,7 @@ void from_json(const json& j, Distance& d);
  * \brief Unit class for time
  */
 class Time : public Unit<0, 1, 0, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Time() = default;
 
@@ -385,7 +385,7 @@ void from_json(const json& j, Time& t);
  * \brief Unit class for mass
  */
 class Mass : public Unit<0, 0, 1, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Mass() = default;
 
@@ -413,7 +413,7 @@ void from_json(const json& j, Mass& m);
  * \brief Unit class for velocity
  */
 class Velocity : public Unit<1, -1, 0, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Velocity() = default;
 
@@ -440,7 +440,7 @@ void from_json(const json& j, Velocity& v);
  * \brief Unit class for acceleration
  */
 class Acceleration : public Unit<1, -2, 0, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Acceleration() = default;
 
@@ -467,7 +467,7 @@ void from_json(const json& j, Acceleration& a);
  * \brief Unit class for density
  */
 class Density : public Unit<-3, 0, 1, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Density() = default;
 
@@ -495,7 +495,7 @@ void from_json(const json& j, Density& a);
  * keeping it between 0 and 2 pi
  */
 class Angle : public Unit<0, 0, 0, 0, 0, 1> {
-  public:
+   public:
     //! \brief Default Constructor
     Angle() = default;
 
@@ -517,7 +517,7 @@ void to_json(json& j, const Angle& a);
 void from_json(const json& j, Angle& a);
 
 class Temperature : public Unit<0, 0, 0, 0, 1, 0> {
-  public:
+   public:
     Temperature() = default;
 
     Temperature(NT value);
@@ -553,7 +553,7 @@ void from_json(const json& j, AngularAcceleration& a);
 
 //! \typedef Area
 class Area : public Unit<2, 0, 0, 0, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Area() = default;
 
@@ -574,7 +574,7 @@ void from_json(const json& j, Area& a);
  * \brief Unit class for voltage
  */
 class Voltage : public Unit<2, -3, 1, -1, 0, 0> {
-  public:
+   public:
     //! \brief Default Constructor
     Voltage() = default;
 
@@ -628,89 +628,89 @@ typedef Unit<-2, 4, -1, 2, 0, 0> Capacitance;
 typedef Unit<0, 0, 0, 0, 0, 0> Unitless;
 
 // Unit constants
-const NT tera = 1e12f;
-const NT giga = 1e9f;
-const NT mega = 1e6f;
-const NT kilo = 1e3f;
-const NT deci = 1e-1f;
-const NT centi = 1e-2f;
-const NT milli = 1e-3f;
-const NT micro = 1e-6f;
-const NT nano = 1e-9f;
-const NT pico = 1e-12f;
-const NT femto = 1e-15f;
-const NT atto = 1e-18f;
-const Distance micron = 1.0f;
+const NT tera                = 1e12f;
+const NT giga                = 1e9f;
+const NT mega                = 1e6f;
+const NT kilo                = 1e3f;
+const NT deci                = 1e-1f;
+const NT centi               = 1e-2f;
+const NT milli               = 1e-3f;
+const NT micro               = 1e-6f;
+const NT nano                = 1e-9f;
+const NT pico                = 1e-12f;
+const NT femto               = 1e-15f;
+const NT atto                = 1e-18f;
+const Distance micron        = 1.0f;
 const Distance tensOfMicrons = micron * 0.1f;
-const Distance m = mega * micron;
-const Distance km = kilo * m;
-const Distance cm = centi * m;
-const Distance mm = milli * m;
-const Distance in = 2.54f * cm;
-const Distance inch = in;
-const Distance inches = in;
-const Distance ft = 12.0f * in;
-const Distance foot = ft;
-const Distance feet = ft;
-const Area m2 = 1.0f * m * m;
-const Area mm2 = 1.0f * mm * mm;
-const Area cm2 = 1.0f * cm * cm;
-const Area in2 = 1.0f * in * in;
-const Area ft2 = 1.0f * ft * ft;
-const Angle radian = 1.0f;
-const Angle rad = 1.0f;
-const Angle pi = static_cast<float>(M_PI) * rad;
-const Angle deg = 1.74532925e-2f * rad;
-const Angle degree = deg;
-const Angle degrees = deg;
-const Angle rev = 2.0f * pi;
-const Mass kg = 1.0f;
-const Mass g = milli * kg;
-const Mass mg = milli * g;
-const Mass lbm = 0.45359237f * kg;
-const Time s = 1.0f;
-const Time ms = milli * s;
-const Time hr = 3600.0f * s;
-const Time hour = hr;
-const Time minute = 60.0f * s;
-const Force N = 1.0f * kg * m / (s * s);
-const Force lbf = 4.4482216f * N;
-const Force oz = lbf / 16.0f;
-const Force ounce = oz;
-const Energy J = 1.0f * N * m;
-const Energy cal = 4.1868f * J;
-const Energy kcal = kilo * cal;
-const Energy eV = 1.6021765e-19f * J;
-const Energy keV = kilo * eV;
-const Energy MeV = mega * eV;
-const Energy GeV = giga * eV;
-const Energy btu = 1055.0559f * J;
-const Power W = 1.0f * J / s;
-const Current A = 1.0f;
-const Current MA = mega * A;
-const Current kA = kilo * A;
-const Current mA = milli * A;
-const Current uA = micro * A;
-const Current nA = nano * A;
-const Current pA = pico * A;
-const Charge C = 1.0f * A * s;
-const Voltage V = 1.0f * J / C;
-const Voltage uV = micro * V;
-const Voltage mV = milli * V;
-const Resistance ohm = 1.0f * V / A;
-const Conductance S = 1.0f / ohm;
-const Capacitance F = 1.0f * C / V;
-const Capacitance pF = pico * F;
-const Capacitance nF = nano * F;
-const Capacitance uF = micro * F;
-const Capacitance mF = milli * F;
-const Pressure Pa = 1.0f;
-const Pressure kPa = 1e3f * Pa;
-const Pressure bar = Pa * 100000.0f;
-const Pressure millibar = 1e-3f * bar;
-const Pressure psi = lbf / (inch * inch);
-const Pressure atm = 101325.0f * Pa;
-const Temperature K = 1.0f;
+const Distance m             = mega * micron;
+const Distance km            = kilo * m;
+const Distance cm            = centi * m;
+const Distance mm            = milli * m;
+const Distance in            = 2.54f * cm;
+const Distance inch          = in;
+const Distance inches        = in;
+const Distance ft            = 12.0f * in;
+const Distance foot          = ft;
+const Distance feet          = ft;
+const Area m2                = 1.0f * m * m;
+const Area mm2               = 1.0f * mm * mm;
+const Area cm2               = 1.0f * cm * cm;
+const Area in2               = 1.0f * in * in;
+const Area ft2               = 1.0f * ft * ft;
+const Angle radian           = 1.0f;
+const Angle rad              = 1.0f;
+const Angle pi               = static_cast<float>(M_PI) * rad;
+const Angle deg              = 1.74532925e-2f * rad;
+const Angle degree           = deg;
+const Angle degrees          = deg;
+const Angle rev              = 2.0f * pi;
+const Mass kg                = 1.0f;
+const Mass g                 = milli * kg;
+const Mass mg                = milli * g;
+const Mass lbm               = 0.45359237f * kg;
+const Time s                 = 1.0f;
+const Time ms                = milli * s;
+const Time hr                = 3600.0f * s;
+const Time hour              = hr;
+const Time minute            = 60.0f * s;
+const Force N                = 1.0f * kg * m / (s * s);
+const Force lbf              = 4.4482216f * N;
+const Force oz               = lbf / 16.0f;
+const Force ounce            = oz;
+const Energy J               = 1.0f * N * m;
+const Energy cal             = 4.1868f * J;
+const Energy kcal            = kilo * cal;
+const Energy eV              = 1.6021765e-19f * J;
+const Energy keV             = kilo * eV;
+const Energy MeV             = mega * eV;
+const Energy GeV             = giga * eV;
+const Energy btu             = 1055.0559f * J;
+const Power W                = 1.0f * J / s;
+const Current A              = 1.0f;
+const Current MA             = mega * A;
+const Current kA             = kilo * A;
+const Current mA             = milli * A;
+const Current uA             = micro * A;
+const Current nA             = nano * A;
+const Current pA             = pico * A;
+const Charge C               = 1.0f * A * s;
+const Voltage V              = 1.0f * J / C;
+const Voltage uV             = micro * V;
+const Voltage mV             = milli * V;
+const Resistance ohm         = 1.0f * V / A;
+const Conductance S          = 1.0f / ohm;
+const Capacitance F          = 1.0f * C / V;
+const Capacitance pF         = pico * F;
+const Capacitance nF         = nano * F;
+const Capacitance uF         = micro * F;
+const Capacitance mF         = milli * F;
+const Pressure Pa            = 1.0f;
+const Pressure kPa           = 1e3f * Pa;
+const Pressure bar           = Pa * 100000.0f;
+const Pressure millibar      = 1e-3f * bar;
+const Pressure psi           = lbf / (inch * inch);
+const Pressure atm           = 101325.0f * Pa;
+const Temperature K          = 1.0f;
 // Since K and degC are the same factor with different offsets, the quick way to make it work in this
 // system is to give degC a tiny difference in the factor. It's not enough to make noticble difference
 // so it should work for now. Not that it isn't stupid/bad to do so.
@@ -718,8 +718,8 @@ const Temperature degC = 1.000001f * K;
 const Temperature degF = 5.0f / 9.0f * K;
 
 const Acceleration AccelerationOfGravity = 9.80665f * m / (s * s);
-const Velocity SpeedOfLight = 2.9979246e8f * m / s;
-const Velocity SpeedOfSound = 331.46f * m / s;
+const Velocity SpeedOfLight              = 2.9979246e8f * m / s;
+const Velocity SpeedOfSound              = 331.46f * m / s;
 
 const Unitless none = 1.0f;
 
@@ -729,4 +729,4 @@ double tan(const Angle& lhs);
 #undef UNITS_FUNC
 #define UNITS_FUNC false
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
-
 #include <QColor>
 #include <QHash>
 #include <QVector3D>
 #include <QVector>
+#include <string>
+
 #include <qcontainerfwd.h>
 
 #include "units/unit.h"
@@ -16,13 +16,13 @@ namespace ORNL {
  * \brief Class that holds all static constants
  */
 class Constants {
-  public:
+   public:
     /*!
      * \class Units
      * \brief Units strings used for preferences
      */
     class Units {
-      public:
+       public:
         static const QString kInch;
         static const QString kInchPerSec;
         static const QString kInchPerMin;
@@ -96,7 +96,7 @@ class Constants {
     };
 
     class RegionTypeStrings {
-      public:
+       public:
         static const QString kUnknown;
         static const QString kPerimeter;
         static const QString kRadial;
@@ -119,13 +119,13 @@ class Constants {
 
     // Used?
     class LegacyRegionTypeStrings {
-      public:
+       public:
         static const QString kThing;
     };
 
     // Used?
     class InfillPatternTypeStrings {
-      public:
+       public:
         static const QString kLines;
         static const QString kGrid;
         static const QString kConcentric;
@@ -139,7 +139,7 @@ class Constants {
 
     // Used?
     class OrderOptimizationTypeStrings {
-      public:
+       public:
         static const QString kShortestTime;
         static const QString kShortestDistance;
         static const QString kLargestDistance;
@@ -154,7 +154,7 @@ class Constants {
     };
 
     class PathModifierStrings {
-      public:
+       public:
         static const QString kPrestart;
         static const QString kInitialStartup;
         static const QString kSlowDown;
@@ -171,9 +171,9 @@ class Constants {
     };
 
     class PrinterSettings {
-      public:
+       public:
         class MachineSetup {
-          public:
+           public:
             static const QString kSyntax;
             static const QString kMachineType;
             static const QString kForceG1;
@@ -200,7 +200,7 @@ class Constants {
          * \brief Keys for machine dimensions
          */
         class Dimensions {
-          public:
+           public:
             static const QString kBuildVolumeType;
             static const QString kXMin;
             static const QString kXMax;
@@ -232,13 +232,13 @@ class Constants {
         };
 
         class Auxiliary {
-          public:
+           public:
             static const QString kEnableTamper;
             static const QString kTamperVoltage;
         };
 
         class MachineSpeed {
-          public:
+           public:
             static const QString kMinXYSpeed;
             static const QString kMaxXYSpeed;
             static const QString kMinExtruderSpeed;
@@ -249,7 +249,7 @@ class Constants {
         };
 
         class Acceleration {
-          public:
+           public:
             static const QString kEnableDynamic;
             static const QString kDefault;
             static const QString kPerimeter;
@@ -261,7 +261,7 @@ class Constants {
         };
 
         class GCode {
-          public:
+           public:
             static const QString kEnableStartupCode;
             static const QString kEnableMaterialLoad;
             static const QString kEnableWaitForUser;
@@ -281,7 +281,7 @@ class Constants {
         //             * \brief Keys for machine syntax
         //             */
         class SyntaxString {
-          public:
+           public:
             static QString kAML3D;
             static QString kBeam;
             static QString kCincinnati;
@@ -323,15 +323,15 @@ class Constants {
      * \brief Keys for material settings
      */
     class MaterialSettings {
-      public:
+       public:
         class Density {
-          public:
+           public:
             static const QString kMaterialType;
             static const QString kDensity;
         };
 
         class Startup {
-          public:
+           public:
             static const QString kPerimeterEnable;
             static const QString kPerimeterDistance;
             static const QString kPerimeterSpeed;
@@ -372,7 +372,7 @@ class Constants {
         };
 
         class Slowdown {
-          public:
+           public:
             static const QString kPerimeterEnable;
             static const QString kPerimeterDistance;
             static const QString kPerimeterLiftDistance;
@@ -413,7 +413,7 @@ class Constants {
         };
 
         class TipWipe {
-          public:
+           public:
             static const QString kPerimeterEnable;
             static const QString kPerimeterDistance;
             static const QString kPerimeterSpeed;
@@ -464,7 +464,7 @@ class Constants {
         };
 
         class SpiralLift {
-          public:
+           public:
             static const QString kPerimeterEnable;
             static const QString kInsetEnable;
             static const QString kSkinEnable;
@@ -478,7 +478,7 @@ class Constants {
         };
 
         class Purge {
-          public:
+           public:
             static const QString kInitialDuration;
             static const QString kInitialScrewRPM;
             static const QString kInitialTipWipeDelay;
@@ -491,7 +491,7 @@ class Constants {
         };
 
         class Extruder {
-          public:
+           public:
             static const QString kInitialSpeed;
             static const QString kExtruderPrimeVolume;
             static const QString kExtruderPrimeSpeed;
@@ -506,7 +506,7 @@ class Constants {
         };
 
         class Filament {
-          public:
+           public:
             static const QString kDiameter;
             static const QString kRelative;
             static const QString kDisableG92;
@@ -514,7 +514,7 @@ class Constants {
         };
 
         class Retraction {
-          public:
+           public:
             static const QString kEnable;
             static const QString kMinTravel;
             static const QString kLength;
@@ -526,7 +526,7 @@ class Constants {
         };
 
         class Temperatures {
-          public:
+           public:
             static const QString kBed;
             static const QString kTwoZones;
             static const QString kThreeZones;
@@ -542,7 +542,7 @@ class Constants {
         };
 
         class Cooling {
-          public:
+           public:
             static const QString kEnable;
             static const QString kDisable;
             static const QString kDisableXLayers;
@@ -558,7 +558,7 @@ class Constants {
         };
 
         class PlatformAdhesion {
-          public:
+           public:
             static const QString kRaftEnable;
             static const QString kRaftOffset;
             static const QString kRaftLayers;
@@ -578,7 +578,7 @@ class Constants {
         };
 
         class MultiMaterial {
-          public:
+           public:
             static const QString kEnable;
             static const QString kPerimeterNum;
             static const QString kInsetNum;
@@ -593,14 +593,14 @@ class Constants {
     };
 
     class ProfileSettings {
-      public:
+       public:
         /*!
          * \class Layer
          *
          * \brief Keys for layer settings
          */
         class Layer {
-          public:
+           public:
             static const QString kLayerHeight;
             static const QString kNozzleDiameter;
             static const QString kBeadWidth;
@@ -610,7 +610,7 @@ class Constants {
         };
 
         class Perimeter {
-          public:
+           public:
             static const QString kEnable;
             static const QString kCount;
             static const QString kBoundarySelection;
@@ -635,7 +635,7 @@ class Constants {
         };
 
         class Inset {
-          public:
+           public:
             static const QString kEnable;
             static const QString kCount;
             static const QString kBeadWidth;
@@ -653,7 +653,7 @@ class Constants {
         };
 
         class Skeleton {
-          public:
+           public:
             static const QString kEnable;
             static const QString kSkeletonInput;
             static const QString kSkeletonInputCleaningDistance;
@@ -685,7 +685,7 @@ class Constants {
         };
 
         class Skin {
-          public:
+           public:
             static const QString kEnable;
             static const QString kTopCount;
             static const QString kBottomCount;
@@ -707,7 +707,7 @@ class Constants {
         };
 
         class Infill {
-          public:
+           public:
             static const QString kEnable;
             static const QString kLineSpacing;
             static const QString kDensity;
@@ -730,7 +730,7 @@ class Constants {
         };
 
         class Support {
-          public:
+           public:
             static const QString kEnable;
             static const QString kPrintFirst;
             static const QString kStructure;
@@ -766,7 +766,7 @@ class Constants {
         };
 
         class Travel {
-          public:
+           public:
             static const QString kSpeed;
             static const QString kInfillMinLength;
             static const QString kMinTravelLength;
@@ -779,7 +779,7 @@ class Constants {
         };
 
         class GCode {
-          public:
+           public:
             static const QString kPerimeterStart;
             static const QString kPerimeterEnd;
             static const QString kInsetStart;
@@ -795,7 +795,7 @@ class Constants {
         };
 
         class SpecialModes {
-          public:
+           public:
             static const QString kSmoothing;
             static const QString kSmoothingType;
             static const QString kSmoothingTolerance;
@@ -815,7 +815,7 @@ class Constants {
         };
 
         class Optimizations {
-          public:
+           public:
             static const QString kLayerOrdering;
             static const QString kLayerGroupingTolerance;
             static const QString kIslandOrder;
@@ -852,14 +852,14 @@ class Constants {
         };
 
         class Ordering {
-          public:
+           public:
             static const QString kRegionOrder;
             static const QString kPerimeterReverseDirection;
             static const QString kInsetReverseDirection;
         };
 
         class LaserScanner {
-          public:
+           public:
             static const QString kLaserScanner;
             static const QString kSpeed;
             static const QString kLaserScannerHeightOffset;
@@ -886,7 +886,7 @@ class Constants {
         };
 
         class ThermalScanner {
-          public:
+           public:
             static const QString kThermalScanner;
             static const QString kThermalScannerTemperatureCutoff;
             static const QString kThermalScannerXOffset;
@@ -894,7 +894,7 @@ class Constants {
         };
 
         class Slicing {
-          public:
+           public:
             static const QString kSlicingMode;
             static const QString kCylindricalPathPattern;
             static const QString kSlicePlaneNormalX;
@@ -918,9 +918,9 @@ class Constants {
     };
 
     class ExperimentalSettings {
-      public:
+       public:
         class Ramping {
-          public:
+           public:
             static const QString kTrajectoryAngleEnabled;
             static const QString kTrajectoryAngleThreshold;
             static const QString kTrajectoryAngleRampDownDistance;
@@ -932,7 +932,7 @@ class Constants {
         };
 
         class FileOutput {
-          public:
+           public:
             static const QString kMeldCompanionOutput;
             static const QString kMeldDiscrete;
             static const QString kTormachOutput;
@@ -951,17 +951,17 @@ class Constants {
         };
 
         class CrossSection {
-          public:
+           public:
             static const QString kLargestGap;
             static const QString kMaxStitch;
         };
     };
 
     class Settings {
-      public:
+       public:
         // NOTE: All keys here are std::strings since they will primarily be used with nlohmann::json.
         class Master {
-          public:
+           public:
             static const std::string kDisplay;
             static const std::string kType;
             static const std::string kToolTip;
@@ -974,7 +974,7 @@ class Constants {
             static const std::string kLocal;
         };
         class Input {
-          public:
+           public:
             static const std::string kName;
             static const std::string kDisplay;
             static const std::string kWidget;
@@ -992,7 +992,7 @@ class Constants {
             static const std::string kVector3;
         };
         class Session {
-          public:
+           public:
             static const std::string kParts;
             static const std::string kName;
             static const std::string kTransform;
@@ -1003,20 +1003,20 @@ class Constants {
             static const std::string kFile;
             static const std::string kDir;
             class LocalFile {
-              public:
+               public:
                 static const std::string kName;
                 static const std::string kSettings;
                 static const std::string kRanges;
             };
             class Range {
-              public:
+               public:
                 static const std::string kLow;
                 static const std::string kHigh;
                 static const std::string kName;
                 static const std::string kSettings;
             };
             class Files {
-              public:
+               public:
                 static const std::string kSession;
                 static const std::string kGlobal;
                 static const std::string kLocal;
@@ -1026,7 +1026,7 @@ class Constants {
         };
 
         class SettingTab {
-          public:
+           public:
             static const QString kPrinter;
             static const QString kMaterial;
             static const QString kProfile;
@@ -1037,7 +1037,7 @@ class Constants {
     //! \class SegmentSettings
     //! \brief The settings that segments use to define their output.
     class SegmentSettings {
-      public:
+       public:
         static const QString kHeight;
         static const QString kWidth;
         static const QString kSpeed;
@@ -1054,13 +1054,13 @@ class Constants {
     };
 
     class Limits {
-      public:
+       public:
         /*!
          * \class Maximums
          * \brief Maximum values for various data types
          */
         class Maximums {
-          public:
+           public:
             static const Distance kMaxDistance;
             static const Velocity kMaxSpeed;
             static const Acceleration kMaxAccel;
@@ -1080,7 +1080,7 @@ class Constants {
          * \brief Minimum values for various data types
          */
         class Minimums {
-          public:
+           public:
             static const Distance kMinDistance;
             static const Distance kMinLocation;
             static const Velocity kMinSpeed;
@@ -1096,7 +1096,7 @@ class Constants {
     };
 
     class Colors {
-      public:
+       public:
         static const QColor kYellow;
         static const QColor kRed;
         static const QColor kBlue;
@@ -1113,11 +1113,11 @@ class Constants {
      * \brief Constants for UI widgets
      */
     class UI {
-      public:
+       public:
         class Common {
-          public:
+           public:
             class DropShadow {
-              public:
+               public:
                 static const int kXOffset;
                 static const int kYOffset;
                 static const int kBlurRadius;
@@ -1126,7 +1126,7 @@ class Constants {
         };
 
         class MainWindow {
-          public:
+           public:
             static const QSize kWindowSize;
             static const QSize kViewWidgetSize;
             static const QSize kLayerbarMinSize;
@@ -1134,14 +1134,14 @@ class Constants {
             static const int kStatusBarMaxHeight;
 
             class SideDock {
-              public:
+               public:
                 static const int kSettingsWidth;
                 static const int kGCodeWidth;
                 static const int kLayerTimesWidth;
             };
 
             class Margins {
-              public:
+               public:
                 static const int kMainLayoutSpacing;
                 static const int kMainContainerSpacing;
                 static const int kMainLayout;
@@ -1150,7 +1150,7 @@ class Constants {
         };
 
         class MainToolbar {
-          public:
+           public:
             static const int kMaxWidth;
             static const int kStartOffset;
             static const int kEndOffset;
@@ -1158,7 +1158,7 @@ class Constants {
         };
 
         class ViewControlsToolbar {
-          public:
+           public:
             static const int kHeight;
             static const int kWidth;
             static const int kRightOffset;
@@ -1166,13 +1166,13 @@ class Constants {
         };
 
         class PartToolbar {
-          public:
+           public:
             static const int kHeight;
             static const int kWidth;
             static const int kLeftOffset;
             static const int kMinTopOffset;
             class Input {
-              public:
+               public:
                 static const int kBoxWidth;
                 static const int kBoxHeight;
                 static const int kExtraButtonWidth;
@@ -1183,14 +1183,14 @@ class Constants {
         };
 
         class PartControl {
-          public:
+           public:
             static const QSize kSize;
             static const int kLeftOffset;
             static const int kBottomOffset;
         };
 
         class Themes {
-          public:
+           public:
             static const QString kSystemMode;
             static const QString kDarkMode;
             static const QStringList kThemes;
@@ -1202,7 +1202,7 @@ class Constants {
      * \brief The constants for the OpenGL widgets
      */
     class OpenGL {
-      public:
+       public:
         static const double kZoomDefault;
         static const double kZoomMax;
         static const double kZoomMin;
@@ -1216,7 +1216,7 @@ class Constants {
         static const float kViewToObject;
 
         class Shader {
-          public:
+           public:
             static const char* kVertShaderFile;
             static const char* kFragShaderFile;
 
@@ -1245,7 +1245,7 @@ class Constants {
     };
 
     class GcodeFileVariables {
-      public:
+       public:
         static const QString kPrinterBaseOffset;
         static const QString kExtrusionWidth;
         static const QString kXOffset;
@@ -1269,7 +1269,7 @@ class Constants {
     };
 
     class SettingFileStrings {
-      public:
+       public:
         static const std::string kHeader;
         static const std::string kCreatedBy;
         static const std::string kCreatedOn;
@@ -1280,7 +1280,7 @@ class Constants {
     };
 
     class ConsoleOptionStrings {
-      public:
+       public:
         static const QString kInputProjectFile;
         static const QString kInputStlFiles;
         static const QString kInputStlFilesDirectory;
@@ -1313,10 +1313,10 @@ class Constants {
 };
 
 // Type aliases for easier reading
-using ES = Constants::ExperimentalSettings;
-using MS = Constants::MaterialSettings;
-using PS = Constants::ProfileSettings;
+using ES  = Constants::ExperimentalSettings;
+using MS  = Constants::MaterialSettings;
+using PS  = Constants::ProfileSettings;
 using PRS = Constants::PrinterSettings;
-using SS = Constants::SegmentSettings;
+using SS  = Constants::SegmentSettings;
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <QCoreApplication>
+#include <QMessageBox>
 #include <cstdint>
 #include <stdexcept>
 
-#include <QCoreApplication>
-#include <QMessageBox>
 #include <qcolor.h>
 #include <qtcoreexports.h>
 
@@ -27,14 +27,14 @@ enum MeshType { kBuild, kClipping, kSettings, kSupport };
  * \brief types of meshes that can be generated
  */
 enum MeshGeneratorType {
-    kNone = 0,
+    kNone                 = 0,
     kDefaultSettingRegion = 1,
-    kOpenTopBox = 2,
-    kRectangularBox = 3,
-    kTriangularPyramid = 4,
-    kCylinder = 5,
-    kCone = 6,
-    kHexagonalPrism = 7
+    kOpenTopBox           = 2,
+    kRectangularBox       = 3,
+    kTriangularPyramid    = 4,
+    kCylinder             = 5,
+    kCone                 = 6,
+    kHexagonalPrism       = 7
 };
 
 /*! \enum BuildVolumeType
@@ -182,20 +182,20 @@ inline QString toString(CylinderAxisSource mode) {
  * \enum AffectedArea
  * \brief The AffectedArea enum
  */
-enum class AffectedArea : int // was uint8_t
+enum class AffectedArea : int  // was uint8_t
 {
-    kNone = 0,
-    kPerimeter = 1 << 0,
-    kInset = 1 << 1,
-    kInfill = 1 << 2,
-    kTopSkin = 1 << 3,
-    kBottomSkin = 1 << 4,
-    kSkin = 1 << 5,
-    kSupport = 1 << 6,
-    kRaft = 1 << 7,
-    kBrim = 1 << 8,
-    kSkirt = 1 << 9,
-    kLaserScan = 1 << 10,
+    kNone        = 0,
+    kPerimeter   = 1 << 0,
+    kInset       = 1 << 1,
+    kInfill      = 1 << 2,
+    kTopSkin     = 1 << 3,
+    kBottomSkin  = 1 << 4,
+    kSkin        = 1 << 5,
+    kSupport     = 1 << 6,
+    kRaft        = 1 << 7,
+    kBrim        = 1 << 8,
+    kSkirt       = 1 << 9,
+    kLaserScan   = 1 << 10,
     kThermalScan = 1 << 11
 };
 
@@ -226,38 +226,38 @@ inline ThemeName themeFromString(const QString& theme) {
  * @brief Available output syntaxes and parser/writer dialects.
  */
 enum class GcodeSyntax : uint8_t {
-    kBeam = 0,
-    kCincinnati = 1,
-    kCommon = 2,
-    kDmgDmu = 3,
-    kGudel = 4,
-    kHaasInch = 5,
-    kHaasMetric = 6,
+    kBeam                 = 0,
+    kCincinnati           = 1,
+    kCommon               = 2,
+    kDmgDmu               = 3,
+    kGudel                = 4,
+    kHaasInch             = 5,
+    kHaasMetric           = 6,
     kHaasMetricNoComments = 7,
-    kHurco = 8,
-    kIngersoll = 9,
-    kMarlin = 10,
-    kJuggerBot = 11,
-    kMazak = 12,
-    kMVP = 13,
-    kRomiFanuc = 14,
-    kSiemens = 15,
-    kThermwood = 16,
-    kWolf = 17,
-    kRepRap = 18,
-    kMach4 = 19,
-    kAeroBasic = 20,
-    kMeld = 21,
-    kORNL = 22,
-    kOkuma = 23,
-    kTormach = 24,
-    kAML3D = 25,
-    kKraussMaffei = 26,
-    kSandia = 27,
-    kMeltio = 28,
-    kAdamantine = 29,
-    kORNLMetric = 30,
-    kArcSpecialties = 31
+    kHurco                = 8,
+    kIngersoll            = 9,
+    kMarlin               = 10,
+    kJuggerBot            = 11,
+    kMazak                = 12,
+    kMVP                  = 13,
+    kRomiFanuc            = 14,
+    kSiemens              = 15,
+    kThermwood            = 16,
+    kWolf                 = 17,
+    kRepRap               = 18,
+    kMach4                = 19,
+    kAeroBasic            = 20,
+    kMeld                 = 21,
+    kORNL                 = 22,
+    kOkuma                = 23,
+    kTormach              = 24,
+    kAML3D                = 25,
+    kKraussMaffei         = 26,
+    kSandia               = 27,
+    kMeltio               = 28,
+    kAdamantine           = 29,
+    kORNLMetric           = 30,
+    kArcSpecialties       = 31
 };
 
 inline QString toString(GcodeSyntax syntax) {
@@ -333,13 +333,13 @@ inline QString toString(GcodeSyntax syntax) {
  * \brief The InfillPatterns enum
  */
 enum class InfillPatterns : uint8_t {
-    kLines = 0,
-    kGrid = 1,
-    kConcentric = 2,
-    kTriangles = 3,
+    kLines                = 0,
+    kGrid                 = 1,
+    kConcentric           = 2,
+    kTriangles            = 3,
     kHexagonsAndTriangles = 4,
-    kHoneycomb = 5,
-    kRadialHatch = 6
+    kHoneycomb            = 5,
+    kRadialHatch          = 6
 };
 
 //! \brief Function for going from json to InfillPatterns
@@ -372,11 +372,11 @@ inline QString toString(InfillPatterns infill_type) {
  * \brief Types of regions, used to lookup when dealing with abstract region.
  */
 enum class RegionType : int {
-    kUnknown = 0,
+    kUnknown   = 0,
     kPerimeter = 1 << 0,
-    kInset = 1 << 1,
-    kInfill = 1 << 2,
-    kSkin = 1 << 3,
+    kInset     = 1 << 1,
+    kInfill    = 1 << 2,
+    kSkin      = 1 << 3,
     kSkirt,
     kBrim,
     kRaft,
@@ -413,54 +413,32 @@ inline constexpr RegionType operator|(const RegionType& lhs, const RegionType& r
     return static_cast<RegionType>(static_cast<int>(lhs) | static_cast<int>(rhs));
 }
 
-inline RegionType& operator|=(RegionType& lhs, const RegionType& rhs) { return lhs = lhs | rhs; }
+inline RegionType& operator|=(RegionType& lhs, const RegionType& rhs) {
+    return lhs = lhs | rhs;
+}
 
 inline constexpr RegionType operator&(const RegionType& lhs, const RegionType& rhs) {
     return static_cast<RegionType>(static_cast<int>(lhs) & static_cast<int>(rhs));
 }
 
-inline RegionType& operator&=(RegionType& lhs, const RegionType& rhs) { return lhs = lhs & rhs; }
+inline RegionType& operator&=(RegionType& lhs, const RegionType& rhs) {
+    return lhs = lhs & rhs;
+}
 
 inline RegionType fromString(QString type) {
-    if (type == Constants::RegionTypeStrings::kUnknown) {
-        return RegionType::kUnknown;
-    }
-    else if (type == Constants::RegionTypeStrings::kPerimeter) {
-        return RegionType::kPerimeter;
-    }
-    else if (type == Constants::RegionTypeStrings::kInset) {
-        return RegionType::kInset;
-    }
-    else if (type == Constants::RegionTypeStrings::kSkin) {
-        return RegionType::kSkin;
-    }
-    else if (type == Constants::RegionTypeStrings::kInfill) {
-        return RegionType::kInfill;
-    }
-    else if (type == Constants::RegionTypeStrings::kSupport) {
-        return RegionType::kSupport;
-    }
-    else if (type == Constants::RegionTypeStrings::kSupportRoof) {
-        return RegionType::kSupportRoof;
-    }
-    else if (type == Constants::RegionTypeStrings::kRaft) {
-        return RegionType::kRaft;
-    }
-    else if (type == Constants::RegionTypeStrings::kBrim) {
-        return RegionType::kBrim;
-    }
-    else if (type == Constants::RegionTypeStrings::kSkirt) {
-        return RegionType::kSkirt;
-    }
-    else if (type == Constants::RegionTypeStrings::kLaserScan) {
-        return RegionType::kLaserScan;
-    }
-    else if (type == Constants::RegionTypeStrings::kThermalScan) {
-        return RegionType::kThermalScan;
-    }
-    else if (type == Constants::RegionTypeStrings::kSkeleton) {
-        return RegionType::kSkeleton;
-    }
+    if (type == Constants::RegionTypeStrings::kUnknown) { return RegionType::kUnknown; }
+    else if (type == Constants::RegionTypeStrings::kPerimeter) { return RegionType::kPerimeter; }
+    else if (type == Constants::RegionTypeStrings::kInset) { return RegionType::kInset; }
+    else if (type == Constants::RegionTypeStrings::kSkin) { return RegionType::kSkin; }
+    else if (type == Constants::RegionTypeStrings::kInfill) { return RegionType::kInfill; }
+    else if (type == Constants::RegionTypeStrings::kSupport) { return RegionType::kSupport; }
+    else if (type == Constants::RegionTypeStrings::kSupportRoof) { return RegionType::kSupportRoof; }
+    else if (type == Constants::RegionTypeStrings::kRaft) { return RegionType::kRaft; }
+    else if (type == Constants::RegionTypeStrings::kBrim) { return RegionType::kBrim; }
+    else if (type == Constants::RegionTypeStrings::kSkirt) { return RegionType::kSkirt; }
+    else if (type == Constants::RegionTypeStrings::kLaserScan) { return RegionType::kLaserScan; }
+    else if (type == Constants::RegionTypeStrings::kThermalScan) { return RegionType::kThermalScan; }
+    else if (type == Constants::RegionTypeStrings::kSkeleton) { return RegionType::kSkeleton; }
     throw UnknownRegionTypeException("Cannot convert this string to RegionType");
 }
 
@@ -501,20 +479,20 @@ inline QString toString(RegionType region_type) {
  * \brief The PathModifiers enum
  */
 enum class PathModifiers : uint16_t {
-    kNone = 0,
-    kReverseTipWipe = 1 << 0,
-    kForwardTipWipe = 1 << 1,
-    kPerimeterTipWipe = 1 << 2, // Rename to not include perimeter
-    kAngledTipWipe = 1 << 3,
-    kInitialStartup = 1 << 4,
-    kSlowDown = 1 << 5,
-    kCoasting = 1 << 6,
-    kPrestart = 1 << 7,
-    kSpiralLift = 1 << 8,
-    kRampingUp = 1 << 9,
-    kRampingDown = 1 << 10,
-    kLeadIn = 1 << 11,
-    kFlyingStart = 1 << 12
+    kNone             = 0,
+    kReverseTipWipe   = 1 << 0,
+    kForwardTipWipe   = 1 << 1,
+    kPerimeterTipWipe = 1 << 2,  // Rename to not include perimeter
+    kAngledTipWipe    = 1 << 3,
+    kInitialStartup   = 1 << 4,
+    kSlowDown         = 1 << 5,
+    kCoasting         = 1 << 6,
+    kPrestart         = 1 << 7,
+    kSpiralLift       = 1 << 8,
+    kRampingUp        = 1 << 9,
+    kRampingDown      = 1 << 10,
+    kLeadIn           = 1 << 11,
+    kFlyingStart      = 1 << 12
 };
 
 enum class TipWipeDirection { kOptimal = 0, kForward = 1, kReverse = 2, kAngled = 3 };
@@ -523,13 +501,17 @@ inline constexpr PathModifiers operator|(const PathModifiers& lhs, const PathMod
     return static_cast<PathModifiers>(static_cast<int>(lhs) | static_cast<int>(rhs));
 }
 
-inline PathModifiers& operator|=(PathModifiers& lhs, const PathModifiers& rhs) { return lhs = lhs | rhs; }
+inline PathModifiers& operator|=(PathModifiers& lhs, const PathModifiers& rhs) {
+    return lhs = lhs | rhs;
+}
 
 inline constexpr PathModifiers operator&(const PathModifiers& lhs, const PathModifiers& rhs) {
     return static_cast<PathModifiers>(static_cast<int>(lhs) & static_cast<int>(rhs));
 }
 
-inline PathModifiers& operator&=(PathModifiers& lhs, const PathModifiers& rhs) { return lhs = lhs & rhs; }
+inline PathModifiers& operator&=(PathModifiers& lhs, const PathModifiers& rhs) {
+    return lhs = lhs & rhs;
+}
 
 inline QString toString(PathModifiers modifier_type) {
     switch (modifier_type) {
@@ -570,10 +552,10 @@ inline QString toString(PathModifiers modifier_type) {
  * \brief The Smoothing Type enum
  */
 enum class SmoothingType : uint8_t {
-    kDouglasPeucker = 0,
-    kRadialDistance = 1,
+    kDouglasPeucker        = 0,
+    kRadialDistance        = 1,
     kPerpendicularDistance = 2,
-    kReumannWitkam = 3
+    kReumannWitkam         = 3
 };
 
 /*!
@@ -581,22 +563,22 @@ enum class SmoothingType : uint8_t {
  * \brief The Path/ Island OrderOptimization enum
  */
 enum class IslandOrderOptimization : uint8_t {
-    kNextClosest = 0,
-    kNextFarthest = 1,
+    kNextClosest            = 0,
+    kNextFarthest           = 1,
     kShortestDistanceApprox = 2,
-    kShortestDistanceBrute = 3,
-    kLeastRecentlyVisited = 4,
-    kRandom = 5,
-    kCustomPoint = 6
+    kShortestDistanceBrute  = 3,
+    kLeastRecentlyVisited   = 4,
+    kRandom                 = 5,
+    kCustomPoint            = 6
 };
 
 enum class PathOrderOptimization : uint8_t {
-    kNextClosest = 0,
+    kNextClosest  = 0,
     kNextFarthest = 1,
-    kRandom = 2,
-    kOutsideIn = 3,
-    kInsideOut = 4,
-    kCustomPoint = 5
+    kRandom       = 2,
+    kOutsideIn    = 3,
+    kInsideOut    = 4,
+    kCustomPoint  = 5
 };
 
 inline PathOrderOptimization optionalPathOrderOptimization(int optimization,
@@ -624,11 +606,11 @@ inline bool optionalPathOrderUsesCustomLocation(int optimization) {
 }
 
 enum class PointOrderOptimization : uint8_t {
-    kNextClosest = 0,
-    kNextFarthest = 1,
-    kRandom = 2,
-    kConsecutive = 3,
-    kCustomPoint = 4,
+    kNextClosest         = 0,
+    kNextFarthest        = 1,
+    kRandom              = 2,
+    kConsecutive         = 3,
+    kCustomPoint         = 4,
     kCustomFarthestPoint = 5
 };
 
@@ -654,26 +636,26 @@ enum class Axis : uint8_t { kX, kY, kZ };
 enum class IslandType : uint8_t { kAll, kBrim, kPolymer, kRaft, kLaserScan, kThermalScan, kSkirt, kSupport };
 
 enum class MachineType : uint8_t {
-    kPellet = 0,
-    kFilament = 1,
-    kWire_Arc = 2,
+    kPellet     = 0,
+    kFilament   = 1,
+    kWire_Arc   = 2,
     kLaser_Wire = 3,
-    kConcrete = 4,
-    kThermoset = 5
+    kConcrete   = 4,
+    kThermoset  = 5
 };
 
 enum class PrintMaterial : uint8_t {
-    kABS20CF = 0,
-    kABS = 1,
-    kPPS = 2,
-    kPPS50CF = 3,
-    kPPSU = 4,
+    kABS20CF  = 0,
+    kABS      = 1,
+    kPPS      = 2,
+    kPPS50CF  = 3,
+    kPPSU     = 4,
     kPPSU25CF = 5,
-    kPESU = 6,
+    kPESU     = 6,
     kPESU25CF = 7,
-    kPLA = 8,
+    kPLA      = 8,
     kConcrete = 9,
-    kOther = 10
+    kOther    = 10
 };
 
 // ToDo: QMap might be preferred
@@ -769,9 +751,9 @@ inline QString toString(DisabledSettingVisibility visibility) {
  * the automatic threshold fallback. Thin Lines disables true-width previews.
  */
 enum class GCodePreviewMode : uint8_t {
-    kAuto = 0,
+    kAuto       = 0,
     kTrueWidths = 1,
-    kThinLines = 2,
+    kThinLines  = 2,
 };
 
 inline QString toString(GCodePreviewMode mode) {
@@ -974,11 +956,11 @@ inline constexpr const QColor VisualizationColorsDefaults(VisualizationColors co
 }
 
 enum class SegmentDisplayType : uint8_t {
-    kNone = 0x00,
-    kLine = 1 << 0,
-    kTravel = 1 << 1,
+    kNone    = 0x00,
+    kLine    = 1 << 0,
+    kTravel  = 1 << 1,
     kSupport = 1 << 2,
-    kAll = 0xff
+    kAll     = 0xff
 };
 
 inline constexpr SegmentDisplayType operator|(const SegmentDisplayType& lhs, const SegmentDisplayType& rhs) {
@@ -1007,21 +989,25 @@ inline constexpr TravelLiftType operator|(const TravelLiftType& lhs, const Trave
     return static_cast<TravelLiftType>(static_cast<int>(lhs) | static_cast<int>(rhs));
 }
 
-inline TravelLiftType& operator|=(TravelLiftType& lhs, const TravelLiftType& rhs) { return lhs = lhs | rhs; }
+inline TravelLiftType& operator|=(TravelLiftType& lhs, const TravelLiftType& rhs) {
+    return lhs = lhs | rhs;
+}
 
 inline constexpr TravelLiftType operator&(const TravelLiftType& lhs, const TravelLiftType& rhs) {
     return static_cast<TravelLiftType>(static_cast<int>(lhs) & static_cast<int>(rhs));
 }
 
-inline TravelLiftType& operator&=(TravelLiftType& lhs, const TravelLiftType& rhs) { return lhs = lhs & rhs; }
+inline TravelLiftType& operator&=(TravelLiftType& lhs, const TravelLiftType& rhs) {
+    return lhs = lhs & rhs;
+}
 
 enum class StatusUpdateStepType : uint8_t {
-    kPreProcess = 0,
-    kCompute = 1,
-    kPostProcess = 2,
+    kPreProcess     = 0,
+    kCompute        = 1,
+    kPostProcess    = 2,
     kGcodeGeneraton = 3,
-    kGcodeParsing = 4,
-    kVisualization = 5,
+    kGcodeParsing   = 4,
+    kVisualization  = 5,
 };
 
 inline QString toString(StatusUpdateStepType statusType) {
@@ -1051,4 +1037,4 @@ enum class TormachMode : uint8_t { kMode21 = 0, kMode40 = 1, kMode102 = 2, kMode
 
 enum class PolygonPartition : uint8_t { kConvex = 0, kMonoX = 1, kMonoY = 2 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/utilities/mathutils.h
+++ b/include/utilities/mathutils.h
@@ -281,5 +281,5 @@ double clamp(double min, double val, double max);
  * \return Cartesian coordinates.
  */
 QVector3D sphericalToCartesian(float rho, float theta, float phi);
-} // namespace MathUtils
-} // namespace ORNL
+}  // namespace MathUtils
+}  // namespace ORNL

--- a/include/utilities/qt_json_conversion.h
+++ b/include/utilities/qt_json_conversion.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QVector3D>
 #include <QVector>
+
 #include <nlohmann/json.hpp>
 
 // Needed for cross compile - includes defintions that qt is looking

--- a/include/utilities/runtime_diagnostics.h
+++ b/include/utilities/runtime_diagnostics.h
@@ -6,4 +6,4 @@ namespace ORNL::Diagnostics {
 QString runtimeSummary(const QString& mode);
 void logLine(const QString& message);
 void logRuntimeSummary(const QString& mode);
-} // namespace ORNL::Diagnostics
+}  // namespace ORNL::Diagnostics

--- a/include/utilities/theme_tool.h
+++ b/include/utilities/theme_tool.h
@@ -2,6 +2,7 @@
 
 #include <QColor>
 #include <QWidget>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qlist.h>
@@ -12,7 +13,7 @@ namespace ORNL {
  * @brief Holds the path to the theme styles and the colors used for drawn objects
  */
 class Theme {
-  public:
+   public:
     //! @brief Constructor
     //! @param themeNum Number corresponding to the desired theme (should be taken from ThemeName enumerator)
     Theme(int themeNum);
@@ -177,7 +178,7 @@ class Theme {
     //! @return QString holding the folder path for the current theme
     QString getFolderPath();
 
-  private:
+   private:
     //! Folder path
     QString m_folder_path;
 
@@ -191,4 +192,4 @@ class Theme {
     QColor m_gcodeLineColor_base;
     QColor m_gcodeLineColor_highlight;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/cmd_widget.h
+++ b/include/widgets/cmd_widget.h
@@ -6,6 +6,7 @@
 #include <QTextEdit>
 #include <QToolButton>
 #include <QWidget>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -17,7 +18,7 @@ namespace ORNL {
  */
 class CmdWidget : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor.
     explicit CmdWidget(QWidget* parent = nullptr);
 
@@ -27,14 +28,14 @@ class CmdWidget : public QWidget {
     //! \brief Function for output.
     void print(QString str);
 
-  public slots:
+   public slots:
     //! \brief Function to run a command. This currently only appends the string if not empty.
     void runCmd(QString cmd);
 
     //! \brief Appends a string to the output.
     void append(QString str);
 
-  private:
+   private:
     //! \brief Setup the static widgets and their layouts.
     void setupWidget();
 
@@ -53,4 +54,4 @@ class CmdWidget : public QWidget {
     // Widgets
     QTextEdit* m_output;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/gcode_info_control.h
+++ b/include/widgets/gcode_info_control.h
@@ -14,6 +14,7 @@
 #include <QPushButton>
 #include <QVector3D>
 #include <QWidget>
+
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qnamespace.h>
@@ -31,20 +32,19 @@ namespace ORNL {
 class QClickableFrame : public QFrame {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: the widget this sits on
     explicit QClickableFrame(QFrame* parent = nullptr) : QFrame(parent) {}
 
-  signals:
+   signals:
     //! \brief Signal that the mouse left button was clicked.
     void mouseLeftButtonClicked();
 
-  private:
+   private:
     //! \brief Mouse press event
     void mousePressEvent(QMouseEvent* event) {
-        if (event->buttons() == Qt::LeftButton)
-            emit mouseLeftButtonClicked();
+        if (event->buttons() == Qt::LeftButton) emit mouseLeftButtonClicked();
     }
 };
 
@@ -55,7 +55,7 @@ class QClickableFrame : public QFrame {
 class GCodeInfoControl : public QWidget {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: the widget this sits on
     explicit GCodeInfoControl(QWidget* parent = nullptr);
@@ -72,7 +72,7 @@ class GCodeInfoControl : public QWidget {
     //! \brief Updates the camera view matrix used to display segment travel direction.
     void setViewMatrix(const QMatrix4x4& viewMatrix);
 
-  private:
+   private:
     //! \brief Display xy direction
     void updateDirection(double angle);
 
@@ -133,4 +133,4 @@ class GCodeInfoControl : public QWidget {
     QPixmap* m_infopm_direction_z;
     QComboBox* m_headercb_lines;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/gcode_widget.h
+++ b/include/widgets/gcode_widget.h
@@ -2,6 +2,7 @@
 
 #include <QVBoxLayout>
 #include <QWidget>
+
 #include <qcontainerfwd.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -20,7 +21,7 @@ namespace ORNL {
  */
 class GCodeWidget : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: A widget.
     GCodeWidget(QWidget* parent = nullptr);
@@ -32,7 +33,7 @@ class GCodeWidget : public QWidget {
     //! \param meta the model the track
     void setPartMeta(QSharedPointer<PartMetaModel> meta);
 
-  signals:
+   signals:
     //! \brief signals when this widget has been resized
     //! \param size
     void resized(QSize size);
@@ -41,7 +42,7 @@ class GCodeWidget : public QWidget {
     //! \param status if the view is using orthographic projection
     void orthographicViewChanged(bool status);
 
-  public slots:
+   public slots:
     //! \brief Adds the GCode to the view after it has been loaded.
     void addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode);
     //! \brief Clears the GCode in the view.
@@ -79,7 +80,7 @@ class GCodeWidget : public QWidget {
     //! \brief Resets the camera to the default position.
     void resetCamera();
 
-  private:
+   private:
     //! \brief Setup the static widgets and their layouts.
     void setupWidget();
 
@@ -111,4 +112,4 @@ class GCodeWidget : public QWidget {
     //! \brief Current overhead orthographic projection state.
     bool m_ortho_enabled = false;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/gcodebar.h
+++ b/include/widgets/gcodebar.h
@@ -10,6 +10,7 @@
 #include <QTimer>
 #include <QToolButton>
 #include <QWidget>
+
 #include <qhash.h>
 #include <qhashfunctions.h>
 #include <qlist.h>
@@ -23,10 +24,10 @@
 namespace ORNL {
 class GcodeBar : public QWidget {
     Q_OBJECT
-  public:
+   public:
     explicit GcodeBar(QWidget* parent = nullptr);
 
-  signals:
+   signals:
     //! \brief Signals to update layer range
     //! \brief new_value: value to set lower/upper to
     void lowerLayerUpdated(int new_value);
@@ -59,7 +60,7 @@ class GcodeBar : public QWidget {
     //! \brief signal to remove highlight on a highlightable line upon search
     void removeHighlight();
 
-  public slots:
+   public slots:
     //! \brief necessary information passing to GcodeBar object after gcode loading
     //! \param text: GCode content
     //! \param fontColors: hash that contains color/highlight information for all lines
@@ -116,7 +117,7 @@ class GcodeBar : public QWidget {
     //! \brief display the next segment after each time window when the play button is pressed
     void drawNextSegment();
 
-  private slots:
+   private slots:
     //! \brief update slots to keep spinboxes and sliders in sync and respect lock
     //! \param new_value: new potential layer
     void updateLowerSpin(int new_value);
@@ -130,7 +131,7 @@ class GcodeBar : public QWidget {
     void updateSegmentUpperSpin(int new_value);
     void updateSegmentUpperSlider(int new_value);
 
-  private:
+   private:
     // Setup the static widgets and their layouts.
     void setupWidget();
 
@@ -204,4 +205,4 @@ class GcodeBar : public QWidget {
     //! \brief If layers are locked, distance between lower/upper bound
     int m_lock_distance;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/gcodehighlighter.h
+++ b/include/widgets/gcodehighlighter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QSyntaxHighlighter>
+
 #include <qhash.h>
 #include <qobject.h>
 #include <qtmetamacros.h>
@@ -12,7 +13,7 @@ namespace ORNL {
 //! \brief This class overrides typical highlighter to highlight text in specific way
 class GcodeHighlighter : public QSyntaxHighlighter {
     Q_OBJECT
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent text document to which highglighting will be applied
     GcodeHighlighter(QTextDocument* parent);
@@ -21,12 +22,12 @@ class GcodeHighlighter : public QSyntaxHighlighter {
     //! \param colorHash: Hash of individual lines and associated color based on gcode comments
     void setColorRules(QHash<QString, QTextCharFormat> colorHash);
 
-  protected:
+   protected:
     //! \brief Line highlight override
     void highlightBlock(const QString& text) override;
 
-  private:
+   private:
     //! \brief Hash holding gcode line as key with associated format
     QHash<QString, QTextCharFormat> m_color_hash;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/gcodetextboxwidget.h
+++ b/include/widgets/gcodetextboxwidget.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QPlainTextEdit>
+
 #include <qevent.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -26,7 +27,7 @@ class LineNumberDisplay;
 class GcodeTextBoxWidget : public QPlainTextEdit {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor for the Gcode Textbox.
     //! \param parent Parent class for the textbox.
     GcodeTextBoxWidget(QWidget* parent = nullptr);
@@ -88,25 +89,25 @@ class GcodeTextBoxWidget : public QPlainTextEdit {
     //! \param searchCount: the number of Enter/Return hits for the same search string
     void search(QString searchString, int searchCount);
 
-  signals:
+   signals:
     //! \brief Signal to indicate a text line was highlighted/unhighlighted
     //! \param linesToAdd: Segments to highlight
     //! \param linesToRemove: Segments to unhighlight
     void lineChange(QList<int> linesToAdd, QList<int> linesToRemove);
 
-  protected:
+   protected:
     //! \brief Overrides for resizing, mouse, and keys
     void resizeEvent(QResizeEvent* event) override;
     virtual void mouseReleaseEvent(QMouseEvent* event) override;
     //! \brief This function overrides for the up for and down arrows
     virtual void keyPressEvent(QKeyEvent* event) override;
 
-  private slots:
+   private slots:
     //! \brief Update display area for text
     void updateLineNumberDisplayAreaWidth(int blockCount);
     void updateLineNumberDisplayArea(const QRect& rect, int height);
 
-  private:
+   private:
     //! \brief Widget and highlight information
     QWidget* m_line_number_display_area;
     GcodeHighlighter m_highlighter;
@@ -137,4 +138,4 @@ class GcodeTextBoxWidget : public QPlainTextEdit {
     //! \brief Last block clicked on
     int m_last_block_clicked_on;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/graphics_view/grid_scene.h
+++ b/include/widgets/graphics_view/grid_scene.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QGraphicsScene>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 #include <qwindowdefs.h>
@@ -8,17 +9,17 @@
 namespace ORNL {
 class GridScene : public QGraphicsScene {
     Q_OBJECT
-  public:
+   public:
     GridScene(QObject* parent = nullptr);
 
     void setGridStep(int step);
 
-  protected:
+   protected:
     void drawBackground(QPainter* painter, const QRectF& rect);
 
     void drawForeground(QPainter* painter, const QRectF& rect);
 
-  private:
+   private:
     int m_grid_step;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/graphics_view/polyline_item.h
+++ b/include/widgets/graphics_view/polyline_item.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QGraphicsItem>
 #include <cstdint>
 
-#include <QGraphicsItem>
 #include <qcolor.h>
 #include <qobject.h>
 
@@ -10,7 +10,7 @@
 
 namespace ORNL {
 class PolylineGraphicsItem : public QGraphicsItem {
-  public:
+   public:
     PolylineGraphicsItem(QGraphicsItem* parent = nullptr);
 
     PolylineGraphicsItem(const Polyline& polyline, QGraphicsItem* parent = nullptr);
@@ -27,7 +27,7 @@ class PolylineGraphicsItem : public QGraphicsItem {
 
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
 
-  private:
+   private:
     Polyline m_polyline;
 
     uint32_t m_draw_to;
@@ -36,4 +36,4 @@ class PolylineGraphicsItem : public QGraphicsItem {
 
     QColor m_color;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/layerbar.h
+++ b/include/widgets/layerbar.h
@@ -19,6 +19,7 @@
 #include <QToolTip>
 #include <QVector>
 #include <QWidget>
+
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qpair.h>
@@ -43,7 +44,7 @@ class LayerBar : public QWidget {
     Q_OBJECT
     friend class LayerDot;
 
-  public:
+   public:
     //! \brief Constructor.
     explicit LayerBar(QSharedPointer<PartMetaModel> pm, QWidget* parent = nullptr);
 
@@ -69,7 +70,7 @@ class LayerBar : public QWidget {
     //! \return an int
     int getLayerCount();
 
-  signals:
+   signals:
     //! \brief Signal that the selection has been altered.
     //! \param name_and_bases: Label plus list of ranges currently selected
     //! \param inherited_bases: Parent settings for each selected base; null entries inherit Global directly
@@ -88,7 +89,7 @@ class LayerBar : public QWidget {
     //! \brief Signal that a settings range needs to be deleted
     void deleteDot(LayerDot* dot);
 
-  public slots:
+   public slots:
     //! \brief Slot to add a layer range to a part.
     void addRange(int lower, int upper);
 
@@ -164,7 +165,7 @@ class LayerBar : public QWidget {
     //! \brief Clear dots and deleted ranges if <no template selected>.
     void clearTemplate();
 
-  private slots:
+   private slots:
     // -- QActions --
 
     //! \brief Slot to delete the currently selected ranges.
@@ -216,7 +217,7 @@ class LayerBar : public QWidget {
     //! \brief Loads layers unto layer bar when new part is selected.
     void loadTemplateLayers();
 
-  private:
+   private:
     // -- Qt Overrides --
     void paintEvent(QPaintEvent* event);
     void mousePressEvent(QMouseEvent* event);
@@ -340,4 +341,4 @@ class LayerBar : public QWidget {
     QAction* m_ungroup_dots;
     QAction* m_select_all;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/layerdot.h
+++ b/include/widgets/layerdot.h
@@ -7,6 +7,7 @@
 #include <QPropertyAnimation>
 #include <QString>
 #include <QWidget>
+
 #include <qcontainerfwd.h>
 #include <qcoreevent.h>
 #include <qnamespace.h>
@@ -23,12 +24,12 @@ class LayerDot : public QWidget {
     Q_OBJECT
     friend class LayerBar;
 
-  public:
+   public:
     //! \brief Constructor.
     explicit LayerDot(QWidget* parent = nullptr, int new_layer = -1,
                       QVector<QColor> m_colors = {Qt::darkGreen, Qt::darkYellow, QColor(255, 172, 28), Qt::darkBlue,
                                                   Qt::white},
-                      bool from_template = false);
+                      bool from_template       = false);
 
     //! \brief Destructor.
     ~LayerDot();
@@ -57,11 +58,11 @@ class LayerDot : public QWidget {
     //! \brief Sets dot color to red (all dots from template are red).
     void isFromTemplate();
 
-  signals:
+   signals:
     //! \brief Signal that the layer was updated.
     void layerChanged(int layer);
 
-  public slots:
+   public slots:
     //! \brief Slot to set the status of the dot (the color).
     void setSelected(bool status);
     //! \brief Slot that sets the layer.
@@ -77,7 +78,7 @@ class LayerDot : public QWidget {
     //! \brief Set the shrink factor.
     void setShrink(int shrink);
 
-  private:
+   private:
     // -- Qt Overrides --
 
     void paintEvent(QPaintEvent* event);
@@ -122,7 +123,7 @@ class LayerDot : public QWidget {
 
     //! \brief Current color.
     QColor m_color;
-    QColor m_default_color; // default color is red if from template, green is added by user.
+    QColor m_default_color;  // default color is red if from template, green is added by user.
     QVector<QColor> m_dot_colors;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/linenumberdisplay.h
+++ b/include/widgets/linenumberdisplay.h
@@ -7,15 +7,15 @@ namespace ORNL {
 class GcodeTextBoxWidget;
 
 class LineNumberDisplay : public QWidget {
-  public:
+   public:
     LineNumberDisplay(GcodeTextBoxWidget* textbox);
 
     QSize sizeHint() const override;
 
-  protected:
+   protected:
     void paintEvent(QPaintEvent* event) override;
 
-  private:
+   private:
     GcodeTextBoxWidget* textBox;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/main_toolbar.h
+++ b/include/widgets/main_toolbar.h
@@ -3,6 +3,7 @@
 #include <QTabBar>
 #include <QToolBar>
 #include <QToolButton>
+
 #include <qobject.h>
 #include <qsize.h>
 #include <qtmetamacros.h>
@@ -16,12 +17,12 @@ namespace ORNL {
  */
 class MainToolbar : public QToolBar {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param optional parent pointer
     MainToolbar(QWidget* parent = nullptr);
 
-  signals:
+   signals:
     //! \brief signals when the view is changed by the tabs on the toolbar
     //! \param index: the index of the tab selected
     void viewChanged(int index);
@@ -68,7 +69,7 @@ class MainToolbar : public QToolBar {
     //! \param mt: the type of part/ mesh this will become (ie build or settings)
     void loadModel(MeshType mt);
 
-  public slots:
+   public slots:
     //! \brief sets the tab selected in the toolbar
     //! \param index: the index of the view
     void setView(int index);
@@ -100,7 +101,7 @@ class MainToolbar : public QToolBar {
     //! \param status if the g-code view is using orthographic projection
     void setOrthoGcodeChecked(bool status);
 
-  private:
+   private:
     //! \brief sets up the widget
     void setup();
 
@@ -164,4 +165,4 @@ class MainToolbar : public QToolBar {
     //! \brief if selected part has layer-specific settings available for visualization
     bool m_layer_settings_range_available = false;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/input/tool_bar_align_input.h
+++ b/include/widgets/part_widget/input/tool_bar_align_input.h
@@ -6,6 +6,7 @@
 #include <QToolButton>
 #include <QVector3D>
 #include <QWidget>
+
 #include <qpoint.h>
 #include <qtmetamacros.h>
 
@@ -16,7 +17,7 @@ namespace ORNL {
  */
 class ToolbarAlignInput : public QFrame {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: the part widget this sits on
     explicit ToolbarAlignInput(QWidget* parent);
@@ -25,7 +26,7 @@ class ToolbarAlignInput : public QFrame {
     //! \param pos the new position
     void setPos(QPoint pos);
 
-  public slots:
+   public slots:
     //! \brief closes this input immediately(no animation)
     void closeInput();
 
@@ -35,12 +36,12 @@ class ToolbarAlignInput : public QFrame {
     //! \brief setup stylesheets for controlling theme
     void setupStyle();
 
-  signals:
+   signals:
     //! \brief signals when to start alignment for a given direction
     //! \param dir direction to align along
     void setAlignment(QVector3D dir);
 
-  private:
+   private:
     //! \brief setups the widget
     void setupWidget();
 
@@ -84,4 +85,4 @@ class ToolbarAlignInput : public QFrame {
     // Keeps track of the open status
     bool is_open = false;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/part_widget/input/tool_bar_input.h
+++ b/include/widgets/part_widget/input/tool_bar_input.h
@@ -13,6 +13,7 @@
 #include <QToolButton>
 #include <QWheelEvent>
 #include <QWidget>
+
 #include <qhashfunctions.h>
 #include <qnamespace.h>
 #include <qpoint.h>
@@ -30,7 +31,7 @@ namespace ORNL {
  */
 class QSlicerDoubleSpinBox : public QDoubleSpinBox {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent required qwidget pointer
     QSlicerDoubleSpinBox(QWidget* parent = 0) : QDoubleSpinBox(parent) {
@@ -38,7 +39,7 @@ class QSlicerDoubleSpinBox : public QDoubleSpinBox {
         setKeyboardTracking(false);
     }
 
-  protected:
+   protected:
     //! \brief mousePressEvent override
     //! \param QMouseEvent pointer
     virtual void mousePressEvent(QMouseEvent* event) {
@@ -69,8 +70,7 @@ class QSlicerDoubleSpinBox : public QDoubleSpinBox {
     //! \brief keyPressEvent override
     //! \param QKeyEvent pointer
     virtual void keyPressEvent(QKeyEvent* event) {
-        if (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down)
-            blockSignals(true);
+        if (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down) blockSignals(true);
         QDoubleSpinBox::keyPressEvent(event);
     }
 
@@ -84,8 +84,7 @@ class QSlicerDoubleSpinBox : public QDoubleSpinBox {
             }
         }
         QDoubleSpinBox::keyReleaseEvent(event);
-        if (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down)
-            blockSignals(false);
+        if (event->key() == Qt::Key_Up || event->key() == Qt::Key_Down) blockSignals(false);
     }
 
     //! \brief focusInEvent override
@@ -105,7 +104,7 @@ class QSlicerDoubleSpinBox : public QDoubleSpinBox {
         QDoubleSpinBox::focusOutEvent(event);
     }
 
-  private:
+   private:
     // Keeps track of the last value
     double m_last_value = 0;
 };
@@ -120,7 +119,7 @@ class PartMetaModel;
  */
 class ToolbarInput : public QFrame {
     Q_OBJECT
-  public:
+   public:
     //! \enum ModelTrackingType
     //! \brief the type of change this box should track
     enum class ModelTrackingType { kTranslation, kRotation, kScale };
@@ -143,7 +142,7 @@ class ToolbarInput : public QFrame {
     //! \param pos the new position
     void setPos(QPoint pos);
 
-  public slots:
+   public slots:
     //! \brief closes this input immediately(no animation)
     void closeInput();
 
@@ -239,7 +238,7 @@ class ToolbarInput : public QFrame {
     //! \brief setup stylesheets for controlling theme
     void setupStyle();
 
-  private slots:
+   private slots:
     //! \brief reads a value
     //! \param val the value to read
     void readValue(double val);
@@ -276,7 +275,7 @@ class ToolbarInput : public QFrame {
     //! \param item the item in question
     void modelRemovalUpdate(QSharedPointer<PartMetaItem> item);
 
-  private:
+   private:
     // Setup the static widgets and their layouts.
     void setupWidget();
 
@@ -340,4 +339,4 @@ class ToolbarInput : public QFrame {
     // Keeps track of the open status
     bool is_open = false;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/part_widget/model/part_meta_item.h
+++ b/include/widgets/part_widget/model/part_meta_item.h
@@ -3,6 +3,7 @@
 #include <GL/gl.h>
 
 #include <QObject>
+
 #include <qlist.h>
 #include <qsharedpointer.h>
 #include <qtmetamacros.h>
@@ -24,7 +25,7 @@ class PartMetaModel;
 class PartMetaItem : public QObject, public QEnableSharedFromThis<PartMetaItem> {
     Q_OBJECT
 
-  private:
+   private:
     //! \enum PartMetaUpdateType
     //! \brief Type of update to model.
     enum class PartMetaUpdateType {
@@ -37,7 +38,7 @@ class PartMetaItem : public QObject, public QEnableSharedFromThis<PartMetaItem> 
         kTransformUpdate
     };
 
-  public:
+   public:
     //! \brief Constructor.
     //! \param p: Part to creat from.
     PartMetaItem(QSharedPointer<Part> p);
@@ -143,11 +144,11 @@ class PartMetaItem : public QObject, public QEnableSharedFromThis<PartMetaItem> 
     //! \brief Sets the number of visible instances for this item.
     void setInstanceCount(int count);
 
-  signals:
+   signals:
     //! \brief Signal that this item was modified.
     void modified(PartMetaUpdateType type);
 
-  private:
+   private:
     //! \brief Model needs access to update type / model setting.
     friend class PartMetaModel;
 
@@ -159,9 +160,9 @@ class PartMetaItem : public QObject, public QEnableSharedFromThis<PartMetaItem> 
     MeshType m_type;
     uint m_transparency;
     bool m_solid_wireframe_mode = false;
-    bool m_wireframe_mode = false;
-    ushort m_render_mode = GL_TRIANGLES;
-    uint m_scale_unit_index = 0;
+    bool m_wireframe_mode       = false;
+    ushort m_render_mode        = GL_TRIANGLES;
+    uint m_scale_unit_index     = 0;
 
     //! \brief Transform
     QVector3D m_translation;
@@ -183,4 +184,4 @@ class PartMetaItem : public QObject, public QEnableSharedFromThis<PartMetaItem> 
     QSharedPointer<PartMetaModel> m_model;
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/model/part_meta_model.h
+++ b/include/widgets/part_widget/model/part_meta_model.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+
 #include <qlist.h>
 #include <qmap.h>
 #include <qsharedpointer.h>
@@ -20,7 +21,7 @@ class Part;
  */
 class PartMetaModel : public QObject, public QEnableSharedFromThis<PartMetaModel> {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     PartMetaModel();
 
@@ -63,7 +64,7 @@ class PartMetaModel : public QObject, public QEnableSharedFromThis<PartMetaModel
     //! \brief Sets the number of items that are instances of this item.
     void setInstanceCount(QSharedPointer<PartMetaItem> pm, int count);
 
-  signals:
+   signals:
     //! \brief Signal that an item was added.
     void itemAddedUpdate(QSharedPointer<PartMetaItem> pm);
     //! \brief Signal that an item was reloaded.
@@ -82,11 +83,11 @@ class PartMetaModel : public QObject, public QEnableSharedFromThis<PartMetaModel
     //! \brief Signal that any update has occured.
     void modelUpdated(QSharedPointer<PartMetaItem> pm);
 
-  private slots:
+   private slots:
     //! \brief Slot to recieve updates from items.
     void itemUpdated(PartMetaItem::PartMetaUpdateType type);
 
-  private:
+   private:
     //! \brief Items need access to private slots.
     friend class PartMetaItem;
 
@@ -99,4 +100,4 @@ class PartMetaModel : public QObject, public QEnableSharedFromThis<PartMetaModel
     //! \brief Gets the items that are instances of the supplied item.
     QList<QSharedPointer<PartMetaItem>> instanceItems(QSharedPointer<PartMetaItem> pm);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/part_control/part_control.h
+++ b/include/widgets/part_widget/part_control/part_control.h
@@ -4,6 +4,7 @@
 #include <QTreeWidget>
 #include <QVBoxLayout>
 #include <QWidget>
+
 #include <qmap.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -22,7 +23,7 @@ namespace ORNL {
 class PartControl : public QWidget {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: the widget this sits on
     explicit PartControl(QWidget* parent = nullptr);
@@ -51,7 +52,7 @@ class PartControl : public QWidget {
     //! \param status if the part is outside the volume
     void setOutsideStatus(const QString& name, bool status);
 
-  private slots:
+   private slots:
     //! \brief Model updates.
     void modelAdditionUpdate(QSharedPointer<PartMetaItem> pm);
     void modelRemovalUpdate(QSharedPointer<PartMetaItem> pm);
@@ -65,7 +66,7 @@ class PartControl : public QWidget {
     //! \brief Handle parenting changes.
     void handleParentingChange();
 
-  private:
+   private:
     //! \brief sets up this widgets sub-widgets
     void setupSubWidgets();
     //! \brief sets up this widget's layout
@@ -87,4 +88,4 @@ class PartControl : public QWidget {
     //! \brief Model
     QSharedPointer<PartMetaModel> m_model;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/part_control/part_control_tree_item.h
+++ b/include/widgets/part_widget/part_control/part_control_tree_item.h
@@ -3,6 +3,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QTreeWidget>
+
 #include <qobject.h>
 #include <qsharedpointer.h>
 #include <qwidget.h>
@@ -17,7 +18,7 @@ namespace ORNL {
  * \brief an item that sits in the part control's list
  */
 class PartControlTreeItem : public QTreeWidgetItem {
-  public:
+   public:
     //! \brief Constructor
     //! \param part: a pointer to the part this item will contain
     explicit PartControlTreeItem(QSharedPointer<PartMetaItem> pm);
@@ -42,11 +43,11 @@ class PartControlTreeItem : public QTreeWidgetItem {
     //! \param floating
     void setFloating(bool floating);
 
-  private:
+   private:
     //! \class Container
     //! \brief a sub-class that is a container for the warning badges
     class Container : public QWidget {
-      public:
+       public:
         //! \brief Contructor
         //! \param name the name of the part
         //! \param closed if the part is a closed mesh
@@ -61,7 +62,7 @@ class PartControlTreeItem : public QTreeWidgetItem {
         //! \param floating
         void showFloatingBadge(bool show);
 
-      private:
+       private:
         QLabel* m_alignment_badge;
     };
 
@@ -74,9 +75,9 @@ class PartControlTreeItem : public QTreeWidgetItem {
     //! \brief container for warning badges
     Container* m_container;
 
-    bool m_is_mesh_closed = true;
+    bool m_is_mesh_closed        = true;
     bool m_is_mesh_inside_volume = true;
-    bool m_is_mesh_floating = true;
-    MeshType m_mesh_type = MeshType::kBuild;
+    bool m_is_mesh_floating      = true;
+    MeshType m_mesh_type         = MeshType::kBuild;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/part_control/part_control_tree_widget.h
+++ b/include/widgets/part_widget/part_control/part_control_tree_widget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QTreeWidget>
+
 #include <qitemselectionmodel.h>
 #include <qtmetamacros.h>
 #include <qwidget.h>
@@ -11,24 +12,24 @@ namespace ORNL {
  */
 class PartControlTreeWidget : public QTreeWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: A widget.
     PartControlTreeWidget(QWidget* parent = nullptr);
 
-  public slots:
+   public slots:
     //! \brief When all parts are selected, ensure that only top level objects are selected.
     void selectAll() override;
 
-  signals:
+   signals:
     //! \brief When a drop ends, signal that parenting may have changed.
     void dropEnded();
 
-  protected slots:
+   protected slots:
     //! \brief Catches when a drop occurs.
     void dropEvent(QDropEvent* event) override;
 
     //! \brief When the selection changes, ensure that only top level objects are selected.
     void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/part_toolbar.h
+++ b/include/widgets/part_widget/part_toolbar.h
@@ -3,6 +3,7 @@
 #include <QToolBar>
 #include <QToolButton>
 #include <QVector3D>
+
 #include <qkeysequence.h>
 #include <qsharedpointer.h>
 #include <qsize.h>
@@ -20,7 +21,7 @@ namespace ORNL {
  */
 class PartToolbar : public QToolBar {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param model the part(s) that are being edited
     //! \param parent optional parent pointer
@@ -36,7 +37,7 @@ class PartToolbar : public QToolBar {
     //! \param old_unit: the old unit
     void updateAngleUnits(Angle new_unit, Angle old_unit);
 
-  signals:
+   signals:
     //! \brief signals to center parts
     void centerParts();
 
@@ -50,7 +51,7 @@ class PartToolbar : public QToolBar {
     //! \brief toggles point-to-point measurement mode
     void measureModeChanged(bool enabled);
 
-  public slots:
+   public slots:
     //! \brief sets the style of the widget according to current theme
     void setupStyle();
 
@@ -65,7 +66,7 @@ class PartToolbar : public QToolBar {
     //! \param status enable/ disable
     void setEnabled(bool status);
 
-  private:
+   private:
     //! \brief setups base widget
     void setupWidget();
 
@@ -134,4 +135,4 @@ class PartToolbar : public QToolBar {
     // Drop to floor
     QToolButton* m_drop_to_floor_btn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/part_widget/part_widget.h
+++ b/include/widgets/part_widget/part_widget.h
@@ -9,6 +9,7 @@
 #include <QTabWidget>
 #include <QToolButton>
 #include <QWidget>
+
 #include <qlist.h>
 #include <qobject.h>
 #include <qpair.h>
@@ -31,7 +32,7 @@ namespace ORNL {
  */
 class PartWidget : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: a widget
     PartWidget(QWidget* parent = nullptr);
@@ -49,7 +50,7 @@ class PartWidget : public QWidget {
     //! \brief Get the view for this widget.
     PartView* view();
 
-  signals:
+   signals:
     //! \brief Signal of parts that have been selected.
     void selected(QSet<QSharedPointer<Part>> pl, QSharedPointer<Part> mp);
 
@@ -69,7 +70,7 @@ class PartWidget : public QWidget {
     //! \brief Signal that the part rotation message needs to be displayed in main windows status bar
     void displayRotationInfoMsg();
 
-  public slots:
+   public slots:
     //! \brief sets the style of the widget according to current theme
     void setupStyle();
 
@@ -157,7 +158,7 @@ class PartWidget : public QWidget {
     //! \note this is pending a better refactor
     void updatePartTransformations();
 
-  private slots:
+   private slots:
     //! \brief Updates to model.
     void modelAdditionUpdate(QSharedPointer<PartMetaItem> item);
     void modelSelectionUpdate(QSharedPointer<PartMetaItem> item);
@@ -174,7 +175,7 @@ class PartWidget : public QWidget {
     //! \brief Updates the measurement readout overlay.
     void setMeasurementReadout(QString readout);
 
-  private:
+   private:
     //! \brief Repositions the measurement readout beside the part toolbar.
     void positionMeasurementReadout();
 
@@ -232,4 +233,4 @@ class PartWidget : public QWidget {
     //! \brief Model for parts loaded.
     QSharedPointer<PartMetaModel> m_model;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/part_widget/right_click_menu.h
+++ b/include/widgets/part_widget/right_click_menu.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMenu>
+
 #include <qaction.h>
 #include <qlist.h>
 #include <qpoint.h>
@@ -19,7 +20,7 @@ namespace ORNL {
 class RightClickMenu : public QMenu {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: the widget this sits on
     explicit RightClickMenu(QWidget* parent);
@@ -30,7 +31,7 @@ class RightClickMenu : public QMenu {
     //! \param transparency: part's current transparency
     void show(const QPointF& pos, QList<QSharedPointer<PartMetaItem>> items);
 
-  private:
+   private:
     //! \brief sets up this menu's actions
     void setupActions();
 
@@ -65,4 +66,4 @@ class RightClickMenu : public QMenu {
 
     QList<QSharedPointer<PartMetaItem>> m_selected_items;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/programmatic_check_box.h
+++ b/include/widgets/programmatic_check_box.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QCheckBox>
+
 #include <qhashfunctions.h>
 #include <qtmetamacros.h>
 #include <qwidget.h>
@@ -13,12 +14,12 @@ namespace ORNL {
  */
 class ProgrammaticCheckBox : public QCheckBox {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor.
     ProgrammaticCheckBox(QString str, QWidget* parent);
 
-  public slots:
+   public slots:
     //! \brief Override to enforce checked/unchecked transition
     void nextCheckState() override;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/scrollable_graphics_view.h
+++ b/include/widgets/scrollable_graphics_view.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QGraphicsView>
+
 #include <qtmetamacros.h>
 #include <qwidget.h>
 
@@ -9,22 +10,22 @@ class QLabel;
 namespace ORNL {
 class ScrollableGraphicsView : public QGraphicsView {
     Q_OBJECT
-  public:
+   public:
     ScrollableGraphicsView(QWidget* parent = nullptr);
 
     void setScrollFactor(double scroll_factor);
     double scrollFactor();
 
-  protected slots:
+   protected slots:
     void resizeEvent(QResizeEvent* event);
 
     void wheelEvent(QWheelEvent* event);
 
     void mouseMoveEvent(QMouseEvent* event);
 
-  private:
+   private:
     double m_scroll_factor;
 
     QLabel* m_pos_label;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_accel_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_accel_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingAccelSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingAccelSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingAccelSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_ang_vel_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_ang_vel_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingAngVelSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingAngVelSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingAngVelSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_angle_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_angle_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingAngleSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingAngleSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingAngleSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_area_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_area_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingAreaSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingAreaSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingAreaSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_density_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_density_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingDensitySpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingDensitySpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingDensitySpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_distance_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_distance_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingDistanceSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingDistanceSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingDistanceSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_speed_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_speed_spin_box.h
@@ -22,7 +22,7 @@ class SettingTab;
 class SettingSpeedSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -39,7 +39,7 @@ class SettingSpeedSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -51,7 +51,7 @@ class SettingSpeedSpinBox : public SettingDoubleSpinBox {
     //! \brief Checks speed-specific dynamic dependencies.
     void checkDynamicDependencies() override;
 
-  private:
+   private:
     //! \brief Returns this row's effective speed value in base units.
     Velocity effectiveSpeed() const;
 
@@ -67,4 +67,4 @@ class SettingSpeedSpinBox : public SettingDoubleSpinBox {
     //! \brief Returns a warning message for one selected base when this row violates the active XY speed range.
     QString speedLimitWarning(int settings_base_index) const;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_temperature_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_temperature_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingTemperatureSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingTemperatureSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingTemperatureSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_time_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_time_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingTimeSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingTimeSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingTimeSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/double_spin_subtypes/setting_voltage_spin_box.h
+++ b/include/widgets/settings/double_spin_subtypes/setting_voltage_spin_box.h
@@ -21,7 +21,7 @@ class SettingTab;
 class SettingVoltageSpinBox : public SettingDoubleSpinBox {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -38,7 +38,7 @@ class SettingVoltageSpinBox : public SettingDoubleSpinBox {
     static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                           fifojson json, QGridLayout* layout, int index);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -47,4 +47,4 @@ class SettingVoltageSpinBox : public SettingDoubleSpinBox {
     //! selects new setting profile
     virtual void reloadValue() override;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_bar.h
+++ b/include/widgets/settings/setting_bar.h
@@ -11,6 +11,7 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QWidget>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -37,7 +38,7 @@ class SettingTab;
  */
 class SettingBar : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor.
     explicit SettingBar(QHash<QString, QString> selectedSettingBases);
 
@@ -62,7 +63,7 @@ class SettingBar : public QWidget {
     //! \param path Path of current folder
     void setCurrentFolder(QString path);
 
-  signals:
+   signals:
     /*!
      * \brief Signals that a setting is about to be modified.
      * \param setting_key   Setting that is about to be modified.
@@ -93,7 +94,7 @@ class SettingBar : public QWidget {
     //! \param category Setting header to add
     void tabHidden(QString pane, QString category);
 
-  public slots:
+   public slots:
     /*!
      * \brief Hides all settings that do not match the filter.
      * \param str   String to filter.
@@ -159,7 +160,7 @@ class SettingBar : public QWidget {
     void finishPairedGlobalSettingChange(QString first_key, double first_value, QString second_key,
                                          double second_value);
 
-  private slots:
+   private slots:
     /*!
      * \brief Re-emits a signal that a setting is about to be modified.
      * \param setting_key   Key that is about to be modified.
@@ -173,7 +174,7 @@ class SettingBar : public QWidget {
      */
     void forwardModifiedSetting(QString setting_key);
 
-  private:
+   private:
     /*!
      * \brief Returns the pane based on the major category.
      * \param major Category.
@@ -205,7 +206,8 @@ class SettingBar : public QWidget {
     //! \brief Rechecks warning-only dependencies that are not part of row visibility logic.
     void refreshDynamicDependencies();
 
-    //! \brief Builds the effective settings for the first selected local target, or global settings if none is selected.
+    //! \brief Builds the effective settings for the first selected local target, or global settings if none is
+    //! selected.
     QSharedPointer<SettingsBase> selectedVisualizationSettings() const;
 
     //! \brief Returns non-null selected local settings bases; empty means global settings should be edited.
@@ -290,4 +292,4 @@ class SettingBar : public QWidget {
     //! \brief Defers full dynamic warning refreshes while rows are reloaded in bulk.
     bool m_suppress_dynamic_dependency_refresh = false;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/settings/setting_check_box.h
+++ b/include/widgets/settings/setting_check_box.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QCheckBox>
+
 #include <qgridlayout.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -20,7 +21,7 @@ class SettingTab;
 class SettingCheckBox : public QCheckBox, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -47,7 +48,7 @@ class SettingCheckBox : public QCheckBox, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -57,7 +58,7 @@ class SettingCheckBox : public QCheckBox, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -66,7 +67,7 @@ class SettingCheckBox : public QCheckBox, public SettingRowBase {
     //! selects new setting profile
     virtual void reloadValue() override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -77,4 +78,4 @@ class SettingCheckBox : public QCheckBox, public SettingRowBase {
     //! \brief Keeps track of if a warning has been emitted or not.
     bool m_warn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_combo_box.h
+++ b/include/widgets/settings/setting_combo_box.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QComboBox>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -22,7 +23,7 @@ class SettingTab;
 class SettingComboBox : public QComboBox, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -49,7 +50,7 @@ class SettingComboBox : public QComboBox, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -59,7 +60,7 @@ class SettingComboBox : public QComboBox, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -68,7 +69,7 @@ class SettingComboBox : public QComboBox, public SettingRowBase {
     //! selects new setting profile
     virtual void reloadValue() override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -89,4 +90,4 @@ class SettingComboBox : public QComboBox, public SettingRowBase {
     //! \brief Index of the previously selected item
     int m_prev;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_double_spin_box.h
+++ b/include/widgets/settings/setting_double_spin_box.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDoubleSpinBox>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -22,7 +23,7 @@ class SettingTab;
 class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -49,7 +50,7 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -59,7 +60,7 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -71,7 +72,7 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! \brief Checks double-based setting dependencies enforced through warnings.
     void checkDynamicDependencies() override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -129,4 +130,4 @@ class SettingDoubleSpinBox : public QDoubleSpinBox, public SettingRowBase {
     //! \brief Keeps track of if a warning has been emitted or not.
     bool m_warn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_header.h
+++ b/include/widgets/settings/setting_header.h
@@ -7,6 +7,7 @@
 #include <QPixmap>
 #include <QPushButton>
 #include <QWidget>
+
 #include <qhashfunctions.h>
 #include <qtmetamacros.h>
 
@@ -21,7 +22,7 @@ namespace ORNL {
  */
 class RemoveButton : public QPushButton {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! isDelete Whether or not button signals delete or hide when clicked
     //! parent Parent widget
@@ -31,13 +32,13 @@ class RemoveButton : public QPushButton {
     //! \return boolean whether or not cursor is inside button bounds
     bool isInside();
 
-  signals:
+   signals:
     //! \brief Emitted to header whenever the cursor is within the button
     //! Signals header to update coloring as Qt does not signal transition events for nested
     //! child widgets
     void childTransition();
 
-  private:
+   private:
     //! \brief Whether the cursor is within the bounds of the button or not
     //! Qt does not signal events for nested child widgets
     bool m_inside;
@@ -55,7 +56,7 @@ class RemoveButton : public QPushButton {
  */
 class SettingHeader : public QFrame {
     Q_OBJECT
-  public:
+   public:
     /*!
      * \brief Constructor
      * \param parent    The parent of this object (for QObject).
@@ -94,7 +95,7 @@ class SettingHeader : public QFrame {
     //! Trigger header to show itself
     void showHeader();
 
-  signals:
+   signals:
     //! \brief Signal that the tab was expanded.
     void expand();
 
@@ -107,7 +108,7 @@ class SettingHeader : public QFrame {
     //! \brief Signal setting tab of header's hide
     void hideHeader();
 
-  public slots:
+   public slots:
     //! \brief Update background after a transition (remove or add highlighting)
     void updateBackground();
 
@@ -117,7 +118,7 @@ class SettingHeader : public QFrame {
     //! \brief Either delete or hide header based on constructor settings
     void deleteOrHideHeader();
 
-  private:
+   private:
     // Qt Overrides.
     void mousePressEvent(QMouseEvent* event);
 
@@ -149,4 +150,4 @@ class SettingHeader : public QFrame {
     RemoveButton* m_remove;
 };
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/settings/setting_line_edit.h
+++ b/include/widgets/settings/setting_line_edit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QLineEdit>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -20,7 +21,7 @@ class SettingTab;
 class SettingLineEdit : public QLineEdit, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -47,7 +48,7 @@ class SettingLineEdit : public QLineEdit, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -57,7 +58,7 @@ class SettingLineEdit : public QLineEdit, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -66,7 +67,7 @@ class SettingLineEdit : public QLineEdit, public SettingRowBase {
     //! selects new setting profile
     virtual void reloadValue() override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -77,4 +78,4 @@ class SettingLineEdit : public QLineEdit, public SettingRowBase {
     //! \brief Keeps track of if a warning has been emitted or not.
     bool m_warn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_numbered_list.h
+++ b/include/widgets/settings/setting_numbered_list.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QTableWidget>
+
 #include <qgridlayout.h>
 #include <qlist.h>
 #include <qobject.h>
@@ -23,7 +24,7 @@ class SettingTab;
 class SettingNumberedList : public QTableWidget, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -50,7 +51,7 @@ class SettingNumberedList : public QTableWidget, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -60,7 +61,7 @@ class SettingNumberedList : public QTableWidget, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -77,7 +78,7 @@ class SettingNumberedList : public QTableWidget, public SettingRowBase {
     //! \param event: captured drop event
     virtual void dropEvent(QDropEvent* event) override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -88,4 +89,4 @@ class SettingNumberedList : public QTableWidget, public SettingRowBase {
     //! \brief Keeps track of if a warning has been emitted or not.
     bool m_warn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_pane.h
+++ b/include/widgets/settings/setting_pane.h
@@ -4,6 +4,7 @@
 #include <QScrollArea>
 #include <QToolButton>
 #include <QWidget>
+
 #include <qboxlayout.h>
 #include <qcontainerfwd.h>
 #include <qhash.h>
@@ -25,7 +26,7 @@ namespace ORNL {
  */
 class SettingPane : public QWidget {
     Q_OBJECT
-  public:
+   public:
     /*!
      * \brief Constructor.
      * \param idx       Index of this pane in SettingsBar tab widget.
@@ -50,7 +51,7 @@ class SettingPane : public QWidget {
     //! \param category Header category to show
     void showTab(QString category);
 
-  public slots:
+   public slots:
     //! \brief Lock all tabs on this pane.
     void setLock(bool status);
     //! \brief Reloads all settings on this pane.
@@ -64,7 +65,7 @@ class SettingPane : public QWidget {
     //! \param count: The number of warnings forwarded from the pane's children
     void paneWarning(int count);
 
-  private slots:
+   private slots:
     /*!
      * \brief Forwards an impending setting modification to the bar for retransmission.
      * \param setting_key   Key that is about to be modified.
@@ -78,7 +79,7 @@ class SettingPane : public QWidget {
      */
     void forwardModifiedSetting(QString setting_key);
 
-  signals:
+   signals:
     /*!
      * \brief Signal that setting is about to be modified.
      * \param setting_key   Key that is about to be modified.
@@ -102,7 +103,7 @@ class SettingPane : public QWidget {
     //! \param pane: String representing the name of the pane that is emitting the signal
     void warnSettingBar(bool warn, QString pane);
 
-  private:
+   private:
     //! \brief Update the configurations listed in the selection box.
     void updateConfigBox();
 
@@ -135,4 +136,4 @@ class SettingPane : public QWidget {
     //! \brief Name of this pane
     QString m_name;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/settings/setting_plain_text_edit.h
+++ b/include/widgets/settings/setting_plain_text_edit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QPlainTextEdit>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -19,7 +20,7 @@ class SettingTab;
 class SettingPlainTextEdit : public QPlainTextEdit, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -46,7 +47,7 @@ class SettingPlainTextEdit : public QPlainTextEdit, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -56,7 +57,7 @@ class SettingPlainTextEdit : public QPlainTextEdit, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -65,7 +66,7 @@ class SettingPlainTextEdit : public QPlainTextEdit, public SettingRowBase {
     //! selects new setting profile
     virtual void reloadValue() override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -76,4 +77,4 @@ class SettingPlainTextEdit : public QPlainTextEdit, public SettingRowBase {
     //! \brief Keeps track of if a warning has been emitted or not.
     bool m_warn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_row_base.h
+++ b/include/widgets/settings/setting_row_base.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <functional>
-
 #include <QCheckBox>
 #include <QComboBox>
 #include <QGridLayout>
@@ -9,6 +7,8 @@
 #include <QObject>
 #include <QToolButton>
 #include <QWidget>
+#include <functional>
+
 #include <qlist.h>
 #include <qscopedpointer.h>
 
@@ -39,8 +39,7 @@ struct DependencyNode {
 //! \brief Base class for widgets that holds additional information such as dependency
 //! logic and json.  Used in combination with child widget types to create a row
 class SettingRowBase {
-
-  public:
+   public:
     using ValueChangeCallback = std::function<void(const QString&, const QList<QSharedPointer<SettingsBase>>&)>;
 
     //! \brief Default Constructor
@@ -131,7 +130,7 @@ class SettingRowBase {
     //! \brief Set callback used to notify before this row writes a new value.
     void setValueChangeCallback(ValueChangeCallback callback);
 
-  protected:
+   protected:
     //! \brief Function to handle value changes for each widget type
     virtual void valueChanged(QVariant val) = 0;
 
@@ -145,18 +144,19 @@ class SettingRowBase {
     void setLocalOverrideKeys(QList<QString> keys);
 
     //! \brief Returns the value inherited by one selected settings base.
-    template <class T> T inheritedValueHelper(const QString& key, int index, const T& global_value) const {
+    template <class T>
+    T inheritedValueHelper(const QString& key, int index, const T& global_value) const {
         if (index >= 0 && index < m_inherited_settings_bases.size()) {
             const QSharedPointer<SettingsBase>& inherited_base = m_inherited_settings_bases[index];
-            if (!inherited_base.isNull() && inherited_base->contains(key))
-                return inherited_base->setting<T>(key);
+            if (!inherited_base.isNull() && inherited_base->contains(key)) return inherited_base->setting<T>(key);
         }
 
         return global_value;
     }
 
     //! \brief Returns the effective value for one selected settings base.
-    template <class T> T effectiveValueHelper(const QString& key, int index, const T& global_value) const {
+    template <class T>
+    T effectiveValueHelper(const QString& key, int index, const T& global_value) const {
         if (index >= 0 && index < m_settings_bases.size() && m_settings_bases[index]->contains(key))
             return m_settings_bases[index]->setting<T>(key);
 
@@ -164,10 +164,11 @@ class SettingRowBase {
     }
 
     //! \brief Removes edited overrides matching the value inherited by each selected base.
-    template <class T> void removeRedundantLocalOverrides(const QString& key, const T& global_value) {
+    template <class T>
+    void removeRedundantLocalOverrides(const QString& key, const T& global_value) {
         for (int index = 0, end = m_settings_bases.size(); index < end; ++index) {
             QSharedPointer<SettingsBase> settings_base = m_settings_bases[index];
-            const T inherited_value = inheritedValueHelper<T>(key, index, global_value);
+            const T inherited_value                    = inheritedValueHelper<T>(key, index, global_value);
             if (settings_base->contains(key) && settings_base->setting<T>(key) == inherited_value)
                 settings_base->remove(key);
         }
@@ -178,12 +179,12 @@ class SettingRowBase {
     bool checkLogic(DependencyNode root);
 
     //! \brief Templated helper for all widget types when value is changed
-    template <class T> void valueChangedHelper(T value) {
+    template <class T>
+    void valueChangedHelper(T value) {
         notifyValueAboutToChange(m_key);
 
         if (m_settings_bases.size() != 0)
-            for (QSharedPointer<SettingsBase> range : m_settings_bases)
-                range->setSetting(m_key, value);
+            for (QSharedPointer<SettingsBase> range : m_settings_bases) range->setSetting(m_key, value);
         else
             m_sb->setSetting(m_key, value);
 
@@ -196,19 +197,19 @@ class SettingRowBase {
         clearNotification();
         styleLabel(true);
 
-        for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
-            row->checkDependencies();
+        for (QSharedPointer<SettingRowBase> row : m_rows_to_notify) row->checkDependencies();
 
         checkDynamicDependencies();
     }
 
     //! \brief Templated helper for all widget types when settings must be reloaded
-    template <class T> T reloadValueHelper(bool& consistent) {
+    template <class T>
+    T reloadValueHelper(bool& consistent) {
         T cur;
         if (m_settings_bases.size() > 0) {
             const T global_value = m_sb->contains(m_key) ? m_sb->setting<T>(m_key)
                                                          : m_json[Constants::Settings::Master::kDefault].get<T>();
-            cur = effectiveValueHelper<T>(m_key, 0, global_value);
+            cur                  = effectiveValueHelper<T>(m_key, 0, global_value);
 
             bool all_bases_consistent = true;
             for (int index = 1, end = m_settings_bases.size(); index < end; ++index)
@@ -223,7 +224,7 @@ class SettingRowBase {
                 // set to default
                 setNotification("Multiple Values");
                 styleLabel(false);
-                cur = m_json[Constants::Settings::Master::kDefault].get<T>();
+                cur        = m_json[Constants::Settings::Master::kDefault].get<T>();
                 consistent = false;
             }
         }
@@ -284,7 +285,7 @@ class SettingRowBase {
     //! \brief Pointer to global setting base
     QSharedPointer<SettingsBase> m_sb;
 
-  protected:
+   protected:
     //! \brief Returns the default tooltip from the row's master setting metadata.
     QString baseToolTip() const;
 
@@ -349,4 +350,4 @@ class SettingRowBase {
     ValueChangeCallback m_value_change_callback;
 };
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/settings/setting_spin_box.h
+++ b/include/widgets/settings/setting_spin_box.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QSpinBox>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
@@ -22,7 +23,7 @@ class SettingTab;
 class SettingSpinBox : public QSpinBox, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Default Constructor
     //! \param parent: parent settingtab to setup events
     //! \param sb: global setting base
@@ -49,7 +50,7 @@ class SettingSpinBox : public QSpinBox, public SettingRowBase {
     //! \param enabled: enable/disable state
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when setting is modified by user
     //! \param key: key of setting modified
     void modified(QString key);
@@ -59,7 +60,7 @@ class SettingSpinBox : public QSpinBox, public SettingRowBase {
     //! warning, 0 does nothing.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to handle when user manually changes value
     //! \param val: value cast to appropriate type within each class
     virtual void valueChanged(QVariant val) override;
@@ -68,7 +69,7 @@ class SettingSpinBox : public QSpinBox, public SettingRowBase {
     //! selects new setting profile
     virtual void reloadValue() override;
 
-  protected:
+   protected:
     //! \brief Sets error notification when dynamic dependency check fails
     //! \param msg: Message to display
     virtual void setNotification(QString msg) override;
@@ -83,4 +84,4 @@ class SettingSpinBox : public QSpinBox, public SettingRowBase {
     //! \brief Keeps track of if a warning has been emitted or not.
     bool m_warn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/setting_tab.h
+++ b/include/widgets/settings/setting_tab.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <functional>
-
 #include <QFrame>
 #include <QGridLayout>
 #include <QWidget>
+#include <functional>
+
 #include <qboxlayout.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -31,7 +31,7 @@ namespace ORNL {
 class SettingTab : public QWidget {
     Q_OBJECT
 
-  public:
+   public:
     /*!
      * \brief Constructor.
      * \param parent    Parent of this object (for QObject).
@@ -74,7 +74,7 @@ class SettingTab : public QWidget {
     //! \brief Returns whether any row in this tab is currently visible.
     bool hasShownRows() const;
 
-  public slots:
+   public slots:
     //! \brief Expand the current tab.
     void expandTab();
 
@@ -105,7 +105,7 @@ class SettingTab : public QWidget {
 
     void keyModified(QString key);
 
-  signals:
+   signals:
     /*!
      * \brief Notification before a setting is modified.
      * \param key   Key that is about to be modified.
@@ -127,7 +127,7 @@ class SettingTab : public QWidget {
     //! \param count: Number of warnings
     void warnPane(int count);
 
-  private:
+   private:
     //! \brief Setup the static widgets and their layouts.
     void setupWidget(bool isHidden);
 
@@ -173,4 +173,4 @@ class SettingTab : public QWidget {
                                                  QGridLayout*, int)>>
         m_creation_mapping;
 };
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/include/widgets/settings/vector2_input_widget.h
+++ b/include/widgets/settings/vector2_input_widget.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <array>
-
 #include <QDoubleSpinBox>
 #include <QEvent>
 #include <QGridLayout>
@@ -9,6 +7,8 @@
 #include <QString>
 #include <QVariant>
 #include <QWidget>
+#include <array>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -25,7 +25,7 @@ class SettingTab;
 class Vector2InputWidget : public QWidget, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     Vector2InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key, QString secondary_key,
                        fifojson json, QGridLayout* layout, int index, Distance primary_default,
                        Distance secondary_default, QString primary_label = "X", QString secondary_label = "Y");
@@ -39,28 +39,28 @@ class Vector2InputWidget : public QWidget, public SettingRowBase {
     //! \brief Enable/disable row.
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when a setting is modified by user.
     void modified(QString key);
 
     //! \brief Signal emitted to pass a warning up to the next level.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to satisfy SettingRowBase; updates the primary setting.
     void valueChanged(QVariant val) override;
 
     //! \brief Slot to handle setting reload when user changes units or selects another setting profile.
     void reloadValue() override;
 
-  protected:
+   protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
     void setNotification(QString msg) override;
 
     void clearNotification() override;
 
-  private:
+   private:
     struct Component {
         QString key;
         QDoubleSpinBox* spin_box;
@@ -81,4 +81,4 @@ class Vector2InputWidget : public QWidget, public SettingRowBase {
     bool m_warn;
     int m_precision = 4;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/settings/vector3_input_widget.h
+++ b/include/widgets/settings/vector3_input_widget.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <array>
-
 #include <QDoubleSpinBox>
 #include <QEvent>
 #include <QGridLayout>
@@ -9,6 +7,8 @@
 #include <QString>
 #include <QVariant>
 #include <QWidget>
+#include <array>
+
 #include <qobject.h>
 #include <qtmetamacros.h>
 
@@ -24,7 +24,7 @@ class SettingTab;
 class Vector3InputWidget : public QWidget, public SettingRowBase {
     Q_OBJECT
 
-  public:
+   public:
     Vector3InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key, QString secondary_key,
                        QString tertiary_key, fifojson json, QGridLayout* layout, int index, double primary_default,
                        double secondary_default, double tertiary_default, QString primary_label = "X",
@@ -39,28 +39,28 @@ class Vector3InputWidget : public QWidget, public SettingRowBase {
     //! \brief Enable/disable row.
     void setEnabled(bool enabled) override;
 
-  signals:
+   signals:
     //! \brief Signal emitted when a setting is modified by user.
     void modified(QString key);
 
     //! \brief Signal emitted to pass a warning up to the next level.
     void warnParent(int count);
 
-  public slots:
+   public slots:
     //! \brief Slot to satisfy SettingRowBase; updates the primary setting.
     void valueChanged(QVariant val) override;
 
     //! \brief Slot to handle setting reload when user selects another setting profile.
     void reloadValue() override;
 
-  protected:
+   protected:
     bool eventFilter(QObject* watched, QEvent* event) override;
 
     void setNotification(QString msg) override;
 
     void clearNotification() override;
 
-  private:
+   private:
     struct Component {
         QString key;
         QDoubleSpinBox* spin_box;
@@ -81,4 +81,4 @@ class Vector3InputWidget : public QWidget, public SettingRowBase {
     bool m_warn;
     int m_precision = 4;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/view_controls_toolbar.h
+++ b/include/widgets/view_controls_toolbar.h
@@ -4,6 +4,7 @@
 #include <QSize>
 #include <QToolBar>
 #include <QToolButton>
+
 #include <qtmetamacros.h>
 
 namespace ORNL {
@@ -13,12 +14,12 @@ namespace ORNL {
  */
 class ViewControlsToolbar : public QToolBar {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent optional parent widget
     ViewControlsToolbar(QWidget* parent = nullptr, bool show_orthographic_button = false);
 
-  signals:
+   signals:
     //! \brief sets the camera to iso view
     void setIsoView();
     //! \brief sets the camera to front view
@@ -30,7 +31,7 @@ class ViewControlsToolbar : public QToolBar {
     //! \brief toggles overhead orthographic g-code projection
     void setOrthographicView(bool enabled);
 
-  public slots:
+   public slots:
     //! \brief sets the style of the widget according to current theme
     void setupStyle();
 
@@ -46,7 +47,7 @@ class ViewControlsToolbar : public QToolBar {
 
     void setEnabled(bool status);
 
-  private:
+   private:
     //! \brief sets up the widget and style
     void setupWidget();
 
@@ -70,4 +71,4 @@ class ViewControlsToolbar : public QToolBar {
     QToolButton* m_top_btn;
     QToolButton* m_ortho_btn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/visualization_color_picker.h
+++ b/include/widgets/visualization_color_picker.h
@@ -5,6 +5,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QWidget>
+
 #include <qcolor.h>
 #include <qobject.h>
 #include <qtmetamacros.h>
@@ -13,14 +14,14 @@ namespace ORNL {
 class VisualizationColorPicker : public QWidget {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Constructor
     //! \param name of color / type
     //! \param color as QColor
     //! \param parent
     explicit VisualizationColorPicker(QString name, QColor color, QWidget* parent = nullptr);
 
-  private:
+   private:
     //! \brief Mouse press event
     void mousePressEvent(QMouseEvent*);
 
@@ -50,4 +51,4 @@ class VisualizationColorPicker : public QWidget {
     //! \brief UI display button control for selecting and setting color
     QPushButton* colorSelectorBtn;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/widgets/xyz_input.h
+++ b/include/widgets/xyz_input.h
@@ -5,6 +5,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QWidget>
+
 #include <qhashfunctions.h>
 #include <qtmetamacros.h>
 #include <qvectornd.h>
@@ -17,7 +18,7 @@ namespace ORNL {
  */
 class XYZInputWidget : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     //! \param parent: A widget.
     XYZInputWidget(QWidget* parent = nullptr);
@@ -25,7 +26,7 @@ class XYZInputWidget : public QWidget {
     //! \brief Value of all 3 spinboxes.
     QVector3D value();
 
-  public slots:
+   public slots:
     //! \brief Shows front label.
     void showLabel(bool show);
     //! \brief Shows unit text.
@@ -60,7 +61,7 @@ class XYZInputWidget : public QWidget {
     //! \brief Sets spinbox increments.
     void setIncrement(double inc);
 
-  signals:
+   signals:
     //! \brief Signal that a spinbox has changed.
     void valueChanged(Axis ax, double val);
 
@@ -74,13 +75,13 @@ class XYZInputWidget : public QWidget {
     //! \brief Signal that any XYZ value has changed.
     void valueChanged(QVector3D xyz);
 
-  private slots:
+   private slots:
     //! \brief Relays info from spinboxes.
     void readValue(double val);
     //! \brief Copies x spinbox to y & z before relaying.
     void lockReadValue(double val);
 
-  private:
+   private:
     // Widget Setup
     void setupWidget();
     void setupEvents();
@@ -101,4 +102,4 @@ class XYZInputWidget : public QWidget {
     // Layout
     QHBoxLayout* m_layout;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/about.h
+++ b/include/windows/about.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QWidget>
+
 #include <qtmetamacros.h>
 
 namespace ORNL {
@@ -10,11 +11,11 @@ namespace ORNL {
  */
 class AboutWindow : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     explicit AboutWindow(QWidget* parent = 0);
 
     //! \brief Destructor
     ~AboutWindow();
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/dialogs/cs_dbg.h
+++ b/include/windows/dialogs/cs_dbg.h
@@ -3,6 +3,7 @@
 #include <QDialog>
 #include <QMap>
 #include <QSet>
+
 #include <qsharedpointer.h>
 #include <qtmetamacros.h>
 #include <qwidget.h>
@@ -24,11 +25,11 @@ namespace ORNL {
  */
 class CsDebugDialog : public QDialog {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor.
     explicit CsDebugDialog(QWidget* parent = nullptr);
 
-  private slots:
+   private slots:
     //! \brief Paint graphics view.
     void paintGraphicsView(int height = -1);
     //! \brief Get updates from combo boxes.
@@ -38,7 +39,7 @@ class CsDebugDialog : public QDialog {
     //! \brief Change the layer painted.
     void changeLayer(int height);
 
-  private:
+   private:
     //! \brief Change the current part.
     void changePart(QSharedPointer<Part> part);
     //! \brief Update the scrollbar.
@@ -82,4 +83,4 @@ class CsDebugDialog : public QDialog {
     // Graphics View
     QGraphicsView* m_view;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/dialogs/slice_dialog.h
+++ b/include/windows/dialogs/slice_dialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 #include <QProgressBar>
+
 #include <qlist.h>
 #include <qtmetamacros.h>
 #include <qwidget.h>
@@ -15,25 +16,25 @@ namespace ORNL {
  */
 class SliceDialog : public QDialog {
     Q_OBJECT
-  public:
+   public:
     //! \brief Standard constructor
     SliceDialog(QWidget* parent = nullptr);
 
-  signals:
+   signals:
     //! \brief Signal slice to cancel when user clicks the button
     void cancelSlice();
 
-  public slots:
+   public slots:
     //! \brief Receive status updates from slicing process
     //! \param type Current step type process
     //! \param percentage Percentage completed
     void updateStatus(StatusUpdateStepType type, int percentage);
 
-  private:
+   private:
     //! \brief Setup the static widgets and their layouts.
     void setupUi();
 
     //! \brief List of progress bars to update via status
     QList<QProgressBar*> m_progress_bars;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/dialogs/template_save.h
+++ b/include/windows/dialogs/template_save.h
@@ -13,6 +13,7 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QToolButton>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -30,7 +31,7 @@ namespace ORNL {
  */
 class TemplateSaveDialog : public QDialog {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor.
     explicit TemplateSaveDialog(QWidget* parent = nullptr);
 
@@ -43,7 +44,7 @@ class TemplateSaveDialog : public QDialog {
     //! \brief Get the optional name from the dialog.
     QString name();
 
-  private slots:
+   private slots:
     //! \brief Checks all items in a selection.
     void checkSelection(QTableWidgetItem* item);
 
@@ -59,7 +60,7 @@ class TemplateSaveDialog : public QDialog {
     //! \brief Update checkbox status
     void updateSelection();
 
-  private:
+   private:
     //! \brief Setup the static widgets and their layouts.
     void setupUi();
 
@@ -136,4 +137,4 @@ class TemplateSaveDialog : public QDialog {
     //! \brief List of types to convert to user preferred unit
     QList<QString> m_convertable_types;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/flowratecalc.h
+++ b/include/windows/flowratecalc.h
@@ -6,6 +6,7 @@
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QWidget>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qtmetamacros.h>
@@ -19,18 +20,18 @@ namespace ORNL {
  */
 class FlowrateCalcWindow : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     explicit FlowrateCalcWindow(QWidget* parent);
 
     //! \brief Destructor
     ~FlowrateCalcWindow();
 
-  protected:
+   protected:
     //! \brief Close event override to reset form values
     void closeEvent(QCloseEvent* event);
 
-  private slots:
+   private slots:
     //! \brief Check that all inputs are valid and perform necessary calculations
     //! Inputs are checked automatically as a user alters them
     void checkInputAndCalculate();
@@ -42,7 +43,7 @@ class FlowrateCalcWindow : public QWidget {
     //! \param index Current combo index
     void enableDensity(int index);
 
-  private:
+   private:
     //! \brief Setup events for widget components
     void setupEvents();
 
@@ -68,11 +69,11 @@ class FlowrateCalcWindow : public QWidget {
     QLabel* m_status_label;
 
     //! \brief Metric to imperial conversion
-    double m_density_metric_to_is; // from metric to British system, g/cm^3 --> lb/in^3
+    double m_density_metric_to_is;  // from metric to British system, g/cm^3 --> lb/in^3
 
     //! \brief Density in Metric
     Density m_density_metric;
     //! \brief parent widget of this flowrate calculator window
     QWidget* m_parent;
-}; // class FlowrateCalcWindow
-} // namespace ORNL
+};  // class FlowrateCalcWindow
+}  // namespace ORNL

--- a/include/windows/gcode_export.h
+++ b/include/windows/gcode_export.h
@@ -8,6 +8,7 @@
 #include <QTextEdit>
 #include <QVector>
 #include <QWidget>
+
 #include <qboxlayout.h>
 #include <qhashfunctions.h>
 #include <qtmetamacros.h>
@@ -22,7 +23,7 @@ namespace ORNL {
  */
 class GcodeExport : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     explicit GcodeExport(QWidget* parent);
 
@@ -33,7 +34,7 @@ class GcodeExport : public QWidget {
     //! \brief Destructor
     ~GcodeExport();
 
-  public slots:
+   public slots:
     //! \brief Handler to receive necessary information once the slice is complete and
     //! gcode generated.  Necessary to add final header comments if user opts to supply any
     //! \param tempLocation current location of temporary gcode file
@@ -47,11 +48,11 @@ class GcodeExport : public QWidget {
     //! \brief Clears parsed G-code visualization segments while a new file is loading.
     void clearVisualizationInformation();
 
-  protected:
+   protected:
     //! \brief Close event override to reset form values
     void closeEvent(QCloseEvent* event);
 
-  private slots:
+   private slots:
     //! \brief Handler for export button click
     void exportGcode();
 
@@ -60,7 +61,7 @@ class GcodeExport : public QWidget {
     //! \param filename Name of the file saved
     void showComplete(QString path, QString filename);
 
-  private:
+   private:
     //! \brief Updates as-printed STL option availability based on visualization state.
     void updateAsPrintedModelOptionState();
 
@@ -92,5 +93,5 @@ class GcodeExport : public QWidget {
     //! \brief Default file name
     QString m_default_name;
 
-}; // class GcodeExport
-} // namespace ORNL
+};  // class GcodeExport
+}  // namespace ORNL

--- a/include/windows/gcode_to_s2c.h
+++ b/include/windows/gcode_to_s2c.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <optional>
-
 #include <QDialog>
 #include <QLabel>
 #include <QLineEdit>
+#include <optional>
+
 #include <qcheckbox.h>
 #include <qdialogbuttonbox.h>
 #include <qgridlayout.h>
@@ -17,18 +17,18 @@ namespace ORNL {
 
 class GcodeToS2CDialog : public QDialog {
     Q_OBJECT
-  public:
+   public:
     explicit GcodeToS2CDialog(QWidget* parent = nullptr);
 
     QString outputFilePath() const;
 
-  private slots:
+   private slots:
     void browseGcodeFile();
     void browseOutputFile();
     void refreshAcceptState();
     void accept() override;
 
-  private:
+   private:
     void setupUi();
     void setDefaultOutputPath();
     std::optional<fifojson> promptForMissingValue(const QString& key, const fifojson& master_entry);
@@ -43,4 +43,4 @@ class GcodeToS2CDialog : public QDialog {
     QDialogButtonBox* m_buttons;
 };
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/layer_times_window.h
+++ b/include/windows/layer_times_window.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QTextEdit>
 #include <QWidget>
+
 #include <qlist.h>
 #include <qtmetamacros.h>
 
@@ -18,12 +19,12 @@ namespace ORNL {
 class LayerTimesWindow : public QWidget {
     Q_OBJECT
 
-  public:
+   public:
     //! \brief Standard widget constructor
     //! \param parent Pointer to parent window
     LayerTimesWindow(QWidget* parent);
 
-  public slots:
+   public slots:
 
     //! \brief Slot to receive updated time information from gcode parse
     //! \param layerTimes list of times for each layer
@@ -34,7 +35,7 @@ class LayerTimesWindow : public QWidget {
     //! \brief Clear Layer times text
     void clear();
 
-  private:
+   private:
     //! \brief Setup widget internal events
     void setupEvents();
     //! \brief Update text after user changes threshold or new time information is received
@@ -70,4 +71,4 @@ class LayerTimesWindow : public QWidget {
     Time m_min, m_max;
     int m_min_index, m_max_index;
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/main_window.h
+++ b/include/windows/main_window.h
@@ -12,6 +12,7 @@
 #include <QToolBar>
 #include <QUdpSocket>
 #include <QUndoStack>
+
 #include <qboxlayout.h>
 #include <qcontainerfwd.h>
 #include <qcoreapplication.h>
@@ -71,7 +72,7 @@ class MainWindow : public QMainWindow {
     friend class PartTransformUndoCommand;
     friend class SettingValueUndoCommand;
 
-  public:
+   public:
     //! \brief Get the singleton instance of the MainWindow.
     static MainWindow* getInstance();
 
@@ -81,11 +82,11 @@ class MainWindow : public QMainWindow {
     //! \brief Get the instance of the cmd widget to access data.
     CmdWidget* getCmdOut();
 
-  signals:
+   signals:
     //! \brief Signal to indicate check of time is complete (if registry check is insufficient)
     void nistDone();
 
-  public slots:
+   public slots:
     //! \brief Override show event to manipulate bounds on cmd_window
     void showEvent(QShowEvent* event);
 
@@ -133,7 +134,7 @@ class MainWindow : public QMainWindow {
     //! \brief loads a point cloud into a surface mesh object
     void loadPointCloud();
 
-  private slots:
+   private slots:
     //! \brief Start the slicing.
     void doSlice();
 
@@ -245,7 +246,7 @@ class MainWindow : public QMainWindow {
     //! \brief Load a template file from a known path.
     void loadTemplateFile(const QString& filename);
 
-  private:
+   private:
     //! \brief Struct to retain action information efficiently.
     struct menu_info {
         //! \brief Display name.
@@ -336,8 +337,8 @@ class MainWindow : public QMainWindow {
     void applyPartTransformSnapshot(QSharedPointer<PartMetaItem> item, const PartTransformSnapshot& snapshot);
 
     //! \brief Takes setting value snapshots for a set of target bases.
-    QVector<SettingValueSnapshot>
-    settingValueSnapshots(const QString& key, const QList<QSharedPointer<SettingsBase>>& settings_bases) const;
+    QVector<SettingValueSnapshot> settingValueSnapshots(
+        const QString& key, const QList<QSharedPointer<SettingsBase>>& settings_bases) const;
 
     //! \brief Applies setting value snapshots as an undo/redo operation.
     void applySettingValueSnapshots(const QVector<SettingValueSnapshot>& snapshots);
@@ -446,7 +447,7 @@ class MainWindow : public QMainWindow {
     //! \brief Setting panel to menu map
     QHash<QString, QMenu*> m_setting_panel_to_menu_map;
 
-  protected:
+   protected:
     void closeEvent(QCloseEvent* event);
 };
-} // namespace ORNL
+}  // namespace ORNL

--- a/include/windows/preferences_window.h
+++ b/include/windows/preferences_window.h
@@ -7,6 +7,7 @@
 #include <QMainWindow>
 #include <QRadioButton>
 #include <QSpinBox>
+
 #include <qhashfunctions.h>
 #include <qlist.h>
 #include <qsharedpointer.h>
@@ -24,17 +25,17 @@ namespace ORNL {
  */
 class PreferencesWindow : public QMainWindow {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     explicit PreferencesWindow(QWidget* parent = 0);
 
     //! \brief Destructor
     ~PreferencesWindow();
 
-  signals:
+   signals:
     void updateTheme();
 
-  private slots:
+   private slots:
     //! \brief Tell the preferences manager to import preferences from file
     void importPreferences();
 
@@ -54,7 +55,7 @@ class PreferencesWindow : public QMainWindow {
     void updateMassUnitVisual(Mass oldUnit, Mass newUnit);
     void updateThemeVisual();
 
-  private:
+   private:
     //! \brief Setup all components
     void setupLayout();
     //! \brief Setup the events for the various widgets.
@@ -102,5 +103,5 @@ class PreferencesWindow : public QMainWindow {
 
     //! \brief Copy of pointer to manager that holds actual preference information
     QSharedPointer<PreferencesManager> m_preferences_manager;
-}; // class PreferencesWindow
-} // namespace ORNL
+};  // class PreferencesWindow
+}  // namespace ORNL

--- a/include/windows/xtrudecalc.h
+++ b/include/windows/xtrudecalc.h
@@ -6,6 +6,7 @@
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QWidget>
+
 #include <qgridlayout.h>
 #include <qobject.h>
 #include <qtmetamacros.h>
@@ -19,18 +20,18 @@ namespace ORNL {
  */
 class XtrudeCalcWindow : public QWidget {
     Q_OBJECT
-  public:
+   public:
     //! \brief Constructor
     explicit XtrudeCalcWindow(QWidget* parent);
 
     //! \brief Destructor
     ~XtrudeCalcWindow();
 
-  protected:
+   protected:
     //! \brief Close event override to reset form values
     void closeEvent(QCloseEvent* event);
 
-  private slots:
+   private slots:
     //! \brief Check to see if preferences were updated in order to update units
     void checkUnitPref();
 
@@ -42,7 +43,7 @@ class XtrudeCalcWindow : public QWidget {
     //! \param index Current combo index
     void enableDensity(int index);
 
-  private:
+   private:
     //! \brief Setup events for widget components
     void setupEvents();
 
@@ -115,5 +116,5 @@ class XtrudeCalcWindow : public QWidget {
 
     //! \brief parent widget of this Xtrude calculator window
     QWidget* m_parent;
-}; // class XtrudeCalcWindow
-} // namespace ORNL
+};  // class XtrudeCalcWindow
+}  // namespace ORNL

--- a/src/algorithms/knn.cpp
+++ b/src/algorithms/knn.cpp
@@ -11,15 +11,15 @@
 namespace ORNL {
 
 kNN::kNN(const QVector<Point>& referencePoints, const QVector<Point>& queryPoints, int kNeighbors) {
-    m_point_dimension = 3;
-    m_kNeighbors = kNeighbors;
+    m_point_dimension     = 3;
+    m_kNeighbors          = kNeighbors;
     m_referencePointsSize = referencePoints.size();
-    m_queryPointsSize = queryPoints.size();
+    m_queryPointsSize     = queryPoints.size();
 
     m_referencePoints = static_cast<float*>(malloc(referencePoints.size() * m_point_dimension * sizeof(float)));
-    m_queryPoints = static_cast<float*>(malloc(queryPoints.size() * m_point_dimension * sizeof(float)));
+    m_queryPoints     = static_cast<float*>(malloc(queryPoints.size() * m_point_dimension * sizeof(float)));
 
-    m_knn_dist = static_cast<float*>(malloc((queryPoints.size()) * m_kNeighbors * sizeof(float)));
+    m_knn_dist  = static_cast<float*>(malloc((queryPoints.size()) * m_kNeighbors * sizeof(float)));
     m_knn_index = static_cast<int*>(malloc((queryPoints.size()) * m_kNeighbors * sizeof(int)));
 
     int refIndex = 0;
@@ -65,17 +65,13 @@ void kNN::execute() {
 
 QVector<Distance> kNN::getNearestDistances() {
     QVector<Distance> nearestDistances;
-    for (int i = 0; i < (m_queryPointsSize * m_kNeighbors); i++) {
-        nearestDistances.push_back(m_knn_dist[i]);
-    }
+    for (int i = 0; i < (m_queryPointsSize * m_kNeighbors); i++) { nearestDistances.push_back(m_knn_dist[i]); }
     return nearestDistances;
 }
 
 QVector<int> kNN::getNearestIndices() {
     QVector<int> nearestIndices;
-    for (int i = 0; i < (m_queryPointsSize * m_kNeighbors); i++) {
-        nearestIndices.push_back(m_knn_index[i]);
-    }
+    for (int i = 0; i < (m_queryPointsSize * m_kNeighbors); i++) { nearestIndices.push_back(m_knn_index[i]); }
     return nearestIndices;
 }
 
@@ -85,26 +81,23 @@ void kNN::modified_insertion_sort(float* dist, int* index, int length, int k) {
 
     // Go through all points
     for (int i = 1; i < length; ++i) {
-
         // Store current distance and associated index
         float curr_dist = dist[i];
-        int curr_index = i;
+        int curr_index  = i;
 
         // Skip the current value if its index is >= k and if it's higher the k-th slready sorted mallest value
-        if (i >= k && curr_dist >= dist[k - 1]) {
-            continue;
-        }
+        if (i >= k && curr_dist >= dist[k - 1]) { continue; }
 
         // Shift values (and indexes) higher that the current distance to the right
         int j = std::min(i, k - 1);
         while (j > 0 && dist[j - 1] > curr_dist) {
-            dist[j] = dist[j - 1];
+            dist[j]  = dist[j - 1];
             index[j] = index[j - 1];
             --j;
         }
 
         // Write the current distance and index at their position
-        dist[j] = curr_dist;
+        dist[j]  = curr_dist;
         index[j] = curr_index;
     }
 }
@@ -121,17 +114,15 @@ float kNN::compute_distance(const float* ref, int ref_nb, const float* query, in
 
 bool kNN::knn_c(const float* ref, int ref_nb, const float* query, int query_nb, int dim, int k, float* knn_dist,
                 int* knn_index) {
-
     // Allocate local array to store all the distances / indexes for a given query point
     float* dist = static_cast<float*>(malloc(ref_nb * sizeof(float)));
-    int* index = static_cast<int*>(malloc(ref_nb * sizeof(int)));
+    int* index  = static_cast<int*>(malloc(ref_nb * sizeof(int)));
 
     // Process one query point at the time
     for (int i = 0; i < query_nb; ++i) {
-
         // Compute all distances / indexes
         for (int j = 0; j < ref_nb; ++j) {
-            dist[j] = compute_distance(ref, ref_nb, query, query_nb, dim, j, i);
+            dist[j]  = compute_distance(ref, ref_nb, query, query_nb, dim, j, i);
             index[j] = j;
         }
 
@@ -140,7 +131,7 @@ bool kNN::knn_c(const float* ref, int ref_nb, const float* query, int query_nb, 
 
         // Copy k smallest distances and their associated index
         for (int j = 0; j < k; ++j) {
-            knn_dist[j * query_nb + i] = dist[j];
+            knn_dist[j * query_nb + i]  = dist[j];
             knn_index[j * query_nb + i] = index[j];
         }
     }
@@ -151,4 +142,4 @@ bool kNN::knn_c(const float* ref, int ref_nb, const float* query, int query_nb, 
     return true;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/algorithms/tsp_brute.cpp
+++ b/src/algorithms/tsp_brute.cpp
@@ -13,9 +13,9 @@
 namespace ORNL {
 
 TspBrute::TspBrute(const QVector<QSharedPointer<IslandBase>>& islands, int startIndex, bool shortest) {
-    m_islands = islands;
-    m_start_index = startIndex;
-    m_shortest = shortest;
+    m_islands           = islands;
+    m_start_index       = startIndex;
+    m_shortest          = shortest;
     m_number_of_islands = islands.size();
 
     QVector<Point> centers;
@@ -29,9 +29,7 @@ TspBrute::TspBrute(const QVector<QSharedPointer<IslandBase>>& islands, int start
 
     QVector<Distance> distances = knn.getNearestDistances();
     for (int i = m_islands.size(); i < distances.size(); i++) {
-        if (distances[i] == 0.0) {
-            m_same_center = true;
-        }
+        if (distances[i] == 0.0) { m_same_center = true; }
     }
 }
 
@@ -40,18 +38,12 @@ void TspBrute::execute() {
     QVector<QSharedPointer<IslandBase>> tmp_island_path;
     QVector<int> island_index_list;
 
-    for (int i = 0; i < m_number_of_islands; ++i) {
-        island_index_list += i;
-    }
+    for (int i = 0; i < m_number_of_islands; ++i) { island_index_list += i; }
 
     Distance overall_extremum_distance;
     Distance tmp_accumulate_distance = Distance(0);
-    if (m_shortest) {
-        overall_extremum_distance = Distance(std::numeric_limits<float>::max());
-    }
-    else {
-        overall_extremum_distance = Distance(0);
-    }
+    if (m_shortest) { overall_extremum_distance = Distance(std::numeric_limits<float>::max()); }
+    else { overall_extremum_distance = Distance(0); }
 
     this->removeValue(island_index_list, m_start_index);
 
@@ -74,18 +66,17 @@ void TspBrute::tsp_brute_force_traverse(QVector<int> island_index_list, Distance
                                         Distance tmp_accumulate_distance,
                                         QVector<QSharedPointer<IslandBase>>& optimized_island_path,
                                         QVector<QSharedPointer<IslandBase>> tmp_island_path, bool shortest) {
-
     if (island_index_list.empty()) {
         if (shortest) {
             if (tmp_accumulate_distance <= overall_extremum_distance) {
                 overall_extremum_distance = tmp_accumulate_distance;
-                optimized_island_path = tmp_island_path;
+                optimized_island_path     = tmp_island_path;
             }
         }
         else {
             if (tmp_accumulate_distance > overall_extremum_distance) {
                 overall_extremum_distance = tmp_accumulate_distance;
-                optimized_island_path = tmp_island_path;
+                optimized_island_path     = tmp_island_path;
             }
         }
     }
@@ -118,15 +109,15 @@ void TspBrute::tsp_brute_force_traverse(QVector<int> island_index_list, Distance
         if (shortest) {
             if (tmp_accumulate_distance < overall_extremum_distance) {
                 overall_extremum_distance = tmp_accumulate_distance;
-                optimized_island_path = tmp_island_path;
-                lastVertexVisited = temp_lastVertexVisited;
+                optimized_island_path     = tmp_island_path;
+                lastVertexVisited         = temp_lastVertexVisited;
             }
         }
         else {
             if (tmp_accumulate_distance > overall_extremum_distance) {
                 overall_extremum_distance = tmp_accumulate_distance;
-                optimized_island_path = tmp_island_path;
-                lastVertexVisited = temp_lastVertexVisited;
+                optimized_island_path     = tmp_island_path;
+                lastVertexVisited         = temp_lastVertexVisited;
             }
         }
     }
@@ -143,17 +134,17 @@ void TspBrute::tsp_brute_force_traverse(QVector<int> island_index_list, Distance
 
             // Find next outermost valid path
             Path next_Outermost_path;
-            bool found_valid_path = false;
+            bool found_valid_path     = false;
             auto& next_island_regions = m_islands[island_index_list[i]]->getRegions();
             for (int j = next_island_regions.size() - 1; i > 0; --i) {
                 if (next_island_regions[j]->getPaths().size() > 0) {
                     next_Outermost_path = next_island_regions[j]->getPaths().first();
-                    found_valid_path = true;
+                    found_valid_path    = true;
                     break;
                 }
             }
 
-            if (!found_valid_path) // There is no path in the next island, so skip it
+            if (!found_valid_path)  // There is no path in the next island, so skip it
                 return;
 
             for (int j = 0; j < next_Outermost_path.size(); j++) {
@@ -171,12 +162,12 @@ void TspBrute::tsp_brute_force_traverse(QVector<int> island_index_list, Distance
 
 void TspBrute::removeValue(QVector<int>& index_list, int value) {
     for (int i = 0; i < index_list.size(); ++i) {
-        if (index_list[i] == value) {
-            index_list.remove(i);
-        }
+        if (index_list[i] == value) { index_list.remove(i); }
     }
 }
 
-QVector<QSharedPointer<IslandBase>> TspBrute::getOptimizedIslandBases() { return m_optimized_islands; }
+QVector<QSharedPointer<IslandBase>> TspBrute::getOptimizedIslandBases() {
+    return m_optimized_islands;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/configs/settings_base.cpp
+++ b/src/configs/settings_base.cpp
@@ -10,50 +10,54 @@
 #include "utilities/qt_json_conversion.h"
 
 namespace ORNL {
-SettingsBase::SettingsBase() { //: m_json(nlohmann::json::object()){
+SettingsBase::SettingsBase() {  //: m_json(nlohmann::json::object()){
     // NOP
 }
 
-void SettingsBase::populate(const QSharedPointer<SettingsBase> other) { this->populate(other->m_json); }
+void SettingsBase::populate(const QSharedPointer<SettingsBase> other) {
+    this->populate(other->m_json);
+}
 
 void SettingsBase::populate(const fifojson& j) {
     int index = 0;
     for (auto& array : j.items()) {
-        for (auto it : array.value().items()) {
-            m_json[index][it.key()] = it.value();
-        }
+        for (auto it : array.value().items()) { m_json[index][it.key()] = it.value(); }
         index++;
     }
 }
 
 void SettingsBase::splice(const fifojson& j) {
     for (auto& array : j.items()) {
-        for (auto it : array.value().items()) {
-            m_json.erase(it.key());
-        }
+        for (auto it : array.value().items()) { m_json.erase(it.key()); }
     }
 }
 
 bool SettingsBase::contains(QString key, int extruder_index) const {
-    if (m_json.size() == 0) {
-        return false;
-    }
-    if (extruder_index == 0) {
-        return m_json[extruder_index].contains(key.toStdString());
-    }
+    if (m_json.size() == 0) { return false; }
+    if (extruder_index == 0) { return m_json[extruder_index].contains(key.toStdString()); }
     else
         return false;
 }
 
-bool SettingsBase::empty() const { return m_json.empty(); }
+bool SettingsBase::empty() const {
+    return m_json.empty();
+}
 
-void SettingsBase::remove(QString key, int extruder_index) { m_json[extruder_index].erase((key).toStdString()); }
+void SettingsBase::remove(QString key, int extruder_index) {
+    m_json[extruder_index].erase((key).toStdString());
+}
 
-void SettingsBase::reset() { m_json.clear(); }
+void SettingsBase::reset() {
+    m_json.clear();
+}
 
-fifojson& SettingsBase::json() { return m_json; }
+fifojson& SettingsBase::json() {
+    return m_json;
+}
 
-void SettingsBase::json(const fifojson& j) { m_json = j; }
+void SettingsBase::json(const fifojson& j) {
+    m_json = j;
+}
 
 void SettingsBase::makeGlobalAdjustments() {
     // Spiralize - should print one single perimeter bead on every layer without and modifiers
@@ -121,7 +125,7 @@ void SettingsBase::makeLocalAdjustments(int layer_number) {
         double dx = setting<double>(PS::Optimizations::kCustomPointXIncrement);
         double dy = setting<double>(PS::Optimizations::kCustomPointYIncrement);
 
-        bool enable_second = setting<bool>(PS::Optimizations::kEnableSecondCustomLocation);
+        bool enable_second           = setting<bool>(PS::Optimizations::kEnableSecondCustomLocation);
         bool enable_second_every_two = setting<bool>(PS::Optimizations::kEnableSecondCustomLocationEveryTwo);
 
         if (enable_second && enable_second_every_two) {
@@ -152,11 +156,11 @@ void SettingsBase::makeLocalAdjustments(int layer_number) {
 
     if (setting<bool>(PS::Infill::kEnable)) {
         // modify the infill_angle for each specific layer before the setting being passed to the island and region
-        Angle infill_angle = setting<Angle>(PS::Infill::kAngle);
+        Angle infill_angle          = setting<Angle>(PS::Infill::kAngle);
         Angle infill_angle_rotation = setting<Angle>(PS::Infill::kAngleRotation);
 
         // For issue #239: combine infill for every X layers
-        int combineXLayers = setting<int>(PS::Infill::kCombineXLayers);
+        int combineXLayers    = setting<int>(PS::Infill::kCombineXLayers);
         int combineLayerShift = setting<int>(PS::Infill::kCombineLayerShift);
         if (combineXLayers > 1) {
             // layer_number is 0 based, while Layer::m_layer_nr is 1 based
@@ -165,29 +169,25 @@ void SettingsBase::makeLocalAdjustments(int layer_number) {
                  ((layer_number + 1 - combineLayerShift) % combineXLayers != 0))) {
                 setSetting(PS::Infill::kEnable, false);
             }
-            else {
-                infill_angle = infill_angle + infill_angle_rotation * (layer_number / combineXLayers);
-            }
+            else { infill_angle = infill_angle + infill_angle_rotation * (layer_number / combineXLayers); }
         }
-        else {
-            infill_angle = infill_angle + infill_angle_rotation * layer_number;
-        }
+        else { infill_angle = infill_angle + infill_angle_rotation * layer_number; }
         setSetting(PS::Infill::kAngle, infill_angle);
     }
 
     if (setting<bool>(PS::Skin::kEnable)) {
         // modify the skin_angle for each specific layer before the setting being passed to the island and region
-        Angle skin_angle = setting<Angle>(PS::Skin::kAngle);
+        Angle skin_angle          = setting<Angle>(PS::Skin::kAngle);
         Angle skin_angle_rotation = setting<Angle>(PS::Skin::kAngleRotation);
-        skin_angle = skin_angle + skin_angle_rotation * layer_number;
+        skin_angle                = skin_angle + skin_angle_rotation * layer_number;
         setSetting(PS::Skin::kAngle, skin_angle);
 
         if (setting<bool>(PS::Skin::kInfillEnable)) {
-            Angle skin_infill_angle = setting<Angle>(PS::Skin::kInfillAngle);
+            Angle skin_infill_angle          = setting<Angle>(PS::Skin::kInfillAngle);
             Angle skin_infill_angle_rotation = setting<Angle>(PS::Skin::kInfillRotation);
-            skin_infill_angle = skin_infill_angle + skin_infill_angle_rotation * layer_number;
+            skin_infill_angle                = skin_infill_angle + skin_infill_angle_rotation * layer_number;
             setSetting(PS::Skin::kInfillAngle, skin_infill_angle);
         }
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/configs/settings_range.cpp
+++ b/src/configs/settings_range.cpp
@@ -7,32 +7,48 @@
 
 namespace ORNL {
 SettingsRange::SettingsRange(int low, int high, QString group_name, QSharedPointer<SettingsBase> sb) {
-    m_low = low;
-    m_high = high;
+    m_low        = low;
+    m_high       = high;
     m_group_name = group_name;
-    m_sb = sb;
+    m_sb         = sb;
 }
 
 SettingsRange::SettingsRange(int low, int high, QString group_name) {
-    m_low = low;
-    m_high = high;
+    m_low        = low;
+    m_high       = high;
     m_group_name = group_name;
-    m_sb = QSharedPointer<SettingsBase>::create();
+    m_sb         = QSharedPointer<SettingsBase>::create();
 }
 
-int SettingsRange::low() { return m_low; }
+int SettingsRange::low() {
+    return m_low;
+}
 
-int SettingsRange::high() { return m_high; }
+int SettingsRange::high() {
+    return m_high;
+}
 
-QString SettingsRange::groupName() { return m_group_name; }
+QString SettingsRange::groupName() {
+    return m_group_name;
+}
 
-QSharedPointer<SettingsBase> SettingsRange::getSb() { return m_sb; }
+QSharedPointer<SettingsBase> SettingsRange::getSb() {
+    return m_sb;
+}
 
-void SettingsRange::setSb(QSharedPointer<SettingsBase> sb) { m_sb = sb; }
+void SettingsRange::setSb(QSharedPointer<SettingsBase> sb) {
+    m_sb = sb;
+}
 
-bool SettingsRange::includesIndex(int index) { return index >= m_low && index <= m_high; }
+bool SettingsRange::includesIndex(int index) {
+    return index >= m_low && index <= m_high;
+}
 
-bool SettingsRange::isSingle() { return (m_low == m_high); }
+bool SettingsRange::isSingle() {
+    return (m_low == m_high);
+}
 
-void SettingsRange::setGroup(QString group) { m_group_name = group; }
-} // namespace ORNL
+void SettingsRange::setGroup(QString group) {
+    m_group_name = group;
+}
+}  // namespace ORNL

--- a/src/console/command_line_processor.cpp
+++ b/src/console/command_line_processor.cpp
@@ -29,7 +29,7 @@ QStringList modelNameFilters() {
     }
     return filters;
 }
-} // namespace
+}  // namespace
 
 CommandLineConverter::CommandLineConverter() {
     m_master = QSharedPointer<SettingsBase>::create();
@@ -41,7 +41,6 @@ CommandLineConverter::CommandLineConverter() {
 }
 
 void CommandLineConverter::setupCommandLineParser(QCommandLineParser& parser) {
-
     // parser in-built options
     parser.addHelpOption();
 
@@ -139,8 +138,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
         QStringList stlList = parser.values(Constants::ConsoleOptionStrings::kInputStlFiles);
         for (int i = 0, end = stlList.size(); i < end; ++i) {
             validSTL = isValidModelFile(stlList[i]);
-            if (!validSTL)
-                return false;
+            if (!validSTL) return false;
 
             options->setSetting(Constants::ConsoleOptionStrings::kInputStlFiles + "_" + QString::number(i), stlList[i]);
         }
@@ -153,8 +151,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
     if (parser.isSet(Constants::ConsoleOptionStrings::kInputStlFilesDirectory)) {
         QDir dir(parser.value(Constants::ConsoleOptionStrings::kInputStlFilesDirectory));
         QStringList names = dir.entryList(modelNameFilters());
-        if (names.size() == 0)
-            return false;
+        if (names.size() == 0) return false;
 
         validSTLDirectory = true;
         for (int i = 0; i < names.size(); ++i)
@@ -216,8 +213,7 @@ bool CommandLineConverter::checkRequiredSettings(QCommandLineParser& parser, QSh
         QStringList stlList = parser.values(Constants::ConsoleOptionStrings::kInputSupportStlFiles);
         for (int i = 0, end = stlList.size(); i < end; ++i) {
             validSTL = isValidModelFile(stlList[i]);
-            if (!validSTL)
-                return false;
+            if (!validSTL) return false;
 
             options->setSetting(Constants::ConsoleOptionStrings::kInputSupportStlFiles + "_" + QString::number(i),
                                 stlList[i]);
@@ -393,4 +389,4 @@ bool CommandLineConverter::isValidModelFile(QString path) {
 
     return true;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/console/main_control.cpp
+++ b/src/console/main_control.cpp
@@ -40,22 +40,17 @@ void MainControl::continueStartup() {
 }
 
 void MainControl::run() {
-
     if (m_options->contains(Constants::ConsoleOptionStrings::kShiftPartsOnLoad)) {
         if (m_options->setting<bool>(Constants::ConsoleOptionStrings::kShiftPartsOnLoad)) {
             PreferencesManager::getInstance()->setFileShiftPreference(PreferenceChoice::kPerformAutomatically);
         }
-        else {
-            PreferencesManager::getInstance()->setFileShiftPreference(PreferenceChoice::kSkipAutomatically);
-        }
+        else { PreferencesManager::getInstance()->setFileShiftPreference(PreferenceChoice::kSkipAutomatically); }
     }
     if (m_options->contains(Constants::ConsoleOptionStrings::kAlignParts)) {
         if (m_options->setting<bool>(Constants::ConsoleOptionStrings::kAlignParts)) {
             PreferencesManager::getInstance()->setAlignPreference(PreferenceChoice::kPerformAutomatically);
         }
-        else {
-            PreferencesManager::getInstance()->setAlignPreference(PreferenceChoice::kSkipAutomatically);
-        }
+        else { PreferencesManager::getInstance()->setAlignPreference(PreferenceChoice::kSkipAutomatically); }
     }
     if (m_options->contains(Constants::ConsoleOptionStrings::kUseImplicitTransforms)) {
         PreferencesManager::getInstance()->setUseImplicitTransforms(
@@ -65,7 +60,7 @@ void MainControl::run() {
     if (static_cast<SlicingMode>(GSM->getGlobal()->setting<int>(PS::Slicing::kSlicingMode)) == SlicingMode::kImage)
         CSM->setDefaultGcodeDir(m_options->setting<QString>(Constants::ConsoleOptionStrings::kOutputLocation));
 
-    int stlCount = m_options->setting<int>(Constants::ConsoleOptionStrings::kInputStlCount);
+    int stlCount        = m_options->setting<int>(Constants::ConsoleOptionStrings::kInputStlCount);
     int supportStlCount = m_options->setting<int>(Constants::ConsoleOptionStrings::kInputSupportStlCount);
     if (stlCount > 0) {
         m_parts_to_load = stlCount + supportStlCount;
@@ -99,18 +94,18 @@ void MainControl::run() {
     }
     else {
         connect(CSM.get(), &SessionManager::totalPartsInProject, this, &MainControl::partsInProject);
-        CSM->loadSession(false, m_options->setting<QString>(Constants::ConsoleOptionStrings::kInputProjectFile),
-                         false);
+        CSM->loadSession(false, m_options->setting<QString>(Constants::ConsoleOptionStrings::kInputProjectFile), false);
     }
 }
 
-void MainControl::partsInProject(int total) { m_parts_to_load = total; }
+void MainControl::partsInProject(int total) {
+    m_parts_to_load = total;
+}
 
 void MainControl::loadComplete() {
     --m_parts_to_load;
 
-    if (m_parts_to_load == 0 && !CSM->doSlice())
-        emit finished();
+    if (m_parts_to_load == 0 && !CSM->doSlice()) emit finished();
 }
 
 void MainControl::sliceComplete(QString filepath, bool alterFile) {
@@ -122,9 +117,7 @@ void MainControl::sliceComplete(QString filepath, bool alterFile) {
         connect(loader, &GCodeLoader::updateDialog, this, &MainControl::displayProgress);
         loader->start();
     }
-    else {
-        emit finished();
-    }
+    else { emit finished(); }
 }
 
 void MainControl::updateOutputInformation(QString tempLocation, GcodeMeta meta) {
@@ -138,8 +131,7 @@ void MainControl::gcodeParseComplete() {
     QString filepath = info.absolutePath();
 
     QString gcodeFileName = filepath % '/' % partName % m_selected_meta.m_file_suffix;
-    if (QFile::exists(gcodeFileName))
-        QFile::remove(gcodeFileName);
+    if (QFile::exists(gcodeFileName)) QFile::remove(gcodeFileName);
 
     QString projectFileName = filepath % '/' % partName % ".s2p";
 
@@ -171,7 +163,6 @@ void MainControl::displayProgress(StatusUpdateStepType type, int percentage) {
 
     std::cout << toString(type).toStdString() << " " << percentage;
 
-    if (percentage == 100)
-        std::cout << "\n";
+    if (percentage == 100) std::cout << "\n";
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/close_polygon_result.cpp
+++ b/src/cross_section/close_polygon_result.cpp
@@ -3,6 +3,6 @@
 namespace ORNL {
 ClosePolygonResult::ClosePolygonResult() {
     polygon_idx = -1;
-    point_idx = -1;
+    point_idx   = -1;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -29,18 +29,18 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
 
         // rotate
         QVector3D point_vec = point_to_rotate.toQVector3D();
-        QVector3D result = rotation.rotatedVector(point_vec);
+        QVector3D result    = rotation.rotatedVector(point_vec);
 
         // reapply translate to account for origin offset
         result.setX(result.x() + shift_amount.x());
         result.setY(result.y() + shift_amount.y());
-        result.setZ(result.z() + shift_amount.z()); // restore original z offset (needed for consistent inverse)
+        result.setZ(result.z() + shift_amount.z());  // restore original z offset (needed for consistent inverse)
 
-        return Point(result); // will un-rotate and un-shift later, just before gcode writing
+        return Point(result);  // will un-rotate and un-shift later, just before gcode writing
     };
 
     QVector<MeshVertex> vertices = mesh->vertices();
-    QVector<MeshFace> faces = mesh->faces();
+    QVector<MeshFace> faces      = mesh->faces();
 
     /*
      * Check every face (triangle) to see if it is cut by the slicing plane
@@ -50,9 +50,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
     int num_intersections = 0;
     QVector3D normal_accumulator(0, 0, 0);
     // Compute shift once (unless caller wants to preserve provided shift reference)
-    if (!preserve_input_shift) {
-        shift = findSlicingPlaneMidPoint(mesh, slicing_plane);
-    }
+    if (!preserve_input_shift) { shift = findSlicingPlaneMidPoint(mesh, slicing_plane); }
 
     // Precompute rotation once
     QQuaternion rotation = MathUtils::CreateQuaternion(slicing_plane.normal(), QVector3D(0, 0, 1));
@@ -61,9 +59,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
         const MeshFace& face = faces[m];
 
         // Skip ignored faces
-        if (face.ignore) {
-            continue;
-        }
+        if (face.ignore) { continue; }
 
         const MeshVertex& v0 = vertices[face.vertex_index[0]];
         const MeshVertex& v1 = vertices[face.vertex_index[1]];
@@ -76,7 +72,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
 
         CrossSectionSegment segment;
         segment.end_vertex = nullptr;
-        int end_edge_idx = -1;
+        int end_edge_idx   = -1;
 
         /*
            Each point is evaluated in the plane equation to
@@ -95,12 +91,10 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
             // p2   p1
             // --------
             //   p0
-            end_edge_idx = 0;
+            end_edge_idx  = 0;
             segment.start = findIntersection(p0, p2, slicing_plane);
-            segment.end = findIntersection(p0, p1, slicing_plane);
-            if (p1_eval == 0) {
-                segment.end_vertex = &v1;
-            }
+            segment.end   = findIntersection(p0, p1, slicing_plane);
+            if (p1_eval == 0) { segment.end_vertex = &v1; }
             intersection = true;
         }
         else if (p0_eval > 0 && p1_eval < 0 && p2_eval < 0) {
@@ -108,52 +102,48 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
             // --------
             // p1  p2
 
-            end_edge_idx = 2;
+            end_edge_idx  = 2;
             segment.start = findIntersection(p1, p0, slicing_plane);
-            segment.end = findIntersection(p2, p0, slicing_plane);
-            intersection = true;
+            segment.end   = findIntersection(p2, p0, slicing_plane);
+            intersection  = true;
         }
         else if (p1_eval < 0 && p0_eval >= 0 && p2_eval >= 0) {
             // p0   p2
             // --------
             //   p1
-            end_edge_idx = 1;
+            end_edge_idx  = 1;
             segment.start = findIntersection(p1, p0, slicing_plane);
-            segment.end = findIntersection(p1, p2, slicing_plane);
-            if (p2_eval == 0) {
-                segment.end_vertex = &v2;
-            }
+            segment.end   = findIntersection(p1, p2, slicing_plane);
+            if (p2_eval == 0) { segment.end_vertex = &v2; }
             intersection = true;
         }
         else if (p1_eval > 0 && p0_eval < 0 && p2_eval < 0) {
             //   p1
             // --------
             // p2  p0
-            end_edge_idx = 0;
+            end_edge_idx  = 0;
             segment.start = findIntersection(p2, p1, slicing_plane);
-            segment.end = findIntersection(p0, p1, slicing_plane);
-            intersection = true;
+            segment.end   = findIntersection(p0, p1, slicing_plane);
+            intersection  = true;
         }
         else if (p2_eval < 0 && p1_eval >= 0 && p0_eval >= 0) {
             // p1   p0
             // --------
             //   p2
-            end_edge_idx = 2;
+            end_edge_idx  = 2;
             segment.start = findIntersection(p2, p1, slicing_plane);
-            segment.end = findIntersection(p2, p0, slicing_plane);
-            if (p0_eval == 0) {
-                segment.end_vertex = &v0;
-            }
+            segment.end   = findIntersection(p2, p0, slicing_plane);
+            if (p0_eval == 0) { segment.end_vertex = &v0; }
             intersection = true;
         }
         else if (p2_eval > 0 && p1_eval < 0 && p0_eval < 0) {
             //   p2
             // --------
             // p0  p1
-            end_edge_idx = 1;
+            end_edge_idx  = 1;
             segment.start = findIntersection(p0, p2, slicing_plane);
-            segment.end = findIntersection(p1, p2, slicing_plane);
-            intersection = true;
+            segment.end   = findIntersection(p1, p2, slicing_plane);
+            intersection  = true;
         }
         else {
             // Not all cases create a segment, because a point of a face
@@ -174,14 +164,14 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
 
         // Rotate into 2D frame using precomputed shift & rotation
         segment.start = rotatePoint(segment.start, rotation, shift);
-        segment.end = rotatePoint(segment.end, rotation, shift);
+        segment.end   = rotatePoint(segment.end, rotation, shift);
 
         // add segment to cross-section
         cs.insertFaceToSegment(m, cs.segments().size());
-        segment.face_index = m;
+        segment.face_index         = m;
         segment.end_other_face_idx = face.connected_face_index[end_edge_idx];
-        segment.added_to_polygon = false;
-        segment.normal = face.normal;
+        segment.added_to_polygon   = false;
+        segment.normal             = face.normal;
         cs.addSegment(segment);
     }
 
@@ -195,7 +185,7 @@ PolygonList CrossSection::doCrossSection(QSharedPointer<MeshBase> mesh, Plane& s
 }
 
 Point CrossSection::findSlicingPlaneMidPoint(QSharedPointer<MeshBase> mesh, Plane& slicing_plane) {
-    Point center = (mesh->min() + mesh->max()) / 2; // center of the bounding box
+    Point center           = (mesh->min() + mesh->max()) / 2;  // center of the bounding box
     Distance max_dimension = mesh->min().distance(mesh->max());
     QVector3D plane_normal = slicing_plane.normal().normalized() * max_dimension();
 
@@ -236,4 +226,4 @@ Point CrossSection::findIntersection(Point& vertex0, Point& vertex1, Plane& slic
     return intersection_point;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/cross_section_object.cpp
+++ b/src/cross_section/cross_section_object.cpp
@@ -44,22 +44,18 @@ CrossSectionObject::CrossSectionObject(QSharedPointer<SettingsBase> sb) : m_sb(s
     largest_neglected_gap_first_phase = m_sb->setting<double>(ES::CrossSection::kLargestGap);
 
     // if unset or 0, default to .1 inches
-    if (largest_neglected_gap_first_phase <= 0)
-        largest_neglected_gap_first_phase = 2540;
+    if (largest_neglected_gap_first_phase <= 0) largest_neglected_gap_first_phase = 2540;
 
     largest_neglected_gap_second_phase = 2.0 * largest_neglected_gap_first_phase;
 
     // if unset or 0, default to 1 inch
     max_stitch1 = m_sb->setting<double>(ES::CrossSection::kMaxStitch);
-    if (max_stitch1 <= 0)
-        max_stitch1 = 25400;
+    if (max_stitch1 <= 0) max_stitch1 = 25400;
 }
 
 bool CrossSectionObject::shorterThan(const Point& p0, int32_t len) {
-    if (p0.x() > len || p0.x() < -len)
-        return false;
-    if (p0.y() > len || p0.y() < -len)
-        return false;
+    if (p0.x() > len || p0.x() < -len) return false;
+    if (p0.y() > len || p0.y() < -len) return false;
     return (p0.x() * p0.x() + p0.y() * p0.y()) <= len * len;
 }
 
@@ -72,8 +68,7 @@ PolygonList CrossSectionObject::makePolygons() {
     possiblePoints.reserve(m_segments.size());
 
     for (unsigned int startSegment = 0, end = m_segments.size(); startSegment < end; ++startSegment) {
-        if (m_segments[startSegment].added_to_polygon)
-            continue;
+        if (m_segments[startSegment].added_to_polygon) continue;
 
         Polygon poly;
         poly += m_segments[startSegment].start;
@@ -86,36 +81,33 @@ PolygonList CrossSectionObject::makePolygons() {
         unsigned int segmentIndex = startSegment;
         bool canClose;
         while (true) {
-            canClose = false;
+            canClose                                  = false;
             m_segments[segmentIndex].added_to_polygon = true;
-            Point p0 = m_segments[segmentIndex].end;
+            Point p0                                  = m_segments[segmentIndex].end;
             poly += p0;
 
             long long startKey = ((quint64)(m_segments[segmentIndex].start.x() * 1000) << 32) |
                                  ((quint64)(m_segments[segmentIndex].start.y() * 1000));
-            long long endKey = ((quint64)(p0.x() * 1000) << 32) | ((quint64)(p0.y() * 1000));
+            long long endKey   = ((quint64)(p0.x() * 1000) << 32) | ((quint64)(p0.y() * 1000));
 
             startPointHash.insert(startKey, segmentIndex);
             endPointHash.insert(endKey, segmentIndex);
             possiblePoints.push_back(p0);
 
-            int nextIndex = -1;
+            int nextIndex      = -1;
             int other_face_idx = m_segments[segmentIndex].end_other_face_idx;
 
             if (other_face_idx > -1 && m_face_idx_to_segment_idx.contains(other_face_idx)) {
-                Point p1 = m_segments[m_face_idx_to_segment_idx[other_face_idx]].start;
+                Point p1   = m_segments[m_face_idx_to_segment_idx[other_face_idx]].start;
                 Point diff = p0 - p1;
                 if (shorterThan(diff, 10)) {
-                    if (m_face_idx_to_segment_idx[other_face_idx] == static_cast<int>(startSegment))
-                        canClose = true;
-                    if (m_segments[m_face_idx_to_segment_idx[other_face_idx]].added_to_polygon)
-                        break;
+                    if (m_face_idx_to_segment_idx[other_face_idx] == static_cast<int>(startSegment)) canClose = true;
+                    if (m_segments[m_face_idx_to_segment_idx[other_face_idx]].added_to_polygon) break;
                     nextIndex = m_face_idx_to_segment_idx[other_face_idx];
                 }
             }
 
-            if (nextIndex == -1)
-                break;
+            if (nextIndex == -1) break;
             segmentIndex = nextIndex;
         }
         if (canClose)
@@ -178,8 +170,8 @@ PolygonList CrossSectionObject::makePolygons() {
     }
     m_polygons.addAll(m_closeable_polygons);
 
-    m_polygons.removeDegenerateVertices(); // Remove vertices connected to
-                                           // overlapping line segments
+    m_polygons.removeDegenerateVertices();  // Remove vertices connected to
+                                            // overlapping line segments
 
     m_polygons = m_polygons.simplify();
 
@@ -189,8 +181,7 @@ PolygonList CrossSectionObject::makePolygons() {
             if (!endPointHash.contains(key)) {
                 Point currentPoint = p;
                 auto it = std::remove_if(possiblePoints.begin(), possiblePoints.end(), [currentPoint](const Point p) {
-                    if (p.x() == currentPoint.x() && p.y() == currentPoint.y())
-                        return true;
+                    if (p.x() == currentPoint.x() && p.y() == currentPoint.y()) return true;
 
                     return false;
                 });
@@ -210,22 +201,26 @@ PolygonList CrossSectionObject::makePolygons() {
     return m_polygons;
 }
 
-QVector<CrossSectionSegment> CrossSectionObject::segments() { return m_segments; }
+QVector<CrossSectionSegment> CrossSectionObject::segments() {
+    return m_segments;
+}
 
-void CrossSectionObject::addSegment(CrossSectionSegment segment) { m_segments.append(segment); }
+void CrossSectionObject::addSegment(CrossSectionSegment segment) {
+    m_segments.append(segment);
+}
 
 void CrossSectionObject::insertFaceToSegment(int face_idx, int segment_idx) {
     m_face_idx_to_segment_idx.insert(face_idx, segment_idx);
 }
 
-PolygonList& CrossSectionObject::getPolygonList() { return m_polygons; }
+PolygonList& CrossSectionObject::getPolygonList() {
+    return m_polygons;
+}
 
 void CrossSectionObject::makeBasicPolygonLoops() {
     // loop through all segments and create loops out of them
     for (int start_idx = 0, end = m_segments.size(); start_idx < end; ++start_idx) {
-        if (!m_segments[start_idx].added_to_polygon) {
-            makeBasicPolygonLoop(start_idx);
-        }
+        if (!m_segments[start_idx].added_to_polygon) { makeBasicPolygonLoop(start_idx); }
     }
 
     // Clear the segment list to save memory
@@ -240,7 +235,7 @@ void CrossSectionObject::makeBasicPolygonLoop(int start_idx) {
         CrossSectionSegment& segment = m_segments[segment_idx];
         polygon += segment.end;
         segment.added_to_polygon = true;
-        segment_idx = getNextSegmentIdx(segment, start_idx);
+        segment_idx              = getNextSegmentIdx(segment, start_idx);
         if (segment_idx == static_cast<int>(start_idx)) {
             // polygon is closed
             m_polygons += polygon;
@@ -260,9 +255,7 @@ int CrossSectionObject::getNextSegmentIdx(const CrossSectionSegment& segment, in
     // side of the edge
     if (segment_ended_at_edge) {
         int face_to_try = segment.end_other_face_idx;
-        if (face_to_try == -1) {
-            return -1;
-        }
+        if (face_to_try == -1) { return -1; }
         return tryFaceNextSegmentIdx(segment, face_to_try, start_idx);
     }
     // If segment ends on a vertex loop through potential faces
@@ -270,9 +263,7 @@ int CrossSectionObject::getNextSegmentIdx(const CrossSectionSegment& segment, in
         const QVector<int>& faces_to_try = segment.end_vertex->connected_faces;
         for (int face_to_try : faces_to_try) {
             int result_idx = tryFaceNextSegmentIdx(segment, face_to_try, start_idx);
-            if (result_idx == static_cast<int>(start_idx)) {
-                return start_idx;
-            }
+            if (result_idx == static_cast<int>(start_idx)) { return start_idx; }
             if (result_idx != -1) {
                 // Not immediately returned since we might still encounter
                 // the start_idx
@@ -284,24 +275,20 @@ int CrossSectionObject::getNextSegmentIdx(const CrossSectionSegment& segment, in
 }
 
 int CrossSectionObject::tryFaceNextSegmentIdx(const CrossSectionSegment& segment, int face_idx, int start_idx) {
-    auto it_end = m_face_idx_to_segment_idx.end();      //!< The iterator corresponding to the end
-    auto it = m_face_idx_to_segment_idx.find(face_idx); //!< The iterator
-                                                        //! corresponding to the
+    auto it_end = m_face_idx_to_segment_idx.end();           //!< The iterator corresponding to the end
+    auto it     = m_face_idx_to_segment_idx.find(face_idx);  //!< The iterator
+                                                             //! corresponding to the
     //! face_idx or end if it
     //! doesn't exist
     if (it != it_end) {
         int segment_idx = it.value();
-        Point p1 = m_segments[segment_idx].start;
-        Point diff = segment.end - p1;
+        Point p1        = m_segments[segment_idx].start;
+        Point diff      = segment.end - p1;
         // If the start of the segment on the trial face is close enough to
         // the end of the previous segment
         if (diff.shorterThan(largest_neglected_gap_first_phase)) {
-            if (segment_idx == static_cast<int>(start_idx)) {
-                return start_idx;
-            }
-            if (m_segments[segment_idx].added_to_polygon) {
-                return -1;
-            }
+            if (segment_idx == static_cast<int>(start_idx)) { return start_idx; }
+            if (m_segments[segment_idx].added_to_polygon) { return -1; }
             return segment_idx;
         }
     }
@@ -336,7 +323,7 @@ GapCloserResult CrossSectionObject::findPolygonGapCloser(Point ip0, Point ip1) {
     ret.polygon_idx = c1.polygon_idx;
     ret.point_idx_a = c1.point_idx;
     ret.point_idx_b = c2.point_idx;
-    ret.a_to_b = true;
+    ret.a_to_b      = true;
 
     if (ret.point_idx_a == ret.point_idx_b) {
         // Connection points are on the same line segment
@@ -344,7 +331,7 @@ GapCloserResult CrossSectionObject::findPolygonGapCloser(Point ip0, Point ip1) {
     }
     else {
         // Find out if we should go from A to B or the other way around
-        Point p0 = m_polygons[ret.polygon_idx][ret.point_idx_a];
+        Point p0          = m_polygons[ret.polygon_idx][ret.point_idx_a];
         Distance length_a = p0.distance(ip0);
         for (uint i = ret.point_idx_a; i != ret.point_idx_b; i = (i + 1) % m_polygons[ret.polygon_idx].size()) {
             Point p1 = m_polygons[ret.polygon_idx][i];
@@ -353,7 +340,7 @@ GapCloserResult CrossSectionObject::findPolygonGapCloser(Point ip0, Point ip1) {
         }
         length_a += p0.distance(ip1);
 
-        p0 = m_polygons[ret.polygon_idx][ret.point_idx_b];
+        p0                = m_polygons[ret.polygon_idx][ret.point_idx_b];
         Distance length_b = p0.distance(ip1);
         for (uint i = ret.point_idx_b; i != ret.point_idx_a; i = (i + 1) % m_polygons[ret.polygon_idx].size()) {
             Point p1 = m_polygons[ret.polygon_idx][i];
@@ -383,7 +370,7 @@ ClosePolygonResult CrossSectionObject::findPolygonPointClosestTo(Point p) {
 
             // Q = A + Normal(B - A) * (((B - A) dot (P - A)) / VSize(A -
             // B));
-            Point p_diff = p1 - p0;
+            Point p_diff         = p1 - p0;
             Distance line_length = p1.distance(p0);
 
             if (line_length() > 1) {
@@ -393,8 +380,8 @@ ClosePolygonResult CrossSectionObject::findPolygonPointClosestTo(Point p) {
                     Point q = p0 + p_diff * dist_on_line / line_length();
                     if ((q - p).shorterThan(.01f * in)) {
                         ret.intersection_point = q;
-                        ret.polygon_idx = n;
-                        ret.point_idx = i;
+                        ret.polygon_idx        = n;
+                        ret.point_idx          = i;
                         return ret;
                     }
                 }
@@ -418,7 +405,7 @@ void CrossSectionObject::stitch_extensive() {
         uint best_polyline_1_idx = -1;
         uint best_polyline_2_idx = -1;
         GapCloserResult best_result;
-        best_result.length = std::numeric_limits<double>::max();
+        best_result.length      = std::numeric_limits<double>::max();
         best_result.polygon_idx = -1;
         best_result.point_idx_a = -1;
         best_result.point_idx_b = -1;
@@ -426,9 +413,7 @@ void CrossSectionObject::stitch_extensive() {
         //! \note m_open_polylines size must be evaluated
         for (int polyline_1_idx = 0; polyline_1_idx < m_open_polylines.size(); ++polyline_1_idx) {
             Polygon polyline_1 = m_open_polylines[polyline_1_idx];
-            if (polyline_1.size() < 1) {
-                continue;
-            }
+            if (polyline_1.size() < 1) { continue; }
 
             // Extra brackets cause res to be scoped
             {
@@ -436,21 +421,19 @@ void CrossSectionObject::stitch_extensive() {
                 if (res.length() > 0 && res.length < best_result.length) {
                     best_polyline_1_idx = polyline_1_idx;
                     best_polyline_2_idx = polyline_1_idx;
-                    best_result = res;
+                    best_result         = res;
                 }
             }
 
             for (int polyline_2_idx = 0; polyline_2_idx < m_open_polylines.size(); polyline_2_idx++) {
                 Polygon polyline_2 = m_open_polylines[polyline_2_idx];
-                if (polyline_2.size() < 1 || polyline_1_idx == polyline_2_idx) {
-                    continue;
-                }
+                if (polyline_2.size() < 1 || polyline_1_idx == polyline_2_idx) { continue; }
 
                 GapCloserResult res = findPolygonGapCloser(polyline_1[0], polyline_2.back());
                 if (res.length() > 0 && res.length < best_result.length) {
                     best_polyline_1_idx = polyline_1_idx;
                     best_polyline_2_idx = polyline_2_idx;
-                    best_result = res;
+                    best_result         = res;
                 }
             }
         }
@@ -464,7 +447,7 @@ void CrossSectionObject::stitch_extensive() {
                 else if (best_result.a_to_b) {
                     Polygon polygon;
                     for (uint j = best_result.point_idx_a; j != best_result.point_idx_b;
-                         j = (j + 1) % m_polygons[best_result.polygon_idx].size()) {
+                         j      = (j + 1) % m_polygons[best_result.polygon_idx].size()) {
                         polygon += m_polygons[best_result.polygon_idx][j];
                     }
                     for (int j = m_open_polylines[best_polyline_1_idx].size() - 1; j >= 0; j--) {
@@ -477,7 +460,7 @@ void CrossSectionObject::stitch_extensive() {
                     uint n = m_polygons.size();
                     m_polygons += m_open_polylines[best_polyline_1_idx];
                     for (uint j = best_result.point_idx_b; j != best_result.point_idx_a;
-                         j = (j + 1) % m_polygons[best_result.polygon_idx].size()) {
+                         j      = (j + 1) % m_polygons[best_result.polygon_idx].size()) {
                         m_polygons[n] += m_polygons[best_result.polygon_idx][j];
                     }
                     m_open_polylines[best_polyline_1_idx].clear();
@@ -493,7 +476,7 @@ void CrossSectionObject::stitch_extensive() {
                 else if (best_result.a_to_b) {
                     Polygon polygon;
                     for (int n = best_result.point_idx_a; n != best_result.point_idx_b;
-                         n = (n + 1) % m_polygons[best_result.polygon_idx].size()) {
+                         n     = (n + 1) % m_polygons[best_result.polygon_idx].size()) {
                         polygon += m_polygons[best_result.polygon_idx][n];
                     }
                     for (int n = polygon.size() - 1; n >= 0; n--) {
@@ -506,7 +489,7 @@ void CrossSectionObject::stitch_extensive() {
                 }
                 else {
                     for (uint n = best_result.point_idx_b; n != best_result.point_idx_a;
-                         n = (n + 1) % m_polygons[best_result.polygon_idx].size()) {
+                         n      = (n + 1) % m_polygons[best_result.polygon_idx].size()) {
                         m_open_polylines[best_polyline_2_idx] += m_polygons[best_result.polygon_idx][n];
                     }
                     for (int n = m_open_polylines[best_polyline_1_idx].size() - 1; n >= 0; n--) {
@@ -516,9 +499,7 @@ void CrossSectionObject::stitch_extensive() {
                 }
             }
         }
-        else {
-            break;
-        }
+        else { break; }
     }
 }
 
@@ -532,15 +513,17 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
     // Represents a terminal point of a polyline in open_polylines.
     struct StitchGridVal {
         uint polyline_idx;
-        Point polyline_term_point; //<! Depending on the
-                                   // SparsePointGridInclusive,
-                                   // either the start point or the end
-                                   // point of the
-                                   // polyline
+        Point polyline_term_point;  //<! Depending on the
+                                    // SparsePointGridInclusive,
+                                    // either the start point or the end
+                                    // point of the
+                                    // polyline
     };
 
     struct StitchGridValLocator {
-        Point operator()(const StitchGridVal& val) const { return val.polyline_term_point; }
+        Point operator()(const StitchGridVal& val) const {
+            return val.polyline_term_point;
+        }
     };
 
     // Used to find nearby end points within a fixed maximum radius
@@ -554,12 +537,10 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
     for (int polyline_0_idx = 0, end = m_open_polylines.size(); polyline_0_idx < end; ++polyline_0_idx) {
         Polyline polyline_0 = m_open_polylines[polyline_0_idx];
 
-        if (polyline_0.empty()) {
-            continue;
-        }
+        if (polyline_0.empty()) { continue; }
 
         StitchGridVal grid_val;
-        grid_val.polyline_idx = static_cast<uint>(polyline_0_idx);
+        grid_val.polyline_idx        = static_cast<uint>(polyline_0_idx);
         grid_val.polyline_term_point = polyline_0.back();
         grid_ends.insert(grid_val);
     }
@@ -569,12 +550,10 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
         for (int polyline_0_idx = 0, end = m_open_polylines.size(); polyline_0_idx < end; ++polyline_0_idx) {
             Polygon polyline_0 = m_open_polylines[polyline_0_idx];
 
-            if (polyline_0.empty()) {
-                continue;
-            }
+            if (polyline_0.empty()) { continue; }
 
             StitchGridVal grid_val;
-            grid_val.polyline_idx = static_cast<uint>(polyline_0_idx);
+            grid_val.polyline_idx        = static_cast<uint>(polyline_0_idx);
             grid_val.polyline_term_point = polyline_0.front();
             grid_starts.insert(grid_val);
         }
@@ -585,9 +564,7 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
     for (int polyline_1_idx = 0; polyline_1_idx < m_open_polylines.size(); ++polyline_1_idx) {
         Polyline polyline_1 = m_open_polylines[polyline_1_idx];
 
-        if (polyline_1.empty()) {
-            continue;
-        }
+        if (polyline_1.empty()) { continue; }
 
         /*
          * Check for stitches that append polyline_1 onto polyline_0
@@ -597,7 +574,7 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
         QVector<StitchGridVal> nearby_ends = grid_ends.getNearby(polyline_1.front(), max_dist);
         for (const auto& nearby_end : nearby_ends) {
             Distance diff = nearby_end.polyline_term_point.distance(polyline_1.front());
-            Area dist2 = diff * diff;
+            Area dist2    = diff * diff;
             if (dist2 < max_distance2) {
                 PossibleStitch poss_stitch;
                 poss_stitch.distance_2 = dist2;
@@ -616,12 +593,10 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
             nearby_ends = grid_ends.getNearby(polyline_1.back(), max_dist);
             for (const auto& nearby_end : nearby_ends) {
                 // Disallow stitching with self with same end point
-                if (nearby_end.polyline_idx == static_cast<uint>(polyline_1_idx)) {
-                    continue;
-                }
+                if (nearby_end.polyline_idx == static_cast<uint>(polyline_1_idx)) { continue; }
 
                 Distance diff = nearby_end.polyline_term_point.distance(polyline_1.back());
-                Area dist2 = diff * diff;
+                Area dist2    = diff * diff;
                 if (dist2 < max_distance2) {
                     PossibleStitch poss_stitch;
                     poss_stitch.distance_2 = dist2;
@@ -639,12 +614,10 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
             QVector<StitchGridVal> nearby_starts = grid_starts.getNearby(polyline_1.front(), max_dist);
             for (const auto& nearby_start : nearby_starts) {
                 // Disallow stitching with self with same end point
-                if (nearby_start.polyline_idx == static_cast<uint>(polyline_1_idx)) {
-                    continue;
-                }
+                if (nearby_start.polyline_idx == static_cast<uint>(polyline_1_idx)) { continue; }
 
                 Distance diff = nearby_start.polyline_term_point.distance(polyline_1.front());
-                Area dist2 = diff * diff;
+                Area dist2    = diff * diff;
                 if (dist2 < max_distance2) {
                     PossibleStitch poss_stitch;
                     poss_stitch.distance_2 = dist2;
@@ -662,10 +635,10 @@ std::priority_queue<PossibleStitch> CrossSectionObject::findPossibleStitches(Dis
 void CrossSectionObject::planPolylineStitch(Terminus& terminus_0, Terminus& terminus_1, bool reverse[2]) const {
     size_t polyline_0_idx = terminus_0.getPolylineIdx();
     size_t polyline_1_idx = terminus_1.getPolylineIdx();
-    bool back_0 = terminus_0.isEnd();
-    bool back_1 = terminus_1.isEnd();
-    reverse[0] = false;
-    reverse[1] = false;
+    bool back_0           = terminus_0.isEnd();
+    bool back_1           = terminus_1.isEnd();
+    reverse[0]            = false;
+    reverse[1]            = false;
     if (back_0) {
         if (back_1) {
             /*
@@ -715,15 +688,11 @@ void CrossSectionObject::joinPolylines(Polyline& polyline_0, Polyline& polyline_
     }
     if (reverse[1]) {
         // reverse polyline_1 by adding in reverse order
-        for (int poly_idx = polyline_1.size() - 1; poly_idx >= 0; --poly_idx) {
-            polyline_0 += polyline_1[poly_idx];
-        }
+        for (int poly_idx = polyline_1.size() - 1; poly_idx >= 0; --poly_idx) { polyline_0 += polyline_1[poly_idx]; }
     }
     else {
         // append polyline_1 onto polyline_0
-        for (const Point& p : polyline_1) {
-            polyline_0 += p;
-        }
+        for (const Point& p : polyline_1) { polyline_0 += p; }
     }
     polyline_1.clear();
 }
@@ -741,15 +710,15 @@ void CrossSectionObject::connectOpenPolylinesImpl(Distance max_dist, Distance ce
         PossibleStitch next_stitch = stitch_queue.top();
         stitch_queue.pop();
         Terminus old_terminus_0 = next_stitch.terminus_0;
-        Terminus terminus_0 = terminus_tracking_map.getCurrentFromOld(old_terminus_0);
-        unsigned long long idx = terminus_0.asIndex();
+        Terminus terminus_0     = terminus_tracking_map.getCurrentFromOld(old_terminus_0);
+        unsigned long long idx  = terminus_0.asIndex();
         if (terminus_0 == Terminus::INVALID_TERMINUS) {
             // if we already used this terminus, then this stitch is no
             // longer usable
             continue;
         }
         Terminus old_terminus_1 = next_stitch.terminus_1;
-        Terminus terminus_1 = terminus_tracking_map.getCurrentFromOld(old_terminus_1);
+        Terminus terminus_1     = terminus_tracking_map.getCurrentFromOld(old_terminus_1);
         if (terminus_1 == Terminus::INVALID_TERMINUS) {
             // if we already used this terminus, then this stitch is no
             // longer usable
@@ -764,12 +733,10 @@ void CrossSectionObject::connectOpenPolylinesImpl(Distance max_dist, Distance ce
             // finished polygon
             Polyline& polyline_0 = m_open_polylines[best_polyline_0_idx];
             m_closeable_polygons.append(polyline_0.close());
-            polyline_0.clear(); // Clear instead of removing, so that the
-                                // indices are still correct
+            polyline_0.clear();  // Clear instead of removing, so that the
+                                 // indices are still correct
             Terminus cur_terms[2] = {{best_polyline_0_idx, false}, {best_polyline_0_idx, true}};
-            for (size_t idx = 0U; idx != 2U; ++idx) {
-                terminus_tracking_map.markRemoved(cur_terms[idx]);
-            }
+            for (size_t idx = 0U; idx != 2U; ++idx) { terminus_tracking_map.markRemoved(cur_terms[idx]); }
             continue;
         }
 
@@ -790,23 +757,19 @@ void CrossSectionObject::connectOpenPolylinesImpl(Distance max_dist, Distance ce
         joinPolylines(m_open_polylines[best_polyline_0_idx], m_open_polylines[best_polyline_1_idx], reverse);
 
         // update terminus_tracking_map
-        Terminus cur_terms[4] = {{best_polyline_0_idx, false},
-                                 {best_polyline_0_idx, true},
-                                 {best_polyline_1_idx, false},
-                                 {best_polyline_1_idx, true}};
+        Terminus cur_terms[4]  = {{best_polyline_0_idx, false},
+                                  {best_polyline_0_idx, true},
+                                  {best_polyline_1_idx, false},
+                                  {best_polyline_1_idx, true}};
         Terminus next_terms[4] = {{best_polyline_0_idx, false},
                                   Terminus::INVALID_TERMINUS,
                                   Terminus::INVALID_TERMINUS,
                                   {best_polyline_0_idx, true}};
-        if (reverse[0]) {
-            std::swap(next_terms[0], next_terms[1]);
-        }
-        if (reverse[1]) {
-            std::swap(next_terms[2], next_terms[3]);
-        }
+        if (reverse[0]) { std::swap(next_terms[0], next_terms[1]); }
+        if (reverse[1]) { std::swap(next_terms[2], next_terms[3]); }
         // cur_terms -> next_terms has movement map
         // best_polyline_1 is always removed
         terminus_tracking_map.updateMap(4U, cur_terms, next_terms, 2U, &cur_terms[2]);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/cross_section_segment.cpp
+++ b/src/cross_section/cross_section_segment.cpp
@@ -2,9 +2,9 @@
 
 namespace ORNL {
 CrossSectionSegment::CrossSectionSegment() {
-    face_index = -1;
+    face_index         = -1;
     end_other_face_idx = -1;
-    end_vertex = nullptr;
-    added_to_polygon = false;
+    end_vertex         = nullptr;
+    added_to_polygon   = false;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/gap_closer_result.cpp
+++ b/src/cross_section/gap_closer_result.cpp
@@ -2,10 +2,10 @@
 
 namespace ORNL {
 GapCloserResult::GapCloserResult() {
-    length = -1;
+    length      = -1;
     polygon_idx = -1;
     point_idx_a = -1;
     point_idx_b = -1;
-    a_to_b = false;
+    a_to_b      = false;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/possible_stitch.cpp
+++ b/src/cross_section/possible_stitch.cpp
@@ -10,37 +10,23 @@ bool PossibleStitch::inOrder() const {
 
 bool PossibleStitch::operator<(const PossibleStitch& other) const {
     // better if lower distance
-    if (distance_2 > other.distance_2) {
-        return true;
-    }
-    else if (distance_2 < other.distance_2) {
-        return false;
-    }
+    if (distance_2 > other.distance_2) { return true; }
+    else if (distance_2 < other.distance_2) { return false; }
 
     // better if in order instead of reversed
-    if (!inOrder() && other.inOrder()) {
-        return true;
-    }
+    if (!inOrder() && other.inOrder()) { return true; }
 
     // better if lower Terminus::Index for terminus_0
     // This just defines a more total order and isn't strictly necessary.
-    if (terminus_0.asIndex() > other.terminus_0.asIndex()) {
-        return true;
-    }
-    else if (terminus_0.asIndex() < other.terminus_0.asIndex()) {
-        return false;
-    }
+    if (terminus_0.asIndex() > other.terminus_0.asIndex()) { return true; }
+    else if (terminus_0.asIndex() < other.terminus_0.asIndex()) { return false; }
 
     // better if lower Terminus::Index for terminus_1
     // This just defines a more total order and isn't strictly necessary.
-    if (terminus_1.asIndex() > other.terminus_1.asIndex()) {
-        return true;
-    }
-    else if (terminus_1.asIndex() < other.terminus_1.asIndex()) {
-        return false;
-    }
+    if (terminus_1.asIndex() > other.terminus_1.asIndex()) { return true; }
+    else if (terminus_1.asIndex() < other.terminus_1.asIndex()) { return false; }
 
     // The stitches have equal goodness
     return false;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/cross_section/terminus.cpp
+++ b/src/cross_section/terminus.cpp
@@ -9,17 +9,31 @@ Terminus::Terminus() : m_idx(-1) {}
 
 Terminus::Terminus(Index idx) : m_idx(idx) {}
 
-Terminus::Terminus(Index polyline_idx, bool is_end) { m_idx = polyline_idx * 2 + (is_end ? 1 : 0); }
+Terminus::Terminus(Index polyline_idx, bool is_end) {
+    m_idx = polyline_idx * 2 + (is_end ? 1 : 0);
+}
 
-Terminus::Index Terminus::getPolylineIdx() const { return m_idx / 2; }
+Terminus::Index Terminus::getPolylineIdx() const {
+    return m_idx / 2;
+}
 
-bool Terminus::isEnd() const { return (m_idx & 1); }
+bool Terminus::isEnd() const {
+    return (m_idx & 1);
+}
 
-Terminus::Index Terminus::asIndex() const { return m_idx; }
+Terminus::Index Terminus::asIndex() const {
+    return m_idx;
+}
 
-Terminus::Index Terminus::endIndexFromPolylineEndIndex(uint polyline_end_idx) { return polyline_end_idx * 2; }
+Terminus::Index Terminus::endIndexFromPolylineEndIndex(uint polyline_end_idx) {
+    return polyline_end_idx * 2;
+}
 
-bool Terminus::operator==(const Terminus& other) { return m_idx == other.m_idx; }
+bool Terminus::operator==(const Terminus& other) {
+    return m_idx == other.m_idx;
+}
 
-bool Terminus::operator!=(const Terminus& other) { return m_idx != other.m_idx; }
-} // namespace ORNL
+bool Terminus::operator!=(const Terminus& other) {
+    return m_idx != other.m_idx;
+}
+}  // namespace ORNL

--- a/src/cross_section/terminus_tracking_map.cpp
+++ b/src/cross_section/terminus_tracking_map.cpp
@@ -13,9 +13,7 @@ TerminusTrackingMap::TerminusTrackingMap(Terminus::Index end_idx)
     : m_terminus_old_to_current_map(end_idx), m_terminus_current_to_old_map(end_idx) {
     // Initialize map to everythin points to itself seince nothing has moved
     // yet
-    for (uint i = 0; i < end_idx; i++) {
-        m_terminus_current_to_old_map[i] = Terminus {i};
-    }
+    for (uint i = 0; i < end_idx; i++) { m_terminus_current_to_old_map[i] = Terminus {i}; }
     m_terminus_old_to_current_map = m_terminus_current_to_old_map;
 }
 
@@ -28,8 +26,8 @@ Terminus TerminusTrackingMap::getOldFromCurrent(const Terminus& current) const {
 }
 
 void TerminusTrackingMap::markRemoved(const Terminus& current) {
-    Terminus old = getOldFromCurrent(current);
-    m_terminus_old_to_current_map[old.asIndex()] = Terminus::INVALID_TERMINUS;
+    Terminus old                                     = getOldFromCurrent(current);
+    m_terminus_old_to_current_map[old.asIndex()]     = Terminus::INVALID_TERMINUS;
     m_terminus_current_to_old_map[current.asIndex()] = Terminus::INVALID_TERMINUS;
 }
 
@@ -38,14 +36,12 @@ void TerminusTrackingMap::updateMap(size_t num_terminuses, const Terminus* curre
                                     const Terminus* removed_current_terminuses) {
     // save old locations
     QVector<Terminus> old_terminuses(num_terminuses);
-    for (uint i = 0; i < num_terminuses; i++) {
-        old_terminuses[i] = getOldFromCurrent(current_terminuses[i]);
-    }
+    for (uint i = 0; i < num_terminuses; i++) { old_terminuses[i] = getOldFromCurrent(current_terminuses[i]); }
 
     // update using maps old <-> current and current <-> next
     for (uint i = 0; i < num_terminuses; i++) {
         m_terminus_old_to_current_map[old_terminuses[i].asIndex()] = next_terminuses[i];
-        Terminus next_terminus = next_terminuses[i];
+        Terminus next_terminus                                     = next_terminuses[i];
         if (next_terminus != Terminus::INVALID_TERMINUS) {
             m_terminus_current_to_old_map[next_terminus.asIndex()] = old_terminuses[i];
         }
@@ -56,4 +52,4 @@ void TerminusTrackingMap::updateMap(size_t num_terminuses, const Terminus* curre
         m_terminus_current_to_old_map[removed_current_terminuses[i].asIndex()] = Terminus::INVALID_TERMINUS;
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/as_printed_model_exporter.cpp
+++ b/src/gcode/as_printed_model_exporter.cpp
@@ -1,17 +1,16 @@
 #include "gcode/as_printed_model_exporter.h"
 
+#include <QByteArray>
+#include <QDataStream>
+#include <QSaveFile>
+#include <QTextStream>
+#include <QVector3D>
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
 #include <limits>
 #include <vector>
-
-#include <QByteArray>
-#include <QDataStream>
-#include <QSaveFile>
-#include <QTextStream>
-#include <QVector3D>
 
 #include "geometry/segments/arc.h"
 #include "geometry/segments/bezier.h"
@@ -22,22 +21,22 @@
 
 namespace ORNL {
 namespace {
-constexpr float kPi = 3.14159265358979323846f;
-constexpr float kTwoPi = 2.0f * kPi;
-constexpr float kVectorEpsilon = 1.0e-6f;
-constexpr float kVectorEpsilonSquared = kVectorEpsilon * kVectorEpsilon;
-constexpr int kCornerBlendSegments = 24;
-constexpr int kCenterlineTubeSides = 8;
-constexpr int kCenterlineCurveSegments = 32;
+constexpr float kPi                        = 3.14159265358979323846f;
+constexpr float kTwoPi                     = 2.0f * kPi;
+constexpr float kVectorEpsilon             = 1.0e-6f;
+constexpr float kVectorEpsilonSquared      = kVectorEpsilon * kVectorEpsilon;
+constexpr int kCornerBlendSegments         = 24;
+constexpr int kCenterlineTubeSides         = 8;
+constexpr int kCenterlineCurveSegments     = 32;
 constexpr float kCenterlineArcSegmentAngle = kTwoPi / 48.0f;
 
-QString formatFloat(float value) { return QString::number(value, 'g', 9); }
+QString formatFloat(float value) {
+    return QString::number(value, 'g', 9);
+}
 
 QVector3D normalFor(const AsPrintedModelExporter::Triangle& triangle) {
     QVector3D normal = QVector3D::crossProduct(triangle.b - triangle.a, triangle.c - triangle.a);
-    if (!qFuzzyIsNull(normal.lengthSquared())) {
-        normal.normalize();
-    }
+    if (!qFuzzyIsNull(normal.lengthSquared())) { normal.normalize(); }
     return normal;
 }
 
@@ -54,12 +53,8 @@ QVector3D slicePlaneNormal() {
     QVector3D normal = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicePlaneNormalX),
                         GSM->getGlobal()->setting<float>(PS::Slicing::kSlicePlaneNormalY),
                         GSM->getGlobal()->setting<float>(PS::Slicing::kSlicePlaneNormalZ)};
-    if (normal.lengthSquared() <= kVectorEpsilonSquared) {
-        normal = QVector3D(0.0f, 0.0f, 1.0f);
-    }
-    else {
-        normal.normalize();
-    }
+    if (normal.lengthSquared() <= kVectorEpsilonSquared) { normal = QVector3D(0.0f, 0.0f, 1.0f); }
+    else { normal.normalize(); }
 
     return normal;
 }
@@ -68,12 +63,8 @@ std::array<QVector3D, 2> planeBasis(const QVector3D& normal) {
     const QVector3D reference =
         std::fabs(normal.x()) < 0.9f ? QVector3D(1.0f, 0.0f, 0.0f) : QVector3D(0.0f, 1.0f, 0.0f);
     QVector3D u = QVector3D::crossProduct(normal, reference);
-    if (u.lengthSquared() <= kVectorEpsilonSquared) {
-        u = QVector3D(0.0f, 1.0f, 0.0f);
-    }
-    else {
-        u.normalize();
-    }
+    if (u.lengthSquared() <= kVectorEpsilonSquared) { u = QVector3D(0.0f, 1.0f, 0.0f); }
+    else { u.normalize(); }
 
     QVector3D v = QVector3D::crossProduct(normal, u);
     v.normalize();
@@ -89,7 +80,9 @@ float viewToOutputScale(const Distance& output_unit) {
     return static_cast<float>(Constants::OpenGL::kViewToObject / output_unit());
 }
 
-QVector3D viewToOutput(const QVector3D& vertex, float output_scale) { return vertex * output_scale; }
+QVector3D viewToOutput(const QVector3D& vertex, float output_scale) {
+    return vertex * output_scale;
+}
 
 void appendOutputTriangle(std::vector<AsPrintedModelExporter::Triangle>& triangles, const QVector3D& a,
                           const QVector3D& b, const QVector3D& c, float output_scale) {
@@ -97,9 +90,7 @@ void appendOutputTriangle(std::vector<AsPrintedModelExporter::Triangle>& triangl
 }
 
 bool isDegenerateSegment(const QSharedPointer<SegmentBase>& segment) {
-    if (dynamic_cast<LineSegment*>(segment.data()) == nullptr) {
-        return false;
-    }
+    if (dynamic_cast<LineSegment*>(segment.data()) == nullptr) { return false; }
 
     return (segment->end().toQVector3D() - segment->start().toQVector3D()).lengthSquared() <= kVectorEpsilonSquared;
 }
@@ -120,29 +111,25 @@ bool isCorner(const QSharedPointer<SegmentBase>& previous, const QSharedPointer<
 void appendCornerBlend(std::vector<AsPrintedModelExporter::Triangle>& triangles,
                        const QSharedPointer<SegmentBase>& previous, const QSharedPointer<SegmentBase>& current,
                        float output_scale) {
-    if (!pointsConnected(previous->end(), current->start()) || !isCorner(previous, current)) {
-        return;
-    }
+    if (!pointsConnected(previous->end(), current->start()) || !isCorner(previous, current)) { return; }
 
     const float radius = std::max(previous->displayWidth(), current->displayWidth()) / 2.0f;
     const float height = std::max(previous->displayHeight(), current->displayHeight());
-    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return;
-    }
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) { return; }
 
-    const QVector3D center = previous->end().toQVector3D();
-    const QVector3D normal = slicePlaneNormal();
-    const auto [u, v] = planeBasis(normal);
-    const QVector3D top_center = center + (normal * (height / 2.0f));
+    const QVector3D center        = previous->end().toQVector3D();
+    const QVector3D normal        = slicePlaneNormal();
+    const auto [u, v]             = planeBasis(normal);
+    const QVector3D top_center    = center + (normal * (height / 2.0f));
     const QVector3D bottom_center = center - (normal * (height / 2.0f));
 
     std::array<QVector3D, kCornerBlendSegments> top_vertices;
     std::array<QVector3D, kCornerBlendSegments> bottom_vertices;
     for (int i = 0; i < kCornerBlendSegments; ++i) {
-        const float theta = (static_cast<float>(i) / static_cast<float>(kCornerBlendSegments)) * kTwoPi;
+        const float theta      = (static_cast<float>(i) / static_cast<float>(kCornerBlendSegments)) * kTwoPi;
         const QVector3D offset = ((std::cos(theta) * u) + (std::sin(theta) * v)) * radius;
-        top_vertices[i] = top_center + offset;
-        bottom_vertices[i] = bottom_center + offset;
+        top_vertices[i]        = top_center + offset;
+        bottom_vertices[i]     = bottom_center + offset;
     }
 
     for (int i = 0; i < kCornerBlendSegments; ++i) {
@@ -163,9 +150,7 @@ void appendCornerBlend(std::vector<AsPrintedModelExporter::Triangle>& triangles,
 
 void appendCornerBlends(std::vector<AsPrintedModelExporter::Triangle>& triangles,
                         const QVector<QSharedPointer<SegmentBase>>& connected_segments, float output_scale) {
-    if (connected_segments.size() < 2) {
-        return;
-    }
+    if (connected_segments.size() < 2) { return; }
 
     for (qsizetype i = 1; i < connected_segments.size(); ++i) {
         appendCornerBlend(triangles, connected_segments[i - 1], connected_segments[i], output_scale);
@@ -175,26 +160,20 @@ void appendCornerBlends(std::vector<AsPrintedModelExporter::Triangle>& triangles
 }
 
 bool centerlineFrameForTangent(QVector3D tangent, QVector3D& u, QVector3D& v) {
-    if (tangent.lengthSquared() <= kVectorEpsilonSquared) {
-        return false;
-    }
+    if (tangent.lengthSquared() <= kVectorEpsilonSquared) { return false; }
     tangent.normalize();
 
     QVector3D normal = slicePlaneNormal();
-    u = QVector3D::crossProduct(tangent, normal);
+    u                = QVector3D::crossProduct(tangent, normal);
     if (u.lengthSquared() <= kVectorEpsilonSquared) {
         normal = std::fabs(tangent.x()) < 0.9f ? QVector3D(1.0f, 0.0f, 0.0f) : QVector3D(0.0f, 1.0f, 0.0f);
-        u = QVector3D::crossProduct(tangent, normal);
+        u      = QVector3D::crossProduct(tangent, normal);
     }
-    if (u.lengthSquared() <= kVectorEpsilonSquared) {
-        return false;
-    }
+    if (u.lengthSquared() <= kVectorEpsilonSquared) { return false; }
     u.normalize();
 
     v = QVector3D::crossProduct(tangent, u);
-    if (v.lengthSquared() <= kVectorEpsilonSquared) {
-        return false;
-    }
+    if (v.lengthSquared() <= kVectorEpsilonSquared) { return false; }
     v.normalize();
 
     return true;
@@ -205,26 +184,26 @@ std::vector<QVector3D> centerlinePointsForLine(const SegmentBase& segment) {
 }
 
 std::vector<QVector3D> centerlinePointsForArc(const ArcSegment& arc) {
-    const Point start = arc.start();
-    const Point center = arc.center();
-    const Point end = arc.end();
+    const Point start   = arc.start();
+    const Point center  = arc.center();
+    const Point end     = arc.end();
     const double radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    const double sweep = arc.angle()();
+    const double sweep  = arc.angle()();
 
     if (!std::isfinite(radius) || !std::isfinite(sweep) || radius <= kVectorEpsilon || sweep <= kVectorEpsilon) {
         return centerlinePointsForLine(arc);
     }
 
-    const int segment_count = std::max(1, static_cast<int>(std::ceil(sweep / kCenterlineArcSegmentAngle)));
-    const double start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const int segment_count   = std::max(1, static_cast<int>(std::ceil(sweep / kCenterlineArcSegmentAngle)));
+    const double start_angle  = std::atan2(start.y() - center.y(), start.x() - center.x());
     const double signed_sweep = arc.counterclockwise() ? sweep : -sweep;
-    const double z_delta = end.z() - start.z();
+    const double z_delta      = end.z() - start.z();
 
     std::vector<QVector3D> points;
     points.reserve(static_cast<std::size_t>(segment_count) + 1);
     points.push_back(start.toQVector3D());
     for (int i = 1; i < segment_count; ++i) {
-        const double t = static_cast<double>(i) / static_cast<double>(segment_count);
+        const double t     = static_cast<double>(i) / static_cast<double>(segment_count);
         const double angle = start_angle + (signed_sweep * t);
         points.push_back(QVector3D(center.x() + (radius * std::cos(angle)), center.y() + (radius * std::sin(angle)),
                                    start.z() + (z_delta * t)));
@@ -246,21 +225,15 @@ std::vector<QVector3D> centerlinePointsForBezier(BezierSegment& curve) {
 }
 
 std::vector<QVector3D> centerlinePointsForSegment(const QSharedPointer<SegmentBase>& segment) {
-    if (auto* arc = dynamic_cast<ArcSegment*>(segment.data())) {
-        return centerlinePointsForArc(*arc);
-    }
-    if (auto* bezier = dynamic_cast<BezierSegment*>(segment.data())) {
-        return centerlinePointsForBezier(*bezier);
-    }
+    if (auto* arc = dynamic_cast<ArcSegment*>(segment.data())) { return centerlinePointsForArc(*arc); }
+    if (auto* bezier = dynamic_cast<BezierSegment*>(segment.data())) { return centerlinePointsForBezier(*bezier); }
 
     return centerlinePointsForLine(*segment);
 }
 
 void appendCenterlineTube(std::vector<AsPrintedModelExporter::Triangle>& triangles,
                           const std::vector<QVector3D>& centerline_points, float radius, float output_scale) {
-    if (centerline_points.size() < 2 || radius <= kVectorEpsilon) {
-        return;
-    }
+    if (centerline_points.size() < 2 || radius <= kVectorEpsilon) { return; }
 
     std::vector<QVector3D> points;
     points.reserve(centerline_points.size());
@@ -269,32 +242,22 @@ void appendCenterlineTube(std::vector<AsPrintedModelExporter::Triangle>& triangl
             points.push_back(point);
         }
     }
-    if (points.size() < 2) {
-        return;
-    }
+    if (points.size() < 2) { return; }
 
     std::vector<std::array<QVector3D, kCenterlineTubeSides>> rings(points.size());
     for (std::size_t i = 0; i < points.size(); ++i) {
         QVector3D tangent;
-        if (i == 0) {
-            tangent = points[1] - points[0];
-        }
-        else if (i == points.size() - 1) {
-            tangent = points[i] - points[i - 1];
-        }
-        else {
-            tangent = points[i + 1] - points[i - 1];
-        }
+        if (i == 0) { tangent = points[1] - points[0]; }
+        else if (i == points.size() - 1) { tangent = points[i] - points[i - 1]; }
+        else { tangent = points[i + 1] - points[i - 1]; }
 
         QVector3D u;
         QVector3D v;
-        if (!centerlineFrameForTangent(tangent, u, v)) {
-            return;
-        }
+        if (!centerlineFrameForTangent(tangent, u, v)) { return; }
 
         for (int j = 0; j < kCenterlineTubeSides; ++j) {
             const float theta = (static_cast<float>(j) / static_cast<float>(kCenterlineTubeSides)) * kTwoPi;
-            rings[i][j] = points[i] + (((std::cos(theta) * u) + (std::sin(theta) * v)) * radius);
+            rings[i][j]       = points[i] + (((std::cos(theta) * u) + (std::sin(theta) * v)) * radius);
         }
     }
 
@@ -321,17 +284,13 @@ void appendCenterlineSegment(std::vector<AsPrintedModelExporter::Triangle>& tria
                              const QSharedPointer<SegmentBase>& segment, const AsPrintedModelExporter::Options& options,
                              float output_scale) {
     const float radius = static_cast<float>(options.centerline_diameter() * Constants::OpenGL::kObjectToView / 2.0);
-    if (!std::isfinite(radius) || radius <= kVectorEpsilon) {
-        return;
-    }
+    if (!std::isfinite(radius) || radius <= kVectorEpsilon) { return; }
 
     appendCenterlineTube(triangles, centerlinePointsForSegment(segment), radius, output_scale);
 }
 
 void normalizeToLocalOrigin(std::vector<AsPrintedModelExporter::Triangle>& triangles) {
-    if (triangles.empty()) {
-        return;
-    }
+    if (triangles.empty()) { return; }
 
     QVector3D minimum(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(),
                       std::numeric_limits<float>::max());
@@ -355,9 +314,7 @@ bool writeAsciiStl(const QString& path, const std::vector<AsPrintedModelExporter
                    QString* error_message) {
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-        if (error_message != nullptr) {
-            *error_message = file.errorString();
-        }
+        if (error_message != nullptr) { *error_message = file.errorString(); }
         return false;
     }
 
@@ -379,9 +336,7 @@ bool writeAsciiStl(const QString& path, const std::vector<AsPrintedModelExporter
     out << "endsolid ornlslicer_as_printed\n";
 
     if (!file.commit()) {
-        if (error_message != nullptr) {
-            *error_message = file.errorString();
-        }
+        if (error_message != nullptr) { *error_message = file.errorString(); }
         return false;
     }
 
@@ -399,9 +354,7 @@ bool writeBinaryStl(const QString& path, const std::vector<AsPrintedModelExporte
 
     QSaveFile file(path);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        if (error_message != nullptr) {
-            *error_message = file.errorString();
-        }
+        if (error_message != nullptr) { *error_message = file.errorString(); }
         return false;
     }
 
@@ -409,9 +362,7 @@ bool writeBinaryStl(const QString& path, const std::vector<AsPrintedModelExporte
     const QByteArray label = QByteArrayLiteral("ORNLSlicer as-printed binary STL");
     std::copy(label.begin(), label.end(), header.begin());
     if (file.write(header) != header.size()) {
-        if (error_message != nullptr) {
-            *error_message = file.errorString();
-        }
+        if (error_message != nullptr) { *error_message = file.errorString(); }
         return false;
     }
 
@@ -429,25 +380,21 @@ bool writeBinaryStl(const QString& path, const std::vector<AsPrintedModelExporte
     }
 
     if (out.status() != QDataStream::Ok) {
-        if (error_message != nullptr) {
-            *error_message = QStringLiteral("Could not write binary STL data.");
-        }
+        if (error_message != nullptr) { *error_message = QStringLiteral("Could not write binary STL data."); }
         return false;
     }
 
     if (!file.commit()) {
-        if (error_message != nullptr) {
-            *error_message = file.errorString();
-        }
+        if (error_message != nullptr) { *error_message = file.errorString(); }
         return false;
     }
 
     return true;
 }
-} // namespace
+}  // namespace
 
-std::vector<AsPrintedModelExporter::Triangle>
-AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode, Options options) {
+std::vector<AsPrintedModelExporter::Triangle> AsPrintedModelExporter::generateTriangles(
+    const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode, Options options) {
     std::vector<Triangle> triangles;
     std::vector<float> vertices;
     std::vector<float> normals;
@@ -465,9 +412,7 @@ AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<S
 
         for (const QSharedPointer<SegmentBase>& segment : layer) {
             if (!shouldExportSegment(segment, options)) {
-                if (blend_corners) {
-                    flushConnectedSegments();
-                }
+                if (blend_corners) { flushConnectedSegments(); }
                 continue;
             }
 
@@ -492,19 +437,13 @@ AsPrintedModelExporter::generateTriangles(const QVector<QVector<QSharedPointer<S
                 }
             }
 
-            if (blend_corners) {
-                connected_segments.push_back(segment);
-            }
+            if (blend_corners) { connected_segments.push_back(segment); }
         }
 
-        if (blend_corners) {
-            flushConnectedSegments();
-        }
+        if (blend_corners) { flushConnectedSegments(); }
     }
 
-    if (options.origin_mode == OriginMode::kLocalOrigin) {
-        normalizeToLocalOrigin(triangles);
-    }
+    if (options.origin_mode == OriginMode::kLocalOrigin) { normalizeToLocalOrigin(triangles); }
 
     return triangles;
 }
@@ -523,24 +462,14 @@ bool AsPrintedModelExporter::writeStl(const QString& path, const QVector<QVector
 }
 
 bool AsPrintedModelExporter::shouldExportSegment(const QSharedPointer<SegmentBase>& segment, const Options& options) {
-    if (segment.isNull()) {
-        return false;
-    }
-    if (isDegenerateSegment(segment)) {
-        return false;
-    }
+    if (segment.isNull()) { return false; }
+    if (isDegenerateSegment(segment)) { return false; }
 
     const SegmentDisplayType type = segment->displayType();
-    if (!options.include_travel && static_cast<bool>(type & SegmentDisplayType::kTravel)) {
-        return false;
-    }
-    if (!options.include_support && static_cast<bool>(type & SegmentDisplayType::kSupport)) {
-        return false;
-    }
-    if (!segment->depositionActive() && !static_cast<bool>(type & SegmentDisplayType::kTravel)) {
-        return false;
-    }
+    if (!options.include_travel && static_cast<bool>(type & SegmentDisplayType::kTravel)) { return false; }
+    if (!options.include_support && static_cast<bool>(type & SegmentDisplayType::kSupport)) { return false; }
+    if (!segment->depositionActive() && !static_cast<bool>(type & SegmentDisplayType::kTravel)) { return false; }
 
     return true;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/gcode_command.cpp
+++ b/src/gcode/gcode_command.cpp
@@ -2,62 +2,106 @@
 
 #include <QMap>
 #include <QString>
+
 #include <qcontainerfwd.h>
 
 #include "geometry/point.h"
 
 namespace ORNL {
 GcodeCommand::GcodeCommand()
-    : m_line_number(-1), m_command(0), m_command_id(-1), m_is_motion_command(false), m_is_end_of_layer(false),
-      m_deposition_active(false), m_extruder_speed(0) {}
+    : m_line_number(-1),
+      m_command(0),
+      m_command_id(-1),
+      m_is_motion_command(false),
+      m_is_end_of_layer(false),
+      m_deposition_active(false),
+      m_extruder_speed(0) {}
 
 GcodeCommand::GcodeCommand(const GcodeCommand& other)
-    : m_line_number(other.m_line_number), m_command(other.m_command), m_command_id(other.m_command_id),
-      m_parameters(other.m_parameters), m_optional_parameters(other.m_optional_parameters), m_comment(other.m_comment),
-      m_is_motion_command(other.m_is_motion_command), m_is_end_of_layer(other.m_is_end_of_layer),
-      m_deposition_active(other.m_deposition_active), m_extruder_speed(other.m_extruder_speed) {}
+    : m_line_number(other.m_line_number),
+      m_command(other.m_command),
+      m_command_id(other.m_command_id),
+      m_parameters(other.m_parameters),
+      m_optional_parameters(other.m_optional_parameters),
+      m_comment(other.m_comment),
+      m_is_motion_command(other.m_is_motion_command),
+      m_is_end_of_layer(other.m_is_end_of_layer),
+      m_deposition_active(other.m_deposition_active),
+      m_extruder_speed(other.m_extruder_speed) {}
 
 //! \brief Retrieves the line number of the command
-const int& GcodeCommand::getLineNumber() const { return m_line_number; }
+const int& GcodeCommand::getLineNumber() const {
+    return m_line_number;
+}
 
 //! \brief Retrieves the Command
-const char& GcodeCommand::getCommand() const { return m_command; }
+const char& GcodeCommand::getCommand() const {
+    return m_command;
+}
 
 //! \brief Retrieves the Command ID
-const int& GcodeCommand::getCommandID() const { return m_command_id; }
+const int& GcodeCommand::getCommandID() const {
+    return m_command_id;
+}
 
 //! \brief Retrieves the Command motion boolean
-const bool& GcodeCommand::getCommandIsMotion() const { return m_is_motion_command; }
+const bool& GcodeCommand::getCommandIsMotion() const {
+    return m_is_motion_command;
+}
 
 //! \brief Retrieves the Command motion boolean
-const bool& GcodeCommand::getCommandIsEndOfLayer() const { return m_is_end_of_layer; }
+const bool& GcodeCommand::getCommandIsEndOfLayer() const {
+    return m_is_end_of_layer;
+}
 
 //! \brief Retrieves the Command
-void GcodeCommand::clearCommand() { m_command = 0; }
+void GcodeCommand::clearCommand() {
+    m_command = 0;
+}
 
 //! \brief Retrieves the Command ID
-void GcodeCommand::clearCommandID() { m_command_id = -1; }
+void GcodeCommand::clearCommandID() {
+    m_command_id = -1;
+}
 
 //! \brief Retrieves all parameters
-const QMap<char, double>& GcodeCommand::getParameters() const { return m_parameters; }
+const QMap<char, double>& GcodeCommand::getParameters() const {
+    return m_parameters;
+}
 
 //! \brief Retrieves optional parameters
-const QMap<char, double>& GcodeCommand::getOptionalParameters() const { return m_optional_parameters; }
+const QMap<char, double>& GcodeCommand::getOptionalParameters() const {
+    return m_optional_parameters;
+}
 
 //! \brief Retrieves the Comment
-const QString& GcodeCommand::getComment() const { return m_comment; }
+const QString& GcodeCommand::getComment() const {
+    return m_comment;
+}
 
-void GcodeCommand::setLineNumber(const int line_number) { m_line_number = line_number; }
+void GcodeCommand::setLineNumber(const int line_number) {
+    m_line_number = line_number;
+}
 
-void GcodeCommand::setCommand(const char command) { m_command = command; }
+void GcodeCommand::setCommand(const char command) {
+    m_command = command;
+}
 
-void GcodeCommand::setCommandID(const int commandID) { m_command_id = commandID; }
+void GcodeCommand::setCommandID(const int commandID) {
+    m_command_id = commandID;
+}
 
-void GcodeCommand::setComment(const QString& comment) { m_comment = comment; }
+void GcodeCommand::setComment(const QString& comment) {
+    m_comment = comment;
+}
 
-void GcodeCommand::setMotionCommand(bool isMotionCommand) { m_is_motion_command = isMotionCommand; }
+void GcodeCommand::setMotionCommand(bool isMotionCommand) {
+    m_is_motion_command = isMotionCommand;
+}
 
-void GcodeCommand::setEndOfLayer(bool isEndOfLayer) { m_is_end_of_layer = isEndOfLayer; }
+void GcodeCommand::setEndOfLayer(bool isEndOfLayer) {
+    m_is_end_of_layer = isEndOfLayer;
+}
 
 void GcodeCommand::addParameter(const char param_key, const double param_value) {
     m_parameters.insert(param_key, param_value);
@@ -67,14 +111,18 @@ void GcodeCommand::addOptionalParameter(const char param_key, const double param
     m_optional_parameters.insert(param_key, param_value);
 }
 
-bool GcodeCommand::removeParameter(const char param_key) { return m_parameters.remove(param_key) > 0; }
+bool GcodeCommand::removeParameter(const char param_key) {
+    return m_parameters.remove(param_key) > 0;
+}
 
 void GcodeCommand::clearParameters() {
     m_parameters.clear();
     m_optional_parameters.clear();
 }
 
-void GcodeCommand::clearComment() { m_comment.clear(); }
+void GcodeCommand::clearComment() {
+    m_comment.clear();
+}
 
 bool GcodeCommand::operator==(const GcodeCommand& r) {
     bool ret = getLineNumber() == r.getLineNumber() && getCommand() == r.getCommand() &&
@@ -89,28 +137,38 @@ bool GcodeCommand::operator==(const GcodeCommand& r) {
     return ret;
 }
 
-bool GcodeCommand::operator!=(const GcodeCommand& r) { return !(*this == r); }
+bool GcodeCommand::operator!=(const GcodeCommand& r) {
+    return !(*this == r);
+}
 
 GcodeCommand& GcodeCommand::operator=(const GcodeCommand& other) {
-    m_line_number = other.m_line_number;
-    m_command = other.m_command;
-    m_command_id = other.m_command_id;
-    m_parameters = other.m_parameters;
+    m_line_number         = other.m_line_number;
+    m_command             = other.m_command;
+    m_command_id          = other.m_command_id;
+    m_parameters          = other.m_parameters;
     m_optional_parameters = other.m_optional_parameters;
-    m_comment = other.m_comment;
-    m_is_motion_command = other.m_is_motion_command;
-    m_is_end_of_layer = other.m_is_end_of_layer;
-    m_deposition_active = other.m_deposition_active;
-    m_extruder_speed = other.m_extruder_speed;
+    m_comment             = other.m_comment;
+    m_is_motion_command   = other.m_is_motion_command;
+    m_is_end_of_layer     = other.m_is_end_of_layer;
+    m_deposition_active   = other.m_deposition_active;
+    m_extruder_speed      = other.m_extruder_speed;
     return *this;
 }
 
-void GcodeCommand::setDepositionActive(bool deposition_active) { m_deposition_active = deposition_active; }
+void GcodeCommand::setDepositionActive(bool deposition_active) {
+    m_deposition_active = deposition_active;
+}
 
-bool GcodeCommand::getDepositionActive() const { return m_deposition_active; }
+bool GcodeCommand::getDepositionActive() const {
+    return m_deposition_active;
+}
 
-void GcodeCommand::setExtruderSpeed(double extruder_speed) { m_extruder_speed = extruder_speed; }
+void GcodeCommand::setExtruderSpeed(double extruder_speed) {
+    m_extruder_speed = extruder_speed;
+}
 
-const double& GcodeCommand::getExtruderSpeed() const { return m_extruder_speed; }
+const double& GcodeCommand::getExtruderSpeed() const {
+    return m_extruder_speed;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/gcode_motion_estimate.cpp
+++ b/src/gcode/gcode_motion_estimate.cpp
@@ -12,38 +12,38 @@
 namespace ORNL {
 void MotionEstimation::Init() {
     // values in Slicer-1 GCodes.cs are in mm/s2, convert to micron/s2
-    m_v_acceleration = Acceleration((1 / 0.5) * 1000000 * 25.4 / 162560 * 1000);
+    m_v_acceleration  = Acceleration((1 / 0.5) * 1000000 * 25.4 / 162560 * 1000);
     m_xy_acceleration = Acceleration((1 / 0.1) * 1000000 * 25.4 / 162560 * 1000);
 
     m_current_acceleration = m_xy_acceleration;
 
     m_previous_distance = Distance(0);
-    m_previous_x = 0;
-    m_previous_y = 0;
-    m_previous_z = 0;
-    m_previous_w = 0;
-    m_previous_e = 0;
-    m_previous_vertical = true; // initialize for the very first move
+    m_previous_x        = 0;
+    m_previous_y        = 0;
+    m_previous_z        = 0;
+    m_previous_w        = 0;
+    m_previous_e        = 0;
+    m_previous_vertical = true;  // initialize for the very first move
 
-    m_current_bead_width = 0;
+    m_current_bead_width  = 0;
     m_current_bead_height = 0;
     m_nominal_bead_height = 0;
-    m_last_print_z = 0;
-    m_last_print_w = 0;
+    m_last_print_z        = 0;
+    m_last_print_w        = 0;
 
     m_incomingV = max_xy_speed;
 }
 
 void MotionEstimation::setBeadGeometry(Distance bead_width, Distance bead_height) {
-    m_current_bead_width = bead_width;
+    m_current_bead_width  = bead_width;
     m_nominal_bead_height = bead_height;
 
-    if (m_current_bead_height <= 0) {
-        m_current_bead_height = bead_height;
-    }
+    if (m_current_bead_height <= 0) { m_current_bead_height = bead_height; }
 }
 
-void MotionEstimation::resetBeadHeight() { m_current_bead_height = 0; }
+void MotionEstimation::resetBeadHeight() {
+    m_current_bead_height = 0;
+}
 
 Distance MotionEstimation::calculateTimeAndVolume(int layer, bool isFIncluded, bool isGOCommand, bool deposition_active,
                                                   Time& G1F_time, Time& layer_time, Volume& layer_volume, bool use_b) {
@@ -89,8 +89,7 @@ Distance MotionEstimation::calculateTimeAndVolume(int layer, bool isFIncluded, b
     if (qAbs(dw) > m_min_threshold && qAbs(dx) < m_min_threshold && qAbs(dy) < m_min_threshold) {
         Time t = MotionEstimation::getTravelTime(dw, w_table_speed, m_v_acceleration);
         layer_time += t;
-        if (isFIncluded)
-            G1F_time += t;
+        if (isFIncluded) G1F_time += t;
         MotionEstimation::setVVector(0, 0, w_table_speed());
         m_previous_w = m_current_w;
 
@@ -102,12 +101,10 @@ Distance MotionEstimation::calculateTimeAndVolume(int layer, bool isFIncluded, b
 
     // Z move: non-zero dz
     if (qAbs(dz) > m_min_threshold && qAbs(dx) < m_min_threshold && qAbs(dy) < m_min_threshold) {
-        if (isFIncluded)
-            z_speed = m_current_speed;
+        if (isFIncluded) z_speed = m_current_speed;
         Time t = MotionEstimation::getTravelTime(dz, z_speed, m_v_acceleration);
         layer_time += t;
-        if (isFIncluded)
-            G1F_time += t;
+        if (isFIncluded) G1F_time += t;
         MotionEstimation::setVVector(0, 0, z_speed());
         m_previous_z = m_current_z;
 
@@ -134,9 +131,7 @@ Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Dist
 
     if (path_length > m_min_threshold) {
         // ToDo, make sure that max_xy_speed is only for G0 XY moves!
-        if (isGOCommand) {
-            m_current_speed = max_xy_speed;
-        }
+        if (isGOCommand) { m_current_speed = max_xy_speed; }
 
         if (m_current_speed != 0) {
             if (m_previous_vertical) {
@@ -152,8 +147,7 @@ Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Dist
                 if (theta <= 0) {
                     Time t = path_length / m_current_speed;
                     layer_time += t;
-                    if (isFIncluded)
-                        G1F_time += t;
+                    if (isFIncluded) G1F_time += t;
                 }
                 else if (qAbs(theta - M_PI) < 0.1) {
                     // Reverse: This happens primarily during infill paths
@@ -177,22 +171,20 @@ Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Dist
 
         // If deposition is active, calculate the deposited volume.
         if (deposition_active) {
-            Distance height = m_current_bead_height > 0 ? m_current_bead_height : m_nominal_bead_height;
+            Distance height     = m_current_bead_height > 0 ? m_current_bead_height : m_nominal_bead_height;
             Distance bead_width = m_current_bead_width > 0 ? m_current_bead_width : extrusionWidth;
 
-            Distance z_delta = qAbs(m_current_z - m_last_print_z);
-            Distance w_delta = qAbs(m_current_w - m_last_print_w);
+            Distance z_delta        = qAbs(m_current_z - m_last_print_z);
+            Distance w_delta        = qAbs(m_current_w - m_last_print_w);
             Distance vertical_delta = z_delta > w_delta ? z_delta : w_delta;
 
-            if (height <= 0) {
-                height = layerThickness;
-            }
+            if (height <= 0) { height = layerThickness; }
 
             const Distance min_inferred_height = height * 0.2;
             const Distance max_inferred_height = height * 5.0;
             if (vertical_delta > m_min_threshold && vertical_delta >= min_inferred_height &&
                 vertical_delta <= max_inferred_height) {
-                height = vertical_delta;
+                height                = vertical_delta;
                 m_current_bead_height = height;
             }
 
@@ -207,11 +199,11 @@ Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Dist
         }
 
         m_previous_distance = path_length;
-        m_previous_x = m_current_x;
-        m_previous_y = m_current_y;
-        m_previous_z = m_current_z;
-        m_previous_w = m_current_w;
-        m_previous_e = m_current_e;
+        m_previous_x        = m_current_x;
+        m_previous_y        = m_current_y;
+        m_previous_z        = m_current_z;
+        m_previous_w        = m_current_w;
+        m_previous_e        = m_current_e;
         m_previous_vertical = false;
 
         return path_length;
@@ -222,13 +214,12 @@ Distance MotionEstimation::calculatePathTimeAndVolume(Distance path_length, Dist
 
 void MotionEstimation::setVVector(float vx, float vy, float vz) {
     m_previous_vv = m_current_vv;
-    m_current_vv = QVector3D(vx, vy, vz);
+    m_current_vv  = QVector3D(vx, vy, vz);
 }
 
 void MotionEstimation::setPreviousVelocityVector(Velocity velocity, Distance dx, Distance dy, Distance dz) {
     const Distance direction_length = sqrt(dx * dx + dy * dy + dz * dz);
-    if (direction_length <= 0)
-        return;
+    if (direction_length <= 0) return;
 
     m_previous_vv.setX((velocity * dx / direction_length)());
     m_previous_vv.setY((velocity * dy / direction_length)());
@@ -243,23 +234,19 @@ double MotionEstimation::getTheta(Distance d, Distance dx, Distance dy, Distance
         (((m_previous_vv.x() * dx + m_previous_vv.y() * dy + m_previous_vv.z() * dz) / (d * m_previous_vv.length()))());
 
     // Applying the bound to make sure that machine roundoff error does not cause a NaN
-    cosTheta = qMin(1.0, cosTheta);
-    cosTheta = qMax(-1.0, cosTheta);
+    cosTheta     = qMin(1.0, cosTheta);
+    cosTheta     = qMax(-1.0, cosTheta);
     double theta = qAcos(cosTheta);
     return theta;
 }
 
 Time MotionEstimation::getTravelTime(Distance d, Velocity v, Acceleration a) {
     Time total;
-    d = abs(d);
-    Time accelTime = v / a;
+    d                  = abs(d);
+    Time accelTime     = v / a;
     Distance accelDist = v * v / (2.0 * a);
-    if (d > 2.0 * accelDist) {
-        total = 2 * accelTime + (d - 2.0 * accelDist) / v;
-    }
-    else {
-        total = sqrt(2.0 * d / a);
-    }
+    if (d > 2.0 * accelDist) { total = 2 * accelTime + (d - 2.0 * accelDist) / v; }
+    else { total = sqrt(2.0 * d / a); }
 
     return total;
 }
@@ -269,35 +256,30 @@ Time MotionEstimation::getTravelTime(Distance d, Velocity v, Acceleration a) {
 //  and deceleration costs extra time
 void MotionEstimation::addPreviousXYDecelerationTime(Time& layer_time) {
     if (!m_previous_vertical) {
-        if (m_previous_acceleration == 0) {
-            m_previous_acceleration = m_current_acceleration;
-        }
-        if (m_previous_acceleration != 0) {
-            layer_time += m_incomingV / m_previous_acceleration;
-        }
+        if (m_previous_acceleration == 0) { m_previous_acceleration = m_current_acceleration; }
+        if (m_previous_acceleration != 0) { layer_time += m_incomingV / m_previous_acceleration; }
     }
 }
 
 // consider only the acceleration from 0-speed
 Time MotionEstimation::firstXYMove(Distance d, Distance dx, Distance dy, Distance dz, Time& G1F_time,
                                    bool isFIncluded) {
-    Time time = 0;
-    Time accelTime = m_current_speed / m_current_acceleration;
+    Time time          = 0;
+    Time accelTime     = m_current_speed / m_current_acceleration;
     Distance accelDist = 0.5 * m_current_acceleration * accelTime * accelTime;
     if (d > accelDist) {
-        time = accelTime + (d - accelDist) / m_current_speed;
+        time        = accelTime + (d - accelDist) / m_current_speed;
         m_incomingV = m_current_speed;
     }
     else {
-        time = sqrt(2.0 * d / m_current_acceleration);
+        time        = sqrt(2.0 * d / m_current_acceleration);
         m_incomingV = time * m_current_acceleration;
     }
     m_previous_vv.setX((m_incomingV * dx / d)());
     m_previous_vv.setY((m_incomingV * dy / d)());
     m_previous_vv.setZ((m_incomingV * dz / d)());
 
-    if (isFIncluded)
-        G1F_time += d / m_current_speed;
+    if (isFIncluded) G1F_time += d / m_current_speed;
 
     return time;
 }
@@ -311,8 +293,7 @@ Time MotionEstimation::firstXYMove(Distance d, Distance dx, Distance dy, Distanc
 Time MotionEstimation::continuousXYMove(double theta, Distance d, Distance dx, Distance dy, Distance dz, Time& G1F_time,
                                         bool isFIncluded) {
     Time time = d / m_current_speed;
-    if (isFIncluded)
-        G1F_time += time;
+    if (isFIncluded) G1F_time += time;
 
     Time addTime = 0;
     // Consider two minor changes
@@ -327,20 +308,20 @@ Time MotionEstimation::continuousXYMove(double theta, Distance d, Distance dx, D
     // get the maximum arc radius based on the speed and the acceleration: a = V^2/R
     // the magnitude of the blendSpeed remains (the smaller of two speeds), while the acceleration changes the speed
     // vector direction
-    Velocity blendSpeed = qMin(m_current_speed, m_incomingV);
-    Distance blendRadius = blendSpeed * blendSpeed / m_current_acceleration;
+    Velocity blendSpeed   = qMin(m_current_speed, m_incomingV);
+    Distance blendRadius  = blendSpeed * blendSpeed / m_current_acceleration;
     Distance byPassLength = blendRadius * qTan(0.5 * theta);
 
     // If the segment length is too small compared to the speed, the arc will cover beyond the segment
     // we assume that the bypass length is at most 1/3 of the shorter of the two segments
     // therefore a slow down might be necessary
-    float bypassMaxRatio = 1.0 / 3.0; // arbitrary for now, should be printer specific
+    float bypassMaxRatio = 1.0 / 3.0;  // arbitrary for now, should be printer specific
     Distance minDistance = qMin(d(), m_previous_distance());
-    bool slowDown = byPassLength > minDistance * bypassMaxRatio;
+    bool slowDown        = byPassLength > minDistance * bypassMaxRatio;
     if (slowDown) {
         // if slow down is needed, calculate the new radius, blend speed and the bypass length
-        blendRadius = bypassMaxRatio * minDistance / qTan(0.5 * theta);
-        blendSpeed = sqrt(blendRadius * m_current_acceleration);
+        blendRadius  = bypassMaxRatio * minDistance / qTan(0.5 * theta);
+        blendSpeed   = sqrt(blendRadius * m_current_acceleration);
         byPassLength = blendRadius * qTan(0.5 * theta);
     }
     // parabolic blend saving: the added value is negative, representing its saving over the two straight line segments
@@ -441,5 +422,5 @@ Velocity MotionEstimation::m_incomingV;
 QVector3D MotionEstimation::m_previous_vv;
 QVector3D MotionEstimation::m_current_vv;
 
-bool MotionEstimation::m_previous_vertical; // Z or W move
-} // namespace ORNL
+bool MotionEstimation::m_previous_vertical;  // Z or W move
+}  // namespace ORNL

--- a/src/gcode/gcode_settings_importer.cpp
+++ b/src/gcode/gcode_settings_importer.cpp
@@ -1,11 +1,11 @@
 #include "gcode/gcode_settings_importer.h"
 
-#include <cmath>
-#include <limits>
-
 #include <QFile>
 #include <QHash>
 #include <QIODevice>
+#include <cmath>
+#include <limits>
+
 #include <qchar.h>
 #include <qcontainerfwd.h>
 
@@ -15,15 +15,14 @@
 
 namespace ORNL {
 namespace {
-constexpr double kIntegerTolerance = 1e-9;
+constexpr double kIntegerTolerance              = 1e-9;
 constexpr double kModifyFeedrateLayerTimeMethod = 1.0;
 
-const QString kSettingsFooter = "Settings Footer";
+const QString kSettingsFooter          = "Settings Footer";
 const QString kInfillMaximumPathLength = "infill_maximum_path_length";
 
 QString jsonString(const fifojson& object, const std::string& key) {
-    if (!object.contains(key) || !object.at(key).is_string())
-        return QString();
+    if (!object.contains(key) || !object.at(key).is_string()) return QString();
 
     return QString::fromStdString(object.at(key).get<std::string>());
 }
@@ -34,16 +33,14 @@ QString settingType(const fifojson& master_entry) {
 
 QString settingDisplay(const QString& key, const fifojson& master) {
     const auto entry = master.find(key.toStdString());
-    if (entry == master.end())
-        return key;
+    if (entry == master.end()) return key;
 
     const QString display = GcodeSettingsImporter::displayName(entry.value());
     return display.isEmpty() ? key : display;
 }
 
 bool numberValue(const fifojson& value, double& result) {
-    if (!value.is_number())
-        return false;
+    if (!value.is_number()) return false;
 
     result = value.get<double>();
     return std::isfinite(result);
@@ -51,8 +48,7 @@ bool numberValue(const fifojson& value, double& result) {
 
 bool integerValue(const fifojson& value, int& result) {
     double number = 0.0;
-    if (!numberValue(value, number))
-        return false;
+    if (!numberValue(value, number)) return false;
 
     const double rounded = std::round(number);
     if (std::abs(number - rounded) > kIntegerTolerance || rounded < std::numeric_limits<int>::min() ||
@@ -72,8 +68,7 @@ bool boolValue(const fifojson& value, bool& result) {
 
     if (value.is_number()) {
         double number = 0.0;
-        if (!numberValue(value, number))
-            return false;
+        if (!numberValue(value, number)) return false;
 
         if (std::abs(number) <= kIntegerTolerance) {
             result = false;
@@ -106,12 +101,9 @@ bool boolValue(const fifojson& value, bool& result) {
 
 QString commentText(const QString& line) {
     const QString trimmed = line.trimmed();
-    if (trimmed.isEmpty())
-        return QString();
+    if (trimmed.isEmpty()) return QString();
 
-    if (trimmed.startsWith(';') || trimmed.startsWith('\'')) {
-        return trimmed.mid(1).trimmed();
-    }
+    if (trimmed.startsWith(';') || trimmed.startsWith('\'')) { return trimmed.mid(1).trimmed(); }
 
     if (trimmed.startsWith('(') && trimmed.endsWith(')') && trimmed.size() >= 2) {
         return trimmed.mid(1, trimmed.size() - 2).trimmed();
@@ -122,8 +114,7 @@ QString commentText(const QString& line) {
 
 int firstSpaceIndex(const QString& value) {
     for (int i = 0, end = value.size(); i < end; ++i) {
-        if (value.at(i).isSpace())
-            return i;
+        if (value.at(i).isSpace()) return i;
     }
 
     return -1;
@@ -134,12 +125,10 @@ bool parseFooterSettings(QIODevice& contents, QHash<QString, QString>& raw_value
 
     while (!contents.atEnd()) {
         const QString text = commentText(QString::fromUtf8(contents.readLine()));
-        if (text.isEmpty())
-            continue;
+        if (text.isEmpty()) continue;
 
         if (!in_footer) {
-            if (text.compare(kSettingsFooter, Qt::CaseInsensitive) == 0)
-                in_footer = true;
+            if (text.compare(kSettingsFooter, Qt::CaseInsensitive) == 0) in_footer = true;
             continue;
         }
 
@@ -149,7 +138,7 @@ bool parseFooterSettings(QIODevice& contents, QHash<QString, QString>& raw_value
             continue;
         }
 
-        const QString key = text.left(separator).trimmed();
+        const QString key   = text.left(separator).trimmed();
         const QString value = text.mid(separator + 1).trimmed();
 
         if (key.isEmpty() || value.isEmpty()) {
@@ -157,8 +146,7 @@ bool parseFooterSettings(QIODevice& contents, QHash<QString, QString>& raw_value
             continue;
         }
 
-        if (raw_values.contains(key))
-            warnings.append("Duplicate footer value for " + key + "; using the last value.");
+        if (raw_values.contains(key)) warnings.append("Duplicate footer value for " + key + "; using the last value.");
 
         raw_values[key] = value;
     }
@@ -202,32 +190,20 @@ bool validateDoubleRange(const QString& key, const QString& type, double value, 
     double minimum = 0.0;
     double maximum = static_cast<double>(std::numeric_limits<float>::max());
 
-    if (type == "location") {
-        minimum = static_cast<double>(std::numeric_limits<float>::lowest());
-    }
+    if (type == "location") { minimum = static_cast<double>(std::numeric_limits<float>::lowest()); }
     else if (type == "unitless_float") {
         minimum = Constants::Limits::Minimums::kMinUnitlessFloat;
         maximum = Constants::Limits::Maximums::kMaxUnitlessFloat;
     }
-    else if (type == "percentage") {
-        maximum = 500.0;
-    }
-    else if (type == "percentage100") {
-        maximum = 100.0;
-    }
-    else if (type == "rpm") {
-        maximum = 9999.99;
-    }
-    else if (type == "density") {
-        maximum = 9999.9999;
-    }
+    else if (type == "percentage") { maximum = 500.0; }
+    else if (type == "percentage100") { maximum = 100.0; }
+    else if (type == "rpm") { maximum = 9999.99; }
+    else if (type == "density") { maximum = 9999.9999; }
     else if (type == "angle") {
         minimum = Constants::Limits::Minimums::kMinAngle();
         maximum = Constants::Limits::Maximums::kMaxAngle();
     }
-    else if (type == "temperature") {
-        minimum = 0.0;
-    }
+    else if (type == "temperature") { minimum = 0.0; }
 
     if (value < minimum || value > maximum) {
         error = key + " is outside the allowed " + type + " range.";
@@ -246,24 +222,20 @@ bool isDoubleType(const QString& type) {
 
 double settingDouble(const fifojson& settings, const QString& key) {
     const auto value = settings.find(key.toStdString());
-    if (value == settings.end())
-        return 0.0;
+    if (value == settings.end()) return 0.0;
 
     double result = 0.0;
-    if (numberValue(value.value(), result))
-        return result;
+    if (numberValue(value.value(), result)) return result;
 
     bool bool_result = false;
-    if (boolValue(value.value(), bool_result))
-        return bool_result ? 1.0 : 0.0;
+    if (boolValue(value.value(), bool_result)) return bool_result ? 1.0 : 0.0;
 
     return 0.0;
 }
 
 bool settingBool(const fifojson& settings, const QString& key) {
     const auto value = settings.find(key.toStdString());
-    if (value == settings.end())
-        return false;
+    if (value == settings.end()) return false;
 
     bool result = false;
     return boolValue(value.value(), result) && result;
@@ -271,12 +243,10 @@ bool settingBool(const fifojson& settings, const QString& key) {
 
 int settingInt(const fifojson& settings, const QString& key) {
     const auto value = settings.find(key.toStdString());
-    if (value == settings.end())
-        return 0;
+    if (value == settings.end()) return 0;
 
     int result = 0;
-    if (integerValue(value.value(), result))
-        return result;
+    if (integerValue(value.value(), result)) return result;
 
     return static_cast<int>(settingDouble(settings, key));
 }
@@ -288,14 +258,13 @@ bool jsonValuesMatch(const fifojson& actual, const fifojson& expected) {
     }
 
     if (expected.is_number()) {
-        double actual_number = 0.0;
+        double actual_number   = 0.0;
         double expected_number = 0.0;
         return numberValue(actual, actual_number) && numberValue(expected, expected_number) &&
                std::abs(actual_number - expected_number) <= kIntegerTolerance;
     }
 
-    if (expected.is_string() && actual.is_string())
-        return actual.get<std::string>() == expected.get<std::string>();
+    if (expected.is_string() && actual.is_string()) return actual.get<std::string>() == expected.get<std::string>();
 
     return actual == expected;
 }
@@ -303,51 +272,41 @@ bool jsonValuesMatch(const fifojson& actual, const fifojson& expected) {
 bool dependencyIsActive(const fifojson& dependency, const fifojson& settings);
 
 bool dependencyArrayIsActive(const fifojson& dependencies, bool require_all, const fifojson& settings) {
-    if (!dependencies.is_array())
-        return true;
+    if (!dependencies.is_array()) return true;
 
     if (require_all) {
         for (const auto& dependency : dependencies) {
-            if (!dependencyIsActive(dependency, settings))
-                return false;
+            if (!dependencyIsActive(dependency, settings)) return false;
         }
         return true;
     }
 
     for (const auto& dependency : dependencies) {
-        if (dependencyIsActive(dependency, settings))
-            return true;
+        if (dependencyIsActive(dependency, settings)) return true;
     }
     return false;
 }
 
 bool dependencyIsActive(const fifojson& dependency, const fifojson& settings) {
-    if (dependency.is_null())
-        return true;
+    if (dependency.is_null()) return true;
 
-    if (dependency.is_string())
-        return dependency.get<std::string>().empty();
+    if (dependency.is_string()) return dependency.get<std::string>().empty();
 
-    if (dependency.is_array())
-        return dependencyArrayIsActive(dependency, true, settings);
+    if (dependency.is_array()) return dependencyArrayIsActive(dependency, true, settings);
 
-    if (!dependency.is_object())
-        return true;
+    if (!dependency.is_object()) return true;
 
     for (const auto& item : dependency.items()) {
         const QString key = QString::fromStdString(item.key());
         if (key == "AND") {
-            if (!dependencyArrayIsActive(item.value(), true, settings))
-                return false;
+            if (!dependencyArrayIsActive(item.value(), true, settings)) return false;
         }
         else if (key == "OR") {
-            if (!dependencyArrayIsActive(item.value(), false, settings))
-                return false;
+            if (!dependencyArrayIsActive(item.value(), false, settings)) return false;
         }
         else {
             const auto actual = settings.find(item.key());
-            if (actual == settings.end() || !jsonValuesMatch(actual.value(), item.value()))
-                return false;
+            if (actual == settings.end() || !jsonValuesMatch(actual.value(), item.value())) return false;
         }
     }
 
@@ -356,24 +315,28 @@ bool dependencyIsActive(const fifojson& dependency, const fifojson& settings) {
 
 bool settingIsActive(const QString& key, const fifojson& master, const fifojson& settings) {
     const auto entry = master.find(key.toStdString());
-    if (entry == master.end())
-        return false;
+    if (entry == master.end()) return false;
 
     const auto dependency = entry.value().find(Constants::Settings::Master::kDepends);
     return dependency == entry.value().end() || dependencyIsActive(dependency.value(), settings);
 }
 
-bool configuredRange(double minimum, double maximum) { return minimum != 0.0 || maximum != 0.0; }
+bool configuredRange(double minimum, double maximum) {
+    return minimum != 0.0 || maximum != 0.0;
+}
 
-bool validRange(double minimum, double maximum) { return configuredRange(minimum, maximum) && minimum < maximum; }
+bool validRange(double minimum, double maximum) {
+    return configuredRange(minimum, maximum) && minimum < maximum;
+}
 
-QString numberText(double value) { return QString::number(value, 'g', 6); }
+QString numberText(double value) {
+    return QString::number(value, 'g', 6);
+}
 
 void addDimensionRangeError(const QString& min_key, const QString& max_key, const QString& min_label,
                             const QString& max_label, const fifojson& settings, const fifojson& master,
                             QStringList& errors) {
-    if (!settingIsActive(min_key, master, settings) && !settingIsActive(max_key, master, settings))
-        return;
+    if (!settingIsActive(min_key, master, settings) && !settingIsActive(max_key, master, settings)) return;
 
     const double minimum = settingDouble(settings, min_key);
     const double maximum = settingDouble(settings, max_key);
@@ -385,12 +348,11 @@ void addDimensionRangeError(const QString& min_key, const QString& max_key, cons
 
 void addBoundsError(const QString& key, const QString& min_key, const QString& max_key, const QString& axis,
                     const fifojson& settings, const fifojson& master, QStringList& errors) {
-    if (!settingIsActive(key, master, settings))
-        return;
+    if (!settingIsActive(key, master, settings)) return;
 
     const double minimum = settingDouble(settings, min_key);
     const double maximum = settingDouble(settings, max_key);
-    const double value = settingDouble(settings, key);
+    const double value   = settingDouble(settings, key);
     if (validRange(minimum, maximum) && (value < minimum || value > maximum)) {
         errors.append(settingDisplay(key, master) + " (" + numberText(value) + ") is outside the " + axis +
                       " build volume range (" + numberText(minimum) + " to " + numberText(maximum) + ").");
@@ -400,8 +362,7 @@ void addBoundsError(const QString& key, const QString& min_key, const QString& m
 void validateActiveStaticSettings(const fifojson& settings, const fifojson& master, QStringList& errors) {
     for (const auto& item : master.items()) {
         const QString key = QString::fromStdString(item.key());
-        if (!settingIsActive(key, master, settings))
-            continue;
+        if (!settingIsActive(key, master, settings)) continue;
 
         const auto value = settings.find(item.key());
         if (value == settings.end()) {
@@ -426,8 +387,8 @@ void validateDynamicSettings(const fifojson& settings, const fifojson& master, Q
     addDimensionRangeError(PRS::Dimensions::kWMin, PRS::Dimensions::kWMax, "Minimum W", "Maximum W", settings, master,
                            errors);
 
-    const double min_extruder_speed = settingDouble(settings, PRS::MachineSpeed::kMinExtruderSpeed);
-    const double max_extruder_speed = settingDouble(settings, PRS::MachineSpeed::kMaxExtruderSpeed);
+    const double min_extruder_speed   = settingDouble(settings, PRS::MachineSpeed::kMinExtruderSpeed);
+    const double max_extruder_speed   = settingDouble(settings, PRS::MachineSpeed::kMaxExtruderSpeed);
     const bool has_min_extruder_speed = min_extruder_speed > 0.0;
     const bool has_max_extruder_speed = max_extruder_speed > 0.0;
     const bool invalid_extruder_range =
@@ -447,11 +408,10 @@ void validateDynamicSettings(const fifojson& settings, const fifojson& master, Q
 
     for (const auto& item : master.items()) {
         const QString key = QString::fromStdString(item.key());
-        if (!settingIsActive(key, master, settings))
-            continue;
+        if (!settingIsActive(key, master, settings)) continue;
 
-        const QString type = settingType(item.value());
-        const double value = settingDouble(settings, key);
+        const QString type    = settingType(item.value());
+        const double value    = settingDouble(settings, key);
         const QString display = settingDisplay(key, master);
 
         if (type == "rpm" && key != PRS::MachineSpeed::kMinExtruderSpeed &&
@@ -497,14 +457,11 @@ void validateDynamicSettings(const fifojson& settings, const fifojson& master, Q
 
     const double layer_height = settingDouble(settings, PS::Layer::kLayerHeight);
     for (const QString& key : bead_width_keys) {
-        if (!settingIsActive(key, master, settings))
-            continue;
+        if (!settingIsActive(key, master, settings)) continue;
 
-        const double value = settingDouble(settings, key);
+        const double value    = settingDouble(settings, key);
         const QString display = settingDisplay(key, master);
-        if (value <= 0.0) {
-            errors.append(display + " must be greater than zero.");
-        }
+        if (value <= 0.0) { errors.append(display + " must be greater than zero."); }
         else if (layer_height > 0.0 && value < layer_height) {
             errors.append(display + " (" + numberText(value) + ") is smaller than Layer Height (" +
                           numberText(layer_height) + ").");
@@ -530,12 +487,10 @@ void validateDynamicSettings(const fifojson& settings, const fifojson& master, Q
     const double z_min = settingDouble(settings, PRS::Dimensions::kZMin);
     const double z_max = settingDouble(settings, PRS::Dimensions::kZMax);
     for (const QString& key : lift_distance_keys) {
-        if (!settingIsActive(key, master, settings))
-            continue;
+        if (!settingIsActive(key, master, settings)) continue;
 
         const double value = settingDouble(settings, key);
-        if (value <= 0.0)
-            continue;
+        if (value <= 0.0) continue;
 
         if (settingDouble(settings, PRS::MachineSpeed::kZSpeed) <= 0.0)
             errors.append(settingDisplay(key, master) + " requires Z Speed to be greater than zero.");
@@ -571,22 +526,23 @@ void validateDynamicSettings(const fifojson& settings, const fifojson& master, Q
 
     if (force_layer_time && use_feedrate_layer_time) {
         if (max_layer_time <= 0.0)
-            errors.append("Maximum Layer Time must be greater than zero when Modify Feedrate layer-time control is "
-                          "selected.");
+            errors.append(
+                "Maximum Layer Time must be greater than zero when Modify Feedrate layer-time control is "
+                "selected.");
         else if (min_layer_time > 0.0 && min_layer_time > max_layer_time)
             errors.append("Minimum Layer Time is greater than Maximum Layer Time.");
 
         if (settingDouble(settings, MS::Cooling::kExtruderScaleFactor) <= 0.0) {
-            errors.append("Extruder Scale Factor must be greater than zero when Modify Feedrate layer-time control is "
-                          "selected.");
+            errors.append(
+                "Extruder Scale Factor must be greater than zero when Modify Feedrate layer-time control is "
+                "selected.");
         }
     }
 }
 
 double currentMasterVersion() {
     QFile versions(":/configs/versions.conf");
-    if (!versions.open(QIODevice::ReadOnly))
-        return 0.0;
+    if (!versions.open(QIODevice::ReadOnly)) return 0.0;
 
     try {
         const fifojson version_data = fifojson::parse(QString(versions.readAll()).toStdString());
@@ -595,18 +551,16 @@ double currentMasterVersion() {
 }
 
 QString limitedList(const QStringList& values, int maximum = 12) {
-    if (values.size() <= maximum)
-        return values.join("\n");
+    if (values.size() <= maximum) return values.join("\n");
 
     QStringList limited = values.mid(0, maximum);
     limited.append(QString("...and %1 more.").arg(values.size() - maximum));
     return limited.join("\n");
 }
-} // namespace
+}  // namespace
 
-GcodeSettingsImporter::ImportResult
-GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_for_missing,
-                                  const MissingValueCallback& missing_value_callback) {
+GcodeSettingsImporter::ImportResult GcodeSettingsImporter::importFile(
+    const QString& gcode_path, bool use_defaults_for_missing, const MissingValueCallback& missing_value_callback) {
     ImportResult result;
 
     QFile gcode_file(gcode_path);
@@ -629,15 +583,14 @@ GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_f
     migrateLegacyRawSettingKeys(raw_values);
 
     const fifojson master = GSM->getMaster()->json();
-    fifojson settings = fifojson::object();
+    fifojson settings     = fifojson::object();
 
     for (auto raw = raw_values.constBegin(); raw != raw_values.constEnd(); ++raw) {
-        if (master.find(raw.key().toStdString()) == master.end())
-            result.unknown_keys.append(raw.key());
+        if (master.find(raw.key().toStdString()) == master.end()) result.unknown_keys.append(raw.key());
     }
 
     for (const auto& item : master.items()) {
-        const QString key = QString::fromStdString(item.key());
+        const QString key            = QString::fromStdString(item.key());
         const fifojson& master_entry = item.value();
         fifojson candidate;
         bool value_was_prompted = false;
@@ -670,7 +623,7 @@ GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_f
                 return result;
             }
 
-            candidate = prompted_value.value();
+            candidate          = prompted_value.value();
             value_was_prompted = true;
             result.prompted_keys.append(key);
         }
@@ -683,21 +636,18 @@ GcodeSettingsImporter::importFile(const QString& gcode_path, bool use_defaults_f
         }
 
         settings[item.key()] = normalized;
-        if (value_was_prompted && !result.prompted_keys.contains(key))
-            result.prompted_keys.append(key);
+        if (value_was_prompted && !result.prompted_keys.contains(key)) result.prompted_keys.append(key);
     }
 
     if (!result.unknown_keys.isEmpty()) {
         result.warnings.append("Unknown footer settings were ignored:\n" + limitedList(result.unknown_keys));
     }
 
-    if (!result.errors.isEmpty())
-        return result;
+    if (!result.errors.isEmpty()) return result;
 
     validateActiveStaticSettings(settings, master, result.errors);
     validateDynamicSettings(settings, master, result.errors);
-    if (!result.errors.isEmpty())
-        return result;
+    if (!result.errors.isEmpty()) return result;
 
     fifojson settings_array = fifojson::array();
     settings_array.push_back(settings);
@@ -729,7 +679,7 @@ bool GcodeSettingsImporter::validateValue(const QString& key, const fifojson& ma
     if (type == "enumeration") {
         int index = -1;
         if (value.is_string()) {
-            const QString option = QString::fromStdString(value.get<std::string>()).trimmed();
+            const QString option      = QString::fromStdString(value.get<std::string>()).trimmed();
             const QStringList options = settingOptions(master_entry);
             for (int i = 0, end = options.size(); i < end; ++i) {
                 if (options[i].compare(option, Qt::CaseInsensitive) == 0) {
@@ -781,8 +731,7 @@ bool GcodeSettingsImporter::validateValue(const QString& key, const fifojson& ma
             return false;
         }
 
-        if (enforce_ranges && !validateDoubleRange(key, type, result, error))
-            return false;
+        if (enforce_ranges && !validateDoubleRange(key, type, result, error)) return false;
 
         normalized_value = result;
         return true;
@@ -826,10 +775,9 @@ QString GcodeSettingsImporter::displayName(const fifojson& master_entry) {
 QStringList GcodeSettingsImporter::settingOptions(const fifojson& master_entry) {
     QStringList options =
         jsonString(master_entry, Constants::Settings::Master::kOptions).split(',', Qt::SkipEmptyParts);
-    for (QString& option : options)
-        option = option.trimmed();
+    for (QString& option : options) option = option.trimmed();
 
     return options;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/adamantine_parser.cpp
+++ b/src/gcode/parsers/adamantine_parser.cpp
@@ -1,8 +1,8 @@
 #include "gcode/parsers/adamantine_parser.h"
 
+#include <QString>
 #include <functional>
 
-#include <QString>
 #include <qcontainerfwd.h>
 #include <qlatin1stringview.h>
 
@@ -14,7 +14,7 @@ AdamantineParser::AdamantineParser(GcodeMeta meta, bool allowLayerAlter, QString
     : CommonParser(meta, allowLayerAlter, lines, upperLines) {
     config();
 
-    m_home_string = QLatin1String("X0 Y0 Z0");
+    m_home_string     = QLatin1String("X0 Y0 Z0");
     m_home_parameters = m_home_string.split(' ');
 }
 
@@ -40,6 +40,8 @@ void AdamantineParser::G92Handler(QVector<QString> params) {
 }
 
 // M83 ; use relative distances for extrusion
-void AdamantineParser::M83Handler(QVector<QString> params) { m_e_absolute = false; }
+void AdamantineParser::M83Handler(QVector<QString> params) {
+    m_e_absolute = false;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/aerobasic_parser.cpp
+++ b/src/gcode/parsers/aerobasic_parser.cpp
@@ -1,8 +1,8 @@
 #include "gcode/parsers/aerobasic_parser.h"
 
+#include <QString>
 #include <functional>
 
-#include <QString>
 #include <qcontainerfwd.h>
 
 #include "gcode/gcode_meta.h"
@@ -14,17 +14,20 @@ AeroBasicParser::AeroBasicParser(GcodeMeta meta, bool allowLayerAlter, QStringLi
     config();
 }
 
-void AeroBasicParser::G0Handler(QVector<QString> params) { CommonParser::G0Handler(params); }
+void AeroBasicParser::G0Handler(QVector<QString> params) {
+    CommonParser::G0Handler(params);
+}
 
-void AeroBasicParser::G1Handler(QVector<QString> params) { CommonParser::G1Handler(params); }
+void AeroBasicParser::G1Handler(QVector<QString> params) {
+    CommonParser::G1Handler(params);
+}
 
 void AeroBasicParser::G2Handler(QVector<QString> params) {
     // AeroBasic supports strining G2/3 with G1 to linearly interpolate in the Z axis,
     // this behaves like if Z was also specified
     QVector<QString> cleaned_params;
     for (auto& param : params)
-        if (param != "G1")
-            cleaned_params.append(param);
+        if (param != "G1") cleaned_params.append(param);
 
     CommonParser::G2Handler(cleaned_params);
 }
@@ -34,13 +37,14 @@ void AeroBasicParser::G3Handler(QVector<QString> params) {
     // this behaves like if Z was also specified
     QVector<QString> cleaned_params;
     for (auto& param : params)
-        if (param != "G1")
-            cleaned_params.append(param);
+        if (param != "G1") cleaned_params.append(param);
 
     CommonParser::G3Handler(cleaned_params);
 }
 
-void AeroBasicParser::G4Handler(QVector<QString> params) { CommonParser::G4Handler(params); }
+void AeroBasicParser::G4Handler(QVector<QString> params) {
+    CommonParser::G4Handler(params);
+}
 
 void AeroBasicParser::config() {
     CommonParser::config();
@@ -56,4 +60,4 @@ void AeroBasicParser::config() {
     // Dwell
     addCommandMapping("DWELL", std::bind(&AeroBasicParser::G4Handler, this, std::placeholders::_1));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/arc_specialties_parser.cpp
+++ b/src/gcode/parsers/arc_specialties_parser.cpp
@@ -1,9 +1,9 @@
 #include "gcode/parsers/arc_specialties_parser.h"
 
-#include <functional>
-
 #include <QRegularExpression>
 #include <QTextStream>
+#include <functional>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qset.h>
@@ -19,7 +19,7 @@ const QRegularExpression kG01CommandPattern("(^\\s*)G01(?=\\s|;|\\(|$)");
 const QRegularExpression kG02CommandPattern("(^\\s*)G02(?=\\s|;|\\(|$)");
 const QRegularExpression kG03CommandPattern("(^\\s*)G03(?=\\s|;|\\(|$)");
 constexpr char kCpOptionalParameter = 'C';
-} // namespace
+}  // namespace
 
 ArcSpecialtiesParser::ArcSpecialtiesParser(GcodeMeta meta, bool allowLayerAlter, QStringList& lines,
                                            QStringList& upperLines)
@@ -52,40 +52,48 @@ void ArcSpecialtiesParser::G0Handler(QVector<QString> params) {
     QVector<QString> filtered_params = normalizeAndStripOrientationAxes(params);
 
     // Orientation-only moves are valid machine positioning moves but do not produce visible XYZ segments.
-    if (!filtered_params.isEmpty()) {
-        CommonParser::G0Handler(filtered_params);
-    }
+    if (!filtered_params.isEmpty()) { CommonParser::G0Handler(filtered_params); }
 }
 
 void ArcSpecialtiesParser::G1Handler(QVector<QString> params) {
     QVector<QString> filtered_params = normalizeAndStripOrientationAxes(params);
     if (!filtered_params.isEmpty()) {
         const bool force_print_state = isCommentedPrintMove();
-        if (force_print_state) {
-            setDepositionActive(true);
-        }
+        if (force_print_state) { setDepositionActive(true); }
 
         CommonParser::G1Handler(filtered_params);
 
-        if (force_print_state) {
-            setDepositionActive(false);
-        }
+        if (force_print_state) { setDepositionActive(false); }
     }
 }
 
-void ArcSpecialtiesParser::G2Handler(QVector<QString> params) { handleArcFeedMove(params, false); }
+void ArcSpecialtiesParser::G2Handler(QVector<QString> params) {
+    handleArcFeedMove(params, false);
+}
 
-void ArcSpecialtiesParser::G3Handler(QVector<QString> params) { handleArcFeedMove(params, true); }
+void ArcSpecialtiesParser::G3Handler(QVector<QString> params) {
+    handleArcFeedMove(params, true);
+}
 
-void ArcSpecialtiesParser::G161Handler(QVector<QString>) { m_use_absolute_arc_centers = true; }
+void ArcSpecialtiesParser::G161Handler(QVector<QString>) {
+    m_use_absolute_arc_centers = true;
+}
 
-void ArcSpecialtiesParser::G162Handler(QVector<QString>) { m_use_absolute_arc_centers = false; }
+void ArcSpecialtiesParser::G162Handler(QVector<QString>) {
+    m_use_absolute_arc_centers = false;
+}
 
-void ArcSpecialtiesParser::G164Handler(QVector<QString>) { m_use_absolute_arc_centers = false; }
+void ArcSpecialtiesParser::G164Handler(QVector<QString>) {
+    m_use_absolute_arc_centers = false;
+}
 
-void ArcSpecialtiesParser::G82Handler(QVector<QString>) { setDepositionActive(true); }
+void ArcSpecialtiesParser::G82Handler(QVector<QString>) {
+    setDepositionActive(true);
+}
 
-void ArcSpecialtiesParser::G83Handler(QVector<QString>) { setDepositionActive(false); }
+void ArcSpecialtiesParser::G83Handler(QVector<QString>) {
+    setDepositionActive(false);
+}
 
 QVector<QString> ArcSpecialtiesParser::normalizeAndStripOrientationAxes(QVector<QString> params,
                                                                         bool ignore_inline_arc_optional_stop) {
@@ -94,13 +102,9 @@ QVector<QString> ArcSpecialtiesParser::normalizeAndStripOrientationAxes(QVector<
 
     for (const QString& raw_param : params) {
         const QString param = raw_param.trimmed();
-        if (param.isEmpty()) {
-            continue;
-        }
+        if (param.isEmpty()) { continue; }
 
-        if (ignore_inline_arc_optional_stop && param.compare("G81", Qt::CaseInsensitive) == 0) {
-            continue;
-        }
+        if (ignore_inline_arc_optional_stop && param.compare("G81", Qt::CaseInsensitive) == 0) { continue; }
 
         QString key;
         QString value;
@@ -116,15 +120,11 @@ QVector<QString> ArcSpecialtiesParser::normalizeAndStripOrientationAxes(QVector<
         if (isOrientationKey(key)) {
             validateUniqueKey(key, used_keys);
             validateNumericValue(value);
-            if (key == "CP") {
-                m_current_gcode_command.addOptionalParameter(kCpOptionalParameter, value.toDouble());
-            }
+            if (key == "CP") { m_current_gcode_command.addOptionalParameter(kCpOptionalParameter, value.toDouble()); }
             continue;
         }
 
-        if (param.contains('=')) {
-            throwIllegalArcSpecialtiesParameter(param);
-        }
+        if (param.contains('=')) { throwIllegalArcSpecialtiesParameter(param); }
 
         filtered_params.push_back(param);
     }
@@ -135,7 +135,7 @@ QVector<QString> ArcSpecialtiesParser::normalizeAndStripOrientationAxes(QVector<
 void ArcSpecialtiesParser::splitParameter(const QString& param, QString& key, QString& value) const {
     const int equal_pos = param.indexOf('=');
     if (equal_pos >= 0) {
-        key = param.left(equal_pos).toUpper();
+        key   = param.left(equal_pos).toUpper();
         value = param.mid(equal_pos + 1);
         return;
     }
@@ -143,12 +143,12 @@ void ArcSpecialtiesParser::splitParameter(const QString& param, QString& key, QS
     const QString upper_param = param.toUpper();
     if (upper_param.startsWith("XR") || upper_param.startsWith("YR") || upper_param.startsWith("ZR") ||
         upper_param.startsWith("AP") || upper_param.startsWith("CP")) {
-        key = upper_param.left(2);
+        key   = upper_param.left(2);
         value = param.mid(2);
         return;
     }
 
-    key = upper_param.left(1);
+    key   = upper_param.left(1);
     value = param.mid(1);
 }
 
@@ -162,9 +162,7 @@ bool ArcSpecialtiesParser::isOrientationKey(const QString& key) const {
 
 void ArcSpecialtiesParser::validateUniqueKey(const QString& key, QSet<QString>& used_keys) {
     if (used_keys.contains(key)) {
-        if (key.size() == 1) {
-            throwMultipleParameterException(key.at(0).toLatin1());
-        }
+        if (key.size() == 1) { throwMultipleParameterException(key.at(0).toLatin1()); }
 
         QString exceptionString;
         QTextStream(&exceptionString) << "Error: Multiple " << key << " parameters passed on GCode line "
@@ -179,9 +177,7 @@ void ArcSpecialtiesParser::validateUniqueKey(const QString& key, QSet<QString>& 
 void ArcSpecialtiesParser::validateNumericValue(const QString& value) {
     bool no_error = false;
     value.toDouble(&no_error);
-    if (!no_error) {
-        throwFloatConversionErrorException();
-    }
+    if (!no_error) { throwFloatConversionErrorException(); }
 }
 
 void ArcSpecialtiesParser::throwIllegalArcSpecialtiesParameter(const QString& param) {
@@ -200,9 +196,7 @@ bool ArcSpecialtiesParser::isCommentedPrintMove() const {
 }
 
 QVector<QString> ArcSpecialtiesParser::convertAbsoluteArcCenterParams(const QVector<QString>& params) {
-    if (!m_use_absolute_arc_centers) {
-        return params;
-    }
+    if (!m_use_absolute_arc_centers) { return params; }
 
     QVector<QString> converted_params;
     converted_params.reserve(params.size());
@@ -210,47 +204,35 @@ QVector<QString> ArcSpecialtiesParser::convertAbsoluteArcCenterParams(const QVec
     for (const QString& param : params) {
         const QString key = param.left(1).toUpper();
         if (key == "I" || key == "J") {
-            bool no_error = false;
+            bool no_error               = false;
             const double absolute_value = param.mid(1).toDouble(&no_error);
-            if (!no_error) {
-                throwFloatConversionErrorException();
-            }
+            if (!no_error) { throwFloatConversionErrorException(); }
 
             const double current_position = key == "I" ? getXPos() : getYPos();
             converted_params.push_back(key % QString::number(absolute_value - current_position, 'g', 17));
         }
-        else {
-            converted_params.push_back(param);
-        }
+        else { converted_params.push_back(param); }
     }
 
     return converted_params;
 }
 
-void ArcSpecialtiesParser::setDepositionActive(bool on) { m_deposition_active = on; }
+void ArcSpecialtiesParser::setDepositionActive(bool on) {
+    m_deposition_active = on;
+}
 
 void ArcSpecialtiesParser::handleArcFeedMove(QVector<QString> params, bool ccw) {
     QVector<QString> filtered_params = normalizeAndStripOrientationAxes(params, true);
-    if (filtered_params.isEmpty()) {
-        return;
-    }
+    if (filtered_params.isEmpty()) { return; }
 
     filtered_params = convertAbsoluteArcCenterParams(filtered_params);
 
     const bool force_print_state = isCommentedPrintMove();
-    if (force_print_state) {
-        setDepositionActive(true);
-    }
+    if (force_print_state) { setDepositionActive(true); }
 
-    if (ccw) {
-        CommonParser::G3Handler(filtered_params);
-    }
-    else {
-        CommonParser::G2Handler(filtered_params);
-    }
+    if (ccw) { CommonParser::G3Handler(filtered_params); }
+    else { CommonParser::G2Handler(filtered_params); }
 
-    if (force_print_state) {
-        setDepositionActive(false);
-    }
+    if (force_print_state) { setDepositionActive(false); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/beam_parser.cpp
+++ b/src/gcode/parsers/beam_parser.cpp
@@ -22,18 +22,14 @@ void BeamParser::config() {
 }
 
 void BeamParser::M110Handler(QVector<QString> params) {
-    if (!params.empty()) {
-        return;
-    }
+    if (!params.empty()) { return; }
 
     m_deposition_active = true;
 }
 
 void BeamParser::M111Handler(QVector<QString> params) {
-    if (!params.empty()) {
-        return;
-    }
+    if (!params.empty()) { return; }
 
     m_deposition_active = false;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/cincinnati_parser.cpp
+++ b/src/gcode/parsers/cincinnati_parser.cpp
@@ -1,11 +1,11 @@
 #include "gcode/parsers/cincinnati_parser.h"
 
-#include <functional>
-
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
 #include <QVector>
+#include <functional>
+
 #include <qcontainerfwd.h>
 
 #include "exceptions/exceptions.h"
@@ -210,7 +210,7 @@ void CincinnatiParser::M65Handler(QVector<QString> params) {
             throw IllegalParameterException(exceptionString);
         }
 
-    m_voltage_control = false;
+    m_voltage_control       = false;
     m_voltage_control_value = 1.0;
 }
 
@@ -233,11 +233,9 @@ void CincinnatiParser::M66Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
 
-        if (!no_error) {
-            throwFloatConversionErrorException();
-        }
+        if (!no_error) { throwFloatConversionErrorException(); }
 
         m_current_gcode_command.addParameter(current_parameter, current_value);
 
@@ -269,9 +267,7 @@ void CincinnatiParser::M66Handler(QVector<QString> params) {
                     setAcceleration(((1 / current_value) * mToMicron * mmToInch / encoderTicksPerInch * mToMM)());
                     l_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
         }
     }
 
@@ -305,8 +301,8 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
     m_return_to_prev_location = false;
     setSpindleSpeed(250.0);
     // TODO: make setters and getters for this handler
-    m_purge_time = 60 * s;
-    m_wait_to_wipe_time = 0 * s;
+    m_purge_time               = 60 * s;
+    m_wait_to_wipe_time        = 0 * s;
     m_wait_time_to_start_purge = 0 * s;
 
     char current_parameter;
@@ -316,10 +312,8 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
-        if (!no_error) {
-            throwFloatConversionErrorException();
-        }
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
+        if (!no_error) { throwFloatConversionErrorException(); }
 
         m_current_gcode_command.addParameter(current_parameter, current_value);
 
@@ -330,9 +324,7 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
                     setSpindleSpeed(current_value);
                     f_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
 
                 break;
 
@@ -340,11 +332,9 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
             case ('l'):
                 if (l_not_used) {
                     m_return_to_prev_location = static_cast<bool>(current_value);
-                    l_not_used = false;
+                    l_not_used                = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
 
                 break;
 
@@ -352,11 +342,9 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
             case ('p'):
                 if (p_not_used) {
                     m_purge_time = current_value * s;
-                    p_not_used = false;
+                    p_not_used   = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
 
                 break;
 
@@ -364,11 +352,9 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
             case ('s'):
                 if (s_not_used) {
                     m_wait_to_wipe_time = current_value * s;
-                    s_not_used = false;
+                    s_not_used          = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
 
                 break;
 
@@ -376,11 +362,9 @@ void CincinnatiParser::M69Handler(QVector<QString> params) {
             case ('t'):
                 if (t_not_used) {
                     m_wait_time_to_start_purge = current_value * s;
-                    t_not_used = false;
+                    t_not_used                 = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
 
                 break;
 
@@ -406,4 +390,4 @@ void CincinnatiParser::ToolChangeHandler(QVector<QString> params) {
         throw IllegalParameterException(exceptionString);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -1,9 +1,5 @@
 #include "gcode/parsers/common_parser.h"
 
-#include <algorithm>
-#include <functional>
-#include <limits>
-
 #include <QRegExp>
 #include <QString>
 #include <QStringBuilder>
@@ -11,6 +7,10 @@
 #include <QTextStream>
 #include <QVector>
 #include <QtMath>
+#include <algorithm>
+#include <functional>
+#include <limits>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlatin1stringview.h>
@@ -34,11 +34,9 @@
 namespace ORNL {
 namespace {
 double parseFooterSettingValue(const QString& value) {
-    if (value.compare("TRUE", Qt::CaseInsensitive) == 0)
-        return 1.0;
+    if (value.compare("TRUE", Qt::CaseInsensitive) == 0) return 1.0;
 
-    if (value.compare("FALSE", Qt::CaseInsensitive) == 0)
-        return 0.0;
+    if (value.compare("FALSE", Qt::CaseInsensitive) == 0) return 0.0;
 
     return value.toDouble();
 }
@@ -50,54 +48,65 @@ bool isDisableFeedrateScalingSetting(const QString& key) {
 
 double positiveSweep(double sweep) {
     const double full_circle = 2.0 * M_PI;
-    while (sweep < 0.0) {
-        sweep += full_circle;
-    }
-    while (sweep >= full_circle) {
-        sweep -= full_circle;
-    }
+    while (sweep < 0.0) { sweep += full_circle; }
+    while (sweep >= full_circle) { sweep -= full_circle; }
     return sweep;
 }
-} // namespace
+}  // namespace
 
 CommonParser::CommonParser(GcodeMeta meta, bool allowLayerAlter, QStringList& lines, QStringList& upperLines)
-    : m_e_absolute(true), m_space(' '), m_distance_unit(meta.m_distance_unit), m_time_unit(meta.m_time_unit),
-      m_angle_unit(meta.m_angle_unit), m_mass_unit(meta.m_mass_unit), m_velocity_unit(meta.m_velocity_unit),
-      m_acceleration_unit(meta.m_acceleration_unit), m_angular_velocity_unit(meta.m_angular_velocity_unit),
-      m_layer_delimiter(meta.m_layer_delimiter), m_layer_count_delimiter(meta.m_layer_count_delimiter),
-      m_allow_layer_alter(allowLayerAlter), m_lines(lines), m_upper_lines(upperLines), m_current_line(0),
-      m_current_end_line(m_lines.size() - 1), m_was_modified(false), m_last_layer_line_start(0), m_g4_prefix("G4 P"),
-      m_g4_comment("DWELL"), m_f_param_and_value("F[^\\D]\\d*\\.*\\d*"), m_q_param_and_value("Q[^\\D]\\d*\\.*\\d*"),
-      m_s_param_and_value("S[^\\D]\\d*\\.*\\d*"), m_f_parameter('F'), m_q_parameter('Q'), m_s_parameter('S'),
-      m_should_cancel(false), m_negate_z_value(false) {
+    : m_e_absolute(true),
+      m_space(' '),
+      m_distance_unit(meta.m_distance_unit),
+      m_time_unit(meta.m_time_unit),
+      m_angle_unit(meta.m_angle_unit),
+      m_mass_unit(meta.m_mass_unit),
+      m_velocity_unit(meta.m_velocity_unit),
+      m_acceleration_unit(meta.m_acceleration_unit),
+      m_angular_velocity_unit(meta.m_angular_velocity_unit),
+      m_layer_delimiter(meta.m_layer_delimiter),
+      m_layer_count_delimiter(meta.m_layer_count_delimiter),
+      m_allow_layer_alter(allowLayerAlter),
+      m_lines(lines),
+      m_upper_lines(upperLines),
+      m_current_line(0),
+      m_current_end_line(m_lines.size() - 1),
+      m_was_modified(false),
+      m_last_layer_line_start(0),
+      m_g4_prefix("G4 P"),
+      m_g4_comment("DWELL"),
+      m_f_param_and_value("F[^\\D]\\d*\\.*\\d*"),
+      m_q_param_and_value("Q[^\\D]\\d*\\.*\\d*"),
+      m_s_param_and_value("S[^\\D]\\d*\\.*\\d*"),
+      m_f_parameter('F'),
+      m_q_parameter('Q'),
+      m_s_parameter('S'),
+      m_should_cancel(false),
+      m_negate_z_value(false) {
     setBlockCommentDelimiters(meta.m_comment_starting_delimiter, meta.m_comment_ending_delimiter);
 
     MotionEstimation::Init();
 
-    if (meta == GcodeMetaList::KraussMaffeiMeta) {
-        m_g4_prefix = "G4 S";
-    }
+    if (meta == GcodeMetaList::KraussMaffeiMeta) { m_g4_prefix = "G4 S"; }
     else if (meta == GcodeMetaList::MVPMeta) {
         m_negate_z_value = true;
-        m_g4_prefix = "G4 F";
+        m_g4_prefix      = "G4 F";
     }
-    else if (meta == GcodeMetaList::IngersollMeta) {
-        m_g4_prefix = "G4 F";
-    }
+    else if (meta == GcodeMetaList::IngersollMeta) { m_g4_prefix = "G4 F"; }
 
     m_insertions = 0;
 
     config();
 
-    MotionEstimation::m_total_distance = 0;
+    MotionEstimation::m_total_distance    = 0;
     MotionEstimation::m_printing_distance = 0;
-    MotionEstimation::m_travel_distance = 0;
-    m_travel_time = 0 * m_time_unit;
+    MotionEstimation::m_travel_distance   = 0;
+    m_travel_time                         = 0 * m_time_unit;
 }
 
 Distance CommonParser::getCurrentGXDistance() {
     QSharedPointer<SettingsBase> sb = GSM->getGlobal();
-    bool uses_b = sb->setting<bool>(MS::Filament::kFilamentBAxis);
+    bool uses_b                     = sb->setting<bool>(MS::Filament::kFilamentBAxis);
 
     updateCurrentBeadGeometry();
 
@@ -105,7 +114,7 @@ Distance CommonParser::getCurrentGXDistance() {
                                                   !feedrateScalingDisabledForCommand(m_current_gcode_command);
 
     const Time adjustable_time_before = m_layer_G1F_times[m_current_layer];
-    const Distance distance = MotionEstimation::calculateTimeAndVolume(
+    const Distance distance           = MotionEstimation::calculateTimeAndVolume(
         m_current_layer, include_feedrate_adjustable_time, m_current_gcode_command.getCommandID() == 0,
         currentMotionDepositsMaterial(), m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer],
         m_layer_volumes[m_current_layer], uses_b);
@@ -137,7 +146,7 @@ Distance CommonParser::getCurrentArcDistance(Distance start_x, Distance start_y,
                                                   !feedrateScalingDisabledForCommand(m_current_gcode_command);
 
     const Time adjustable_time_before = m_layer_G1F_times[m_current_layer];
-    const Distance distance = MotionEstimation::calculatePathTimeAndVolume(
+    const Distance distance           = MotionEstimation::calculatePathTimeAndVolume(
         path_length, start_direction_x, start_direction_y, start_direction_z, end_direction_x, end_direction_y,
         end_direction_z, include_feedrate_adjustable_time, false, currentMotionDepositsMaterial(),
         m_layer_G1F_times[m_current_layer], m_layer_times[m_current_layer], m_layer_volumes[m_current_layer]);
@@ -155,18 +164,18 @@ Distance CommonParser::arcPathLength(Distance start_x, Distance start_y, Distanc
                                      Distance& start_direction_x, Distance& start_direction_y,
                                      Distance& start_direction_z, Distance& end_direction_x, Distance& end_direction_y,
                                      Distance& end_direction_z) const {
-    const Distance dx = end_x - start_x;
-    const Distance dy = end_y - start_y;
-    const Distance dz = end_z - start_z;
-    const Distance chord_length = sqrt(dx * dx + dy * dy + dz * dz);
+    const Distance dx                  = end_x - start_x;
+    const Distance dy                  = end_y - start_y;
+    const Distance dz                  = end_z - start_z;
+    const Distance chord_length        = sqrt(dx * dx + dy * dy + dz * dz);
     const Distance planar_chord_length = sqrt(dx * dx + dy * dy);
 
     auto set_linear_direction = [&](Distance path_length) {
         if (chord_length > 0) {
             const double scale = path_length() / chord_length();
-            start_direction_x = dx * scale;
-            start_direction_y = dy * scale;
-            start_direction_z = dz * scale;
+            start_direction_x  = dx * scale;
+            start_direction_y  = dy * scale;
+            start_direction_z  = dz * scale;
         }
         else {
             start_direction_x = path_length;
@@ -186,11 +195,11 @@ Distance CommonParser::arcPathLength(Distance start_x, Distance start_y, Distanc
     if (has_center) {
         const Distance start_radius_x = start_x - m_current_arc_center_x;
         const Distance start_radius_y = start_y - m_current_arc_center_y;
-        const Distance end_radius_x = end_x - m_current_arc_center_x;
-        const Distance end_radius_y = end_y - m_current_arc_center_y;
-        const Distance start_radius = sqrt(start_radius_x * start_radius_x + start_radius_y * start_radius_y);
-        const Distance end_radius = sqrt(end_radius_x * end_radius_x + end_radius_y * end_radius_y);
-        radius = (start_radius + end_radius) / 2.0;
+        const Distance end_radius_x   = end_x - m_current_arc_center_x;
+        const Distance end_radius_y   = end_y - m_current_arc_center_y;
+        const Distance start_radius   = sqrt(start_radius_x * start_radius_x + start_radius_y * start_radius_y);
+        const Distance end_radius     = sqrt(end_radius_x * end_radius_x + end_radius_y * end_radius_y);
+        radius                        = (start_radius + end_radius) / 2.0;
 
         if (radius <= 0) {
             set_linear_direction(chord_length);
@@ -198,23 +207,21 @@ Distance CommonParser::arcPathLength(Distance start_x, Distance start_y, Distanc
         }
 
         const double start_angle = qAtan2(start_radius_y(), start_radius_x());
-        const double end_angle = qAtan2(end_radius_y(), end_radius_x());
-        sweep = positiveSweep(ccw ? end_angle - start_angle : start_angle - end_angle);
+        const double end_angle   = qAtan2(end_radius_y(), end_radius_x());
+        sweep                    = positiveSweep(ccw ? end_angle - start_angle : start_angle - end_angle);
 
-        if (sweep <= 1.0e-9 && planar_chord_length <= 1.0) {
-            sweep = 2.0 * M_PI;
-        }
+        if (sweep <= 1.0e-9 && planar_chord_length <= 1.0) { sweep = 2.0 * M_PI; }
 
-        planar_arc_length = radius * sweep;
+        planar_arc_length          = radius * sweep;
         const Distance path_length = sqrt(planar_arc_length * planar_arc_length + dz * dz);
 
         const double direction = ccw ? 1.0 : -1.0;
-        start_direction_x = planar_arc_length * (-direction * start_radius_y() / radius());
-        start_direction_y = planar_arc_length * (direction * start_radius_x() / radius());
-        start_direction_z = dz;
-        end_direction_x = planar_arc_length * (-direction * end_radius_y() / radius());
-        end_direction_y = planar_arc_length * (direction * end_radius_x() / radius());
-        end_direction_z = dz;
+        start_direction_x      = planar_arc_length * (-direction * start_radius_y() / radius());
+        start_direction_y      = planar_arc_length * (direction * start_radius_x() / radius());
+        start_direction_z      = dz;
+        end_direction_x        = planar_arc_length * (-direction * end_radius_y() / radius());
+        end_direction_y        = planar_arc_length * (direction * end_radius_x() / radius());
+        end_direction_z        = dz;
         return path_length;
     }
 
@@ -226,15 +233,11 @@ Distance CommonParser::arcPathLength(Distance start_x, Distance start_y, Distanc
         }
 
         const double chord_ratio = std::clamp((planar_chord_length / (2.0 * radius))(), 0.0, 1.0);
-        sweep = 2.0 * qAsin(chord_ratio);
-        if (m_current_arc_radius < 0) {
-            sweep = 2.0 * M_PI - sweep;
-        }
-        if (sweep <= 1.0e-9 && planar_chord_length <= 1.0) {
-            sweep = 2.0 * M_PI;
-        }
+        sweep                    = 2.0 * qAsin(chord_ratio);
+        if (m_current_arc_radius < 0) { sweep = 2.0 * M_PI - sweep; }
+        if (sweep <= 1.0e-9 && planar_chord_length <= 1.0) { sweep = 2.0 * M_PI; }
 
-        planar_arc_length = radius * sweep;
+        planar_arc_length          = radius * sweep;
         const Distance path_length = sqrt(planar_arc_length * planar_arc_length + dz * dz);
         set_linear_direction(path_length);
         return path_length;
@@ -251,9 +254,7 @@ void CommonParser::updateCurrentBeadGeometry() {
 
 Distance CommonParser::fileDistanceSetting(const QString& key) const {
     const auto setting = m_file_settings.constFind(key);
-    if (setting != m_file_settings.constEnd()) {
-        return Distance(setting.value());
-    }
+    if (setting != m_file_settings.constEnd()) { return Distance(setting.value()); }
 
     return GSM->getGlobal()->setting<Distance>(key);
 }
@@ -269,20 +270,16 @@ Distance CommonParser::beadWidthForComment(const QString& comment) const {
 
     auto widthForRegionComment = [&](const QString& region_name, Distance fallback_width) -> Distance {
         const int region_start = comment.indexOf(region_name);
-        const int width_start = comment.indexOf('-', region_start + region_name.size());
+        const int width_start  = comment.indexOf('-', region_start + region_name.size());
 
         if (width_start >= 0) {
             const int value_start = width_start + 1;
-            int value_end = comment.indexOf(' ', value_start);
-            if (value_end < 0) {
-                value_end = comment.size();
-            }
+            int value_end         = comment.indexOf(' ', value_start);
+            if (value_end < 0) { value_end = comment.size(); }
 
-            bool ok = false;
+            bool ok                   = false;
             const double parsed_width = comment.mid(value_start, value_end - value_start).toDouble(&ok);
-            if (ok && parsed_width > 0) {
-                return parsed_width * m_distance_unit;
-            }
+            if (ok && parsed_width > 0) { return parsed_width * m_distance_unit; }
         }
 
         return fallback_width;
@@ -332,8 +329,7 @@ Distance CommonParser::beadWidthForComment(const QString& comment) const {
 bool CommonParser::feedrateScalingDisabledForCommand(const GcodeCommand& command) const {
     const QString& comment = command.getComment();
 
-    if (comment.isEmpty())
-        return false;
+    if (comment.isEmpty()) return false;
 
     if (fileBoolSetting(MS::TipWipe::kDisableFeedrateScaling) &&
         (comment.contains(Constants::PathModifierStrings::kForwardTipWipe) ||
@@ -359,13 +355,12 @@ bool CommonParser::feedrateScalingDisabledForCommand(const GcodeCommand& command
 }
 
 bool CommonParser::currentMotionDepositsMaterial() const {
-    return m_deposition_active && !m_current_gcode_command.getComment().contains(Constants::RegionTypeStrings::kTravel,
-                                                                                 Qt::CaseInsensitive);
+    return m_deposition_active &&
+           !m_current_gcode_command.getComment().contains(Constants::RegionTypeStrings::kTravel, Qt::CaseInsensitive);
 }
 
 void CommonParser::recordModalFeedrateForCommand(const GcodeCommand& command) {
-    if (m_has_modal_feedrate)
-        m_command_modal_feedrates.insert(command.getLineNumber(), m_modal_feedrate);
+    if (m_has_modal_feedrate) m_command_modal_feedrates.insert(command.getLineNumber(), m_modal_feedrate);
 }
 
 void CommonParser::setCommandFeedrate(QString& line, double feedrate) {
@@ -373,24 +368,22 @@ void CommonParser::setCommandFeedrate(QString& line, double feedrate) {
         "(^|[\\s,/*()])(F(?:[-+]?\\d*\\.?\\d+(?:[Ee][-+]?\\d+)?|#[A-Za-z0-9_]+))",
         QRegularExpression::CaseInsensitiveOption);
 
-    int comment_start = line.size();
+    int comment_start               = line.size();
     const QString comment_delimiter = getCommentStartDelimiter();
     if (!comment_delimiter.isEmpty()) {
         const int delimiter_index = line.indexOf(comment_delimiter);
-        if (delimiter_index >= 0)
-            comment_start = delimiter_index;
+        if (delimiter_index >= 0) comment_start = delimiter_index;
     }
 
     const QRegularExpressionMatch match = feedrate_token.match(line.left(comment_start));
-    const QString replacement = m_f_parameter % QString::number(feedrate, 'f', 4);
+    const QString replacement           = m_f_parameter % QString::number(feedrate, 'f', 4);
     if (match.hasMatch()) {
         line.replace(match.capturedStart(2), match.capturedLength(2), replacement);
         return;
     }
 
     int insert_at = comment_start;
-    while (insert_at > 0 && line.at(insert_at - 1).isSpace())
-        --insert_at;
+    while (insert_at > 0 && line.at(insert_at - 1).isSpace()) --insert_at;
     line.insert(insert_at, m_space % replacement);
 }
 
@@ -398,32 +391,30 @@ bool CommonParser::commandFeedrate(const QString& line, double& feedrate) {
     static const QRegularExpression feedrate_token("(^|[\\s,/*()])(F[-+]?\\d*\\.?\\d+(?:[Ee][-+]?\\d+)?)",
                                                    QRegularExpression::CaseInsensitiveOption);
 
-    int comment_start = line.size();
+    int comment_start               = line.size();
     const QString comment_delimiter = getCommentStartDelimiter();
     if (!comment_delimiter.isEmpty()) {
         const int delimiter_index = line.indexOf(comment_delimiter);
-        if (delimiter_index >= 0)
-            comment_start = delimiter_index;
+        if (delimiter_index >= 0) comment_start = delimiter_index;
     }
 
     const QRegularExpressionMatch match = feedrate_token.match(line.left(comment_start));
-    if (!match.hasMatch())
-        return false;
+    if (!match.hasMatch()) return false;
 
     bool converted = false;
-    feedrate = match.captured(2).mid(1).toDouble(&converted);
+    feedrate       = match.captured(2).mid(1).toDouble(&converted);
     return converted;
 }
 
 void CommonParser::materializeFeedrateTransitions(double modifier) {
     bool emitted_feedrate_set = false;
-    double emitted_feedrate = 0.0;
-    auto explicit_feedrate = m_explicit_modal_feedrates.upperBound(m_last_layer_line_start);
+    double emitted_feedrate   = 0.0;
+    auto explicit_feedrate    = m_explicit_modal_feedrates.upperBound(m_last_layer_line_start);
 
     for (GcodeCommand& command : m_motion_commands[m_current_layer]) {
         while (explicit_feedrate != m_explicit_modal_feedrates.cend() &&
                explicit_feedrate.key() < command.getLineNumber()) {
-            emitted_feedrate = explicit_feedrate.value();
+            emitted_feedrate     = explicit_feedrate.value();
             emitted_feedrate_set = true;
             ++explicit_feedrate;
         }
@@ -444,7 +435,7 @@ void CommonParser::materializeFeedrateTransitions(double modifier) {
             command.addParameter(m_f_parameter.toLatin1(), original_feedrate * m_velocity_unit());
         }
 
-        emitted_feedrate = desired_feedrate;
+        emitted_feedrate     = desired_feedrate;
         emitted_feedrate_set = true;
 
         while (explicit_feedrate != m_explicit_modal_feedrates.cend() &&
@@ -463,8 +454,7 @@ void CommonParser::parseHeader() {
             delimiterSearch.indexIn(m_upper_lines[m_current_line]) == -1) ||
            m_upper_lines[m_current_line].length() == 0) {
         ++m_current_line;
-        if (m_current_line > totalLines)
-            break;
+        if (m_current_line > totalLines) break;
     }
 }
 
@@ -474,7 +464,7 @@ QHash<QString, double> CommonParser::parseFooter() {
     Velocity v;
     m_necessary_variables_copy = Constants::GcodeFileVariables::kNecessaryVariables;
 
-    bool foundForcedMinLayerTime = false;
+    bool foundForcedMinLayerTime       = false;
     bool foundForcedMinLayerTimeMethod = false;
     while (startsWithDelimiter(m_upper_lines[m_current_end_line]) || m_upper_lines[m_current_end_line].length() == 0) {
         if (m_upper_lines[m_current_end_line].length() > 0) {
@@ -483,14 +473,13 @@ QHash<QString, double> CommonParser::parseFooter() {
                 QVector<QString> setting_split = setting.split(' ', Qt::SkipEmptyParts);
                 // make sure we have a valid pair
                 if (setting_split.size() == 2) {
-                    QString key = setting_split[0]; // may or may not be suffixed
+                    QString key      = setting_split[0];  // may or may not be suffixed
                     QString key_root = key;
 
                     // if key is suffixed, remove the suffix
                     int suffix_loc = -1;
-                    suffix_loc = key_root.lastIndexOf(QRegularExpression("_\\d+"));
-                    if (suffix_loc >= 0)
-                        key_root.truncate(suffix_loc);
+                    suffix_loc     = key_root.lastIndexOf(QRegularExpression("_\\d+"));
+                    if (suffix_loc >= 0) key_root.truncate(suffix_loc);
 
                     // search for root when deciding whether or not to parse the setting
                     QHash<QString, QString>::const_iterator it = m_necessary_variables_copy.find(key_root);
@@ -521,8 +510,7 @@ QHash<QString, double> CommonParser::parseFooter() {
             }
         }
         --m_current_end_line;
-        if (m_current_end_line < 0)
-            break;
+        if (m_current_end_line < 0) break;
     }
 
     // convert force minimum layer time setting from Slicer-1 to ORNLSlicer if needed
@@ -565,13 +553,13 @@ void CommonParser::checkAndSetNecessarySettings() {
         }
     }
 
-    MotionEstimation::z_speed = m_file_settings[PRS::MachineSpeed::kZSpeed];
-    MotionEstimation::max_xy_speed = m_file_settings[PRS::MachineSpeed::kMaxXYSpeed];
-    MotionEstimation::w_table_speed = m_file_settings[PRS::MachineSpeed::kWTableSpeed];
-    MotionEstimation::layerThickness = m_file_settings[PS::Layer::kLayerHeight];
-    MotionEstimation::extrusionWidth = m_file_settings[PS::Layer::kBeadWidth];
+    MotionEstimation::z_speed               = m_file_settings[PRS::MachineSpeed::kZSpeed];
+    MotionEstimation::max_xy_speed          = m_file_settings[PRS::MachineSpeed::kMaxXYSpeed];
+    MotionEstimation::w_table_speed         = m_file_settings[PRS::MachineSpeed::kWTableSpeed];
+    MotionEstimation::layerThickness        = m_file_settings[PS::Layer::kLayerHeight];
+    MotionEstimation::extrusionWidth        = m_file_settings[PS::Layer::kBeadWidth];
     MotionEstimation::initialLayerThickness = MotionEstimation::layerThickness;
-    MotionEstimation::layer0extrusionWidth = MotionEstimation::extrusionWidth;
+    MotionEstimation::layer0extrusionWidth  = MotionEstimation::extrusionWidth;
     MotionEstimation::setBeadGeometry(MotionEstimation::extrusionWidth, MotionEstimation::layerThickness);
 
     if (MotionEstimation::max_xy_speed == 0) {
@@ -611,9 +599,7 @@ void CommonParser::preallocateVisualCommands() {
 
         if (m_upper_lines[i].length() > 0) {
             // most common case, valid motion command
-            if (m_upper_lines[i].indexOf(gMotionCommand) == 0) {
-                commandsInLayer++;
-            }
+            if (m_upper_lines[i].indexOf(gMotionCommand) == 0) { commandsInLayer++; }
             // lastly, when reaching a new layer or the final line, allocate memory
             else if (layerDelimiter.indexIn(m_upper_lines[i]) != -1) {
                 QList<GcodeCommand> commands;
@@ -662,18 +648,14 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
             // parser that is formatted the way a line is normally formatted (without the variable)
             double zVal;
             int second = m_upper_lines[m_current_line].indexOf("]");
-            int zLoc = m_upper_lines[m_current_line].indexOf("Z");
+            int zLoc   = m_upper_lines[m_current_line].indexOf("Z");
             if (m_upper_lines[m_current_line].contains("+")) {
-                int first = m_upper_lines[m_current_line].indexOf("+") + 2;
+                int first               = m_upper_lines[m_current_line].indexOf("+") + 2;
                 QString zAdditionString = m_upper_lines[m_current_line].mid(first, second - first);
-                zVal = zAdditionString.toDouble(&no_error);
-                if (!no_error) {
-                    throwFloatConversionErrorException();
-                }
+                zVal                    = zAdditionString.toDouble(&no_error);
+                if (!no_error) { throwFloatConversionErrorException(); }
             }
-            else {
-                zVal = 0;
-            }
+            else { zVal = 0; }
 
             zVal += currentZOffset;
             newCurrentLine = m_upper_lines[m_current_line].mid(0, zLoc + 1) % QString::number(zVal, 'f', 4) %
@@ -694,13 +676,11 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
         else if (m_upper_lines[m_current_line].contains("EXTRUDER(")) {
             m_deposition_active = true;
 
-            int first = m_upper_lines[m_current_line].indexOf("(") + 1;
-            int second = m_upper_lines[m_current_line].indexOf(")");
+            int first             = m_upper_lines[m_current_line].indexOf("(") + 1;
+            int second            = m_upper_lines[m_current_line].indexOf(")");
             QString spindleString = m_upper_lines[m_current_line].mid(first, second - first);
-            double spindleSpeed = spindleString.toDouble(&no_error);
-            if (!no_error) {
-                throwFloatConversionErrorException();
-            }
+            double spindleSpeed   = spindleString.toDouble(&no_error);
+            if (!no_error) { throwFloatConversionErrorException(); }
             setSpindleSpeed(spindleSpeed * m_angular_velocity_unit());
 
             continue;
@@ -725,27 +705,27 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
 
                     double minModifier = std::numeric_limits<double>::max();
                     double maxModifier = 1;
-                    if (increaseTime > 0 || decreaseTime > 0)
-                        getMinMaxModifier(minModifier, maxModifier);
+                    if (increaseTime > 0 || decreaseTime > 0) getMinMaxModifier(minModifier, maxModifier);
 
                     if (m_layer_G1F_times[m_current_layer] > 0) {
-                        if (increaseTime > 0) { // If layer time less than minimum, slow feedrate or add dwell
+                        if (increaseTime > 0) {  // If layer time less than minimum, slow feedrate or add dwell
                             if (m_min_layer_time_choice == ForceMinimumLayerTime::kSlow_Feedrate) {
                                 // Ratio uses the layer time as well as the total time for all G1 F moves, which are
                                 // what get adjusted
-                                double ratio = (increaseTime / m_layer_G1F_times[m_current_layer])();
+                                double ratio    = (increaseTime / m_layer_G1F_times[m_current_layer])();
                                 double modifier = 1 / (1.0 + ratio);
 
                                 if (modifier < minModifier && minModifier > 0 && minModifier < 1) {
                                     modifier = minModifier;
-                                    emit forwardInfoToMainWindow("Computed speed is lower than min machine speed, "
-                                                                 "machine min speed will be used");
+                                    emit forwardInfoToMainWindow(
+                                        "Computed speed is lower than min machine speed, "
+                                        "machine min speed will be used");
                                 }
 
                                 if (modifier > 0 && modifier < 1) {
                                     AdjustFeedrate(modifier);
                                     layer_feedrate_adjusted = true;
-                                    m_was_modified = true;
+                                    m_was_modified          = true;
                                 }
                             }
                             else if (m_min_layer_time_choice == ForceMinimumLayerTime::kUse_Purge_Dwells) {
@@ -753,11 +733,11 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
                                 m_was_modified = true;
                             }
                         }
-                        else if (decreaseTime > 0) { // If layer time more than maximum, increase feedrate
+                        else if (decreaseTime > 0) {  // If layer time more than maximum, increase feedrate
                             if (m_min_layer_time_choice == ForceMinimumLayerTime::kSlow_Feedrate) {
                                 // Ratio uses the layer time as well as the total time for all G1 F moves, which are
                                 // what get adjusted
-                                double ratio = (decreaseTime / m_layer_G1F_times[m_current_layer])();
+                                double ratio    = (decreaseTime / m_layer_G1F_times[m_current_layer])();
                                 double modifier = 1 / (1.0 - ratio);
 
                                 if (modifier > maxModifier && maxModifier > 1) {
@@ -769,7 +749,7 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
                                 if (modifier > 1) {
                                     AdjustFeedrate(modifier);
                                     layer_feedrate_adjusted = true;
-                                    m_was_modified = true;
+                                    m_was_modified          = true;
                                 }
                             }
                             else if (m_min_layer_time_choice == ForceMinimumLayerTime::kUse_Purge_Dwells) {
@@ -786,8 +766,7 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
                     materializeFeedrateTransitions(1.0);
                 }
 
-                if (m_current_line == m_current_end_line)
-                    break;
+                if (m_current_line == m_current_end_line) break;
 
                 m_last_layer_line_start = m_current_line;
                 ++m_current_layer;
@@ -810,8 +789,7 @@ QList<QList<GcodeCommand>> CommonParser::parseLines() {
             }
         }
 
-        if (m_should_cancel)
-            return QList<QList<GcodeCommand>>();
+        if (m_should_cancel) return QList<QList<GcodeCommand>>();
     }
 
     // emit layer times and key info
@@ -832,49 +810,85 @@ void CommonParser::config() {
     addCommandMapping("M5", std::bind(&CommonParser::M5Handler, this, std::placeholders::_1));
 }
 
-NT CommonParser::getXPos() const { return getXPos(m_distance_unit); }
+NT CommonParser::getXPos() const {
+    return getXPos(m_distance_unit);
+}
 
-NT CommonParser::getXPos(Distance distance_unit) const { return MotionEstimation::m_current_x.to(distance_unit); }
+NT CommonParser::getXPos(Distance distance_unit) const {
+    return MotionEstimation::m_current_x.to(distance_unit);
+}
 
-NT CommonParser::getYPos() const { return getYPos(m_distance_unit); }
+NT CommonParser::getYPos() const {
+    return getYPos(m_distance_unit);
+}
 
-NT CommonParser::getYPos(Distance distance_unit) const { return MotionEstimation::m_current_y.to(distance_unit); }
+NT CommonParser::getYPos(Distance distance_unit) const {
+    return MotionEstimation::m_current_y.to(distance_unit);
+}
 
-NT CommonParser::getZPos() const { return getZPos(m_distance_unit); }
+NT CommonParser::getZPos() const {
+    return getZPos(m_distance_unit);
+}
 
-NT CommonParser::getZPos(Distance distance_unit) const { return MotionEstimation::m_current_z.to(distance_unit); }
+NT CommonParser::getZPos(Distance distance_unit) const {
+    return MotionEstimation::m_current_z.to(distance_unit);
+}
 
-NT CommonParser::getWPos() const { return getWPos(m_distance_unit); }
+NT CommonParser::getWPos() const {
+    return getWPos(m_distance_unit);
+}
 
-NT CommonParser::getWPos(Distance distance_unit) const { return MotionEstimation::m_current_w.to(distance_unit); }
+NT CommonParser::getWPos(Distance distance_unit) const {
+    return MotionEstimation::m_current_w.to(distance_unit);
+}
 
-NT CommonParser::getArcXPos() const { return getArcXPos(m_distance_unit); }
+NT CommonParser::getArcXPos() const {
+    return getArcXPos(m_distance_unit);
+}
 
-NT CommonParser::getArcXPos(Distance distance_unit) const { return m_current_arc_center_x.to(distance_unit); }
+NT CommonParser::getArcXPos(Distance distance_unit) const {
+    return m_current_arc_center_x.to(distance_unit);
+}
 
-NT CommonParser::getArcYPos() const { return getArcYPos(m_distance_unit); }
+NT CommonParser::getArcYPos() const {
+    return getArcYPos(m_distance_unit);
+}
 
-NT CommonParser::getArcYPos(Distance distance_unit) const { return m_current_arc_center_y.to(distance_unit); }
+NT CommonParser::getArcYPos(Distance distance_unit) const {
+    return m_current_arc_center_y.to(distance_unit);
+}
 
-NT CommonParser::getSpeed() const { return getSpeed(m_velocity_unit); }
+NT CommonParser::getSpeed() const {
+    return getSpeed(m_velocity_unit);
+}
 
-NT CommonParser::getSpeed(Velocity velocity_unit) const { return MotionEstimation::m_current_speed.to(velocity_unit); }
+NT CommonParser::getSpeed(Velocity velocity_unit) const {
+    return MotionEstimation::m_current_speed.to(velocity_unit);
+}
 
-NT CommonParser::getSpindleSpeed() const { return getSpindleSpeed(rev / minute); }
+NT CommonParser::getSpindleSpeed() const {
+    return getSpindleSpeed(rev / minute);
+}
 
 NT CommonParser::getSpindleSpeed(AngularVelocity angular_velocity_unit) const {
     return m_current_spindle_speed.to(angular_velocity_unit);
 }
 
-NT CommonParser::getAcceleration() const { return getAcceleration(m_acceleration_unit); }
+NT CommonParser::getAcceleration() const {
+    return getAcceleration(m_acceleration_unit);
+}
 
 NT CommonParser::getAcceleration(Acceleration acceleration_unit) const {
     return MotionEstimation::m_current_acceleration.to(acceleration_unit);
 }
 
-NT CommonParser::getSleepTime() const { return getSleepTime(m_time_unit); }
+NT CommonParser::getSleepTime() const {
+    return getSleepTime(m_time_unit);
+}
 
-NT CommonParser::getSleepTime(Time time_unit) const { return m_sleep_time.to(time_unit); }
+NT CommonParser::getSleepTime(Time time_unit) const {
+    return m_sleep_time.to(time_unit);
+}
 
 void CommonParser::reset() {
     resetInternalState();
@@ -897,25 +911,27 @@ void CommonParser::reset() {
     // So don't reset to 0 here and leave it to the default acceleration set in the constructor
     // m_current_acceleration = 0 * m_acceleration_unit;
 
-    m_sleep_time = 0 * m_time_unit;
-    m_purge_time = 0 * m_time_unit;
-    m_wait_to_wipe_time = 0 * m_time_unit;
+    m_sleep_time               = 0 * m_time_unit;
+    m_purge_time               = 0 * m_time_unit;
+    m_wait_to_wipe_time        = 0 * m_time_unit;
     m_wait_time_to_start_purge = 0 * m_time_unit;
-    m_travel_time = 0 * m_time_unit;
+    m_travel_time              = 0 * m_time_unit;
 
-    m_deposition_active = false;
+    m_deposition_active       = false;
     m_dynamic_spindle_control = false;
-    m_park = false;
-    m_with_F_value = false;
-    m_modal_feedrate = 0.0;
-    m_has_modal_feedrate = false;
+    m_park                    = false;
+    m_with_F_value            = false;
+    m_modal_feedrate          = 0.0;
+    m_has_modal_feedrate      = false;
     m_command_modal_feedrates.clear();
     m_explicit_modal_feedrates.clear();
     m_command_G1F_times.clear();
     m_layer_dwell_adjustments.clear();
 }
 
-QList<Time> CommonParser::getLayerTimes() { return m_layer_times; }
+QList<Time> CommonParser::getLayerTimes() {
+    return m_layer_times;
+}
 
 QList<Time> CommonParser::getAdjustedLayerTimes() {
     QList<Time> adjusted_layer_times = m_layer_times;
@@ -925,33 +941,32 @@ QList<Time> CommonParser::getAdjustedLayerTimes() {
 
     const bool has_adjusted_feedrates = std::any_of(m_layer_FR_modifiers.cbegin(), m_layer_FR_modifiers.cend(),
                                                     [](double modifier) { return modifier > 0 && modifier != 1.0; });
-    if (!has_adjusted_feedrates)
-        return adjusted_layer_times;
+    if (!has_adjusted_feedrates) return adjusted_layer_times;
 
     bool emitted_feedrate_set = false;
-    double emitted_feedrate = 0.0;
-    auto explicit_feedrate = m_explicit_modal_feedrates.cbegin();
+    double emitted_feedrate   = 0.0;
+    auto explicit_feedrate    = m_explicit_modal_feedrates.cbegin();
 
     for (int layer = 0; layer < m_motion_commands.size() && layer < adjusted_layer_times.size(); ++layer) {
         for (const GcodeCommand& command : m_motion_commands[layer]) {
             const int line_number = command.getLineNumber();
             while (explicit_feedrate != m_explicit_modal_feedrates.cend() && explicit_feedrate.key() < line_number) {
-                emitted_feedrate = explicit_feedrate.value();
+                emitted_feedrate     = explicit_feedrate.value();
                 emitted_feedrate_set = true;
                 ++explicit_feedrate;
             }
 
-            const double original_feedrate = m_command_modal_feedrates.value(line_number, 0.0);
+            const double original_feedrate   = m_command_modal_feedrates.value(line_number, 0.0);
             double explicit_command_feedrate = 0.0;
             if (line_number >= 0 && line_number < m_lines.size() &&
                 commandFeedrate(m_lines[line_number], explicit_command_feedrate)) {
-                emitted_feedrate = explicit_command_feedrate;
+                emitted_feedrate     = explicit_command_feedrate;
                 emitted_feedrate_set = true;
             }
             else if (command.getParameters().contains(m_f_parameter.toLatin1()) && original_feedrate > 0) {
                 // Macro feedrates such as F#981 cannot be read back numerically, but their authored value was
                 // resolved while parsing and remains unchanged unless setCommandFeedrate replaced the token.
-                emitted_feedrate = original_feedrate;
+                emitted_feedrate     = original_feedrate;
                 emitted_feedrate_set = true;
             }
 
@@ -970,65 +985,111 @@ QList<Time> CommonParser::getAdjustedLayerTimes() {
     return adjusted_layer_times;
 }
 
-QList<double> CommonParser::getLayerFeedRateModifiers() { return m_layer_FR_modifiers; }
+QList<double> CommonParser::getLayerFeedRateModifiers() {
+    return m_layer_FR_modifiers;
+}
 
-QList<Volume> CommonParser::getLayerVolumes() { return m_layer_volumes; }
+QList<Volume> CommonParser::getLayerVolumes() {
+    return m_layer_volumes;
+}
 
-Distance CommonParser::getTotalDistance() { return MotionEstimation::m_total_distance; }
+Distance CommonParser::getTotalDistance() {
+    return MotionEstimation::m_total_distance;
+}
 
-Distance CommonParser::getPrintingDistance() { return MotionEstimation::m_printing_distance; }
+Distance CommonParser::getPrintingDistance() {
+    return MotionEstimation::m_printing_distance;
+}
 
-Distance CommonParser::getTravelDistance() { return MotionEstimation::m_travel_distance; }
+Distance CommonParser::getTravelDistance() {
+    return MotionEstimation::m_travel_distance;
+}
 
-Time CommonParser::getTravelTime() { return m_travel_time; }
+Time CommonParser::getTravelTime() {
+    return m_travel_time;
+}
 
-bool CommonParser::getWasModified() { return m_was_modified; }
+bool CommonParser::getWasModified() {
+    return m_was_modified;
+}
 
-void CommonParser::cancelSlice() { m_should_cancel = true; }
+void CommonParser::cancelSlice() {
+    m_should_cancel = true;
+}
 
-QList<int> CommonParser::getLayerStartLines() { return m_layer_start_lines; }
+QList<int> CommonParser::getLayerStartLines() {
+    return m_layer_start_lines;
+}
 
-int CommonParser::getCurrentLine() { return m_current_line; }
+int CommonParser::getCurrentLine() {
+    return m_current_line;
+}
 
-void CommonParser::alterCurrentEndLine(int count) { m_current_end_line += count; }
+void CommonParser::alterCurrentEndLine(int count) {
+    m_current_end_line += count;
+}
 
-void CommonParser::setModified() { m_was_modified = true; }
+void CommonParser::setModified() {
+    m_was_modified = true;
+}
 
 void CommonParser::recordMotionEstimate(Distance distance, Time time_delta) {
     MotionEstimation::m_total_distance += distance;
 
-    if (currentMotionDepositsMaterial()) {
-        MotionEstimation::m_printing_distance += distance;
-    }
+    if (currentMotionDepositsMaterial()) { MotionEstimation::m_printing_distance += distance; }
     else {
         MotionEstimation::m_travel_distance += distance;
         m_travel_time += time_delta;
     }
 }
 
-void CommonParser::setXPos(NT value) { MotionEstimation::m_current_x = value; }
+void CommonParser::setXPos(NT value) {
+    MotionEstimation::m_current_x = value;
+}
 
-void CommonParser::setYPos(NT value) { MotionEstimation::m_current_y = value; }
+void CommonParser::setYPos(NT value) {
+    MotionEstimation::m_current_y = value;
+}
 
-void CommonParser::setZPos(NT value) { MotionEstimation::m_current_z = value; }
+void CommonParser::setZPos(NT value) {
+    MotionEstimation::m_current_z = value;
+}
 
-void CommonParser::setWPos(NT value) { MotionEstimation::m_current_w = value; }
+void CommonParser::setWPos(NT value) {
+    MotionEstimation::m_current_w = value;
+}
 
-void CommonParser::setArcXPos(NT value) { m_current_arc_center_x = value; }
+void CommonParser::setArcXPos(NT value) {
+    m_current_arc_center_x = value;
+}
 
-void CommonParser::setArcYPos(NT value) { m_current_arc_center_y = value; }
+void CommonParser::setArcYPos(NT value) {
+    m_current_arc_center_y = value;
+}
 
-void CommonParser::setArcZPos(NT value) { m_current_arc_center_z = value; }
+void CommonParser::setArcZPos(NT value) {
+    m_current_arc_center_z = value;
+}
 
-void CommonParser::setArcRPos(NT value) { m_current_arc_radius = value; }
+void CommonParser::setArcRPos(NT value) {
+    m_current_arc_radius = value;
+}
 
-void CommonParser::setSpeed(NT value) { MotionEstimation::m_current_speed = value; }
+void CommonParser::setSpeed(NT value) {
+    MotionEstimation::m_current_speed = value;
+}
 
-void CommonParser::setSpindleSpeed(NT value) { m_current_spindle_speed = value * m_angular_velocity_unit; }
+void CommonParser::setSpindleSpeed(NT value) {
+    m_current_spindle_speed = value * m_angular_velocity_unit;
+}
 
-void CommonParser::setAcceleration(NT value) { MotionEstimation::m_current_acceleration = value; }
+void CommonParser::setAcceleration(NT value) {
+    MotionEstimation::m_current_acceleration = value;
+}
 
-void CommonParser::setSleepTime(NT value) { m_sleep_time = value; }
+void CommonParser::setSleepTime(NT value) {
+    m_sleep_time = value;
+}
 
 void CommonParser::G0Handler(QVector<QString> params) {
     if (params.empty()) {
@@ -1049,10 +1110,8 @@ void CommonParser::G0Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
-        if (!no_error) {
-            throwFloatConversionErrorException();
-        }
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
+        if (!no_error) { throwFloatConversionErrorException(); }
 
         current_value *= m_distance_unit();
         m_current_gcode_command.addParameter(current_parameter, current_value);
@@ -1061,48 +1120,40 @@ void CommonParser::G0Handler(QVector<QString> params) {
             case ('x'):
                 if (x_not_used) {
                     setXPos(current_value);
-                    x_not_used = false;
+                    x_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Y'):
             case ('y'):
                 if (y_not_used) {
                     setYPos(current_value);
-                    y_not_used = false;
+                    y_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Z'):
             case ('z'):
                 if (z_not_used) {
                     setZPos(current_value);
-                    z_not_used = false;
+                    z_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('W'):
             case ('w'):
                 if (w_not_used) {
                     setWPos(current_value);
-                    w_not_used = false;
+                    w_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             default:
@@ -1118,12 +1169,10 @@ void CommonParser::G0Handler(QVector<QString> params) {
     m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
-    if (is_motion_command) {
-        m_motion_commands[m_current_layer].push_back(m_current_gcode_command);
-    }
+    if (is_motion_command) { m_motion_commands[m_current_layer].push_back(m_current_gcode_command); }
 
     const Time layer_time_before = m_layer_times[m_current_layer];
-    Distance temp = getCurrentGXDistance();
+    Distance temp                = getCurrentGXDistance();
     recordMotionEstimate(temp, m_layer_times[m_current_layer] - layer_time_before);
 }
 
@@ -1146,10 +1195,8 @@ void CommonParser::G1Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
-        if (!no_error) {
-            throwFloatConversionErrorException();
-        }
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
+        if (!no_error) { throwFloatConversionErrorException(); }
 
         switch (current_parameter) {
             case ('X'):
@@ -1157,12 +1204,10 @@ void CommonParser::G1Handler(QVector<QString> params) {
                 if (x_not_used) {
                     current_value *= m_distance_unit();
                     setXPos(current_value);
-                    x_not_used = false;
+                    x_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Y'):
@@ -1170,28 +1215,22 @@ void CommonParser::G1Handler(QVector<QString> params) {
                 if (y_not_used) {
                     current_value *= m_distance_unit();
                     setYPos(current_value);
-                    y_not_used = false;
+                    y_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Z'):
             case ('z'):
                 if (z_not_used) {
-                    if (m_negate_z_value) {
-                        current_value = current_value * -1;
-                    }
+                    if (m_negate_z_value) { current_value = current_value * -1; }
                     current_value *= m_distance_unit();
                     setZPos(current_value);
-                    z_not_used = false;
+                    z_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('W'):
@@ -1199,26 +1238,22 @@ void CommonParser::G1Handler(QVector<QString> params) {
                 if (w_not_used) {
                     current_value *= m_distance_unit();
                     setWPos(current_value);
-                    w_not_used = false;
+                    w_not_used        = false;
                     is_motion_command = true;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('F'):
             case ('f'):
                 if (f_not_used) {
-                    m_modal_feedrate = current_value;
+                    m_modal_feedrate     = current_value;
                     m_has_modal_feedrate = true;
                     current_value *= m_velocity_unit();
                     setSpeed(current_value);
                     f_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('S'):
@@ -1228,9 +1263,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
                     setSpindleSpeed(current_value);
                     s_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Q'):
@@ -1240,9 +1273,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
                     setSpindleSpeed(current_value);
                     s_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('M'):
@@ -1286,11 +1317,9 @@ void CommonParser::G1Handler(QVector<QString> params) {
                             setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
-                    e_not_used = false;
+                    e_not_used                    = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             default:
@@ -1306,8 +1335,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
     m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
-    if (!f_not_used)
-        m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
+    if (!f_not_used) m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
 
     if (is_motion_command) {
         recordModalFeedrateForCommand(m_current_gcode_command);
@@ -1318,7 +1346,7 @@ void CommonParser::G1Handler(QVector<QString> params) {
         is_motion_command && m_has_modal_feedrate && !feedrateScalingDisabledForCommand(m_current_gcode_command);
 
     const Time layer_time_before = m_layer_times[m_current_layer];
-    Distance temp = getCurrentGXDistance();
+    Distance temp                = getCurrentGXDistance();
     recordMotionEstimate(temp, m_layer_times[m_current_layer] - layer_time_before);
 }
 
@@ -1330,7 +1358,7 @@ void CommonParser::G1HandlerHelper(QVector<QString> params, QVector<QString> opt
     for (QString ref : optionalParams) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
         m_current_gcode_command.addOptionalParameter(current_parameter, current_value * m_distance_unit());
     }
 
@@ -1361,10 +1389,8 @@ void CommonParser::G2Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
-        if (!no_error) {
-            throwFloatConversionErrorException();
-        }
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
+        if (!no_error) { throwFloatConversionErrorException(); }
 
         const NT authored_value = current_value;
         if (current_parameter == 'F' || current_parameter == 'f')
@@ -1377,47 +1403,39 @@ void CommonParser::G2Handler(QVector<QString> params) {
             case ('X'):
             case ('x'):
                 if (x_not_used) {
-                    temp_x = current_value;
+                    temp_x     = current_value;
                     x_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Y'):
             case ('y'):
                 if (y_not_used) {
-                    temp_y = current_value;
+                    temp_y     = current_value;
                     y_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Z'):
             case ('z'):
                 if (z_not_used) {
-                    temp_z = current_value;
+                    temp_z     = current_value;
                     z_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('F'):
             case ('f'):
                 if (f_not_used) {
-                    m_modal_feedrate = authored_value;
+                    m_modal_feedrate     = authored_value;
                     m_has_modal_feedrate = true;
                     setSpeed(current_value);
                     f_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('I'):
@@ -1426,9 +1444,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     setArcXPos(start_x() + current_value);
                     i_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('J'):
@@ -1437,9 +1453,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     setArcYPos(start_y() + current_value);
                     j_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('K'):
@@ -1448,9 +1462,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     setArcZPos(start_z() + current_value);
                     k_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('R'):
             case ('r'):
@@ -1458,9 +1470,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     setArcRPos(current_value);
                     r_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('S'):
             case ('s'):
@@ -1469,9 +1479,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     setSpindleSpeed(current_value);
                     s_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('W'):
             case ('w'):
@@ -1479,9 +1487,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
                     setWPos(current_value);
                     w_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('E'):
             case ('e'):
@@ -1500,11 +1506,9 @@ void CommonParser::G2Handler(QVector<QString> params) {
                             setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
-                    e_not_used = false;
+                    e_not_used                    = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             default:
                 QString exceptionString;
@@ -1518,8 +1522,7 @@ void CommonParser::G2Handler(QVector<QString> params) {
     m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
-    if (!f_not_used)
-        m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
+    if (!f_not_used) m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
     recordModalFeedrateForCommand(m_current_gcode_command);
     m_motion_commands[m_current_layer].push_back(m_current_gcode_command);
 
@@ -1566,7 +1569,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
         if (!no_error) {
             QString exceptionString;
             QTextStream(&exceptionString) << "Error with float conversion on GCode line "
@@ -1586,47 +1589,39 @@ void CommonParser::G3Handler(QVector<QString> params) {
             case ('X'):
             case ('x'):
                 if (x_not_used) {
-                    temp_x = current_value;
+                    temp_x     = current_value;
                     x_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Y'):
             case ('y'):
                 if (y_not_used) {
-                    temp_y = current_value;
+                    temp_y     = current_value;
                     y_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('Z'):
             case ('z'):
                 if (z_not_used) {
-                    temp_z = current_value;
+                    temp_z     = current_value;
                     z_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('F'):
             case ('f'):
                 if (f_not_used) {
-                    m_modal_feedrate = authored_value;
+                    m_modal_feedrate     = authored_value;
                     m_has_modal_feedrate = true;
                     setSpeed(current_value);
                     f_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('I'):
@@ -1635,9 +1630,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     setArcXPos(start_x() + current_value);
                     i_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('J'):
@@ -1646,9 +1639,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     setArcYPos(start_y() + current_value);
                     j_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
 
             case ('K'):
@@ -1657,9 +1648,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     setArcZPos(start_z() + current_value);
                     k_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('R'):
             case ('r'):
@@ -1667,9 +1656,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     setArcRPos(current_value);
                     r_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('S'):
             case ('s'):
@@ -1678,9 +1665,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     setSpindleSpeed(current_value);
                     s_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('W'):
             case ('w'):
@@ -1688,9 +1673,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
                     setWPos(current_value);
                     w_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('E'):
             case ('e'):
@@ -1709,11 +1692,9 @@ void CommonParser::G3Handler(QVector<QString> params) {
                             setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
-                    e_not_used = false;
+                    e_not_used                    = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             default:
                 QString exceptionString;
@@ -1727,8 +1708,7 @@ void CommonParser::G3Handler(QVector<QString> params) {
     m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
-    if (!f_not_used)
-        m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
+    if (!f_not_used) m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
     recordModalFeedrateForCommand(m_current_gcode_command);
     m_motion_commands[m_current_layer].push_back(m_current_gcode_command);
 
@@ -1775,10 +1755,8 @@ void CommonParser::G4Handler(QVector<QString> params) {
     for (QString ref : params) {
         // Retriving the first character in the QString and making it a char
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&no_error);
-        if (!no_error) {
-            throwFloatConversionErrorException();
-        }
+        current_value     = ref.right(ref.size() - 1).toDouble(&no_error);
+        if (!no_error) { throwFloatConversionErrorException(); }
 
         current_value *= m_time_unit();
         m_current_gcode_command.addParameter(current_parameter, current_value);
@@ -1790,9 +1768,7 @@ void CommonParser::G4Handler(QVector<QString> params) {
                     setSleepTime(current_value);
                     p_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('S'):
             case ('s'):
@@ -1800,9 +1776,7 @@ void CommonParser::G4Handler(QVector<QString> params) {
                     setSleepTime(current_value);
                     s_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('F'):
             case ('f'):
@@ -1810,9 +1784,7 @@ void CommonParser::G4Handler(QVector<QString> params) {
                     setSleepTime(current_value);
                     f_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('X'):
             case ('x'):
@@ -1820,9 +1792,7 @@ void CommonParser::G4Handler(QVector<QString> params) {
                     setSleepTime(current_value);
                     x_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             default:
                 QString exceptionString;
@@ -1864,7 +1834,7 @@ void CommonParser::G5Handler(QVector<QString> params) {
 
     for (const QString& ref : params) {
         current_parameter = ref.at(0).toLatin1();
-        current_value = ref.right(ref.size() - 1).toDouble(&number_error);
+        current_value     = ref.right(ref.size() - 1).toDouble(&number_error);
         if (!number_error) {
             QString exceptionString;
             QTextStream(&exceptionString) << "Error with float conversion on GCode line "
@@ -1884,84 +1854,68 @@ void CommonParser::G5Handler(QVector<QString> params) {
             case ('X'):
             case ('x'):
                 if (x_not_used) {
-                    temp_x = current_value;
+                    temp_x     = current_value;
                     x_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('Y'):
             case ('y'):
                 if (y_not_used) {
-                    temp_y = current_value;
+                    temp_y     = current_value;
                     y_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('Z'):
             case ('z'):
                 if (z_not_used) {
-                    temp_z = current_value;
+                    temp_z     = current_value;
                     z_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('F'):
             case ('f'):
                 if (f_not_used) {
-                    m_modal_feedrate = authored_value;
+                    m_modal_feedrate     = authored_value;
                     m_has_modal_feedrate = true;
                     setSpeed(current_value);
                     f_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('I'):
             case ('i'):
                 if (i_not_used) {
                     m_current_spline_control_a_x = getXPos() + current_value;
-                    i_not_used = false;
+                    i_not_used                   = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('J'):
             case ('j'):
                 if (j_not_used) {
                     m_current_spline_control_a_y = getYPos() + current_value;
-                    j_not_used = false;
+                    j_not_used                   = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('P'):
             case ('p'):
                 if (p_not_used) {
                     m_current_spline_control_b_x = temp_x + current_value;
-                    p_not_used = false;
+                    p_not_used                   = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('Q'):
             case ('q'):
                 if (q_not_used) {
                     m_current_spline_control_b_y = temp_y + current_value;
-                    q_not_used = false;
+                    q_not_used                   = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('S'):
             case ('s'):
@@ -1970,9 +1924,7 @@ void CommonParser::G5Handler(QVector<QString> params) {
                     setSpindleSpeed(current_value);
                     s_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('W'):
             case ('w'):
@@ -1980,9 +1932,7 @@ void CommonParser::G5Handler(QVector<QString> params) {
                     setWPos(current_value);
                     w_not_used = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             case ('E'):
             case ('e'):
@@ -2001,11 +1951,9 @@ void CommonParser::G5Handler(QVector<QString> params) {
                             setDepositionActive(false);
                     }
                     MotionEstimation::m_current_e = current_value;
-                    e_not_used = false;
+                    e_not_used                    = false;
                 }
-                else {
-                    throwMultipleParameterException(current_parameter);
-                }
+                else { throwMultipleParameterException(current_parameter); }
                 break;
             default:
                 QString exceptionString;
@@ -2019,8 +1967,7 @@ void CommonParser::G5Handler(QVector<QString> params) {
     m_current_gcode_command.setDepositionActive(currentMotionDepositsMaterial());
     m_current_gcode_command.setExtruderSpeed(m_current_extruder_speed);
 
-    if (!f_not_used)
-        m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
+    if (!f_not_used) m_explicit_modal_feedrates.insert(m_current_gcode_command.getLineNumber(), m_modal_feedrate);
     recordModalFeedrateForCommand(m_current_gcode_command);
     m_motion_commands[m_current_layer].push_back(m_current_gcode_command);
 
@@ -2046,8 +1993,7 @@ void CommonParser::M3Handler(QVector<QString> params) {
         if (current_parameter == 'S' || current_parameter == 's') {
             m_current_extruder_speed = ref.right(ref.size() - 1).toDouble(&no_error);
 
-            if (!no_error)
-                m_current_extruder_speed = 0;
+            if (!no_error) m_current_extruder_speed = 0;
 
             setSpindleSpeed(m_current_extruder_speed * m_angular_velocity_unit());
         }
@@ -2058,11 +2004,11 @@ void CommonParser::M3Handler(QVector<QString> params) {
 
 void CommonParser::M5Handler(QVector<QString> params) {
     m_current_spindle_speed = m_current_extruder_speed = 0;
-    m_deposition_active = false;
+    m_deposition_active                                = false;
 }
 
 void CommonParser::AddDwell(double dwellTime) {
-    int insertIndex = m_current_line - 1 + m_insertions;
+    int insertIndex                 = m_current_line - 1 + m_insertions;
     QSharedPointer<SettingsBase> sb = GSM->getGlobal();
     if (m_current_layer >= 0 && m_current_layer < m_layer_dwell_adjustments.size()) {
         m_layer_dwell_adjustments[m_current_layer] += Time(dwellTime);
@@ -2073,7 +2019,7 @@ void CommonParser::AddDwell(double dwellTime) {
 
         QString custom_code = sb->setting<QString>(MS::Cooling::kPostPauseCode);
         if (!(custom_code.isNull() || custom_code.isEmpty())) {
-            auto custom_code_lines = custom_code.split('\n');
+            auto custom_code_lines       = custom_code.split('\n');
             auto custom_code_lines_count = custom_code_lines.length();
             for (auto i = custom_code_lines_count; i > 0;) {
                 m_lines.insert(insertIndex, custom_code_lines[--i]);
@@ -2087,12 +2033,10 @@ void CommonParser::AddDwell(double dwellTime) {
         double purgeRate;
         if (sb->setting<MachineType>(PRS::MachineSetup::kMachineType) == MachineType::kFilament) {
             double purgeLength = sb->setting<double>(MS::Purge::kPurgeLength);
-            double purgeRate = sb->setting<double>(MS::Purge::kPurgeFeedrate);
-            new_dwellTime = dwellTime - purgeLength / purgeRate;
+            double purgeRate   = sb->setting<double>(MS::Purge::kPurgeFeedrate);
+            new_dwellTime      = dwellTime - purgeLength / purgeRate;
         }
-        else {
-            new_dwellTime = dwellTime - purgeTime;
-        }
+        else { new_dwellTime = dwellTime - purgeTime; }
 
         // Purge
         if (sb->setting<MachineType>(PRS::MachineSetup::kMachineType) == MachineType::kFilament) {
@@ -2145,7 +2089,7 @@ void CommonParser::AddDwell(double dwellTime) {
 
         custom_code = sb->setting<QString>(MS::Cooling::kPrePauseCode);
         if (!(custom_code.isNull() || custom_code.isEmpty())) {
-            auto custom_code_lines = custom_code.split('\n');
+            auto custom_code_lines       = custom_code.split('\n');
             auto custom_code_lines_count = custom_code_lines.length();
             for (auto i = custom_code_lines_count; i > 0;) {
                 m_lines.insert(insertIndex, custom_code_lines[--i]);
@@ -2156,7 +2100,7 @@ void CommonParser::AddDwell(double dwellTime) {
     else {
         QString custom_code = sb->setting<QString>(MS::Cooling::kPostPauseCode);
         if (!(custom_code.isNull() || custom_code.isEmpty())) {
-            auto custom_code_lines = custom_code.split('\n');
+            auto custom_code_lines       = custom_code.split('\n');
             auto custom_code_lines_count = custom_code_lines.length();
             for (auto i = custom_code_lines_count; i > 0;) {
                 m_lines.insert(insertIndex, custom_code_lines[--i]);
@@ -2171,7 +2115,7 @@ void CommonParser::AddDwell(double dwellTime) {
 
         custom_code = sb->setting<QString>(MS::Cooling::kPrePauseCode);
         if (!(custom_code.isNull() || custom_code.isEmpty())) {
-            auto custom_code_lines = custom_code.split('\n');
+            auto custom_code_lines       = custom_code.split('\n');
             auto custom_code_lines_count = custom_code_lines.length();
             for (auto i = custom_code_lines_count; i > 0;) {
                 m_lines.insert(insertIndex, custom_code_lines[--i]);
@@ -2195,11 +2139,9 @@ void CommonParser::getMinMaxModifier(double& minModifier, double& maxModifier) {
             double value = m_command_modal_feedrates.value(command.getLineNumber(), 0.0);
             if (value <= 0 && command.getParameters().contains(m_f_parameter.toLatin1())) {
                 const QRegularExpressionMatch match = m_f_param_and_value.match(m_lines[command.getLineNumber()]);
-                if (match.hasMatch())
-                    value = match.captured().mid(1).toDouble();
+                if (match.hasMatch()) value = match.captured().mid(1).toDouble();
             }
-            if (value <= 0)
-                continue;
+            if (value <= 0) continue;
 
             minFeedRate = std::min(minFeedRate, value);
             maxFeedRate = std::max(maxFeedRate, value);
@@ -2225,15 +2167,15 @@ void CommonParser::AdjustFeedrate(double modifier) {
             }
 
             double tempModifier = modifier;
-            auto parameters = command.getParameters();
+            auto parameters     = command.getParameters();
             if (parameters.contains(m_q_parameter.toLatin1()) &&
-                command.getCommandID() != 5) // G5 also used the Q param, so spline are not supported
-                                             // by syntaxes that use it for spindle control
+                command.getCommandID() != 5)  // G5 also used the Q param, so spline are not supported
+                                              // by syntaxes that use it for spindle control
             {
-                QString& line = m_lines[command.getLineNumber()];
+                QString& line                   = m_lines[command.getLineNumber()];
                 QRegularExpressionMatch myMatch = m_q_param_and_value.match(line);
-                double value = myMatch.captured().mid(1).toDouble();
-                double extruderModifier = sb->setting<double>(MS::Cooling::kExtruderScaleFactor);
+                double value                    = myMatch.captured().mid(1).toDouble();
+                double extruderModifier         = sb->setting<double>(MS::Cooling::kExtruderScaleFactor);
                 // If slowing down, the multiplier for the extruder should be the inverse of the scale factor
                 if (modifier < 1) {
                     extruderModifier = 1 / extruderModifier;
@@ -2257,10 +2199,10 @@ void CommonParser::AdjustFeedrate(double modifier) {
             }
             if (parameters.contains(m_s_parameter.toLatin1()) &&
                 !sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight)) {
-                QString& line = m_lines[command.getLineNumber()];
+                QString& line                   = m_lines[command.getLineNumber()];
                 QRegularExpressionMatch myMatch = m_s_param_and_value.match(line);
-                double value = myMatch.captured().mid(1).toDouble();
-                double extruderModifier = sb->setting<double>(MS::Cooling::kExtruderScaleFactor);
+                double value                    = myMatch.captured().mid(1).toDouble();
+                double extruderModifier         = sb->setting<double>(MS::Cooling::kExtruderScaleFactor);
                 // If slowing down, the multiplier for the extruder should be the inverse of the scale factor
                 if (modifier < 1) {
                     extruderModifier = 1 / extruderModifier;
@@ -2290,7 +2232,7 @@ void CommonParser::AdjustFeedrate(double modifier) {
 
                     if (line.startsWith("M3 ")) {
                         QRegularExpressionMatch myMatch = m_s_param_and_value.match(line);
-                        double value = myMatch.captured().mid(1).toDouble();
+                        double value                    = myMatch.captured().mid(1).toDouble();
 
                         if (value != 0) {
                             double extruderModifier = sb->setting<double>(MS::Cooling::kExtruderScaleFactor);
@@ -2327,7 +2269,7 @@ void CommonParser::AdjustFeedrate(double modifier) {
                         // Handle the case where the line starts with "EXTRUDER("
                         static const QRegularExpression extruderPattern("EXTRUDER\\((\\d+\\.?\\d*)\\)");
                         const QRegularExpressionMatch extruderMatch = extruderPattern.match(line);
-                        double extruderValue = 0.0; // Default value if no match is found
+                        double extruderValue                        = 0.0;  // Default value if no match is found
                         if (extruderMatch.hasMatch()) {
                             const double extruderValue = extruderMatch.captured(1).toDouble();
                             if (extruderValue != 0.0) {
@@ -2368,14 +2310,12 @@ void CommonParser::AdjustFeedrate(double modifier) {
                 }
 
                 QString& line = m_lines[command.getLineNumber()];
-                double value = m_command_modal_feedrates.value(command.getLineNumber(), 0.0);
+                double value  = m_command_modal_feedrates.value(command.getLineNumber(), 0.0);
                 if (value <= 0) {
                     const QRegularExpressionMatch match = m_f_param_and_value.match(line);
-                    if (match.hasMatch())
-                        value = match.captured().mid(1).toDouble();
+                    if (match.hasMatch()) value = match.captured().mid(1).toDouble();
                 }
-                if (value <= 0)
-                    continue;
+                if (value <= 0) continue;
 
                 setCommandFeedrate(line, value * tempModifier);
                 command.addParameter(m_f_parameter.toLatin1(), parameters[m_f_parameter.toLatin1()] * tempModifier);
@@ -2391,24 +2331,16 @@ QString CommonParser::removeRotations(QString currentLine) {
     QString xval, yval, zval, velocity, feedrate, newLine, temp, comment;
 
     if (currentLine.startsWith(G0) || currentLine.startsWith(G1)) {
-        temp = currentLine.mid(0, currentLine.indexOf(getCommentStartDelimiter()));
+        temp    = currentLine.mid(0, currentLine.indexOf(getCommentStartDelimiter()));
         comment = currentLine.mid(currentLine.indexOf(getCommentStartDelimiter()), currentLine.indexOf(newline));
     }
-    else {
-        return currentLine;
-    }
+    else { return currentLine; }
 
     QVector<QString> params = temp.split(space);
 
-    if (params[0] == G1) {
-        newLine = "G1 ";
-    }
-    else if (params[0] == G0) {
-        newLine = "G0 ";
-    }
-    else {
-        return currentLine;
-    }
+    if (params[0] == G1) { newLine = "G1 "; }
+    else if (params[0] == G0) { newLine = "G0 "; }
+    else { return currentLine; }
 
     for (int i = 1, end = params.size(); i < end; ++i) {
         if (params[i].startsWith(RX) || params[i].startsWith(RY) || params[i].startsWith(RZ) ||
@@ -2452,5 +2384,7 @@ void CommonParser::throwIntegerConversionErrorException() {
     throw IllegalParameterException(exceptionString);
 }
 
-void CommonParser::setDepositionActive(bool on) { m_deposition_active = on; }
-} // namespace ORNL
+void CommonParser::setDepositionActive(bool on) {
+    m_deposition_active = on;
+}
+}  // namespace ORNL

--- a/src/gcode/parsers/marlin_parser.cpp
+++ b/src/gcode/parsers/marlin_parser.cpp
@@ -1,8 +1,8 @@
 #include "gcode/parsers/marlin_parser.h"
 
+#include <QString>
 #include <functional>
 
-#include <QString>
 #include <qcontainerfwd.h>
 #include <qlatin1stringview.h>
 
@@ -14,7 +14,7 @@ MarlinParser::MarlinParser(GcodeMeta meta, bool allowLayerAlter, QStringList& li
     : CommonParser(meta, allowLayerAlter, lines, upperLines) {
     config();
 
-    m_home_string = QLatin1String("X0 Y0 Z0");
+    m_home_string     = QLatin1String("X0 Y0 Z0");
     m_home_parameters = m_home_string.split(' ');
 }
 
@@ -40,5 +40,7 @@ void MarlinParser::G92Handler(QVector<QString> params) {
 }
 
 // M83 ; use relative distances for extrusion
-void MarlinParser::M83Handler(QVector<QString> params) { m_e_absolute = false; }
-} // namespace ORNL
+void MarlinParser::M83Handler(QVector<QString> params) {
+    m_e_absolute = false;
+}
+}  // namespace ORNL

--- a/src/gcode/parsers/mazak_parser.cpp
+++ b/src/gcode/parsers/mazak_parser.cpp
@@ -1,8 +1,8 @@
 #include "gcode/parsers/mazak_parser.h"
 
+#include <QStringBuilder>
 #include <functional>
 
-#include <QStringBuilder>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 
@@ -12,7 +12,7 @@
 namespace ORNL {
 MazakParser::MazakParser(GcodeMeta meta, bool allowLayerAlter, QStringList& lines, QStringList& upperLines)
     : CommonParser(meta, allowLayerAlter, lines, upperLines) {
-    m_f_parameter = QChar('F');
+    m_f_parameter        = QChar('F');
     m_feedrate_reference = "#981";
     config();
 }
@@ -43,21 +43,19 @@ void MazakParser::G1Handler(QVector<QString> params) {
 
 // G441 (Turn Laser ON)
 void MazakParser::G441Handler(QVector<QString> params) {
-    if (!params.empty()) {
-        return;
-    }
+    if (!params.empty()) { return; }
 
     m_deposition_active = true;
 }
 
 // G442 (LASER OFF)
 void MazakParser::G442Handler(QVector<QString> params) {
-    if (!params.empty()) {
-        return;
-    }
+    if (!params.empty()) { return; }
 
     m_deposition_active = false;
 }
 
-void MazakParser::FeedRateHandler(QVector<QString> params) { m_feedrate = "F" % params[1]; }
-} // namespace ORNL
+void MazakParser::FeedRateHandler(QVector<QString> params) {
+    m_feedrate = "F" % params[1];
+}
+}  // namespace ORNL

--- a/src/gcode/parsers/mvp_parser.cpp
+++ b/src/gcode/parsers/mvp_parser.cpp
@@ -1,11 +1,11 @@
 #include "gcode/parsers/mvp_parser.h"
 
-#include <functional>
-
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
 #include <QVector>
+#include <functional>
+
 #include <qcontainerfwd.h>
 
 #include "gcode/gcode_meta.h"
@@ -29,4 +29,4 @@ void MVPParser::M124Handler(QVector<QString> params) {
     CommonParser::M5Handler(params);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/parser_base.cpp
+++ b/src/gcode/parsers/parser_base.cpp
@@ -1,14 +1,14 @@
 #include "gcode/parsers/parser_base.h"
 
-#include <algorithm>
-#include <functional>
-#include <string>
-
 #include <QDebug>
 #include <QRegularExpressionMatch>
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
+#include <algorithm>
+#include <functional>
+#include <string>
+
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qnamespace.h>
@@ -19,7 +19,7 @@
 namespace ORNL {
 ParserBase::ParserBase() {
     m_block_split_delimiter = QRegularExpression("[\\(*\\)*\\,*\\s]|/");
-    m_leading_colon = QChar(':');
+    m_leading_colon         = QChar(':');
     m_beginning_layer_matcher.setPattern("BEGINNING LAYER");
     m_layer_pattern = QRegularExpression("W*(\\d+)W*");
 }
@@ -46,9 +46,7 @@ GcodeCommand ParserBase::parseCommand(QString command_string, int line_number) {
     if (command_string_split.isEmpty()) {
         if (m_beginning_layer_matcher.indexIn(m_current_gcode_command.getComment()) != -1) {
             auto match = m_layer_pattern.match(m_current_gcode_command.getComment());
-            if (match.hasMatch() && match.captured(0).toInt() > 0) {
-                m_current_gcode_command.setEndOfLayer(true);
-            }
+            if (match.hasMatch() && match.captured(0).toInt() > 0) { m_current_gcode_command.setEndOfLayer(true); }
         }
 
         return m_current_gcode_command;
@@ -58,9 +56,8 @@ GcodeCommand ParserBase::parseCommand(QString command_string, int line_number) {
     // for later matching.  Must have QString to match in hash so no need to keep ref.
     // However, all other parameters can remain as ref.
     std::string stdCommand = command_string_split[0].toStdString();
-    int firstNonZero = std::min(stdCommand.find_first_not_of('0', 1), stdCommand.size() - 1);
-    if (firstNonZero != 1)
-        stdCommand.erase(1, firstNonZero);
+    int firstNonZero       = std::min(stdCommand.find_first_not_of('0', 1), stdCommand.size() - 1);
+    if (firstNonZero != 1) stdCommand.erase(1, firstNonZero);
     QString command = QString::fromStdString(stdCommand);
 
     QHash<QString, std::function<void(QVector<QString>)>>::iterator temp_iter;
@@ -88,27 +85,27 @@ void ParserBase::resetInternalState() {
 }
 
 void ParserBase::addCommandMapping(QString command_string, std::function<void(QVector<QString>)> function_handle) {
-    if (m_command_mapping.contains(command_string))
-        m_command_mapping.remove(command_string);
+    if (m_command_mapping.contains(command_string)) m_command_mapping.remove(command_string);
 
     m_command_mapping.insert(command_string, function_handle);
 }
 
 void ParserBase::setBlockCommentDelimiters(const QString beginning_delimiter, const QString ending_delimiter) {
     m_block_comment_starting_delimiter = beginning_delimiter;
-    m_block_comment_ending_delimiter = ending_delimiter;
+    m_block_comment_ending_delimiter   = ending_delimiter;
     m_block_comment_starting_delimiter_matcher.setPattern(beginning_delimiter);
     m_block_comment_ending_delimiter_matcher.setPattern(ending_delimiter);
 }
 
 bool ParserBase::startsWithDelimiter(QString& str) {
-    if (m_block_comment_starting_delimiter_matcher.indexIn(str) == 0)
-        return true;
+    if (m_block_comment_starting_delimiter_matcher.indexIn(str) == 0) return true;
 
     return false;
 }
 
-void ParserBase::setLineCommentString(const QString line_comment) { m_line_comment = line_comment; }
+void ParserBase::setLineCommentString(const QString line_comment) {
+    m_line_comment = line_comment;
+}
 
 void ParserBase::extractComments(QString& command) {
     int start_index = m_block_comment_starting_delimiter_matcher.indexIn(command);
@@ -125,9 +122,7 @@ void ParserBase::extractComments(QString& command) {
                                               << "With GCode command string: " << getCurrentCommandString();
                 throw IllegalParameterException(exceptionString);
             }
-            else {
-                end_index = end_index - start_index - m_block_comment_ending_delimiter.size();
-            }
+            else { end_index = end_index - start_index - m_block_comment_ending_delimiter.size(); }
         }
 
         QString comment(command.mid(start_index + m_block_comment_starting_delimiter.size(), end_index));
@@ -154,9 +149,7 @@ QString ParserBase::parseComment(QString& line) {
                                           << "With GCode command string: " << getCurrentCommandString();
             throw IllegalParameterException(exceptionString);
         }
-        else {
-            end_index = end_index - start_index;
-        }
+        else { end_index = end_index - start_index; }
     }
     else
         end_index = line.length() - 1;
@@ -179,11 +172,19 @@ void ParserBase::setCurrentCommand(QString command) {
     }
 }
 
-const QString& ParserBase::getCurrentCommandString() const { return m_current_command_string; }
+const QString& ParserBase::getCurrentCommandString() const {
+    return m_current_command_string;
+}
 
-void ParserBase::setLineNumber(int linenumber) { m_current_gcode_command.setLineNumber(linenumber); }
+void ParserBase::setLineNumber(int linenumber) {
+    m_current_gcode_command.setLineNumber(linenumber);
+}
 
-QString ParserBase::getCommentStartDelimiter() { return m_block_comment_starting_delimiter; }
+QString ParserBase::getCommentStartDelimiter() {
+    return m_block_comment_starting_delimiter;
+}
 
-QString ParserBase::getCommentEndDelimiter() { return m_block_comment_ending_delimiter; }
-} // namespace ORNL
+QString ParserBase::getCommentEndDelimiter() {
+    return m_block_comment_ending_delimiter;
+}
+}  // namespace ORNL

--- a/src/gcode/parsers/siemens_parser.cpp
+++ b/src/gcode/parsers/siemens_parser.cpp
@@ -1,10 +1,10 @@
 #include "gcode/parsers/siemens_parser.h"
 
-#include <functional>
-
 #include <QString>
 #include <QStringList>
 #include <QVector>
+#include <functional>
+
 #include <qcontainerfwd.h>
 
 #include "gcode/gcode_meta.h"
@@ -33,4 +33,4 @@ void SiemensParser::ExtruderOffHandler(QVector<QString> params) {
     // redirect - essentially M5 command
     CommonParser::M5Handler(params);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/parsers/tormach_parser.cpp
+++ b/src/gcode/parsers/tormach_parser.cpp
@@ -21,8 +21,12 @@ void TormachParser::config() {
     addCommandMapping("M65", std::bind(&TormachParser::M65Handler, this, std::placeholders::_1));
 }
 
-void TormachParser::M64Handler(QVector<QString> params) { m_deposition_active = true; }
+void TormachParser::M64Handler(QVector<QString> params) {
+    m_deposition_active = true;
+}
 
-void TormachParser::M65Handler(QVector<QString> params) { m_deposition_active = false; }
+void TormachParser::M65Handler(QVector<QString> params) {
+    m_deposition_active = false;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/adamantine_writer.cpp
+++ b/src/gcode/writers/adamantine_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/adamantine_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
 #include <qvectornd.h>
@@ -22,33 +23,33 @@ QString AdamantineWriter::writeInitialSetup(Distance minimum_x, Distance minimum
     QString rv;
     rv = "Mode" % m_space % "x" % m_space % "y" % m_space % "z" % m_space % "pmod" % m_space % "param\n";
     return rv;
-} // writeInitialSetup
+}  // writeInitialSetup
 
 QString AdamantineWriter::writeBeforeLayer(float min_z, QSharedPointer<SettingsBase> sb) {
     QString rv;
     return rv;
-} // writeBeforeLayer
+}  // writeBeforeLayer
 
 QString AdamantineWriter::writeBeforePart(QVector3D normal) {
     QString rv;
     return rv;
-} // writeBeforePart
+}  // writeBeforePart
 
 QString AdamantineWriter::writeBeforeIsland() {
     QString rv;
     return rv;
-} // writeBeforeIsland
+}  // writeBeforeIsland
 
 QString AdamantineWriter::writeBeforeRegion(RegionType type, int pathSize) {
     QString rv;
     return rv;
-} // writeBeforeRegion
+}  // writeBeforeRegion
 
 QString AdamantineWriter::writeBeforePath(RegionType type) {
     m_region_type = type;
     QString rv;
     return rv;
-} // writeBeforePath
+}  // writeBeforePath
 
 QString AdamantineWriter::writeTravel(Point start_location, Point target_location, TravelLiftType lType,
                                       QSharedPointer<SettingsBase> params) {
@@ -88,7 +89,7 @@ QString AdamantineWriter::writeTravel(Point start_location, Point target_locatio
     // else
     return rv;
 
-} // writeTravel
+}  // writeTravel
 
 QString AdamantineWriter::writeLine(const Point& start_point, const Point& target_point,
                                     const QSharedPointer<SettingsBase> params) {
@@ -106,43 +107,43 @@ QString AdamantineWriter::writeLine(const Point& start_point, const Point& targe
           QString::number(speed.to(m_meta.m_velocity_unit), 'f', 5) % "\n";
     return rv;
 
-} // writeLine
+}  // writeLine
 
 QString AdamantineWriter::writeAfterPath(RegionType type) {
     QString rv;
     return rv;
-} // writeAfterPath
+}  // writeAfterPath
 
 QString AdamantineWriter::writeAfterRegion(RegionType type) {
     QString rv;
     return rv;
-} // writeAfterRegion
+}  // writeAfterRegion
 
 QString AdamantineWriter::writeAfterIsland() {
     QString rv;
     return rv;
-} // writeAfterIsland
+}  // writeAfterIsland
 
 QString AdamantineWriter::writeAfterPart() {
     QString rv;
     rv = "Number of path segments\n" % QString::number(counter);
     return rv;
-} // writeAfterPart
+}  // writeAfterPart
 
 QString AdamantineWriter::writeAfterLayer() {
     QString rv;
     return rv;
-} // writeAfterLayer
+}  // writeAfterLayer
 
 QString AdamantineWriter::writeShutdown() {
     QString rv;
     return rv;
-} // writeShutdown
+}  // writeShutdown
 
 QString AdamantineWriter::writeDwell(Time time) {
     if (time >= 0)
         return QString::number(time.to(m_meta.m_time_unit), 'f', 4);
     else
         return {};
-} // writeDwell
-} // namespace ORNL
+}  // writeDwell
+}  // namespace ORNL

--- a/src/gcode/writers/aerobasic_writer.cpp
+++ b/src/gcode/writers/aerobasic_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/aerobasic_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -25,12 +26,12 @@ QString AeroBasicWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
                                            Distance maximum_y, int num_layers) {
     QString rv;
 
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
 
-    m_first_print = true;
+    m_first_print  = true;
     m_first_travel = true;
-    m_min_z = 0.0f;
+    m_min_z        = 0.0f;
 
     rv += commentLine("Layer height: " %
                       QString::number(m_sb->setting<Distance>(PS::Layer::kLayerHeight).to(m_meta.m_distance_unit)));
@@ -53,8 +54,7 @@ QString AeroBasicWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
     }
 
     // Adds user-defined start code
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -132,8 +132,7 @@ QString AeroBasicWriter::writeTravel(Point start_location, Point target_location
     QString rv;
 
     // Disable extruder for travels
-    if (m_deposition_active)
-        rv += "$DO[0].X=0" % commentLine("Extruder Off for travel");
+    if (m_deposition_active) rv += "$DO[0].X=0" % commentLine("Extruder Off for travel");
 
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
 
@@ -160,7 +159,7 @@ QString AeroBasicWriter::writeTravel(Point start_location, Point target_location
 
     // write the lift
     if (travel_lift_required) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % writeCoordinates(lift_destination) % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               commentSpaceLine("TRAVEL LIFT Z");
@@ -171,7 +170,7 @@ QString AeroBasicWriter::writeTravel(Point start_location, Point target_location
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % writeCoordinates(travel_destination) % m_f % QString::number(speed.to(m_meta.m_velocity_unit)) %
           commentSpaceLine("TRAVEL");
@@ -188,8 +187,7 @@ QString AeroBasicWriter::writeTravel(Point start_location, Point target_location
     }
 
     // Enable extruder after travel
-    if (m_deposition_active)
-        rv += "$DO[0].X=1" % commentLine("Extruder On after travel");
+    if (m_deposition_active) rv += "$DO[0].X=1" % commentLine("Extruder On after travel");
 
     m_first_travel = false;
     return rv;
@@ -199,8 +197,8 @@ QString AeroBasicWriter::writeLine(const Point& start_point, const Point& target
                                    const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     rv += m_G1;
@@ -229,8 +227,8 @@ QString AeroBasicWriter::writeArc(const Point& start_point, const Point& end_poi
                                   const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -248,7 +246,7 @@ QString AeroBasicWriter::writeArc(const Point& start_point, const Point& end_poi
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     rv += m_r % QString::number(Distance(end_point.y()).to(m_meta.m_distance_unit), 'f', 4);
@@ -334,7 +332,9 @@ QString AeroBasicWriter::writeShutdown() {
     return rv;
 }
 
-QString AeroBasicWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString AeroBasicWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString AeroBasicWriter::writeDwell(Time time) {
     if (time > 0)
@@ -357,7 +357,7 @@ QString AeroBasicWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
@@ -371,4 +371,4 @@ QString AeroBasicWriter::writePrime() {
     QString rv;
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/aml3d_writer.cpp
+++ b/src/gcode/writers/aml3d_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/aml3d_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -29,21 +30,19 @@ QString AML3DWriter::writeSettingsHeader(GcodeSyntax syntax) {
 
 QString AML3DWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                        int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_tip_wipe = false;
-    m_min_z = 0.0f;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_tip_wipe          = false;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
         rv += "G1 F120 " % commentLine("SET INITIAL FEEDRATE");
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
         rv += writeDwell(0.25);
     }
 
@@ -68,13 +67,10 @@ QString AML3DWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         rv +=
             writePurge(m_sb->setting<int>(MS::Purge::kInitialScrewRPM), m_sb->setting<int>(MS::Purge::kInitialDuration),
                        m_sb->setting<int>(MS::Purge::kInitialTipWipeDelay));
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -85,7 +81,7 @@ QString AML3DWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
 
 QString AML3DWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     rv += "M1 " % commentLine("OPTIONAL STOP - LAYER CHANGE");
     return rv;
@@ -161,7 +157,7 @@ QString AML3DWriter::writeTravel(Point start_location, Point target_location, Tr
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -175,7 +171,7 @@ QString AML3DWriter::writeTravel(Point start_location, Point target_location, Tr
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
 
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
@@ -186,13 +182,13 @@ QString AML3DWriter::writeTravel(Point start_location, Point target_location, Tr
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     // write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
@@ -205,12 +201,12 @@ QString AML3DWriter::writeTravel(Point start_location, Point target_location, Tr
 
 QString AML3DWriter::writeLine(const Point& start_point, const Point& target_point,
                                const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -266,16 +262,14 @@ QString AML3DWriter::writeArc(const Point& start_point, const Point& end_point, 
                               const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, 0, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -302,7 +296,7 @@ QString AML3DWriter::writeArc(const Point& start_point, const Point& end_point, 
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -322,7 +316,7 @@ QString AML3DWriter::writeScan(Point target_point, Velocity speed, bool on_off) 
 QString AML3DWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -494,8 +488,8 @@ QString AML3DWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -2,11 +2,11 @@
 
 #include <math.h>
 
+#include <QStringBuilder>
 #include <algorithm>
 #include <cmath>
 #include <limits>
 
-#include <QStringBuilder>
 #include <qcontainerfwd.h>
 #include <qsharedpointer.h>
 #include <qvectornd.h>
@@ -50,9 +50,9 @@ static const Distance kStartupWorldApproachZBuffer = 100.0 * mm;
 Point radialLiftedPoint(const Point& point, const QSharedPointer<SettingsBase>& params, Distance lift_height) {
     const double center_x = params->setting<Distance>(kRadialCenterX)();
     const double center_y = params->setting<Distance>(kRadialCenterY)();
-    const double dx = point.x() - center_x;
-    const double dy = point.y() - center_y;
-    const double length = std::hypot(dx, dy);
+    const double dx       = point.x() - center_x;
+    const double dy       = point.y() - center_y;
+    const double length   = std::hypot(dx, dy);
 
     if (length <= std::numeric_limits<double>::epsilon()) {
         // There is no outward radial direction on the cylinder axis.
@@ -73,21 +73,15 @@ double radialDistance(const Point& point, const QSharedPointer<SettingsBase>& pa
 //! @brief Returns the shortest signed angular sweep from start to end.
 double shortestAngularDelta(double start_angle, double end_angle) {
     double delta = end_angle - start_angle;
-    while (delta > M_PI) {
-        delta -= 2.0 * M_PI;
-    }
-    while (delta < -M_PI) {
-        delta += 2.0 * M_PI;
-    }
+    while (delta > M_PI) { delta -= 2.0 * M_PI; }
+    while (delta < -M_PI) { delta += 2.0 * M_PI; }
     return delta;
 }
 
 //! @brief Normalizes an angle in degrees to [0, 360).
 double normalizeDegrees(double degrees) {
     degrees = std::fmod(degrees, 360.0);
-    if (degrees < 0.0) {
-        degrees += 360.0;
-    }
+    if (degrees < 0.0) { degrees += 360.0; }
 
     return degrees;
 }
@@ -102,7 +96,9 @@ constexpr int kDefaultG83Mode = 0;
 constexpr int kMaxG83Mode = 4;
 
 //! @brief Returns a supported G83 mode, falling back to weld-stop-only behavior for invalid input.
-int validatedG83Mode(int mode) { return mode >= kDefaultG83Mode && mode <= kMaxG83Mode ? mode : kDefaultG83Mode; }
+int validatedG83Mode(int mode) {
+    return mode >= kDefaultG83Mode && mode <= kMaxG83Mode ? mode : kDefaultG83Mode;
+}
 
 //! @brief Formats a distance using the output unit declared by the active gcode metadata.
 QString formatDistance(Distance value, Distance unit) {
@@ -110,8 +106,10 @@ QString formatDistance(Distance value, Distance unit) {
 }
 
 //! @brief Formats an angle using the output unit declared by the active gcode metadata.
-QString formatAngle(Angle value, Angle unit) { return QString::number(value.to(unit), 'f', 4) % unit.toString(); }
-} // namespace
+QString formatAngle(Angle value, Angle unit) {
+    return QString::number(value.to(unit), 'f', 4) % unit.toString();
+}
+}  // namespace
 
 ArcSpecialtiesWriter::ArcSpecialtiesWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
     : WriterBase(meta, sb) {}
@@ -131,13 +129,14 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
     const CylindricalPathPattern path_pattern =
         static_cast<CylindricalPathPattern>(m_sb->setting<int>(PS::Slicing::kCylindricalPathPattern));
     const bool cylindrical_mode = slicing_mode == SlicingMode::kCylindrical;
-    const bool helical_mode = path_pattern == CylindricalPathPattern::kHelical;
+    const bool helical_mode     = path_pattern == CylindricalPathPattern::kHelical;
     if (cylindrical_mode) {
         text += commentLine(helical_mode ? "Arc Specialties Helical Slicing Parameters"
                                          : "Arc Specialties Radial Slicing Parameters");
         text += commentLine("Cylindrical Path Pattern: " % toString(path_pattern));
-        text += commentLine("Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
-                            "offset");
+        text += commentLine(
+            "Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
+            "offset");
         text += commentLine(
             "G-Code Coordinate Frame Rotation: X=" %
             formatAngle(m_sb->setting<Angle>(PRS::MachineSetup::kGCodeCoordinateFrameRotationX), m_meta.m_angle_unit) %
@@ -153,10 +152,10 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
         text += commentLine(QString("Initial World Approach Tool Frame Rotation: XR=") %
                             QString::number(kToolFrameXR, 'f', 4) % "deg YR=" % QString::number(kToolFrameYR, 'f', 4) %
                             "deg ZR=" % QString::number(kRapidTravelToolFrameZR, 'f', 4) % "deg");
-        text += commentLine("Initial Approach: TRAFO-off world approach uses cylinder center XY and the greater of "
-                            "part maximum Z and Cylinder Height plus " %
-                            formatDistance(kStartupWorldApproachZBuffer, m_meta.m_distance_unit) %
-                            " before work-object kinematics");
+        text += commentLine(
+            "Initial Approach: TRAFO-off world approach uses cylinder center XY and the greater of "
+            "part maximum Z and Cylinder Height plus " %
+            formatDistance(kStartupWorldApproachZBuffer, m_meta.m_distance_unit) % " before work-object kinematics");
         text += commentLine(
             QString("Cylinder Inner Radius: ") %
             formatDistance(m_sb->setting<Distance>(PS::Slicing::kCylinderInnerRadius), m_meta.m_distance_unit));
@@ -255,8 +254,9 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
     }
     else if (slicing_mode == SlicingMode::kPlanar) {
         text += commentLine("Arc Specialties Planar Slicing Parameters");
-        text += commentLine("Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
-                            "offset");
+        text += commentLine(
+            "Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
+            "offset");
         text += commentLine(QString("Slice Plane Normal: X=") %
                             QString::number(m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalX), 'f', 4) % " Y=" %
                             QString::number(m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalY), 'f', 4) % " Z=" %
@@ -307,10 +307,10 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
 
 QString ArcSpecialtiesWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                                 Distance maximum_y, int num_layers) {
-    m_first_travel = true;
-    m_layer_start = true;
+    m_first_travel                     = true;
+    m_layer_start                      = true;
     m_absolute_arc_center_mode_enabled = usesAbsoluteArcCenters();
-    m_startup_kinematics_written = false;
+    m_startup_kinematics_written       = false;
     m_pending_layer_change.clear();
     setFeedrate(0.0);
 
@@ -368,17 +368,23 @@ QString ArcSpecialtiesWriter::writeLayerChange(uint layer_number) {
 
 QString ArcSpecialtiesWriter::writeBeforeLayer(float min_z, QSharedPointer<SettingsBase> sb) {
     QString rv;
-    m_layer_start = true;
+    m_layer_start  = true;
     m_current_bead = 1;
     m_current_layer++;
     return rv;
 }
 
-QString ArcSpecialtiesWriter::writeBeforePart(QVector3D normal) { return QString(); }
+QString ArcSpecialtiesWriter::writeBeforePart(QVector3D normal) {
+    return QString();
+}
 
-QString ArcSpecialtiesWriter::writeBeforeIsland() { return QString(); }
+QString ArcSpecialtiesWriter::writeBeforeIsland() {
+    return QString();
+}
 
-QString ArcSpecialtiesWriter::writeBeforeRegion(RegionType type, int pathSize) { return QString(); }
+QString ArcSpecialtiesWriter::writeBeforeRegion(RegionType type, int pathSize) {
+    return QString();
+}
 
 QString ArcSpecialtiesWriter::writeBeforePath(RegionType type) {
     m_region_type = type;
@@ -389,14 +395,10 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
                                           QSharedPointer<SettingsBase> params) {
     QString rv;
     Velocity speed = params->setting<Velocity>(PS::Travel::kSpeed);
-    if (speed <= 0) {
-        speed = params->setting<Velocity>(PRS::MachineSpeed::kMaxXYSpeed);
-    }
+    if (speed <= 0) { speed = params->setting<Velocity>(PRS::MachineSpeed::kMaxXYSpeed); }
 
     Velocity lift_speed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
-    if (lift_speed <= 0) {
-        lift_speed = speed;
-    }
+    if (lift_speed <= 0) { lift_speed = speed; }
 
     // Determine if travel length is short enough to keep welder on
     Distance travel_distance = start_location.distance(target_location);
@@ -408,7 +410,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     }
 
     const Distance lift_height = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
-    bool travel_lift_required = lift_height > 0 && lType != TravelLiftType::kNoLift;
+    bool travel_lift_required  = lift_height > 0 && lType != TravelLiftType::kNoLift;
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
         travel_lift_required = false;
     }
@@ -426,41 +428,37 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     auto writeRadialArcTravel = [this, &params, &writeBeginningBead](Point start, Point end,
                                                                      Velocity move_speed) -> QString {
         QString rv;
-        const double center_x = params->setting<Distance>(kRadialCenterX)();
-        const double center_y = params->setting<Distance>(kRadialCenterY)();
+        const double center_x     = params->setting<Distance>(kRadialCenterX)();
+        const double center_y     = params->setting<Distance>(kRadialCenterY)();
         const double start_radius = radialDistance(start, params);
-        const double end_radius = radialDistance(end, params);
+        const double end_radius   = radialDistance(end, params);
 
         if (start_radius <= std::numeric_limits<double>::epsilon() ||
             end_radius <= std::numeric_limits<double>::epsilon()) {
             rv += writeMotion("G00", end, move_speed, params, "TRAVEL");
         }
         else {
-            const double start_angle = std::atan2(start.y() - center_y, start.x() - center_x);
-            const double end_angle = std::atan2(end.y() - center_y, end.x() - center_x);
-            const double delta_angle = shortestAngularDelta(start_angle, end_angle);
-            const int arcs_per_revolution = std::max(1, params->contains(PS::Slicing::kArcsPerRevolution)
-                                                            ? params->setting<int>(PS::Slicing::kArcsPerRevolution)
-                                                            : m_sb->setting<int>(PS::Slicing::kArcsPerRevolution));
+            const double start_angle          = std::atan2(start.y() - center_y, start.x() - center_x);
+            const double end_angle            = std::atan2(end.y() - center_y, end.x() - center_x);
+            const double delta_angle          = shortestAngularDelta(start_angle, end_angle);
+            const int arcs_per_revolution     = std::max(1, params->contains(PS::Slicing::kArcsPerRevolution)
+                                                                ? params->setting<int>(PS::Slicing::kArcsPerRevolution)
+                                                                : m_sb->setting<int>(PS::Slicing::kArcsPerRevolution));
             const double target_segment_angle = (2.0 * M_PI) / static_cast<double>(arcs_per_revolution);
-            const double travel_angle = std::abs(delta_angle);
+            const double travel_angle         = std::abs(delta_angle);
 
-            if (travel_angle <= target_segment_angle) {
-                rv += writeMotion("G00", end, move_speed, params, "TRAVEL");
-            }
+            if (travel_angle <= target_segment_angle) { rv += writeMotion("G00", end, move_speed, params, "TRAVEL"); }
             else {
                 const int segments =
                     std::clamp(static_cast<int>(std::ceil(travel_angle / target_segment_angle)), 2, 180);
 
                 for (int i = 1; i <= segments; ++i) {
-                    const double t = static_cast<double>(i) / static_cast<double>(segments);
-                    const double angle = start_angle + delta_angle * t;
+                    const double t      = static_cast<double>(i) / static_cast<double>(segments);
+                    const double angle  = start_angle + delta_angle * t;
                     const double radius = start_radius + (end_radius - start_radius) * t;
                     Point waypoint(center_x + radius * std::cos(angle), center_y + radius * std::sin(angle),
                                    start.z() + (end.z() - start.z()) * t);
-                    if (i == segments) {
-                        waypoint = end;
-                    }
+                    if (i == segments) { waypoint = end; }
 
                     rv += writeMotion("G00", waypoint, move_speed, params, "TRAVEL ARC");
                 }
@@ -480,9 +478,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     };
 
     auto liftPoint = [this, &params, cylindrical_mode, lift_height](const Point& point) -> Point {
-        if (cylindrical_mode) {
-            return radialLiftedPoint(point, params, lift_height);
-        }
+        if (cylindrical_mode) { return radialLiftedPoint(point, params, lift_height); }
 
         return point + Point::fromQVector3D(getLiftVector(lift_height));
     };
@@ -496,9 +492,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     }
 
     Point travel_destination = target_location;
-    if (travel_lift_required) {
-        travel_destination = liftPoint(target_location);
-    }
+    if (travel_lift_required) { travel_destination = liftPoint(target_location); }
 
     const bool travel_lower_required =
         travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly);
@@ -545,13 +539,9 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
 
     m_layer_start = false;
 
-    if (!m_deposition_active) {
-        rv += writeWelderOn();
-    }
+    if (!m_deposition_active) { rv += writeWelderOn(); }
 
-    if (speed <= 0) {
-        speed = 10.0 * mm / s;
-    }
+    if (speed <= 0) { speed = 10.0 * mm / s; }
 
     rv += writeMotion("G01", target_point, speed, params, printMoveComment());
     return rv;
@@ -559,22 +549,16 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
 
 QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& end_point, const Point& center_point,
                                        const Angle&, const bool& ccw, const QSharedPointer<SettingsBase> params) {
-    if (!m_sb->setting<bool>(PRS::MachineSetup::kSupportG3)) {
-        return writeLine(start_point, end_point, params);
-    }
+    if (!m_sb->setting<bool>(PRS::MachineSetup::kSupportG3)) { return writeLine(start_point, end_point, params); }
 
     QString rv;
     rv += writeStartupKinematics();
     rv += writePendingLayerChange();
 
-    if (!m_deposition_active) {
-        rv += writeWelderOn();
-    }
+    if (!m_deposition_active) { rv += writeWelderOn(); }
 
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    if (speed <= 0) {
-        speed = 10.0 * mm / s;
-    }
+    if (speed <= 0) { speed = 10.0 * mm / s; }
 
     setFeedrate(speed);
     m_layer_start = false;
@@ -626,11 +610,17 @@ QString ArcSpecialtiesWriter::writeAfterPath(RegionType type) {
     return rv;
 }
 
-QString ArcSpecialtiesWriter::writeAfterRegion(RegionType type) { return QString(); }
+QString ArcSpecialtiesWriter::writeAfterRegion(RegionType type) {
+    return QString();
+}
 
-QString ArcSpecialtiesWriter::writeAfterIsland() { return QString(); }
+QString ArcSpecialtiesWriter::writeAfterIsland() {
+    return QString();
+}
 
-QString ArcSpecialtiesWriter::writeAfterPart() { return QString(); }
+QString ArcSpecialtiesWriter::writeAfterPart() {
+    return QString();
+}
 
 QString ArcSpecialtiesWriter::writeAfterLayer() {
     QString layer_code = m_sb->setting<QString>(PRS::GCode::kLayerCodeChange);
@@ -643,9 +633,7 @@ QString ArcSpecialtiesWriter::writeShutdown() {
     if (!m_sb->setting<QString>(PRS::GCode::kEndCode).isEmpty()) {
         rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline;
     }
-    if (m_startup_kinematics_written && m_absolute_arc_center_mode_enabled) {
-        rv += "G164" % m_newline;
-    }
+    if (m_startup_kinematics_written && m_absolute_arc_center_mode_enabled) { rv += "G164" % m_newline; }
     rv += "M49" % commentSpaceLine("ROBOT GO HOME");
     rv += "#CHANNEL INIT [CMDPOS]" % m_newline;
     rv += "M02" % commentSpaceLine("PROGRAM END");
@@ -667,9 +655,7 @@ QString ArcSpecialtiesWriter::writeWelderOn() {
         m_deposition_active = true;
         return rv;
     }
-    else {
-        return QString();
-    }
+    else { return QString(); }
 }
 
 QString ArcSpecialtiesWriter::writeWelderOff(int mode) {
@@ -681,9 +667,7 @@ QString ArcSpecialtiesWriter::writeWelderOff(int mode) {
         m_deposition_active = false;
         return rv;
     }
-    else {
-        return QString();
-    }
+    else { return QString(); }
 }
 
 QString ArcSpecialtiesWriter::writeMotion(const QString& command, const Point& destination, Velocity speed,
@@ -706,9 +690,7 @@ QString ArcSpecialtiesWriter::writeMotion(const QString& command, const Point& d
 }
 
 QString ArcSpecialtiesWriter::writeStartupKinematics() {
-    if (m_startup_kinematics_written) {
-        return QString();
-    }
+    if (m_startup_kinematics_written) { return QString(); }
 
     QString rv;
     rv += "#KIN ID [9]" % m_newline;
@@ -733,9 +715,7 @@ QString ArcSpecialtiesWriter::writeStartupKinematics() {
 }
 
 QString ArcSpecialtiesWriter::writePendingLayerChange() {
-    if (m_pending_layer_change.isEmpty()) {
-        return QString();
-    }
+    if (m_pending_layer_change.isEmpty()) { return QString(); }
 
     m_pending_layer_change.prepend(m_newline);
     QString rv = m_pending_layer_change;
@@ -750,8 +730,8 @@ QString ArcSpecialtiesWriter::writeCoordinates(const Point& destination, const Q
 
 QString ArcSpecialtiesWriter::writeCoordinates(const Point& destination, const QSharedPointer<SettingsBase>& params,
                                                double tool_frame_zr, const Point& cp_reference) {
-    const double ap_output = m_sb->setting<Angle>(PRS::MachineSetup::kAxisA).to(m_meta.m_angle_unit);
-    const double cp_output = Angle(cpAxisForPoint(cp_reference, params) * degree).to(m_meta.m_angle_unit);
+    const double ap_output         = m_sb->setting<Angle>(PRS::MachineSetup::kAxisA).to(m_meta.m_angle_unit);
+    const double cp_output         = Angle(cpAxisForPoint(cp_reference, params) * degree).to(m_meta.m_angle_unit);
     const Point output_destination = rotateGCodeCoordinateFramePoint(destination);
 
     return QString(" X=") % QString::number(Distance(output_destination.x()).to(m_meta.m_distance_unit), 'f', 4) %
@@ -765,7 +745,7 @@ QString ArcSpecialtiesWriter::writeCoordinates(const Point& destination, const Q
 Point ArcSpecialtiesWriter::firstTravelPointAboveTravelLowerDestination(const Point& travel_destination,
                                                                         const Point& travel_lower_destination,
                                                                         Distance travel_lift_height) const {
-    const Point lower_output_destination = rotateGCodeCoordinateFramePoint(travel_lower_destination);
+    const Point lower_output_destination  = rotateGCodeCoordinateFramePoint(travel_lower_destination);
     Point first_travel_output_destination = rotateGCodeCoordinateFramePoint(travel_destination);
     first_travel_output_destination.y(lower_output_destination.y());
     first_travel_output_destination.z(Distance(lower_output_destination.z()) + travel_lift_height);
@@ -784,21 +764,17 @@ Point ArcSpecialtiesWriter::safeStartupWorldApproachPoint(const Point& travel_de
     Distance safe_z(travel_destination.z());
     bool apply_startup_buffer = false;
     if (hasBuildMaximumZ()) {
-        safe_z = getBuildMaximumZ();
+        safe_z               = getBuildMaximumZ();
         apply_startup_buffer = true;
     }
 
     if (isCylindricalSlicingMode()) {
         const Distance cylinder_height = m_sb->setting<Distance>(PS::Slicing::kCylinderHeight);
-        if (cylinder_height > safe_z) {
-            safe_z = cylinder_height;
-        }
+        if (cylinder_height > safe_z) { safe_z = cylinder_height; }
         apply_startup_buffer = apply_startup_buffer || cylinder_height > 0;
     }
 
-    if (apply_startup_buffer) {
-        safe_z += kStartupWorldApproachZBuffer;
-    }
+    if (apply_startup_buffer) { safe_z += kStartupWorldApproachZBuffer; }
     approach.z(static_cast<float>(safe_z()));
 
     return approach;
@@ -831,13 +807,13 @@ double ArcSpecialtiesWriter::cpAxisForPoint(const Point& destination, const QSha
         return normalizeDegrees(m_sb->setting<Angle>(PRS::MachineSetup::kAxisC).to(degree));
     }
 
-    const double center_x = params->setting<Distance>(kRadialCenterX)();
-    const double center_y = params->setting<Distance>(kRadialCenterY)();
+    const double center_x               = params->setting<Distance>(kRadialCenterX)();
+    const double center_y               = params->setting<Distance>(kRadialCenterY)();
     const Point transformed_destination = rotateGCodeCoordinateFramePoint(destination);
-    const Point transformed_center = rotateGCodeCoordinateFramePoint(Point(center_x, center_y, destination.z()));
-    double cp_degrees = std::atan2(transformed_destination.y() - transformed_center.y(),
-                                   transformed_destination.x() - transformed_center.x()) *
-                        180.0 / M_PI;
+    const Point transformed_center      = rotateGCodeCoordinateFramePoint(Point(center_x, center_y, destination.z()));
+    double cp_degrees                   = std::atan2(transformed_destination.y() - transformed_center.y(),
+                                                     transformed_destination.x() - transformed_center.x()) *
+                                          180.0 / M_PI;
 
     if (isHelicalPathPattern()) {
         const HelicalPathHandedness handedness =
@@ -882,4 +858,4 @@ bool ArcSpecialtiesWriter::isCylindricalSlicingMode() const {
     const SlicingMode slicing_mode = static_cast<SlicingMode>(m_sb->setting<int>(PS::Slicing::kSlicingMode));
     return slicing_mode == SlicingMode::kCylindrical;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/cincinnati_writer.cpp
+++ b/src/gcode/writers/cincinnati_writer.cpp
@@ -1,9 +1,9 @@
 #include "gcode/writers/cincinnati_writer.h"
 
+#include <QStringBuilder>
 #include <cmath>
 #include <limits>
 
-#include <QStringBuilder>
 #include <qcontainerfwd.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,29 +19,29 @@
 
 namespace ORNL {
 CincinnatiWriter::CincinnatiWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) : WriterBase(meta, sb) {
-    m_laser_prefix = "G104 P60000 ";
+    m_laser_prefix    = "G104 P60000 ";
     m_laser_delimiter = '|';
-    m_M10 = "M10";
-    m_M11 = "M11";
-    m_M64 = "M64";
-    m_M65 = "M65";
+    m_M10             = "M10";
+    m_M11             = "M11";
+    m_M64             = "M64";
+    m_M65             = "M65";
 }
 
 QString CincinnatiWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                             Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_is_lift = false;
-    m_is_travel = false;
-    m_z_travel = false;
-    m_w_travel = false;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_is_lift           = false;
+    m_is_travel         = false;
+    m_z_travel          = false;
+    m_w_travel          = false;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
@@ -55,9 +55,7 @@ QString CincinnatiWriter::writeInitialSetup(Distance minimum_x, Distance minimum
             rv += "M270 L1 " % commentLine("SET FEEDRATE MULTIPLIER TO 100%");
         }
         rv += "G1 F120 " % commentLine("SET INITIAL FEEDRATE");
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
         rv += writeDwell(0.25);
 
         if (m_sb->setting<int>(PRS::Dimensions::kLayerChangeAxis) != static_cast<int>(LayerChange::kW_only)) {
@@ -68,9 +66,7 @@ QString CincinnatiWriter::writeInitialSetup(Distance minimum_x, Distance minimum
                       " Z0" % commentSpaceLine("LIFT Z FOR SAFETY");
                 setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
             }
-            else {
-                rv += "G0 Z0 " % commentLine("LIFT Z FOR SAFETY");
-            }
+            else { rv += "G0 Z0 " % commentLine("LIFT Z FOR SAFETY"); }
             m_current_z = 0;
         }
     }
@@ -102,9 +98,7 @@ QString CincinnatiWriter::writeInitialSetup(Distance minimum_x, Distance minimum
         rv +=
             writePurge(m_sb->setting<int>(MS::Purge::kInitialScrewRPM), m_sb->setting<int>(MS::Purge::kInitialDuration),
                        m_sb->setting<int>(MS::Purge::kInitialTipWipeDelay));
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
     }
 
     if (m_sb->setting<bool>(PS::LaserScanner::kLaserScanner) &&
@@ -138,9 +132,7 @@ QString CincinnatiWriter::writeInitialSetup(Distance minimum_x, Distance minimum
               commentLine(Constants::RegionTypeStrings::kThermalScan % " - TRANSMIT FILENAME|#TEMPFILENAME#");
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") {
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
-    }
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") { rv += m_sb->setting<QString>(PRS::GCode::kStartCode); }
 
     rv += m_newline;
 
@@ -155,7 +147,7 @@ QString CincinnatiWriter::writeBeforeLayer(float new_min_z, QSharedPointer<Setti
     m_layer_start = true;
 
     const Distance& layer_height = sb->setting<Distance>(PS::Layer::kLayerHeight);
-    m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
+    m_spiral_layer               = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
 
     // Retrieve the slicing plane normal
     QVector3D slicing_vector = {sb->setting<float>(PS::Slicing::kSlicePlaneNormalX),
@@ -173,9 +165,7 @@ QString CincinnatiWriter::writeBeforeLayer(float new_min_z, QSharedPointer<Setti
         slicing_vector == QVector3D(0, 0, 1) && !m_spiral_layer) {
         // Means that a layer doesn't have geometry on it, didn't find a lower point don't want this to affect table
         // height
-        if (new_min_z == std::numeric_limits<float>::max()) {
-            new_min_z = m_min_z;
-        }
+        if (new_min_z == std::numeric_limits<float>::max()) { new_min_z = m_min_z; }
 
         float z_change = (new_min_z - m_min_z);
 
@@ -225,9 +215,13 @@ QString CincinnatiWriter::writeBeforeLayer(float new_min_z, QSharedPointer<Setti
     return rv;
 }
 
-QString CincinnatiWriter::writeBeforePart(QVector3D normal) { return QString(); }
+QString CincinnatiWriter::writeBeforePart(QVector3D normal) {
+    return QString();
+}
 
-QString CincinnatiWriter::writeBeforeIsland() { return QString(); }
+QString CincinnatiWriter::writeBeforeIsland() {
+    return QString();
+}
 
 QString CincinnatiWriter::writeBeforeScan(Point min, Point max, int layer, int boundingBox, Axis axis, Angle angle) {
     QString rv;
@@ -247,25 +241,13 @@ QString CincinnatiWriter::writeBeforeScan(Point min, Point max, int layer, int b
 QString CincinnatiWriter::writeBeforeRegion(RegionType type, int pathSize) {
     QString rv;
     if (!m_spiral_layer || m_first_print) {
-        if (type == RegionType::kPerimeter) {
-            rv += "M12 (PERIMETER SPINDLE ADJUSTMENT)\n";
-        }
-        else if (type == RegionType::kInset) {
-            rv += "M13 (INSET SPINDLE ADJUSTMENT)\n";
-        }
-        else if (type == RegionType::kSkin) {
-            rv += "M15 (SKIN SPINDLE ADJUSTMENT)\n";
-        }
-        else if (type == RegionType::kInfill) {
-            rv += "M14 (INFILL SPINDLE ADJUSTMENT)\n";
-        }
+        if (type == RegionType::kPerimeter) { rv += "M12 (PERIMETER SPINDLE ADJUSTMENT)\n"; }
+        else if (type == RegionType::kInset) { rv += "M13 (INSET SPINDLE ADJUSTMENT)\n"; }
+        else if (type == RegionType::kSkin) { rv += "M15 (SKIN SPINDLE ADJUSTMENT)\n"; }
+        else if (type == RegionType::kInfill) { rv += "M14 (INFILL SPINDLE ADJUSTMENT)\n"; }
         else if (type == RegionType::kSkeleton) {
-            if (m_sb->setting<bool>(PS::Skeleton::kUseSkinMcode)) {
-                rv += "M15 (SKIN SPINDLE ADJUSTMENT)\n";
-            }
-            else {
-                rv += "M13 (INSET SPINDLE ADJUSTMENT)\n";
-            }
+            if (m_sb->setting<bool>(PS::Skeleton::kUseSkinMcode)) { rv += "M15 (SKIN SPINDLE ADJUSTMENT)\n"; }
+            else { rv += "M13 (INSET SPINDLE ADJUSTMENT)\n"; }
         }
     }
     return rv;
@@ -311,9 +293,7 @@ QString CincinnatiWriter::writeBeforePath(RegionType type) {
             }
             rv += writeAcceleration(m_sb->setting<Acceleration>(PRS::Acceleration::kSupport));
         }
-        else {
-            rv += writeAcceleration(m_sb->setting<Acceleration>(PRS::Acceleration::kDefault));
-        }
+        else { rv += writeAcceleration(m_sb->setting<Acceleration>(PRS::Acceleration::kDefault)); }
     }
     return rv;
 }
@@ -323,7 +303,7 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
     QString rv;
 
     Point new_start_location;
-    RegionType rType = params->setting<RegionType>(SS::kRegionType);
+    RegionType rType           = params->setting<RegionType>(SS::kRegionType);
     bool w_active_first_travel = false;
 
     // Determine if travel length is short enough to keep deposition active.
@@ -334,28 +314,20 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
         rv += writeExtruderOn(rType == RegionType::kUnknown ? RegionType::kPerimeter : rType, rpm, params);
     }
 
-    if (m_first_travel) {
-        w_active_first_travel = true;
-    }
+    if (m_first_travel) { w_active_first_travel = true; }
 
     // Use updated start location if this is the first travel
-    if (m_first_travel) {
-        new_start_location = m_start_point;
-    }
-    else {
-        new_start_location = start_location;
-    }
+    if (m_first_travel) { new_start_location = m_start_point; }
+    else { new_start_location = start_location; }
 
     Distance liftDist;
     if (rType == RegionType::kLaserScan) {
         liftDist = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerHeight) -
                    m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerHeightOffset);
     }
-    else {
-        liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
-    }
+    else { liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight); }
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -369,9 +341,9 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        m_is_lift = true;
-        m_is_travel = false;
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        m_is_lift              = true;
+        m_is_travel            = false;
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
             if (m_sb->setting<int>(PRS::Dimensions::kLayerChangeAxis) == static_cast<int>(LayerChange::kW_only)) {
                 rv += m_G1 % m_f %
@@ -385,9 +357,7 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
                       writeCoordinates(lift_destination);
             }
         }
-        else {
-            rv += m_G0 % writeCoordinates(lift_destination);
-        }
+        else { rv += m_G0 % writeCoordinates(lift_destination); }
 
         if (m_w_travel) {
             rv += commentSpaceLine("TRAVEL LOWER W");
@@ -401,31 +371,27 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
 
     // write the travel
     Point travel_destination = target_location;
-    m_is_travel = true;
-    if (m_first_travel) {
-        travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
-    }
+    m_is_travel              = true;
+    if (m_first_travel) { travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)())); }
     else if (travel_lift_required) {
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
     }
 
     if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
         rv += m_G1 % m_f % QString::number(m_sb->setting<Velocity>(PS::Travel::kSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     }
-    else {
-        rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
-    }
+    else { rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL"); }
 
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
-    if (m_first_travel) {       // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel) {        // if this is the first travel
+        m_first_travel = false;  // update for next one
     }
 
     // write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
-        m_is_lift = false;
+        m_is_lift   = false;
         m_is_travel = false;
         if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
             if (m_sb->setting<int>(PRS::Dimensions::kLayerChangeAxis) == static_cast<int>(LayerChange::kW_only)) {
@@ -440,9 +406,7 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
                       writeCoordinates(target_location);
             }
         }
-        else {
-            rv += m_G0 % writeCoordinates(target_location);
-        }
+        else { rv += m_G0 % writeCoordinates(target_location); }
 
         if (m_w_travel) {
             rv += commentSpaceLine("TRAVEL LIFT W");
@@ -463,9 +427,7 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
                       QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
                       m_z % "[#200]" % commentSpaceLine("TRAVEL SET PRINTING Z HEIGHT");
             }
-            else {
-                rv += m_G0 % m_z % "[#200]" % commentSpaceLine("TRAVEL SET PRINTING Z HEIGHT");
-            }
+            else { rv += m_G0 % m_z % "[#200]" % commentSpaceLine("TRAVEL SET PRINTING Z HEIGHT"); }
         }
         else {
             if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
@@ -495,9 +457,7 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
                       QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
                       m_z % "[#200]" % commentSpaceLine("TRAVEL SET PRINTING Z HEIGHT");
             }
-            else {
-                rv += m_G0 % m_z % "[#200]" % commentSpaceLine("TRAVEL SET PRINTING Z HEIGHT");
-            }
+            else { rv += m_G0 % m_z % "[#200]" % commentSpaceLine("TRAVEL SET PRINTING Z HEIGHT"); }
         }
         else {
             if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
@@ -523,12 +483,12 @@ QString CincinnatiWriter::writeTravel(Point start_location, Point target_locatio
 
 QString CincinnatiWriter::writeLine(const Point& start_point, const Point& target_point,
                                     const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -564,9 +524,7 @@ QString CincinnatiWriter::writeLine(const Point& start_point, const Point& targe
         setFeedrate(speed);
         rv += m_f % QString::number(speed.to(m_meta.m_velocity_unit));
 
-        if (!m_sb->setting<int>(MS::Extruder::kEnableM3S)) {
-            rv += m_s % QString::number(output_rpm);
-        }
+        if (!m_sb->setting<int>(MS::Extruder::kEnableM3S)) { rv += m_s % QString::number(output_rpm); }
         m_current_rpm = rpm;
 
         m_layer_start = false;
@@ -600,9 +558,7 @@ QString CincinnatiWriter::writeLine(const Point& start_point, const Point& targe
     }
 
     // Add path modifiers to comments
-    if (path_modifiers != PathModifiers::kNone) {
-        comment += m_space % toString(path_modifiers);
-    }
+    if (path_modifiers != PathModifiers::kNone) { comment += m_space % toString(path_modifiers); }
 
     // Add comment
     rv += commentSpaceLine(comment);
@@ -616,21 +572,19 @@ QString CincinnatiWriter::writeArc(const Point& start_point, const Point& end_po
                                    const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // update the material number if needed
     if (material_number != m_material_number && m_sb->setting<int>(MS::MultiMaterial::kEnable)) {
         if (m_sb->setting<int>(MS::MultiMaterial::kUseM222)) {
             rv += "M222 P" % QString::number(material_number) % commentSpaceLine("CHANGE MATERIAL");
         }
-        else {
-            rv += "M237 L" % QString::number(material_number) % commentSpaceLine("CHANGE MATERIAL");
-        }
+        else { rv += "M237 L" % QString::number(material_number) % commentSpaceLine("CHANGE MATERIAL"); }
         m_material_number = material_number;
     }
 
@@ -642,9 +596,7 @@ QString CincinnatiWriter::writeArc(const Point& start_point, const Point& end_po
         }
     }
 
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     // Update extruder speed if not correct and if M3 S is desired rather than G* S which is issued later
     if (m_sb->setting<int>(MS::Extruder::kEnableM3S) && rpm != m_current_rpm) {
@@ -673,9 +625,7 @@ QString CincinnatiWriter::writeArc(const Point& start_point, const Point& end_po
     if (path_modifiers != PathModifiers::kNone) {
         rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
     }
-    else {
-        rv += commentSpaceLine(toString(region_type));
-    }
+    else { rv += commentSpaceLine(toString(region_type)); }
 
     return rv;
 }
@@ -689,9 +639,7 @@ QString CincinnatiWriter::writeScan(Point target_point, Velocity speed, bool on_
                   Constants::RegionTypeStrings::kLaserScan % " - START|" %
                   QString::number(m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerStepDistance).to(mm), 'f', 4));
     }
-    else {
-        rv += m_laser_prefix % commentLine(Constants::RegionTypeStrings::kLaserScan % " - STOP");
-    }
+    else { rv += m_laser_prefix % commentLine(Constants::RegionTypeStrings::kLaserScan % " - STOP"); }
 
     rv += m_G1 % m_x % QString::number(Distance(target_point.x()).to(m_meta.m_distance_unit), 'f', 4) % m_y %
           QString::number(Distance(target_point.y()).to(m_meta.m_distance_unit), 'f', 4) %
@@ -703,7 +651,7 @@ QString CincinnatiWriter::writeScan(Point target_point, Velocity speed, bool on_
 QString CincinnatiWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(); // update to turn off the extruder
+        rv += writeExtruderOff();  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty()) {
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -738,7 +686,9 @@ QString CincinnatiWriter::writeAfterPath(RegionType type) {
     return rv;
 }
 
-QString CincinnatiWriter::writeAfterRegion(RegionType type) { return QString(); }
+QString CincinnatiWriter::writeAfterRegion(RegionType type) {
+    return QString();
+}
 
 QString CincinnatiWriter::writeAfterScan(Distance beadWidth, Distance laserStep, Distance laserResolution) {
     int xDistance = round((beadWidth.to(mm) / laserStep.to(mm)));
@@ -749,9 +699,13 @@ QString CincinnatiWriter::writeAfterScan(Distance beadWidth, Distance laserStep,
                        m_laser_delimiter % QString::number(yDistance));
 }
 
-QString CincinnatiWriter::writeAfterIsland() { return QString(); }
+QString CincinnatiWriter::writeAfterIsland() {
+    return QString();
+}
 
-QString CincinnatiWriter::writeAfterPart() { return QString(); }
+QString CincinnatiWriter::writeAfterPart() {
+    return QString();
+}
 
 QString CincinnatiWriter::writeAfterLayer() {
     QString rv;
@@ -783,14 +737,12 @@ QString CincinnatiWriter::writeShutdown() {
 
 QString CincinnatiWriter::writeFinalLift() {
     const Distance final_lift = m_sb->setting<Distance>(PS::Travel::kFinalLiftDistance);
-    if (final_lift <= 0 || !hasCurrentPosition()) {
-        return QString();
-    }
+    if (final_lift <= 0 || !hasCurrentPosition()) { return QString(); }
 
     QString rv;
     const Point lift_destination = getCurrentPosition() + getLiftVector(final_lift);
 
-    m_is_lift = true;
+    m_is_lift   = true;
     m_is_travel = false;
 
     if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
@@ -807,16 +759,10 @@ QString CincinnatiWriter::writeFinalLift() {
             setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
         }
     }
-    else {
-        rv += m_G0 % writeCoordinates(lift_destination);
-    }
+    else { rv += m_G0 % writeCoordinates(lift_destination); }
 
-    if (m_w_travel) {
-        rv += commentSpaceLine("TRAVEL FINAL LIFT W");
-    }
-    else {
-        rv += commentSpaceLine("TRAVEL FINAL LIFT Z");
-    }
+    if (m_w_travel) { rv += commentSpaceLine("TRAVEL FINAL LIFT W"); }
+    else { rv += commentSpaceLine("TRAVEL FINAL LIFT Z"); }
 
     setCurrentPosition(lift_destination);
     m_is_lift = false;
@@ -832,9 +778,7 @@ QString CincinnatiWriter::writeDwell(Time time) {
     if (time > 0) {
         return m_G4 % m_p % QString::number(time.to(m_meta.m_time_unit), 'f', 4) % commentSpaceLine("DWELL");
     }
-    else {
-        return QString();
-    }
+    else { return QString(); }
 }
 
 QString CincinnatiWriter::writeTamperOn() {
@@ -842,18 +786,12 @@ QString CincinnatiWriter::writeTamperOn() {
         return m_M64 % m_l % QString::number(m_sb->setting<Voltage>(PRS::Auxiliary::kTamperVoltage).to(V)) %
                commentSpaceLine("TURN TAMPER ON");
     }
-    else {
-        return QString();
-    }
+    else { return QString(); }
 }
 
 QString CincinnatiWriter::writeTamperOff() {
-    if (m_sb->setting<int>(PRS::Auxiliary::kEnableTamper)) {
-        return m_M65 % commentSpaceLine("TURN TAMPER OFF");
-    }
-    else {
-        return QString();
-    }
+    if (m_sb->setting<int>(PRS::Auxiliary::kEnableTamper)) { return m_M65 % commentSpaceLine("TURN TAMPER OFF"); }
+    else { return QString(); }
 }
 
 QString CincinnatiWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPointer<SettingsBase>& params) {
@@ -945,10 +883,9 @@ QString CincinnatiWriter::writeExtruderOff() {
 }
 
 QString CincinnatiWriter::writeAcceleration(Acceleration acc) {
-    float ci_acc = acc.to(m_meta.m_acceleration_unit) / 386.08858; // Convert to units of G
+    float ci_acc = acc.to(m_meta.m_acceleration_unit) / 386.08858;  // Convert to units of G
 
-    if (ci_acc == 0)
-        return QString();
+    if (ci_acc == 0) return QString();
 
     ci_acc = (1 / ci_acc * 1000000 * 25.4 / 162560) / (1000 * 9.81);
     return "M66 L" % QString::number(ci_acc, 'g', 4) % commentSpaceLine("SET ACCELERATION");
@@ -972,7 +909,7 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
     // only output Z/W coordinate if there was a change in Z/W
     Distance temp_dest_z = destination.z();
     Distance temp_last_z = m_last_z;
-    Distance z_offset = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    Distance z_offset    = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
 
     if (m_sb->setting<int>(PRS::Dimensions::kLayerChangeAxis) == static_cast<int>(LayerChange::kZ_only)) {
         // move in Z only
@@ -982,12 +919,12 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
         // to the next.
         if (m_sb->setting<int>(PS::Optimizations::kLayerOrdering) == static_cast<int>(LayerOrdering::kByPart) &&
             m_is_lift == true && (target_z < m_last_z)) {
-            target_z = m_last_z + m_sb->setting<Distance>(PS::Travel::kLiftHeight);
+            target_z  = m_last_z + m_sb->setting<Distance>(PS::Travel::kLiftHeight);
             m_is_lift = false;
         }
         else if (m_sb->setting<int>(PS::Optimizations::kLayerOrdering) == static_cast<int>(LayerOrdering::kByPart) &&
                  m_is_travel == true && (target_z < m_last_z)) {
-            target_z = m_last_z;
+            target_z    = m_last_z;
             m_is_travel = false;
         }
 
@@ -996,12 +933,10 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
                 rv += m_z % "[#200 + " % QString::number(Distance(destination.z()).to(m_meta.m_distance_unit), 'f', 4) %
                       "]";
             }
-            else {
-                rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
-            }
+            else { rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4); }
             m_current_z = target_z;
-            m_last_z = target_z;
-            m_z_travel = true;
+            m_last_z    = target_z;
+            m_z_travel  = true;
         }
     }
     else if (m_sb->setting<int>(PRS::Dimensions::kLayerChangeAxis) == static_cast<int>(LayerChange::kW_only)) {
@@ -1012,23 +947,23 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
         // moving to the next.
         if (m_sb->setting<int>(PS::Optimizations::kLayerOrdering) == static_cast<int>(LayerOrdering::kByPart) &&
             m_is_lift == true && (target_w > m_last_w)) {
-            target_w = m_last_w - m_sb->setting<Distance>(PS::Travel::kLiftHeight);
+            target_w  = m_last_w - m_sb->setting<Distance>(PS::Travel::kLiftHeight);
             m_is_lift = false;
         }
         else if (m_sb->setting<int>(PS::Optimizations::kLayerOrdering) == static_cast<int>(LayerOrdering::kByPart) &&
                  m_is_travel == true && (target_w > m_last_w)) {
-            target_w = m_last_w;
+            target_w    = m_last_w;
             m_is_travel = false;
         }
 
         if (qAbs(target_w - m_last_w) > 10 && !m_first_travel) {
             rv += m_w % QString::number(Distance(target_w).to(m_meta.m_distance_unit), 'f', 4);
             m_current_w = target_w;
-            m_last_w = target_w;
-            m_w_travel = true;
+            m_last_w    = target_w;
+            m_w_travel  = true;
         }
     }
-    else { // Both Z and W
+    else {  // Both Z and W
         if (m_spiral_layer) {
             if (m_first_travel) {
                 // use Z for first travels to lower extruder down - bed is raised to top by the initial setup
@@ -1040,12 +975,10 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
                                               4) %
                               "]";
                     }
-                    else {
-                        rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
-                    }
+                    else { rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4); }
                     m_current_z = target_z;
-                    m_last_z = target_z;
-                    m_z_travel = true;
+                    m_last_z    = target_z;
+                    m_z_travel  = true;
                 }
             }
             else {
@@ -1059,16 +992,14 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
                                               4) %
                               "]";
                     }
-                    else {
-                        rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
-                    }
+                    else { rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4); }
                     m_current_z = target_z;
-                    m_last_z = target_z;
-                    m_z_travel = true;
+                    m_last_z    = target_z;
+                    m_z_travel  = true;
                 }
                 else {
                     m_current_w = target_w;
-                    m_last_w = target_w;
+                    m_last_w    = target_w;
                     rv += m_w % QString::number(Distance(target_w).to(m_meta.m_distance_unit), 'f', 4);
                     m_w_travel = true;
                 }
@@ -1091,15 +1022,13 @@ QString CincinnatiWriter::getZWValue(const Point& destination) {
                           QString::number(Distance(destination.z() + m_current_w).to(m_meta.m_distance_unit), 'f', 4) %
                           "]";
                 }
-                else {
-                    rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
-                }
+                else { rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4); }
                 m_current_z = target_z;
-                m_last_z = target_z;
-                m_z_travel = true;
+                m_last_z    = target_z;
+                m_z_travel  = true;
             }
         }
     }
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/dmg_dmu_writer.cpp
+++ b/src/gcode/writers/dmg_dmu_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/dmg_dmu_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ DMGDMUWriter::DMGDMUWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& s
 
 QString DMGDMUWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                         int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "G40 G17 G71 G90" % m_newline % "G500" % m_newline % "G64" % m_newline % "M56" % m_newline % "STOPRE" %
@@ -53,8 +54,7 @@ QString DMGDMUWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -65,7 +65,7 @@ QString DMGDMUWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
 
 QString DMGDMUWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -125,7 +125,7 @@ QString DMGDMUWriter::writeTravel(Point start_location, Point target_location, T
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -139,7 +139,7 @@ QString DMGDMUWriter::writeTravel(Point start_location, Point target_location, T
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -149,7 +149,7 @@ QString DMGDMUWriter::writeTravel(Point start_location, Point target_location, T
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -160,26 +160,24 @@ QString DMGDMUWriter::writeTravel(Point start_location, Point target_location, T
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString DMGDMUWriter::writeLine(const Point& start_point, const Point& target_point,
                                 const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -222,17 +220,15 @@ QString DMGDMUWriter::writeArc(const Point& start_point, const Point& end_point,
                                const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -258,7 +254,7 @@ QString DMGDMUWriter::writeArc(const Point& start_point, const Point& end_point,
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -420,9 +416,9 @@ QString DMGDMUWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/gudel_writer.cpp
+++ b/src/gcode/writers/gudel_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/gudel_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ GudelWriter::GudelWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
 
 QString GudelWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                        int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "TRAORI" % m_newline % "FFWON" % m_newline % "SOFT" % m_newline % "G642" % m_newline % "G54" % m_newline;
@@ -49,8 +50,7 @@ QString GudelWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -61,7 +61,7 @@ QString GudelWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
 
 QString GudelWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -121,7 +121,7 @@ QString GudelWriter::writeTravel(Point start_location, Point target_location, Tr
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -135,7 +135,7 @@ QString GudelWriter::writeTravel(Point start_location, Point target_location, Tr
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -145,7 +145,7 @@ QString GudelWriter::writeTravel(Point start_location, Point target_location, Tr
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -156,26 +156,24 @@ QString GudelWriter::writeTravel(Point start_location, Point target_location, Tr
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString GudelWriter::writeLine(const Point& start_point, const Point& target_point,
                                const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -218,12 +216,12 @@ QString GudelWriter::writeArc(const Point& start_point, const Point& end_point, 
                               const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -248,7 +246,7 @@ QString GudelWriter::writeArc(const Point& start_point, const Point& end_point, 
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -406,9 +404,9 @@ QString GudelWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/haas_metric_no_comments_writer.cpp
+++ b/src/gcode/writers/haas_metric_no_comments_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/haas_metric_no_comments_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -20,15 +21,15 @@ HaasMetricNoCommentsWriter::HaasMetricNoCommentsWriter(GcodeMeta meta, const QSh
 
 QString HaasMetricNoCommentsWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                                       Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "M06 T2" % m_newline % "G90G00G54X0.Y0." % m_newline % "G43H2Z100." % m_newline;
@@ -49,8 +50,7 @@ QString HaasMetricNoCommentsWriter::writeInitialSetup(Distance minimum_x, Distan
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -61,7 +61,7 @@ QString HaasMetricNoCommentsWriter::writeInitialSetup(Distance minimum_x, Distan
 
 QString HaasMetricNoCommentsWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -127,7 +127,7 @@ QString HaasMetricNoCommentsWriter::writeTravel(Point start_location, Point targ
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -141,7 +141,7 @@ QString HaasMetricNoCommentsWriter::writeTravel(Point start_location, Point targ
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % m_newline;
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -151,7 +151,7 @@ QString HaasMetricNoCommentsWriter::writeTravel(Point start_location, Point targ
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % m_newline;
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -162,30 +162,26 @@ QString HaasMetricNoCommentsWriter::writeTravel(Point start_location, Point targ
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString HaasMetricNoCommentsWriter::writeLine(const Point& start_point, const Point& target_point,
                                               const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed         = params->setting<Velocity>(SS::kSpeed);
+    int rpm                = params->setting<int>(SS::kExtruderSpeed);
     RegionType region_type = params->setting<RegionType>(SS::kRegionType);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm       = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     // turn off extruder with an M5 before the line, rather than in-line with S0
-    if (rpm == 0 && m_deposition_active == true) {
-        rv += writeExtruderOff();
-    }
+    if (rpm == 0 && m_deposition_active == true) { rv += writeExtruderOff(); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -224,17 +220,15 @@ QString HaasMetricNoCommentsWriter::writeArc(const Point& start_point, const Poi
                                              const Point& center_point, const Angle& angle, const bool& ccw,
                                              const QSharedPointer<SettingsBase> params) {
     QString rv;
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -260,7 +254,7 @@ QString HaasMetricNoCommentsWriter::writeArc(const Point& start_point, const Poi
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -338,7 +332,9 @@ QString HaasMetricNoCommentsWriter::writeShutdown() {
     return rv;
 }
 
-QString HaasMetricNoCommentsWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString HaasMetricNoCommentsWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString HaasMetricNoCommentsWriter::writeDwell(Time time) {
     if (time > 0)
@@ -427,9 +423,9 @@ QString HaasMetricNoCommentsWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/haas_writer.cpp
+++ b/src/gcode/writers/haas_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/haas_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,16 +20,16 @@ HaasWriter::HaasWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) :
 
 QString HaasWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                       int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
-    m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
-    m_tool_number = m_sb->setting<int>(Constants::PrinterSettings::MachineSetup::kToolNumber);
+    m_current_z          = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w          = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm        = 0;
+    m_deposition_active  = false;
+    m_first_travel       = true;
+    m_first_print        = true;
+    m_layer_start        = true;
+    m_min_z              = 0.0f;
+    m_material_number    = -1;
+    m_tool_number        = m_sb->setting<int>(Constants::PrinterSettings::MachineSetup::kToolNumber);
     Distance tool_offset = 100000;
 
     QString rv;
@@ -57,8 +58,7 @@ QString HaasWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -69,7 +69,7 @@ QString HaasWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
 
 QString HaasWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -135,7 +135,7 @@ QString HaasWriter::writeTravel(Point start_location, Point target_location, Tra
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -149,7 +149,7 @@ QString HaasWriter::writeTravel(Point start_location, Point target_location, Tra
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -159,7 +159,7 @@ QString HaasWriter::writeTravel(Point start_location, Point target_location, Tra
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -170,31 +170,27 @@ QString HaasWriter::writeTravel(Point start_location, Point target_location, Tra
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString HaasWriter::writeLine(const Point& start_point, const Point& target_point,
                               const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     // turn off extruder with an M5 before the line, rather than in-line with S0
-    if (rpm == 0 && m_deposition_active == true) {
-        rv += writeExtruderOff();
-    }
+    if (rpm == 0 && m_deposition_active == true) { rv += writeExtruderOff(); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -237,17 +233,15 @@ QString HaasWriter::writeArc(const Point& start_point, const Point& end_point, c
                              const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -273,7 +267,7 @@ QString HaasWriter::writeArc(const Point& start_point, const Point& end_point, c
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -442,9 +436,9 @@ QString HaasWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/hurco_writer.cpp
+++ b/src/gcode/writers/hurco_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/hurco_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ HurcoWriter::HurcoWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
 
 QString HurcoWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                        int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "T2M6" % m_newline % "G00G90G21" % m_newline % "G54" % m_newline % "(toolbegin)" % m_newline % "T2" %
@@ -51,8 +52,7 @@ QString HurcoWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -63,7 +63,7 @@ QString HurcoWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
 
 QString HurcoWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -129,7 +129,7 @@ QString HurcoWriter::writeTravel(Point start_location, Point target_location, Tr
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -143,7 +143,7 @@ QString HurcoWriter::writeTravel(Point start_location, Point target_location, Tr
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -153,7 +153,7 @@ QString HurcoWriter::writeTravel(Point start_location, Point target_location, Tr
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -164,26 +164,24 @@ QString HurcoWriter::writeTravel(Point start_location, Point target_location, Tr
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString HurcoWriter::writeLine(const Point& start_point, const Point& target_point,
                                const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -226,17 +224,15 @@ QString HurcoWriter::writeArc(const Point& start_point, const Point& end_point, 
                               const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -262,7 +258,7 @@ QString HurcoWriter::writeArc(const Point& start_point, const Point& end_point, 
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -430,9 +426,9 @@ QString HurcoWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/ingersoll_writer.cpp
+++ b/src/gcode/writers/ingersoll_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/ingersoll_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -20,14 +21,14 @@ IngersollWriter::IngersollWriter(GcodeMeta meta, const QSharedPointer<SettingsBa
 
 QString IngersollWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                            Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
 
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
@@ -52,8 +53,7 @@ QString IngersollWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
 
     if (m_sb->setting<int>(PRS::GCode::kEnableMaterialLoad)) {}
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -64,7 +64,7 @@ QString IngersollWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
 
 QString IngersollWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -135,7 +135,7 @@ QString IngersollWriter::writeTravel(Point start_location, Point target_location
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -149,15 +149,13 @@ QString IngersollWriter::writeTravel(Point start_location, Point target_location
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
             rv += m_G1 % m_f %
                   QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
                   writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         }
-        else {
-            rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
-        }
+        else { rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z"); }
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
@@ -166,15 +164,13 @@ QString IngersollWriter::writeTravel(Point start_location, Point target_location
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     if (m_sb->setting<int>(PRS::MachineSetup::kForceG1)) {
         rv += m_G1 % m_f % QString::number(m_sb->setting<Velocity>(PS::Travel::kSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(travel_destination);
     }
-    else {
-        rv += m_G0 % writeCoordinates(travel_destination);
-    }
+    else { rv += m_G0 % writeCoordinates(travel_destination); }
 
     rv += commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -186,26 +182,24 @@ QString IngersollWriter::writeTravel(Point start_location, Point target_location
                   QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
                   writeCoordinates(target_location) % commentSpaceLine("TRAVEL LOWER Z");
         }
-        else {
-            rv += m_G0 % writeCoordinates(target_location) % commentSpaceLine("TRAVEL LOWER Z");
-        }
+        else { rv += m_G0 % writeCoordinates(target_location) % commentSpaceLine("TRAVEL LOWER Z"); }
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString IngersollWriter::writeLine(const Point& start_point, const Point& target_point,
                                    const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    float rpm = params->setting<float>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    float rpm                    = params->setting<float>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -245,16 +239,14 @@ QString IngersollWriter::writeArc(const Point& start_point, const Point& end_poi
                                   const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, 0, params); }
     // Update extruder speed if needed
     if (m_deposition_active && rpm != m_current_rpm) {
         rv += "EXTRUDER(" % QString::number(output_rpm) % ")" % commentSpaceLine("UPDATE EXTRUDER RPM");
@@ -290,7 +282,7 @@ QString IngersollWriter::writeScan(Point target_point, Velocity speed, bool on_o
 QString IngersollWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -325,7 +317,9 @@ QString IngersollWriter::writeAfterRegion(RegionType type) {
     return rv;
 }
 
-QString IngersollWriter::writeAfterScan(Distance beadWidth, Distance laserStep, Distance laserResolution) { return {}; }
+QString IngersollWriter::writeAfterScan(Distance beadWidth, Distance laserStep, Distance laserResolution) {
+    return {};
+}
 
 QString IngersollWriter::writeAfterIsland() {
     QString rv;
@@ -356,12 +350,14 @@ QString IngersollWriter::writeShutdown() {
             return QString(m_G0 % writeCoordinates(destination));
         },
         "TRAVEL FINAL LIFT Z");
-    rv += writeExtruderOff(0); // update to turn off the extruder
+    rv += writeExtruderOff(0);  // update to turn off the extruder
     rv += m_sb->setting<QString>(PRS::GCode::kEndCode);
     return rv;
 }
 
-QString IngersollWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString IngersollWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString IngersollWriter::writeDwell(Time time) {
     if (time > 0)
@@ -447,9 +443,9 @@ QString IngersollWriter::getZWValue(const Point& destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/juggerbot_writer.cpp
+++ b/src/gcode/writers/juggerbot_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/juggerbot_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ JuggerBotWriter::JuggerBotWriter(GcodeMeta meta, const QSharedPointer<SettingsBa
 
 QString JuggerBotWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                            Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_current_bead_area = 0;
     m_deposition_active = false;
-    m_material_number = -1;
-    m_first_print = true;
-    m_first_travel = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_material_number   = -1;
+    m_first_print       = true;
+    m_first_travel      = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "G29" % commentSpaceLine("ENABLE BED COMPENSATION");
@@ -53,8 +54,7 @@ QString JuggerBotWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -65,7 +65,7 @@ QString JuggerBotWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
 
 QString JuggerBotWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -130,10 +130,10 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
     }
     else if (travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
         RegionType region_type = params->setting<RegionType>(SS::kRegionType);
-        int rpm = params->contains(SS::kExtruderSpeed) ? params->setting<int>(SS::kExtruderSpeed)
-                                                       : m_sb->setting<int>(PS::Perimeter::kExtruderSpeed);
-        Distance width = params->contains(SS::kWidth) ? params->setting<Distance>(SS::kWidth)
-                                                      : m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
+        int rpm         = params->contains(SS::kExtruderSpeed) ? params->setting<int>(SS::kExtruderSpeed)
+                                                               : m_sb->setting<int>(PS::Perimeter::kExtruderSpeed);
+        Distance width  = params->contains(SS::kWidth) ? params->setting<Distance>(SS::kWidth)
+                                                       : m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
         Distance height = params->contains(SS::kHeight) ? params->setting<Distance>(SS::kHeight)
                                                         : m_sb->setting<Distance>(PS::Layer::kLayerHeight);
         rv += writeExtruderOn(region_type == RegionType::kUnknown ? RegionType::kPerimeter : region_type, rpm, width,
@@ -150,7 +150,7 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
 
     Distance liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -163,7 +163,7 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
 
     // write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % " F" %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
@@ -173,7 +173,7 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % " F" % QString::number(speed.to(m_meta.m_velocity_unit)) % writeCoordinates(travel_destination) %
           commentSpaceLine("TRAVEL");
@@ -187,24 +187,24 @@ QString JuggerBotWriter::writeTravel(Point start_location, Point target_location
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString JuggerBotWriter::writeLine(const Point& start_point, const Point& target_point,
                                    const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
-    Distance width = params->setting<Distance>(SS::kWidth);
-    Distance height = params->setting<Distance>(SS::kHeight);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    Distance width               = params->setting<Distance>(SS::kWidth);
+    Distance height              = params->setting<Distance>(SS::kHeight);
     Area bead_area = (width - height) * height +
-                     (pi() * (height / 2) * (height / 2)); // Rectangle with two half circles used as cross-section
+                     (pi() * (height / 2) * (height / 2));  // Rectangle with two half circles used as cross-section
 
     QString rv;
 
@@ -217,7 +217,7 @@ QString JuggerBotWriter::writeLine(const Point& start_point, const Point& target
     // determine if writeExtruderOn is necessary
     bool requiresWriteExtruderOn = !m_deposition_active;
 
-    if (requiresWriteExtruderOn && rpm > 0) // && !m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight))
+    if (requiresWriteExtruderOn && rpm > 0)  // && !m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight))
     {
         rv += writeExtruderOn(region_type, rpm, width, height, params);
         // m_current_rpm = rpm;
@@ -228,7 +228,7 @@ QString JuggerBotWriter::writeLine(const Point& start_point, const Point& target
         rv += m_M3 % m_s % QString::number(output_rpm) % commentSpaceLine("UPDATE EXTRUDER RPM");
         m_current_rpm = rpm;
     }
-    else if (rpm != m_current_rpm && rpm == 0) // && !m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight))
+    else if (rpm != m_current_rpm && rpm == 0)  // && !m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight))
     {
         rv += writeExtruderOff();
     }
@@ -269,13 +269,13 @@ QString JuggerBotWriter::writeArc(const Point& start_point, const Point& end_poi
                                   const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    Distance width = params->setting<Distance>(SS::kWidth);
-    Distance height = params->setting<Distance>(SS::kHeight);
+    Distance width      = params->setting<Distance>(SS::kWidth);
+    Distance height     = params->setting<Distance>(SS::kHeight);
 
     // Update the material number if necessary
     if (material_number != m_material_number && m_sb->setting<int>(MS::MultiMaterial::kEnable)) {
@@ -286,9 +286,7 @@ QString JuggerBotWriter::writeArc(const Point& start_point, const Point& end_poi
     // determine if writeExtruderOn is necessary
     bool requiresWriteExtruderOn = !m_deposition_active;
 
-    if (requiresWriteExtruderOn && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, width, height, params);
-    }
+    if (requiresWriteExtruderOn && rpm > 0) { rv += writeExtruderOn(region_type, rpm, width, height, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -314,7 +312,7 @@ QString JuggerBotWriter::writeArc(const Point& start_point, const Point& end_poi
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -397,7 +395,9 @@ QString JuggerBotWriter::writeShutdown() {
     return rv;
 }
 
-QString JuggerBotWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString JuggerBotWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString JuggerBotWriter::writeDwell(Time time) {
     if (time > 0)
@@ -410,8 +410,8 @@ QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance widt
                                          const QSharedPointer<SettingsBase>& params) {
     m_deposition_active = true;
     QString rv;
-    Area bead_area = (width - height) * height +
-                     (pi() * (height / 2) * (height / 2)); // Rectangle with two half circles used as cross-section
+    Area bead_area  = (width - height) * height +
+                      (pi() * (height / 2) * (height / 2));  // Rectangle with two half circles used as cross-section
     int initial_rpm = getInitialExtruderSpeed(params);
 
     if (!m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight)) {
@@ -481,7 +481,7 @@ QString JuggerBotWriter::writeExtruderOn(RegionType type, int rpm, Distance widt
                              (Distance(height).to(m_meta.m_distance_unit) / 2)));
         rv += commentSpaceLine("SET BEAD AREA");
         m_current_bead_area = bead_area;
-        m_current_rpm = rpm;
+        m_current_rpm       = rpm;
     }
 
     return rv;
@@ -497,7 +497,7 @@ QString JuggerBotWriter::writeExtruderOff() {
     }
     rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF");
 
-    m_current_rpm = 0;
+    m_current_rpm       = 0;
     m_current_bead_area = 0;
 
     return rv;
@@ -517,9 +517,9 @@ QString JuggerBotWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/kraussmaffei_writer.cpp
+++ b/src/gcode/writers/kraussmaffei_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/kraussmaffei_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -21,12 +22,12 @@ KraussMaffeiWriter::KraussMaffeiWriter(GcodeMeta meta, const QSharedPointer<Sett
 
 QString KraussMaffeiWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                               Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_deposition_active = false;
-    m_first_print = true;
-    m_first_travel = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_print       = true;
+    m_first_travel      = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("START OF THE START G-CODE");
@@ -56,8 +57,7 @@ QString KraussMaffeiWriter::writeInitialSetup(Distance minimum_x, Distance minim
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -72,7 +72,7 @@ QString KraussMaffeiWriter::writeInitialSetup(Distance minimum_x, Distance minim
 
 QString KraussMaffeiWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -147,7 +147,7 @@ QString KraussMaffeiWriter::writeTravel(Point start_location, Point target_locat
 
     Distance liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -163,7 +163,7 @@ QString KraussMaffeiWriter::writeTravel(Point start_location, Point target_locat
     // write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly) &&
         !m_first_travel) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
@@ -173,7 +173,7 @@ QString KraussMaffeiWriter::writeTravel(Point start_location, Point target_locat
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(speed);
@@ -194,14 +194,14 @@ QString KraussMaffeiWriter::writeTravel(Point start_location, Point target_locat
 
 QString KraussMaffeiWriter::writeLine(const Point& start_point, const Point& target_point,
                                       const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -287,9 +287,9 @@ QString KraussMaffeiWriter::writeLine(const Point& start_point, const Point& tar
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance segment_length = start_point.distance(target_point).to(m_meta.m_distance_unit);
-        Distance width = params->setting<Distance>(SS::kWidth).to(m_meta.m_distance_unit);
-        Distance height = params->setting<Distance>(SS::kHeight).to(m_meta.m_distance_unit);
+        Distance segment_length         = start_point.distance(target_point).to(m_meta.m_distance_unit);
+        Distance width                  = params->setting<Distance>(SS::kWidth).to(m_meta.m_distance_unit);
+        Distance height                 = params->setting<Distance>(SS::kHeight).to(m_meta.m_distance_unit);
         Volume segment_extrusion_amount = segment_length * width * height;
         segment_extrusion_amount *= current_multiplier;
 
@@ -311,14 +311,14 @@ QString KraussMaffeiWriter::writeArc(const Point& start_point, const Point& end_
                                      const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -395,7 +395,7 @@ QString KraussMaffeiWriter::writeArc(const Point& start_point, const Point& end_
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // calculate and write E value if path is an extrusion path
@@ -417,9 +417,9 @@ QString KraussMaffeiWriter::writeArc(const Point& start_point, const Point& end_
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance length                 = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
+        Distance width                  = params->setting<Distance>(SS::kWidth);
+        Distance height                 = params->setting<Distance>(SS::kHeight);
         Volume segment_extrusion_amount = length * width * height;
         segment_extrusion_amount *= current_multiplier;
 
@@ -533,7 +533,7 @@ QString KraussMaffeiWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
@@ -544,23 +544,13 @@ QString KraussMaffeiWriter::writePrime(RegionType region_type) {
           QString::number(m_sb->setting<Velocity>(MS::Extruder::kExtruderPrimeSpeed).to(m_meta.m_velocity_unit)) % m_e %
           QString::number(m_sb->setting<float>(MS::Extruder::kExtruderPrimeVolume)) % commentSpaceLine("PRIMING");
     Time dwellTime;
-    if (region_type == RegionType::kPerimeter) {
-        dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelayPerimeter);
-    }
-    else if (region_type == RegionType::kInset) {
-        dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelayInset);
-    }
-    else if (region_type == RegionType::kSkin) {
-        dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelaySkin);
-    }
-    else if (region_type == RegionType::kInfill) {
-        dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelayInfill);
-    }
-    else if (region_type == RegionType::kSkeleton) {
-        dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelaySkeleton);
-    }
+    if (region_type == RegionType::kPerimeter) { dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelayPerimeter); }
+    else if (region_type == RegionType::kInset) { dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelayInset); }
+    else if (region_type == RegionType::kSkin) { dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelaySkin); }
+    else if (region_type == RegionType::kInfill) { dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelayInfill); }
+    else if (region_type == RegionType::kSkeleton) { dwellTime = m_sb->setting<Time>(MS::Extruder::kOnDelaySkeleton); }
     rv += writeDwell(dwellTime);
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/mach4_writer.cpp
+++ b/src/gcode/writers/mach4_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/mach4_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -21,13 +22,13 @@ Mach4Writer::Mach4Writer(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
 
 QString Mach4Writer::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                        int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
     m_deposition_active = false;
-    m_first_print = true;
-    m_first_travel = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_print       = true;
+    m_first_travel      = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "M140 P" % QString::number(m_sb->setting<Temperature>(MS::Temperatures::kBed).to(degC)) %
@@ -49,9 +50,7 @@ QString Mach4Writer::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         if (m_sb->setting<int>(MS::Filament::kRelative) > 0) {
             rv += "G91" % commentSpaceLine("USE RELATIVE EXTRUSION DISTANCES");
         }
-        else {
-            rv += "G90" % commentSpaceLine("USE ABSOLUTE EXTRUSION DISTANCES");
-        }
+        else { rv += "G90" % commentSpaceLine("USE ABSOLUTE EXTRUSION DISTANCES"); }
 
         rv += "G92 A0" % commentSpaceLine("RESET FILAMENT AXIS TO 0");
 
@@ -81,8 +80,7 @@ QString Mach4Writer::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -93,7 +91,7 @@ QString Mach4Writer::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
 
 QString Mach4Writer::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     if (m_sb->setting<bool>(MS::Retraction::kEnable) && m_sb->setting<bool>(MS::Retraction::kLayerChange) &&
         new_min_z > sb->setting<Distance>(PS::Layer::kLayerHeight)) {
@@ -176,7 +174,7 @@ QString Mach4Writer::writeTravel(Point start_location, Point target_location, Tr
 
     Distance liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -195,7 +193,7 @@ QString Mach4Writer::writeTravel(Point start_location, Point target_location, Tr
 
     // write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
@@ -205,7 +203,7 @@ QString Mach4Writer::writeTravel(Point start_location, Point target_location, Tr
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(speed.to(m_meta.m_velocity_unit)) % writeCoordinates(travel_destination) %
           commentSpaceLine("TRAVEL");
@@ -225,14 +223,14 @@ QString Mach4Writer::writeTravel(Point start_location, Point target_location, Tr
 
 QString Mach4Writer::writeLine(const Point& start_point, const Point& target_point,
                                const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -285,8 +283,7 @@ QString Mach4Writer::writeLine(const Point& start_point, const Point& target_poi
             }
         }
 
-        if (m_filament_location < 0)
-            rv += writePrime();
+        if (m_filament_location < 0) rv += writePrime();
     }
 
     rv += m_G1;
@@ -319,9 +316,9 @@ QString Mach4Writer::writeLine(const Point& start_point, const Point& target_poi
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance segment_length = start_point.distance(target_point);
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance segment_length    = start_point.distance(target_point);
+        Distance width             = params->setting<Distance>(SS::kWidth);
+        Distance height            = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);
         Distance segment_filament_length =
             (segment_length * width * height) / ((filament_diameter / 2) * (filament_diameter / 2) * 3.14159);
@@ -354,14 +351,14 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
                               const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -414,8 +411,7 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
             }
         }
 
-        if (m_filament_location < 0)
-            rv += writePrime();
+        if (m_filament_location < 0) rv += writePrime();
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -439,7 +435,7 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // calculate and write E value if path is an extrusion path
@@ -461,9 +457,9 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance length            = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
+        Distance width             = params->setting<Distance>(SS::kWidth);
+        Distance height            = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);
         Distance segment_filament_length =
             (length * width * height) / ((filament_diameter / 2) * (filament_diameter / 2) * 3.14159);
@@ -558,7 +554,9 @@ QString Mach4Writer::writeShutdown() {
     return rv;
 }
 
-QString Mach4Writer::writePurge(int RPM, int duration, int delay) { return {}; }
+QString Mach4Writer::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString Mach4Writer::writeDwell(Time time) {
     if (time > 0)
@@ -581,7 +579,7 @@ QString Mach4Writer::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
@@ -590,8 +588,7 @@ QString Mach4Writer::writeRetraction() {
     QString rv;
 
     if (m_filament_location >= 0 && m_sb->setting<bool>(MS::Retraction::kEnable)) {
-        if (m_filament_location != 0)
-            rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0");
+        if (m_filament_location != 0) rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0");
         m_filament_location = 0.0;
 
         rv += m_G1 % m_f % QString::number(m_sb->setting<Velocity>(MS::Retraction::kSpeed).to(m_meta.m_velocity_unit)) %
@@ -627,4 +624,4 @@ QString Mach4Writer::writePrime() {
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/marlin_writer.cpp
+++ b/src/gcode/writers/marlin_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/marlin_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -21,13 +22,13 @@ MarlinWriter::MarlinWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& s
 
 QString MarlinWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                         int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
     m_deposition_active = false;
-    m_first_print = true;
-    m_first_travel = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_print       = true;
+    m_first_travel      = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "M140 S" % QString::number(m_sb->setting<Temperature>(MS::Temperatures::kBed).to(degC)) %
@@ -113,9 +114,7 @@ QString MarlinWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         if (m_sb->setting<int>(MS::Filament::kRelative) > 0) {
             rv += "M83" % commentSpaceLine("USE RELATIVE EXTRUSION DISTANCES");
         }
-        else {
-            rv += "M82" % commentSpaceLine("USE ABSOLUTE EXTRUSION DISTANCES");
-        }
+        else { rv += "M82" % commentSpaceLine("USE ABSOLUTE EXTRUSION DISTANCES"); }
 
         // Cooling fan
         if (m_sb->setting<bool>(MS::Cooling::kEnable))
@@ -132,9 +131,7 @@ QString MarlinWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
             rv += "G92 B0" % commentSpaceLine("RESET FILAMENT TO 0");
         }
-        else {
-            rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0");
-        }
+        else { rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0"); }
     }
 
     if (m_sb->setting<int>(PRS::GCode::kEnableBoundingBox)) {
@@ -152,8 +149,7 @@ QString MarlinWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -164,7 +160,7 @@ QString MarlinWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
 
 QString MarlinWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     if (m_sb->setting<bool>(MS::Retraction::kEnable) && m_sb->setting<bool>(MS::Retraction::kLayerChange) &&
         new_min_z > sb->setting<Distance>(PS::Layer::kLayerHeight)) {
@@ -220,9 +216,7 @@ QString MarlinWriter::writeBeforePath(RegionType type) {
         if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
             rv += "G92 B0" % commentSpaceLine("RESET FILAMENT TO 0");
         }
-        else {
-            rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0");
-        }
+        else { rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0"); }
         m_filament_location = 0.0;
     }
 
@@ -252,7 +246,7 @@ QString MarlinWriter::writeTravel(Point start_location, Point target_location, T
 
     Distance liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -272,7 +266,7 @@ QString MarlinWriter::writeTravel(Point start_location, Point target_location, T
     // write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly) &&
         !m_first_travel) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
@@ -282,7 +276,7 @@ QString MarlinWriter::writeTravel(Point start_location, Point target_location, T
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(speed.to(m_meta.m_velocity_unit)) % writeCoordinates(travel_destination) %
           commentSpaceLine("TRAVEL");
@@ -302,14 +296,14 @@ QString MarlinWriter::writeTravel(Point start_location, Point target_location, T
 
 QString MarlinWriter::writeLine(const Point& start_point, const Point& target_point,
                                 const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -362,8 +356,7 @@ QString MarlinWriter::writeLine(const Point& start_point, const Point& target_po
             }
         }
 
-        if (m_filament_location < 0)
-            rv += writePrime();
+        if (m_filament_location < 0) rv += writePrime();
     }
 
     rv += m_G1;
@@ -396,9 +389,9 @@ QString MarlinWriter::writeLine(const Point& start_point, const Point& target_po
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance segment_length = start_point.distance(target_point);
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance segment_length    = start_point.distance(target_point);
+        Distance width             = params->setting<Distance>(SS::kWidth);
+        Distance height            = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);
         Distance segment_filament_length =
             (segment_length * width * height) / ((filament_diameter / 2) * (filament_diameter / 2) * 3.14159);
@@ -410,9 +403,7 @@ QString MarlinWriter::writeLine(const Point& start_point, const Point& target_po
             if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
                 rv += m_b % QString::number(Distance(segment_filament_length).to(m_meta.m_distance_unit), 'f', 4);
             }
-            else {
-                rv += m_e % QString::number(Distance(segment_filament_length).to(m_meta.m_distance_unit), 'f', 4);
-            }
+            else { rv += m_e % QString::number(Distance(segment_filament_length).to(m_meta.m_distance_unit), 'f', 4); }
         }
         // if using absolute E, update total length and write value
         else {
@@ -420,9 +411,7 @@ QString MarlinWriter::writeLine(const Point& start_point, const Point& target_po
             if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
                 rv += m_b % QString::number(Distance(m_filament_location).to(m_meta.m_distance_unit), 'f', 4);
             }
-            else {
-                rv += m_e % QString::number(Distance(m_filament_location).to(m_meta.m_distance_unit), 'f', 4);
-            }
+            else { rv += m_e % QString::number(Distance(m_filament_location).to(m_meta.m_distance_unit), 'f', 4); }
         }
     }
 
@@ -441,14 +430,14 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
                                const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -501,8 +490,7 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
             }
         }
 
-        if (m_filament_location < 0)
-            rv += writePrime();
+        if (m_filament_location < 0) rv += writePrime();
     }
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -526,7 +514,7 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // calculate and write E value if path is an extrusion path
@@ -548,9 +536,9 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance length            = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
+        Distance width             = params->setting<Distance>(SS::kWidth);
+        Distance height            = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);
         Distance segment_filament_length =
             (length * width * height) / ((filament_diameter / 2) * (filament_diameter / 2) * 3.14159);
@@ -562,9 +550,7 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
             if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
                 rv += m_b % QString::number(segment_filament_length.to(m_meta.m_distance_unit));
             }
-            else {
-                rv += m_e % QString::number(segment_filament_length.to(m_meta.m_distance_unit));
-            }
+            else { rv += m_e % QString::number(segment_filament_length.to(m_meta.m_distance_unit)); }
         }
         // if using absolute E, update total length and write value
         else {
@@ -572,9 +558,7 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
             if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
                 rv += m_b % QString::number(m_filament_location.to(m_meta.m_distance_unit));
             }
-            else {
-                rv += m_e % QString::number(m_filament_location.to(m_meta.m_distance_unit));
-            }
+            else { rv += m_e % QString::number(m_filament_location.to(m_meta.m_distance_unit)); }
         }
     }
 
@@ -665,7 +649,7 @@ QString MarlinWriter::writePurge(int RPM, int duration, int delay) {
     QString rv;
 
     QVector3D travel_lift = getTravelLift();
-    auto liftZ = Distance(travel_lift.z()).to(m_meta.m_distance_unit) + m_current_z.to(m_meta.m_distance_unit);
+    auto liftZ  = Distance(travel_lift.z()).to(m_meta.m_distance_unit) + m_current_z.to(m_meta.m_distance_unit);
     auto purgeZ = m_sb->setting<Distance>(PRS::Dimensions::kPurgeZ).to(m_meta.m_distance_unit);
 
     rv += m_G1 % m_f % QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
@@ -675,8 +659,7 @@ QString MarlinWriter::writePurge(int RPM, int duration, int delay) {
           m_y % QString::number(m_sb->setting<Distance>(PRS::Dimensions::kPurgeY).to(m_meta.m_distance_unit)) %
           commentSpaceLine("TRAVEL");
 
-    if (liftZ > purgeZ)
-        rv += m_G1 % m_z % QString::number(purgeZ) % commentSpaceLine("TRAVEL LOWER Z");
+    if (liftZ > purgeZ) rv += m_G1 % m_z % QString::number(purgeZ) % commentSpaceLine("TRAVEL LOWER Z");
 
     auto length = m_sb->setting<Distance>(MS::Purge::kPurgeLength).to(m_meta.m_distance_unit);
     if (m_sb->setting<bool>(MS::Filament::kRelative))
@@ -697,8 +680,7 @@ QString MarlinWriter::writePurge(int RPM, int duration, int delay) {
               commentSpaceLine("PURGE");
     }
 
-    if (liftZ > purgeZ)
-        rv += m_G1 % m_z % QString::number(liftZ) % commentSpaceLine("TRAVEL LIFT Z");
+    if (liftZ > purgeZ) rv += m_G1 % m_z % QString::number(liftZ) % commentSpaceLine("TRAVEL LIFT Z");
 
     return rv;
 }
@@ -724,7 +706,7 @@ QString MarlinWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
@@ -737,9 +719,7 @@ QString MarlinWriter::writeRetraction() {
             if (m_sb->setting<bool>(MS::Filament::kFilamentBAxis)) {
                 rv += "G92 B0" % commentSpaceLine("RESET FILAMENT TO 0");
             }
-            else {
-                rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0");
-            }
+            else { rv += "G92 E0" % commentSpaceLine("RESET FILAMENT TO 0"); }
             m_filament_location = 0.0;
         }
 
@@ -803,4 +783,4 @@ QString MarlinWriter::writePrime() {
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/mazak_writer.cpp
+++ b/src/gcode/writers/mazak_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/mazak_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ MazakWriter::MazakWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
 
 QString MazakWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                        int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
 
     // Define the speed variable, this should be inside the startup if a setting is added to
@@ -74,8 +75,7 @@ QString MazakWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -86,7 +86,7 @@ QString MazakWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
 
 QString MazakWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -152,7 +152,7 @@ QString MazakWriter::writeTravel(Point start_location, Point target_location, Tr
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -166,7 +166,7 @@ QString MazakWriter::writeTravel(Point start_location, Point target_location, Tr
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -176,7 +176,7 @@ QString MazakWriter::writeTravel(Point start_location, Point target_location, Tr
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -187,19 +187,19 @@ QString MazakWriter::writeTravel(Point start_location, Point target_location, Tr
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString MazakWriter::writeLine(const Point& start_point, const Point& target_point,
                                const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -250,17 +250,15 @@ QString MazakWriter::writeArc(const Point& start_point, const Point& end_point, 
                               const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -286,7 +284,7 @@ QString MazakWriter::writeArc(const Point& start_point, const Point& end_point, 
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -408,9 +406,9 @@ QString MazakWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/meld_writer.cpp
+++ b/src/gcode/writers/meld_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/meld_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ MeldWriter::MeldWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) :
 
 QString MeldWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                       int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("preamble");
@@ -53,8 +54,7 @@ QString MeldWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -65,7 +65,7 @@ QString MeldWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
 
 QString MeldWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -119,7 +119,7 @@ QString MeldWriter::writeBeforePath(RegionType type) {
 QString MeldWriter::writeTravel(Point start_location, Point target_location, TravelLiftType lType,
                                 QSharedPointer<SettingsBase> params) {
     QString rv;
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
+    Velocity speed  = params->setting<Velocity>(SS::kSpeed);
     Velocity zSpeed = m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed);
 
     Point new_start_location;
@@ -133,7 +133,7 @@ QString MeldWriter::writeTravel(Point start_location, Point target_location, Tra
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -147,7 +147,7 @@ QString MeldWriter::writeTravel(Point start_location, Point target_location, Tra
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % m_f % QString::number(zSpeed.to(m_meta.m_velocity_unit)) % writeCoordinates(lift_destination) %
               commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
@@ -158,7 +158,7 @@ QString MeldWriter::writeTravel(Point start_location, Point target_location, Tra
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(speed.to(m_meta.m_velocity_unit)) % writeCoordinates(travel_destination) %
           commentSpaceLine("TRAVEL");
@@ -171,30 +171,26 @@ QString MeldWriter::writeTravel(Point start_location, Point target_location, Tra
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString MeldWriter::writeLine(const Point& start_point, const Point& target_point,
                               const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
-    if (rpm == 0 && m_deposition_active == true) {
-        rv += writeExtruderOff();
-    }
+    if (rpm == 0 && m_deposition_active == true) { rv += writeExtruderOff(); }
 
     rv += m_G1;
     // update feedrate if needed
@@ -222,16 +218,14 @@ QString MeldWriter::writeArc(const Point& start_point, const Point& end_point, c
                              const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -257,7 +251,7 @@ QString MeldWriter::writeArc(const Point& start_point, const Point& end_point, c
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -355,7 +349,7 @@ QString MeldWriter::writeExtruderOn(RegionType type, int rpm, const QSharedPoint
     m_deposition_active = true;
     float output_rpm;
     int initial_rpm = getInitialExtruderSpeed(params);
-    output_rpm = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
+    output_rpm      = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio) * initial_rpm;
 
     if (!m_sb->setting<int>(ES::FileOutput::kMeldDiscrete)) {
         rv += "M4" % m_s % QString::number(output_rpm) % " @714" % commentSpaceLine("TURN SPINDLE ON");
@@ -429,9 +423,9 @@ QString MeldWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/meltio_writer.cpp
+++ b/src/gcode/writers/meltio_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/meltio_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -29,12 +30,12 @@ QString MeltioWriter::writeSettingsHeader(GcodeSyntax syntax) {
 
 QString MeltioWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                         int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
@@ -71,8 +72,7 @@ QString MeltioWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -83,7 +83,7 @@ QString MeltioWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
 
 QString MeltioWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -151,7 +151,7 @@ QString MeltioWriter::writeTravel(Point start_location, Point target_location, T
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -165,7 +165,7 @@ QString MeltioWriter::writeTravel(Point start_location, Point target_location, T
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
 
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
@@ -176,13 +176,13 @@ QString MeltioWriter::writeTravel(Point start_location, Point target_location, T
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     // write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
@@ -195,12 +195,12 @@ QString MeltioWriter::writeTravel(Point start_location, Point target_location, T
 
 QString MeltioWriter::writeLine(const Point& start_point, const Point& target_point,
                                 const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -241,16 +241,14 @@ QString MeltioWriter::writeArc(const Point& start_point, const Point& end_point,
                                const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, 0); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -272,7 +270,7 @@ QString MeltioWriter::writeArc(const Point& start_point, const Point& end_point,
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -287,7 +285,7 @@ QString MeltioWriter::writeArc(const Point& start_point, const Point& end_point,
 QString MeltioWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -395,8 +393,8 @@ QString MeltioWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/mvp_writer.cpp
+++ b/src/gcode/writers/mvp_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/mvp_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -21,12 +22,12 @@ MVPWriter::MVPWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) : W
 
 QString MVPWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                      int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += "G54" % commentSpaceLine("ENABLE W01") % m_G1 % m_f %
@@ -46,8 +47,7 @@ QString MVPWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Dis
               commentSpaceLine("BOUNDING BOX") % "M0" % commentSpaceLine("WAIT FOR USER");
     }
 
-    if (!m_sb->setting<QString>(PRS::GCode::kStartCode).isEmpty())
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (!m_sb->setting<QString>(PRS::GCode::kStartCode).isEmpty()) rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -58,7 +58,7 @@ QString MVPWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Dis
 
 QString MVPWriter::writeBeforeLayer(float min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     rv += "M01 " % commentLine("OPTIONAL STOP - LAYER CHANGE");
     return rv;
@@ -74,7 +74,9 @@ QString MVPWriter::writeBeforeIsland() {
     return rv;
 }
 
-QString MVPWriter::writeBeforeRegion(RegionType type, int pathSize) { return {}; }
+QString MVPWriter::writeBeforeRegion(RegionType type, int pathSize) {
+    return {};
+}
 
 QString MVPWriter::writeBeforePath(RegionType type) {
     QString rv;
@@ -145,7 +147,7 @@ QString MVPWriter::writeTravel(Point start_location, Point target_location, Trav
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -155,7 +157,7 @@ QString MVPWriter::writeTravel(Point start_location, Point target_location, Trav
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -166,26 +168,24 @@ QString MVPWriter::writeTravel(Point start_location, Point target_location, Trav
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString MVPWriter::writeLine(const Point& start_point, const Point& target_point,
                              const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     if (rpm != m_current_rpm && rpm == 0) {
         rv += writeExtruderOff();
@@ -288,7 +288,9 @@ QString MVPWriter::writeShutdown() {
     return rv;
 }
 
-QString MVPWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString MVPWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString MVPWriter::writeDwell(Time time) {
     if (time > 0)
@@ -366,9 +368,9 @@ QString MVPWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/okuma_writer.cpp
+++ b/src/gcode/writers/okuma_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/okuma_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,15 +20,15 @@ OkumaWriter::OkumaWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
 
 QString OkumaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                        int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     rv += "( --- header.txt --- )" % m_newline;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
@@ -74,8 +75,7 @@ QString OkumaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -86,7 +86,7 @@ QString OkumaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, D
 
 QString OkumaWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     rv += "( -------------------- laser_on.txt --- )" % m_newline;
     return rv;
@@ -153,7 +153,7 @@ QString OkumaWriter::writeTravel(Point start_location, Point target_location, Tr
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -167,7 +167,7 @@ QString OkumaWriter::writeTravel(Point start_location, Point target_location, Tr
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -177,7 +177,7 @@ QString OkumaWriter::writeTravel(Point start_location, Point target_location, Tr
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -188,26 +188,24 @@ QString OkumaWriter::writeTravel(Point start_location, Point target_location, Tr
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString OkumaWriter::writeLine(const Point& start_point, const Point& target_point,
                                const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -242,17 +240,15 @@ QString OkumaWriter::writeArc(const Point& start_point, const Point& end_point, 
                               const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -274,7 +270,7 @@ QString OkumaWriter::writeArc(const Point& start_point, const Point& end_point, 
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -364,7 +360,9 @@ QString OkumaWriter::writeShutdown() {
     return rv;
 }
 
-QString OkumaWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString OkumaWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString OkumaWriter::writeDwell(Time time) {
     if (time > 0)
@@ -407,9 +405,9 @@ QString OkumaWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/ornl_writer.cpp
+++ b/src/gcode/writers/ornl_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/ornl_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -29,21 +30,19 @@ QString ORNLWriter::writeSettingsHeader(GcodeSyntax syntax) {
 
 QString ORNLWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                       int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
-    m_current_robot = 1;
-    m_machine_type = m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
+    m_current_robot     = 1;
+    m_machine_type      = m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType);
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
         rv += writeDwell(0.25);
     }
 
@@ -68,13 +67,10 @@ QString ORNLWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
         rv +=
             writePurge(m_sb->setting<int>(MS::Purge::kInitialScrewRPM), m_sb->setting<int>(MS::Purge::kInitialDuration),
                        m_sb->setting<int>(MS::Purge::kInitialTipWipeDelay));
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -85,7 +81,7 @@ QString ORNLWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
 
 QString ORNLWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     rv += "M01 " % commentLine("OPTIONAL STOP - LAYER CHANGE");
     return rv;
@@ -187,7 +183,7 @@ QString ORNLWriter::writeTravel(Point start_location, Point target_location, Tra
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -197,7 +193,7 @@ QString ORNLWriter::writeTravel(Point start_location, Point target_location, Tra
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
 
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
@@ -210,13 +206,13 @@ QString ORNLWriter::writeTravel(Point start_location, Point target_location, Tra
                                   m_sb->setting<Distance>(PS::Travel::kLiftHeight)() +
                                   m_sb->setting<Distance>(PS::Layer::kLayerHeight)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     // write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
@@ -230,12 +226,12 @@ QString ORNLWriter::writeTravel(Point start_location, Point target_location, Tra
 QString ORNLWriter::writeLine(const Point& start_point, const Point& target_point,
                               const QSharedPointer<SettingsBase> params) {
     // Get the settings
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -249,9 +245,7 @@ QString ORNLWriter::writeLine(const Point& start_point, const Point& target_poin
     if (m_layer_start && m_machine_type != MachineType::kWire_Arc) {
         setFeedrate(speed);
         rv += m_f % QString::number(speed.to(m_meta.m_velocity_unit));
-        if (m_machine_type != MachineType::kWire_Arc) {
-            rv += m_s % QString::number(output_rpm);
-        }
+        if (m_machine_type != MachineType::kWire_Arc) { rv += m_s % QString::number(output_rpm); }
 
         m_current_rpm = rpm;
 
@@ -289,17 +283,15 @@ QString ORNLWriter::writeArc(const Point& start_point, const Point& end_point, c
     QString rv;
 
     // Get the settings
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
-    Distance z_offset = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    Distance z_offset   = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
 
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, 0, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -324,16 +316,14 @@ QString ORNLWriter::writeArc(const Point& start_point, const Point& end_point, c
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
     if (path_modifiers != PathModifiers::kNone) {
         rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
     }
-    else {
-        rv += commentSpaceLine(toString(region_type));
-    }
+    else { rv += commentSpaceLine(toString(region_type)); }
 
     return rv;
 }
@@ -341,7 +331,7 @@ QString ORNLWriter::writeArc(const Point& start_point, const Point& end_point, c
 QString ORNLWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -435,8 +425,8 @@ QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extrude
     }
     else {
         // Retrieve relevant settings
-        int initial_speed = getInitialExtruderSpeed(params);
-        float gear_ratio = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+        int initial_speed         = getInitialExtruderSpeed(params);
+        float gear_ratio          = m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
         bool force_min_layer_time = m_sb->setting<bool>(MS::Cooling::kForceMinLayerTime);
         ForceMinimumLayerTime force_min_layer_time_method =
             m_sb->setting<ForceMinimumLayerTime>(MS::Cooling::kForceMinLayerTimeMethod);
@@ -476,9 +466,7 @@ QString ORNLWriter::writeExtruderOn(RegionType region_type, int rpm, int extrude
             }
 
             // Write the appropriate dwell time for the region
-            if (dwell_time > 0) {
-                rv += writeDwell(dwell_time);
-            }
+            if (dwell_time > 0) { rv += writeDwell(dwell_time); }
         }
         else {
             output_rpm = gear_ratio * rpm;
@@ -515,9 +503,7 @@ QString ORNLWriter::writeExtruderOff(int extruder_number) {
             rv += "M105" % commentSpaceLine("WIRE SHIELDING OFF");
         }
     }
-    else if (off_delay > 0) {
-        rv += writeDwell(off_delay);
-    }
+    else if (off_delay > 0) { rv += writeDwell(off_delay); }
 
     rv += m_M5 % commentSpaceLine("TURN EXTRUDER OFF");
     m_current_rpm = 0;
@@ -549,14 +535,10 @@ QString ORNLWriter::writeCoordinates(Point destination) {
 
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
 
-        if (m_current_robot == 1) {
-            rv += " X_R=-180 Y_R=0 Z_R=-135 A_P=0 C_P=0";
-        }
-        else if (m_current_robot == 2) {
-            rv += " X_R=180 Y_R=0 Z_R=90 A_P=0 C_P=0";
-        }
+        if (m_current_robot == 1) { rv += " X_R=-180 Y_R=0 Z_R=-135 A_P=0 C_P=0"; }
+        else if (m_current_robot == 2) { rv += " X_R=180 Y_R=0 Z_R=90 A_P=0 C_P=0"; }
     }
     else {
         // always specify X and Y
@@ -576,10 +558,10 @@ QString ORNLWriter::writeCoordinates(Point destination) {
         if (qAbs(target_z - m_last_z) > 10) {
             rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
             m_current_z = target_z;
-            m_last_z = target_z;
+            m_last_z    = target_z;
         }
     }
 
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/reprap_writer.cpp
+++ b/src/gcode/writers/reprap_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/reprap_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -22,13 +23,13 @@ RepRapWriter::RepRapWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& s
 
 QString RepRapWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                         int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
     m_filament_location = 0.0;
     m_deposition_active = false;
-    m_first_print = true;
-    m_first_travel = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_print       = true;
+    m_first_travel      = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
 
     rv += commentLine("Layer height: " %
@@ -54,9 +55,7 @@ QString RepRapWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         if (m_sb->setting<int>(MS::Filament::kRelative) > 0) {
             rv += "M83" % commentSpaceLine("USE RELATIVE EXTRUSION DISTANCES");
         }
-        else {
-            rv += "M82" % commentSpaceLine("USE ABSOLUTE EXTRUSION DISTANCES");
-        }
+        else { rv += "M82" % commentSpaceLine("USE ABSOLUTE EXTRUSION DISTANCES"); }
 
         rv += "G92 E0" % commentSpaceLine("RESET FILAMENT AXIS TO 0");
 
@@ -78,8 +77,7 @@ QString RepRapWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -90,7 +88,7 @@ QString RepRapWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
 
 QString RepRapWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
 
     if (m_sb->setting<bool>(MS::Retraction::kEnable) && m_sb->setting<bool>(MS::Retraction::kLayerChange) &&
@@ -187,7 +185,7 @@ QString RepRapWriter::writeTravel(Point start_location, Point target_location, T
 
     Distance liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -206,7 +204,7 @@ QString RepRapWriter::writeTravel(Point start_location, Point target_location, T
 
     // write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
@@ -216,7 +214,7 @@ QString RepRapWriter::writeTravel(Point start_location, Point target_location, T
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(speed.to(m_meta.m_velocity_unit)) % writeCoordinates(travel_destination) %
           commentSpaceLine("TRAVEL");
@@ -236,14 +234,14 @@ QString RepRapWriter::writeTravel(Point start_location, Point target_location, T
 
 QString RepRapWriter::writeLine(const Point& start_point, const Point& target_point,
                                 const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     QString rv;
 
     // check if extruder needs priming
-    bool needs_prime = !m_deposition_active;
+    bool needs_prime    = !m_deposition_active;
     m_deposition_active = true;
 
     // If first printing segment, prime extruder, or at least undo any retraction, and update acceleration
@@ -296,8 +294,7 @@ QString RepRapWriter::writeLine(const Point& start_point, const Point& target_po
             }
         }
 
-        if (m_filament_location < 0)
-            rv += writePrime();
+        if (m_filament_location < 0) rv += writePrime();
     }
 
     rv += m_G1;
@@ -315,7 +312,6 @@ QString RepRapWriter::writeLine(const Point& start_point, const Point& target_po
     if (path_modifiers != PathModifiers::kCoasting && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kPerimeterTipWipe && path_modifiers != PathModifiers::kReverseTipWipe &&
         path_modifiers != PathModifiers::kSpiralLift) {
-
         // Set extrusion multiplier, or use default value of 1.0
         double current_multiplier;
         if (region_type == RegionType::kPerimeter)
@@ -331,9 +327,9 @@ QString RepRapWriter::writeLine(const Point& start_point, const Point& target_po
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance segment_length = start_point.distance(target_point);
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance segment_length    = start_point.distance(target_point);
+        Distance width             = params->setting<Distance>(SS::kWidth);
+        Distance height            = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);
         Distance segment_filament_length =
             (segment_length * width * height) / ((filament_diameter / 2) * (filament_diameter / 2) * 3.14159);
@@ -366,10 +362,10 @@ QString RepRapWriter::writeArc(const Point& start_point, const Point& end_point,
                                const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     rv += ((ccw) ? m_G3 : m_G2);
@@ -387,14 +383,13 @@ QString RepRapWriter::writeArc(const Point& start_point, const Point& end_point,
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // calculate and write E value if path is an extrusion path
     if (path_modifiers != PathModifiers::kCoasting && path_modifiers != PathModifiers::kForwardTipWipe &&
         path_modifiers != PathModifiers::kPerimeterTipWipe && path_modifiers != PathModifiers::kReverseTipWipe &&
         path_modifiers != PathModifiers::kSpiralLift) {
-
         // Set extrusion multiplier, or use default value of 1.0
         double current_multiplier;
         if (region_type == RegionType::kPerimeter)
@@ -410,9 +405,9 @@ QString RepRapWriter::writeArc(const Point& start_point, const Point& end_point,
         else
             current_multiplier = m_sb->setting<double>(PS::Perimeter::kExtrusionMultiplier);
 
-        Distance segment_length = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
-        Distance width = params->setting<Distance>(SS::kWidth);
-        Distance height = params->setting<Distance>(SS::kHeight);
+        Distance segment_length    = ArcSegment(start_point, end_point, center_point, angle, ccw).length();
+        Distance width             = params->setting<Distance>(SS::kWidth);
+        Distance height            = params->setting<Distance>(SS::kHeight);
         Distance filament_diameter = m_sb->setting<Distance>(MS::Filament::kDiameter);
         Distance segment_filament_length =
             (segment_length * width * height) / ((filament_diameter / 2) * (filament_diameter / 2) * 3.14159);
@@ -508,7 +503,9 @@ QString RepRapWriter::writeShutdown() {
     return rv;
 }
 
-QString RepRapWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString RepRapWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString RepRapWriter::writeDwell(Time time) {
     if (time > 0)
@@ -531,7 +528,7 @@ QString RepRapWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
@@ -577,4 +574,4 @@ QString RepRapWriter::writePrime() {
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/romi_fanuc_writer.cpp
+++ b/src/gcode/writers/romi_fanuc_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/romi_fanuc_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,14 +20,14 @@ RomiFanucWriter::RomiFanucWriter(GcodeMeta meta, const QSharedPointer<SettingsBa
 
 QString RomiFanucWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                            Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     // m_G0 = "G00";
     // m_G1 = "G01";
     m_material_number = -1;
@@ -51,8 +52,7 @@ QString RomiFanucWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -63,7 +63,7 @@ QString RomiFanucWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
 
 QString RomiFanucWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -129,7 +129,7 @@ QString RomiFanucWriter::writeTravel(Point start_location, Point target_location
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -143,7 +143,7 @@ QString RomiFanucWriter::writeTravel(Point start_location, Point target_location
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -153,7 +153,7 @@ QString RomiFanucWriter::writeTravel(Point start_location, Point target_location
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -164,26 +164,24 @@ QString RomiFanucWriter::writeTravel(Point start_location, Point target_location
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString RomiFanucWriter::writeLine(const Point& start_point, const Point& target_point,
                                    const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (m_deposition_active == false && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (m_deposition_active == false && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -226,17 +224,15 @@ QString RomiFanucWriter::writeArc(const Point& start_point, const Point& end_poi
                                   const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -262,7 +258,7 @@ QString RomiFanucWriter::writeArc(const Point& start_point, const Point& end_poi
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -430,9 +426,9 @@ QString RomiFanucWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/sandia_writer.cpp
+++ b/src/gcode/writers/sandia_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/sandia_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -29,24 +30,21 @@ QString SandiaWriter::writeSettingsHeader(GcodeSyntax syntax) {
 
 QString SandiaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                         int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
         rv += writeDwell(0.25);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -57,7 +55,7 @@ QString SandiaWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, 
 
 QString SandiaWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     rv += "M1 " % commentLine("OPTIONAL STOP - LAYER CHANGE");
     return rv;
@@ -120,7 +118,7 @@ QString SandiaWriter::writeTravel(Point start_location, Point target_location, T
     QString rv;
 
     Point new_start_location;
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
+    Velocity speed   = params->setting<Velocity>(SS::kSpeed);
     RegionType rType = params->setting<RegionType>(SS::kRegionType);
 
     // Use updated start location if this is the first travel
@@ -132,7 +130,7 @@ QString SandiaWriter::writeTravel(Point start_location, Point target_location, T
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -146,7 +144,7 @@ QString SandiaWriter::writeTravel(Point start_location, Point target_location, T
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
 
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
@@ -159,14 +157,14 @@ QString SandiaWriter::writeTravel(Point start_location, Point target_location, T
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(speed.to(m_meta.m_velocity_unit)) % writeCoordinates(travel_destination) %
           commentSpaceLine("TRAVEL");
     setFeedrate(speed);
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     // write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
@@ -181,12 +179,12 @@ QString SandiaWriter::writeTravel(Point start_location, Point target_location, T
 
 QString SandiaWriter::writeLine(const Point& start_point, const Point& target_point,
                                 const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -236,16 +234,14 @@ QString SandiaWriter::writeArc(const Point& start_point, const Point& end_point,
                                const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, 0, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, 0, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -272,7 +268,7 @@ QString SandiaWriter::writeArc(const Point& start_point, const Point& end_point,
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 3);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -292,7 +288,7 @@ QString SandiaWriter::writeScan(Point target_point, Velocity speed, bool on_off)
 QString SandiaWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -469,8 +465,8 @@ QString SandiaWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 3);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/siemens_writer.cpp
+++ b/src/gcode/writers/siemens_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/siemens_writer.h"
 
 #include <QStringBuilder>
+
 #include <qnumeric.h>
 #include <qsharedpointer.h>
 #include <qvectornd.h>
@@ -21,14 +22,14 @@ SiemensWriter::SiemensWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>&
 
 QString SiemensWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                          int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_w = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_w         = m_sb->setting<Distance>(PRS::Dimensions::kWMax);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_print = true;
-    m_first_travel = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_print       = true;
+    m_first_travel      = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
@@ -54,8 +55,7 @@ QString SiemensWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y,
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -66,7 +66,7 @@ QString SiemensWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y,
 
 QString SiemensWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -115,7 +115,7 @@ QString SiemensWriter::writeTravel(Point start_location, Point target_location, 
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -128,7 +128,7 @@ QString SiemensWriter::writeTravel(Point start_location, Point target_location, 
 
     // write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
@@ -136,7 +136,7 @@ QString SiemensWriter::writeTravel(Point start_location, Point target_location, 
     // write the travel
     Point travel_destination = target_location;
     if (travel_lift_required) {
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
     }
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
@@ -148,16 +148,16 @@ QString SiemensWriter::writeTravel(Point start_location, Point target_location, 
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString SiemensWriter::writeLine(const Point& start_point, const Point& target_point,
                                  const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     QString rv;
@@ -254,16 +254,14 @@ QString SiemensWriter::writeArc(const Point& start_point, const Point& end_point
                                 const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -289,7 +287,7 @@ QString SiemensWriter::writeArc(const Point& start_point, const Point& end_point
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -371,7 +369,9 @@ QString SiemensWriter::writeShutdown() {
     return rv;
 }
 
-QString SiemensWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString SiemensWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString SiemensWriter::writeDwell(Time time) {
     if (time > 0)
@@ -380,9 +380,13 @@ QString SiemensWriter::writeDwell(Time time) {
         return {};
 }
 
-QString SiemensWriter::writeTamperOn() { return {}; }
+QString SiemensWriter::writeTamperOn() {
+    return {};
+}
 
-QString SiemensWriter::writeTamperOff() { return {}; }
+QString SiemensWriter::writeTamperOff() {
+    return {};
+}
 
 QString SiemensWriter::writeExtruderOn(RegionType type, int rpm) {
     QString rv;
@@ -409,9 +413,9 @@ QString SiemensWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/thermwood_writer.cpp
+++ b/src/gcode/writers/thermwood_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/thermwood_writer.h"
 
 #include <QStringBuilder>
+
 #include <qhashfunctions.h>
 #include <qnumeric.h>
 #include <qsharedpointer.h>
@@ -19,23 +20,21 @@ ThermwoodWriter::ThermwoodWriter(GcodeMeta meta, const QSharedPointer<SettingsBa
 
 QString ThermwoodWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x,
                                            Distance maximum_y, int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
-    m_material_number = -1;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
+    m_material_number   = -1;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         // rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
         // rv += "G70" % commentSpaceLine("ENGLISH UNITS");
 
         // rv += "G1 F120 " % commentLine("SET INITIAL FEEDRATE");
-        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) {
-            rv += "M0" % commentSpaceLine("WAIT FOR USER");
-        }
+        if (m_sb->setting<int>(PRS::GCode::kEnableWaitForUser)) { rv += "M0" % commentSpaceLine("WAIT FOR USER"); }
     }
 
     if (m_sb->setting<int>(PRS::GCode::kEnableBoundingBox)) {
@@ -57,8 +56,7 @@ QString ThermwoodWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
 
     if (m_sb->setting<int>(PRS::GCode::kEnableMaterialLoad)) {}
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -69,7 +67,7 @@ QString ThermwoodWriter::writeInitialSetup(Distance minimum_x, Distance minimum_
 
 QString ThermwoodWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
+    m_layer_start  = true;
     QString rv;
     return rv;
 }
@@ -139,7 +137,7 @@ QString ThermwoodWriter::writeTravel(Point start_location, Point target_location
     else
         liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -153,7 +151,7 @@ QString ThermwoodWriter::writeTravel(Point start_location, Point target_location
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
               writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
@@ -165,7 +163,7 @@ QString ThermwoodWriter::writeTravel(Point start_location, Point target_location
     if (m_first_travel)
         travel_destination.z(qAbs(m_sb->setting<Distance>(PRS::Dimensions::kZOffset)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(m_sb->setting<Velocity>(PS::Travel::kSpeed).to(m_meta.m_velocity_unit)) %
           writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
@@ -179,27 +177,25 @@ QString ThermwoodWriter::writeTravel(Point start_location, Point target_location
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
     }
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     return rv;
 }
 
 QString ThermwoodWriter::writeLine(const Point& start_point, const Point& target_point,
                                    const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
     // turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += m_G1;
     // Forces first motion of layer to issue speed (needed for spiralize mode so that feedrate is scaled properly)
@@ -242,17 +238,15 @@ QString ThermwoodWriter::writeArc(const Point& start_point, const Point& end_poi
                                   const Angle& angle, const bool& ccw, const QSharedPointer<SettingsBase> params) {
     QString rv;
 
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
+    Velocity speed      = params->setting<Velocity>(SS::kSpeed);
+    int rpm             = params->setting<int>(SS::kExtruderSpeed);
     int material_number = params->setting<int>(SS::kMaterialNumber);
-    auto region_type = params->setting<RegionType>(SS::kRegionType);
+    auto region_type    = params->setting<RegionType>(SS::kRegionType);
     auto path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm    = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     // Turn on the extruder if it isn't already on
-    if (!m_deposition_active && rpm > 0) {
-        rv += writeExtruderOn(region_type, rpm, params);
-    }
+    if (!m_deposition_active && rpm > 0) { rv += writeExtruderOn(region_type, rpm, params); }
 
     rv += ((ccw) ? m_G3 : m_G2);
 
@@ -278,7 +272,7 @@ QString ThermwoodWriter::writeArc(const Point& start_point, const Point& end_poi
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     // Add comment for gcode parser
@@ -359,7 +353,9 @@ QString ThermwoodWriter::writeShutdown() {
     return rv;
 }
 
-QString ThermwoodWriter::writePurge(int RPM, int duration, int delay) { return {}; }
+QString ThermwoodWriter::writePurge(int RPM, int duration, int delay) {
+    return {};
+}
 
 QString ThermwoodWriter::writeDwell(Time time) {
     if (time > 0)
@@ -445,9 +441,9 @@ QString ThermwoodWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/tormach_writer.cpp
+++ b/src/gcode/writers/tormach_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/tormach_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -29,19 +30,19 @@ QString TormachWriter::writeSettingsHeader(GcodeSyntax syntax) {
 
 QString TormachWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                          int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_tip_wipe = false;
-    m_min_z = 0.0f;
-    m_bead_number = 0;
-    m_minimum_x = minimum_x;
-    m_maximum_x = maximum_x;
-    m_minimum_y = minimum_y;
-    m_maximum_y = maximum_y;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_tip_wipe          = false;
+    m_min_z             = 0.0f;
+    m_bead_number       = 0;
+    m_minimum_x         = minimum_x;
+    m_maximum_x         = maximum_x;
+    m_minimum_y         = minimum_y;
+    m_maximum_y         = maximum_y;
     QString rv;
     if (m_sb->setting<int>(PRS::GCode::kEnableStartupCode)) {
         rv += commentLine("SAFETY BLOCK - ESTABLISH OPERATIONAL MODES");
@@ -69,8 +70,7 @@ QString TormachWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y,
         m_start_point = Point(minimum_x, minimum_y, 0);
     }
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -81,8 +81,8 @@ QString TormachWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y,
 
 QString TormachWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
-    m_bead_number = 0;
+    m_layer_start  = true;
+    m_bead_number  = 0;
     QString rv;
     rv += "M1 " % commentLine("OPTIONAL STOP - LAYER CHANGE");
     return rv;
@@ -159,7 +159,7 @@ QString TormachWriter::writeTravel(Point start_location, Point target_location, 
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -172,7 +172,7 @@ QString TormachWriter::writeTravel(Point start_location, Point target_location, 
 
     // Write the lift
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
 
         rv += m_G0 % writeCoordinates(lift_destination) % commentSpaceLine("TRAVEL LIFT Z");
         setFeedrate(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed));
@@ -197,13 +197,13 @@ QString TormachWriter::writeTravel(Point start_location, Point target_location, 
     // Write the travel
     Point travel_destination = target_location;
     if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G0 % writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     // Write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
@@ -216,12 +216,12 @@ QString TormachWriter::writeTravel(Point start_location, Point target_location, 
 
 QString TormachWriter::writeLine(const Point& start_point, const Point& target_point,
                                  const QSharedPointer<SettingsBase> params) {
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -273,7 +273,7 @@ QString TormachWriter::writeScan(Point target_point, Velocity speed, bool on_off
 QString TormachWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -409,14 +409,14 @@ QString TormachWriter::writeCoordinates(Point destination) {
 
     Distance target_z = destination.z() + z_offset;
     if (qAbs(target_z - m_last_z) > 10) {
-        if (target_z > -1 && target_z < 1) // fix for small value creating negative 0 g-code output
+        if (target_z > -1 && target_z < 1)  // fix for small value creating negative 0 g-code output
         {
             target_z = 0;
         }
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/wolf_writer.cpp
+++ b/src/gcode/writers/wolf_writer.cpp
@@ -1,6 +1,7 @@
 #include "gcode/writers/wolf_writer.h"
 
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qnumeric.h>
@@ -28,19 +29,18 @@ QString WolfWriter::writeSettingsHeader(GcodeSyntax syntax) {
 
 QString WolfWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Distance maximum_x, Distance maximum_y,
                                       int num_layers) {
-    m_current_z = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
-    m_current_rpm = 0;
-    m_current_robot = 1;
-    m_machine_type = m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType);
+    m_current_z         = m_sb->setting<Distance>(PRS::Dimensions::kZOffset);
+    m_current_rpm       = 0;
+    m_current_robot     = 1;
+    m_machine_type      = m_sb->setting<MachineType>(PRS::MachineSetup::kMachineType);
     m_deposition_active = false;
-    m_first_travel = true;
-    m_first_print = true;
-    m_layer_start = true;
-    m_min_z = 0.0f;
+    m_first_travel      = true;
+    m_first_print       = true;
+    m_layer_start       = true;
+    m_min_z             = 0.0f;
     QString rv;
 
-    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "")
-        rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
+    if (m_sb->setting<QString>(PRS::GCode::kStartCode) != "") rv += m_sb->setting<QString>(PRS::GCode::kStartCode);
 
     rv += m_newline;
 
@@ -51,8 +51,8 @@ QString WolfWriter::writeInitialSetup(Distance minimum_x, Distance minimum_y, Di
 
 QString WolfWriter::writeBeforeLayer(float new_min_z, QSharedPointer<SettingsBase> sb) {
     m_spiral_layer = sb->setting<bool>(PS::SpecialModes::kEnableSpiralize);
-    m_layer_start = true;
-    m_bead_count = 0;
+    m_layer_start  = true;
+    m_bead_count   = 0;
     QString rv;
     return rv;
 }
@@ -138,7 +138,7 @@ QString WolfWriter::writeTravel(Point start_location, Point target_location, Tra
     Distance liftDist;
     liftDist = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
 
-    bool travel_lift_required = liftDist > 0; // && !m_first_travel; //do not write a lift on first travel
+    bool travel_lift_required = liftDist > 0;  // && !m_first_travel; //do not write a lift on first travel
 
     // Don't lift for short travel moves
     if (start_location.distance(target_location) < m_sb->setting<Distance>(PS::Travel::kMinTravelForLift)) {
@@ -148,7 +148,7 @@ QString WolfWriter::writeTravel(Point start_location, Point target_location, Tra
     // write the lift
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
-        Point lift_destination = new_start_location + travel_lift; // lift destination is above start location
+        Point lift_destination = new_start_location + travel_lift;  // lift destination is above start location
 
         rv += m_G1 % m_f %
               QString::number(m_sb->setting<Velocity>(PRS::MachineSpeed::kZSpeed).to(m_meta.m_velocity_unit)) %
@@ -163,14 +163,14 @@ QString WolfWriter::writeTravel(Point start_location, Point target_location, Tra
                                   m_sb->setting<Distance>(PS::Travel::kLiftHeight)() +
                                   m_sb->setting<Distance>(PS::Layer::kLayerHeight)()));
     else if (travel_lift_required)
-        travel_destination = travel_destination + travel_lift; // travel destination is above the target point
+        travel_destination = travel_destination + travel_lift;  // travel destination is above the target point
 
     rv += m_G1 % m_f % QString::number(m_sb->setting<Velocity>(PS::Travel::kSpeed).to(m_meta.m_velocity_unit)) %
           writeCoordinates(travel_destination) % commentSpaceLine("TRAVEL");
     setFeedrate(m_sb->setting<Velocity>(PS::Travel::kSpeed));
 
-    if (m_first_travel)         // if this is the first travel
-        m_first_travel = false; // update for next one
+    if (m_first_travel)          // if this is the first travel
+        m_first_travel = false;  // update for next one
 
     // write the travel lower (undo the lift)
     if (travel_lift_required && (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftLowerOnly)) {
@@ -186,12 +186,12 @@ QString WolfWriter::writeTravel(Point start_location, Point target_location, Tra
 QString WolfWriter::writeLine(const Point& start_point, const Point& target_point,
                               const QSharedPointer<SettingsBase> params) {
     // Get the settings
-    Velocity speed = params->setting<Velocity>(SS::kSpeed);
-    int rpm = params->setting<int>(SS::kExtruderSpeed);
-    int material_number = params->setting<int>(SS::kMaterialNumber);
-    RegionType region_type = params->setting<RegionType>(SS::kRegionType);
+    Velocity speed               = params->setting<Velocity>(SS::kSpeed);
+    int rpm                      = params->setting<int>(SS::kExtruderSpeed);
+    int material_number          = params->setting<int>(SS::kMaterialNumber);
+    RegionType region_type       = params->setting<RegionType>(SS::kRegionType);
     PathModifiers path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
-    float output_rpm = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
+    float output_rpm             = rpm * m_sb->setting<float>(PRS::MachineSpeed::kGearRatio);
 
     QString rv;
 
@@ -245,7 +245,7 @@ QString WolfWriter::writeArc(const Point& start_point, const Point& end_point, c
 QString WolfWriter::writeAfterPath(RegionType type) {
     QString rv;
     if (!m_spiral_layer) {
-        rv += writeExtruderOff(0); // update to turn off the extruder
+        rv += writeExtruderOff(0);  // update to turn off the extruder
         if (type == RegionType::kPerimeter) {
             if (!m_sb->setting<QString>(PS::GCode::kPerimeterEnd).isEmpty())
                 rv += m_sb->setting<QString>(PS::GCode::kPerimeterEnd) % m_newline;
@@ -348,9 +348,7 @@ QString WolfWriter::writeExtruderOn(RegionType region_type, int rpm, int extrude
     }
 
     // Write the appropriate dwell time for the region
-    if (dwell_time > 0) {
-        rv += writeDwell(dwell_time);
-    }
+    if (dwell_time > 0) { rv += writeDwell(dwell_time); }
 
     return rv;
 }
@@ -361,9 +359,7 @@ QString WolfWriter::writeExtruderOff(int extruder_number) {
 
     // Retrieve relevant settings
     Time off_delay = m_sb->setting<Time>(MS::Extruder::kOffDelay);
-    if (off_delay > 0) {
-        rv += writeDwell(off_delay);
-    }
+    if (off_delay > 0) { rv += writeDwell(off_delay); }
 
     rv += "M103" % commentSpaceLine("TURN PUMP OFF");
     m_current_rpm = 0;
@@ -386,9 +382,9 @@ QString WolfWriter::writeCoordinates(Point destination) {
     if (qAbs(target_z - m_last_z) > 10) {
         rv += m_z % QString::number(Distance(target_z).to(m_meta.m_distance_unit), 'f', 4);
         m_current_z = target_z;
-        m_last_z = target_z;
+        m_last_z    = target_z;
     }
 
     return rv;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/gcode/writers/writer_base.cpp
+++ b/src/gcode/writers/writer_base.cpp
@@ -1,7 +1,8 @@
 #include "gcode/writers/writer_base.h"
 
-#include <CGAL/property_map.h>
 #include <QStringBuilder>
+
+#include <CGAL/property_map.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
 #include <qvectornd.h>
@@ -17,39 +18,39 @@
 
 namespace ORNL {
 WriterBase::WriterBase(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb) : m_sb(sb) {
-    m_meta = meta;
-    m_newline = '\n';
-    m_empty_step_comment = "INTENTIONALLY BLANK - NO PATHING PRODUCED USING CURRENT SETTINGS";
-    m_space = ' ';
-    m_x = " X";
-    m_y = " Y";
-    m_z = " Z";
-    m_w = " W";
-    m_e = " E";
-    m_f = " F";
-    m_s = " S";
-    m_p = " P";
-    m_i = " I";
-    m_j = " J";
-    m_k = " K";
-    m_r = " R";
-    m_l = " L";
-    m_q = " Q";
-    m_a = " A";
-    m_b = " B";
-    m_G0 = "G0";
-    m_G1 = "G1";
-    m_G2 = "G2";
-    m_G3 = "G3";
-    m_G4 = "G4";
-    m_G5 = "G5";
-    m_M3 = "M3";
-    m_M5 = "M5";
-    m_start_point = Point(0, 0, 0);
-    m_current_position = Point(0, 0, 0);
+    m_meta                 = meta;
+    m_newline              = '\n';
+    m_empty_step_comment   = "INTENTIONALLY BLANK - NO PATHING PRODUCED USING CURRENT SETTINGS";
+    m_space                = ' ';
+    m_x                    = " X";
+    m_y                    = " Y";
+    m_z                    = " Z";
+    m_w                    = " W";
+    m_e                    = " E";
+    m_f                    = " F";
+    m_s                    = " S";
+    m_p                    = " P";
+    m_i                    = " I";
+    m_j                    = " J";
+    m_k                    = " K";
+    m_r                    = " R";
+    m_l                    = " L";
+    m_q                    = " Q";
+    m_a                    = " A";
+    m_b                    = " B";
+    m_G0                   = "G0";
+    m_G1                   = "G1";
+    m_G2                   = "G2";
+    m_G3                   = "G3";
+    m_G4                   = "G4";
+    m_G5                   = "G5";
+    m_M3                   = "M3";
+    m_M5                   = "M5";
+    m_start_point          = Point(0, 0, 0);
+    m_current_position     = Point(0, 0, 0);
     m_has_current_position = false;
-    m_build_maximum_z = Distance(0.0);
-    m_has_build_maximum_z = false;
+    m_build_maximum_z      = Distance(0.0);
+    m_has_build_maximum_z  = false;
 
     m_deposition_active = false;
 }
@@ -67,7 +68,9 @@ QString WriterBase::commentSpaceLine(const QString& text) {
                    m_newline);
 }
 
-QVector3D WriterBase::getTravelLift() { return getLiftVector(m_sb->setting<Distance>(PS::Travel::kLiftHeight)); }
+QVector3D WriterBase::getTravelLift() {
+    return getLiftVector(m_sb->setting<Distance>(PS::Travel::kLiftHeight));
+}
 
 QVector3D WriterBase::getLiftVector(Distance lift_height) const {
     // Retrieve the slicing plane normal
@@ -83,13 +86,17 @@ QVector3D WriterBase::getLiftVector(Distance lift_height) const {
 }
 
 void WriterBase::setCurrentPosition(const Point& point) {
-    m_current_position = point;
+    m_current_position     = point;
     m_has_current_position = true;
 }
 
-bool WriterBase::hasCurrentPosition() const { return m_has_current_position; }
+bool WriterBase::hasCurrentPosition() const {
+    return m_has_current_position;
+}
 
-Point WriterBase::getCurrentPosition() const { return m_current_position; }
+Point WriterBase::getCurrentPosition() const {
+    return m_current_position;
+}
 
 int WriterBase::getInitialExtruderSpeed(const QSharedPointer<SettingsBase>& params) const {
     if (params != nullptr && params->contains(MS::Extruder::kInitialSpeed)) {
@@ -159,7 +166,7 @@ QString WriterBase::writeSettingsHeader(GcodeSyntax syntax) {
         text += commentLine(
             QString("Nozzle Diameter: %0in").arg(m_sb->setting<Distance>(PS::Layer::kNozzleDiameter).to(in)));
     }
-    if (m_sb->setting<int>(PRS::MachineSetup::kMachineType) == 1) // If filament machine type
+    if (m_sb->setting<int>(PRS::MachineSetup::kMachineType) == 1)  // If filament machine type
     {
         text += commentLine(
             QString("Filament Diameter: %0mm").arg(m_sb->setting<Distance>(MS::Filament::kDiameter).to(mm)));
@@ -191,8 +198,7 @@ QString WriterBase::writeSettingsHeader(GcodeSyntax syntax) {
 
     if (m_sb->setting<int>(PS::SpecialModes::kEnableSpiralize)) {
         text += commentLine(QString("Spiralize is turned ON"));
-        if (m_sb->setting<int>(PS::SpecialModes::kSmoothing))
-            text += commentLine("Smoothing is turned ON");
+        if (m_sb->setting<int>(PS::SpecialModes::kSmoothing)) text += commentLine("Smoothing is turned ON");
         if (m_sb->setting<int>(PS::SpecialModes::kEnableOversize)) {
             text += commentLine(QString("Oversize part by: %0in")
                                     .arg(m_sb->setting<Distance>(PS::SpecialModes::kOversizeDistance).to(in)));
@@ -273,8 +279,7 @@ QString WriterBase::writeSettingsHeader(GcodeSyntax syntax) {
                                     .arg(m_sb->setting<Distance>(PS::SpecialModes::kOversizeDistance).to(in)));
         }
     }
-    if (syntax == GcodeSyntax::kIngersoll)
-        text += commentLine("---END HEADER");
+    if (syntax == GcodeSyntax::kIngersoll) text += commentLine("---END HEADER");
 
     text += m_newline;
     return text;
@@ -287,8 +292,7 @@ QString WriterBase::writeLayerChange(uint layer_number) {
 QString WriterBase::writeSettingsFooter() {
     QString rv;
     const fifojson& settings = m_sb->json();
-    if (!settings.is_array() || settings.empty() || !settings.front().is_object())
-        return rv;
+    if (!settings.is_array() || settings.empty() || !settings.front().is_object()) return rv;
 
     if (m_sb->setting<int>(Constants::PrinterSettings::GCode::kEnableSettingsFooter)) {
         rv += m_newline % commentLine("Settings Footer");
@@ -301,21 +305,33 @@ QString WriterBase::writeSettingsFooter() {
     return rv;
 }
 
-QString WriterBase::writeEmptyStep() { return commentLine(m_empty_step_comment); }
+QString WriterBase::writeEmptyStep() {
+    return commentLine(m_empty_step_comment);
+}
 
-QString WriterBase::writeCommentLine(QString comment) { return "\n" + commentLine(comment); }
+QString WriterBase::writeCommentLine(QString comment) {
+    return "\n" + commentLine(comment);
+}
 
-void WriterBase::setFeedrate(Velocity feedrate) { m_feedrate = feedrate; }
+void WriterBase::setFeedrate(Velocity feedrate) {
+    m_feedrate = feedrate;
+}
 
-Velocity WriterBase::getFeedrate() const { return m_feedrate; }
+Velocity WriterBase::getFeedrate() const {
+    return m_feedrate;
+}
 
 void WriterBase::setBuildMaximumZ(Distance maximum_z) {
-    m_build_maximum_z = maximum_z;
+    m_build_maximum_z     = maximum_z;
     m_has_build_maximum_z = true;
 }
 
-bool WriterBase::hasBuildMaximumZ() const { return m_has_build_maximum_z; }
+bool WriterBase::hasBuildMaximumZ() const {
+    return m_has_build_maximum_z;
+}
 
-Distance WriterBase::getBuildMaximumZ() const { return m_build_maximum_z; }
+Distance WriterBase::getBuildMaximumZ() const {
+    return m_build_maximum_z;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/b_spline.cpp
+++ b/src/geometry/b_spline.cpp
@@ -11,23 +11,25 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
-BSpline::BSpline(const Point& start) { m_knot_points.append(start); }
+BSpline::BSpline(const Point& start) {
+    m_knot_points.append(start);
+}
 
 void BSpline::append(const Point& knot) {
     assert(!m_is_closed && "Cannot add point to closed BSpline!");
 
-    if (knot == m_knot_points.first()) // This point will close the BSpline
+    if (knot == m_knot_points.first())  // This point will close the BSpline
         close();
     else {
         m_knot_points.append(knot);
 
-        if (m_knot_points.size() >= 3) // Compute new control points
+        if (m_knot_points.size() >= 3)  // Compute new control points
         {
             Point& a = m_knot_points[m_knot_points.size() - 3];
             Point& b = m_knot_points[m_knot_points.size() - 2];
             Point& c = m_knot_points[m_knot_points.size() - 1];
 
-            double t = 0.25;
+            double t                = 0.25;
             auto new_control_points = BezierSegment::ComputeControlPoints(a, b, c, t);
 
             m_control_points.append(new_control_points.first);
@@ -50,7 +52,7 @@ void BSpline::close() {
         control_points = BezierSegment::ComputeControlPoints(m_knot_points[m_knot_points.size() - 1], m_knot_points[0],
                                                              m_knot_points[1], t);
         m_control_points.append(control_points.first);
-        m_control_points.prepend(control_points.second); // Prepend this point since it belongs to the first BSpline
+        m_control_points.prepend(control_points.second);  // Prepend this point since it belongs to the first BSpline
 
         m_is_closed = true;
     }
@@ -89,8 +91,8 @@ QVector<QSharedPointer<BezierSegment>> BSpline::toBezierSegments() {
     assert(m_knot_points.size() > 2);
 
     int end = m_knot_points.size();
-    if (!m_is_closed) // If this is not closed, then we need to add extra control points on the ends to handle the
-                      // boundary conditions
+    if (!m_is_closed)  // If this is not closed, then we need to add extra control points on the ends to handle the
+                       // boundary conditions
     {
         // Clone first and last control points
         m_control_points.prepend(m_control_points.first());
@@ -100,7 +102,7 @@ QVector<QSharedPointer<BezierSegment>> BSpline::toBezierSegments() {
 
     for (int i = 0; i < end; ++i) {
         Point start_point = m_knot_points[i];
-        Point end_point = m_knot_points[(i + 1) % m_knot_points.size()];
+        Point end_point   = m_knot_points[(i + 1) % m_knot_points.size()];
 
         Point control_a = m_control_points[(i * 2)];
         Point control_b = m_control_points[(i * 2) + 1];
@@ -110,4 +112,4 @@ QVector<QSharedPointer<BezierSegment>> BSpline::toBezierSegments() {
 
     return segments;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/geometry_debug.cpp
+++ b/src/geometry/geometry_debug.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QMutex>
 #include <QMutexLocker>
+
 #include <qcontainerfwd.h>
 #include <qlogging.h>
 
@@ -23,91 +24,63 @@ void printDesmosSegment(const ORNL::Point& start, const ORNL::Point& end) {
 }
 
 void printDesmosPolyline(const ORNL::Polyline& polyline) {
-    if (polyline.size() < 2) {
-        return;
-    }
+    if (polyline.size() < 2) { return; }
 
-    for (int i = 0; i < polyline.size() - 1; ++i) {
-        printDesmosSegment(polyline[i], polyline[i + 1]);
-    }
+    for (int i = 0; i < polyline.size() - 1; ++i) { printDesmosSegment(polyline[i], polyline[i + 1]); }
 }
 
 void printDesmosPolygon(const ORNL::Polygon& polygon) {
-    if (polygon.size() < 2) {
-        return;
-    }
+    if (polygon.size() < 2) { return; }
 
-    for (int i = 0; i < polygon.size() - 1; ++i) {
-        printDesmosSegment(polygon[i], polygon[i + 1]);
-    }
+    for (int i = 0; i < polygon.size() - 1; ++i) { printDesmosSegment(polygon[i], polygon[i + 1]); }
     printDesmosSegment(polygon.last(), polygon.first());
 }
 
 void printDesmosEdgeList(const ORNL::GeometryDebug::EdgeList& edge_list) {
-    for (const QPair<ORNL::Point, ORNL::Point>& edge : edge_list) {
-        printDesmosSegment(edge.first, edge.second);
-    }
+    for (const QPair<ORNL::Point, ORNL::Point>& edge : edge_list) { printDesmosSegment(edge.first, edge.second); }
 }
 
-} // namespace
+}  // namespace
 
 namespace ORNL {
 namespace GeometryDebug {
 void printDesmos(const Polyline& polyline, QString label) {
     QMutexLocker locker(&desmosOutputMutex());
-    if (!label.isEmpty()) {
-        qDebug() << label;
-    }
+    if (!label.isEmpty()) { qDebug() << label; }
     printDesmosPolyline(polyline);
 }
 
 void printDesmos(const QVector<Polyline>& polylines, QString label) {
     QMutexLocker locker(&desmosOutputMutex());
-    if (!label.isEmpty()) {
-        qDebug() << label;
-    }
-    for (const Polyline& polyline : polylines) {
-        printDesmosPolyline(polyline);
-    }
+    if (!label.isEmpty()) { qDebug() << label; }
+    for (const Polyline& polyline : polylines) { printDesmosPolyline(polyline); }
 }
 
 void printDesmos(const QVector<QVector<Polyline>>& geometry, QString label) {
     QMutexLocker locker(&desmosOutputMutex());
-    if (!label.isEmpty()) {
-        qDebug() << label;
-    }
+    if (!label.isEmpty()) { qDebug() << label; }
     for (const QVector<Polyline>& polyline_group : geometry) {
-        for (const Polyline& polyline : polyline_group) {
-            printDesmosPolyline(polyline);
-        }
+        for (const Polyline& polyline : polyline_group) { printDesmosPolyline(polyline); }
     }
 }
 
 void printDesmos(const Polygon& polygon, QString label) {
     QMutexLocker locker(&desmosOutputMutex());
-    if (!label.isEmpty()) {
-        qDebug() << label;
-    }
+    if (!label.isEmpty()) { qDebug() << label; }
     printDesmosPolygon(polygon);
 }
 
 void printDesmos(const PolygonList& polygon_list, QString label) {
     QMutexLocker locker(&desmosOutputMutex());
-    if (!label.isEmpty()) {
-        qDebug() << label;
-    }
-    for (const Polygon& polygon : polygon_list) {
-        printDesmosPolygon(polygon);
-    }
+    if (!label.isEmpty()) { qDebug() << label; }
+    for (const Polygon& polygon : polygon_list) { printDesmosPolygon(polygon); }
 }
 
 void printDesmos(const EdgeList& edge_list, QString label) {
     QMutexLocker locker(&desmosOutputMutex());
-    if (!label.isEmpty()) {
-        qDebug() << label;
-    }
+    if (!label.isEmpty()) { qDebug() << label; }
     printDesmosEdgeList(edge_list);
 }
 
-} // namespace GeometryDebug
-} // namespace ORNL
+}  // namespace GeometryDebug
+}  // namespace ORNL

--- a/src/geometry/mesh/closed_mesh.cpp
+++ b/src/geometry/mesh/closed_mesh.cpp
@@ -1,5 +1,6 @@
 #include "geometry/mesh/closed_mesh.h"
 
+#include <QtDebug>
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -37,7 +38,6 @@
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <CGAL/exceptions.h>
-#include <QtDebug>
 #include <qcontainerfwd.h>
 #include <qhashfunctions.h>
 #include <qsharedpointer.h>
@@ -58,18 +58,17 @@
 
 namespace ORNL {
 namespace {
-using PolyhedronFaceDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor;
+using PolyhedronFaceDescriptor     = boost::graph_traits<MeshTypes::Polyhedron>::face_descriptor;
 using PolyhedronHalfedgeDescriptor = boost::graph_traits<MeshTypes::Polyhedron>::halfedge_descriptor;
 
 constexpr std::size_t kMaxSmallModelBoundaryHalfedgesForHoleFilling = 32;
-constexpr std::size_t kMaxBoundaryHalfedgesForHoleFilling = 512;
-constexpr std::size_t kMaxBoundaryHalfedgeToFacetRatio = 8;
+constexpr std::size_t kMaxBoundaryHalfedgesForHoleFilling           = 512;
+constexpr std::size_t kMaxBoundaryHalfedgeToFacetRatio              = 8;
 
 std::size_t countBorderHalfedges(MeshTypes::Polyhedron& polyhedron) {
     std::size_t count = 0;
     for (PolyhedronHalfedgeDescriptor h : halfedges(polyhedron)) {
-        if (CGAL::is_border(h, polyhedron))
-            ++count;
+        if (CGAL::is_border(h, polyhedron)) ++count;
     }
 
     return count;
@@ -83,17 +82,14 @@ ClosedMesh::RepairResult holeFillingPreflightResult(MeshTypes::Polyhedron& polyh
     const std::size_t max_boundary_halfedges = std::max(kMaxSmallModelBoundaryHalfedgesForHoleFilling,
                                                         polyhedron.size_of_facets() / kMaxBoundaryHalfedgeToFacetRatio);
 
-    if (border_halfedges > max_boundary_halfedges) {
-        return ClosedMesh::RepairResult::kSkippedLargeBoundary;
-    }
+    if (border_halfedges > max_boundary_halfedges) { return ClosedMesh::RepairResult::kSkippedLargeBoundary; }
 
     return ClosedMesh::RepairResult::kSuccess;
 }
 
 std::optional<PolyhedronHalfedgeDescriptor> firstBorderHalfedge(MeshTypes::Polyhedron& polyhedron) {
     for (PolyhedronHalfedgeDescriptor h : halfedges(polyhedron)) {
-        if (CGAL::is_border(h, polyhedron))
-            return h;
+        if (CGAL::is_border(h, polyhedron)) return h;
     }
 
     return std::nullopt;
@@ -113,28 +109,22 @@ bool fillBorderHole(MeshTypes::Polyhedron& polyhedron, PolyhedronHalfedgeDescrip
 }
 
 ClosedMesh::RepairResult fillBorderHoles(MeshTypes::Polyhedron& polyhedron) {
-    const std::size_t border_halfedges = countBorderHalfedges(polyhedron);
+    const std::size_t border_halfedges        = countBorderHalfedges(polyhedron);
     ClosedMesh::RepairResult preflight_result = holeFillingPreflightResult(polyhedron, border_halfedges);
-    if (preflight_result != ClosedMesh::RepairResult::kSuccess)
-        return preflight_result;
+    if (preflight_result != ClosedMesh::RepairResult::kSuccess) return preflight_result;
 
     std::size_t remaining_attempts = border_halfedges;
 
     while (!polyhedron.is_closed()) {
-        if (remaining_attempts == 0) {
-            return ClosedMesh::RepairResult::kFailedHoleFilling;
-        }
+        if (remaining_attempts == 0) { return ClosedMesh::RepairResult::kFailedHoleFilling; }
 
         std::optional<PolyhedronHalfedgeDescriptor> border_halfedge = firstBorderHalfedge(polyhedron);
-        if (!border_halfedge.has_value()) {
-            return ClosedMesh::RepairResult::kFailedHoleFilling;
-        }
+        if (!border_halfedge.has_value()) { return ClosedMesh::RepairResult::kFailedHoleFilling; }
 
         --remaining_attempts;
 
         try {
-            if (!fillBorderHole(polyhedron, *border_halfedge))
-                return ClosedMesh::RepairResult::kFailedHoleFilling;
+            if (!fillBorderHole(polyhedron, *border_halfedge)) return ClosedMesh::RepairResult::kFailedHoleFilling;
         } catch (const CGAL::Failure_exception& error) {
             qWarning() << "CGAL hole filling failed:" << error.what();
             return ClosedMesh::RepairResult::kFailedHoleFilling;
@@ -146,14 +136,16 @@ ClosedMesh::RepairResult fillBorderHoles(MeshTypes::Polyhedron& polyhedron) {
 
     return ClosedMesh::RepairResult::kSuccess;
 }
-} // namespace
+}  // namespace
 
-ClosedMesh::ClosedMesh() : MeshBase() { m_is_closed = true; }
+ClosedMesh::ClosedMesh() : MeshBase() {
+    m_is_closed = true;
+}
 
 ClosedMesh::ClosedMesh(const QVector<MeshVertex>& vertices, const QVector<MeshFace>& faces)
     : MeshBase(vertices, faces) {
-    m_representation = MeshTypes::Polyhedron(PolyhedronFromVerticesAndFaces(m_vertices, m_faces));
-    m_original_representation = MeshTypes::Polyhedron(m_representation); // Create a copy
+    m_representation          = MeshTypes::Polyhedron(PolyhedronFromVerticesAndFaces(m_vertices, m_faces));
+    m_original_representation = MeshTypes::Polyhedron(m_representation);  // Create a copy
     updateDims();
     m_is_closed = true;
 }
@@ -161,8 +153,8 @@ ClosedMesh::ClosedMesh(const QVector<MeshVertex>& vertices, const QVector<MeshFa
 ClosedMesh::ClosedMesh(const QString& name, const QString& path, const QVector<MeshVertex>& vertices,
                        const QVector<MeshFace>& faces, MeshType type)
     : MeshBase(vertices, faces, name, path, type) {
-    m_representation = MeshTypes::Polyhedron(PolyhedronFromVerticesAndFaces(m_vertices, m_faces));
-    m_original_representation = MeshTypes::Polyhedron(m_representation); // Create a copy
+    m_representation          = MeshTypes::Polyhedron(PolyhedronFromVerticesAndFaces(m_vertices, m_faces));
+    m_original_representation = MeshTypes::Polyhedron(m_representation);  // Create a copy
     updateDims();
     m_is_closed = true;
 }
@@ -179,16 +171,18 @@ ClosedMesh::ClosedMesh(MeshTypes::Polyhedron poly, QString name, QString file) :
     CGAL::copy_face_graph(m_representation, m_original_representation);
     updateDims();
     m_original_dimensions = m_dimensions;
-    m_is_closed = true;
+    m_is_closed           = true;
 }
 
 ClosedMesh::ClosedMesh(QSharedPointer<ClosedMesh> mesh) : MeshBase(mesh) {
-    m_representation = mesh->m_representation;
+    m_representation          = mesh->m_representation;
     m_original_representation = mesh->m_original_representation;
-    m_is_closed = true;
+    m_is_closed               = true;
 }
 
-MeshTypes::Polyhedron ClosedMesh::polyhedron() { return m_representation; }
+MeshTypes::Polyhedron ClosedMesh::polyhedron() {
+    return m_representation;
+}
 
 void ClosedMesh::center() {
     //! Compose translation
@@ -235,14 +229,14 @@ QVector<Point> ClosedMesh::boundingBox() {
 
 Area ClosedMesh::area() {
     double area = 0.0;
-    area = CGAL::Polygon_mesh_processing::area(m_representation);
+    area        = CGAL::Polygon_mesh_processing::area(m_representation);
     Area a;
     return a.from(area, (micron * micron));
 }
 
 Volume ClosedMesh::volume() {
     double volume = 0.0;
-    volume = CGAL::Polygon_mesh_processing::volume(m_representation);
+    volume        = CGAL::Polygon_mesh_processing::volume(m_representation);
     Volume v;
     return v.from(volume, (micron * micron * micron));
 }
@@ -263,22 +257,22 @@ QVector<Point> ClosedMesh::intersect(Point start, Point end) {
     return intersection_points;
 }
 
-QVector<Point> ClosedMesh::intersect(LineSegment line) { return intersect(line.start(), line.end()); }
+QVector<Point> ClosedMesh::intersect(LineSegment line) {
+    return intersect(line.start(), line.end());
+}
 
 QVector<Point> ClosedMesh::intersect(Polyline line) {
     QVector<Point> intersections;
-    for (int i = 1, end = line.size(); i < end; ++i)
-        intersections.append(intersect(line[i - 1], line[i]));
+    for (int i = 1, end = line.size(); i < end; ++i) intersections.append(intersect(line[i - 1], line[i]));
 
     return intersections;
 }
 
 QVector<Point> ClosedMesh::intersect(Path path) {
     QVector<Point> intersections;
-    for (auto& seg : path)
-        intersections.append(intersect(seg->start(), seg->end()));
+    for (auto& seg : path) intersections.append(intersect(seg->start(), seg->end()));
 
-    if (path.front()->start() == path.back()->end()) // Is this path is a closed loop
+    if (path.front()->start() == path.back()->end())  // Is this path is a closed loop
         intersections.append(intersect(path.back()->end(), path.front()->start()));
 
     return intersections;
@@ -286,10 +280,9 @@ QVector<Point> ClosedMesh::intersect(Path path) {
 
 QVector<Point> ClosedMesh::intersect(Polygon poly) {
     QVector<Point> intersections;
-    for (int i = 1, end = poly.size(); i < end; ++i)
-        intersections.append(intersect(poly[i - 1], poly[i]));
+    for (int i = 1, end = poly.size(); i < end; ++i) intersections.append(intersect(poly[i - 1], poly[i]));
 
-    intersections.append(intersect(poly.last(), poly.first())); // Add loop back line
+    intersections.append(intersect(poly.last(), poly.first()));  // Add loop back line
 
     return intersections;
 }
@@ -305,19 +298,15 @@ std::pair<QVector<Polyline>, QVector<Polygon>> ClosedMesh::intersect(Plane plane
     QVector<Polygon> result_polygons;
 
     for (auto& cgal_polyline : cgal_polylines) {
-        if (cgal_polyline.front() == cgal_polyline.back()) // Can this be closed into a polygon?
+        if (cgal_polyline.front() == cgal_polyline.back())  // Can this be closed into a polygon?
         {
             Polygon new_polygon;
-            for (auto& point : cgal_polyline) {
-                new_polygon.append(Point::FromCGALPoint(point));
-            }
+            for (auto& point : cgal_polyline) { new_polygon.append(Point::FromCGALPoint(point)); }
             result_polygons.push_back(new_polygon);
         }
         else {
             Polyline new_line;
-            for (auto& point : cgal_polyline) {
-                new_line.append(Point::FromCGALPoint(point));
-            }
+            for (auto& point : cgal_polyline) { new_line.append(Point::FromCGALPoint(point)); }
             result_polylines.push_back(new_line);
         }
     }
@@ -330,8 +319,8 @@ void ClosedMesh::difference(ClosedMesh& clipper) {
 
     // Convert back to a mesh
     auto vertices_and_faces = FacesAndVerticesFromPolyhedron(m_representation);
-    m_vertices = vertices_and_faces.first;
-    m_faces = vertices_and_faces.second;
+    m_vertices              = vertices_and_faces.first;
+    m_faces                 = vertices_and_faces.second;
 
     updateDims();
 }
@@ -339,15 +328,15 @@ void ClosedMesh::difference(ClosedMesh& clipper) {
 void ClosedMesh::intersection(ClosedMesh mesh_to_intersect) {
     // Convert both to CGAL polyhedrons
     MeshTypes::Polyhedron subject = polyhedron();
-    MeshTypes::Polyhedron clip = mesh_to_intersect.polyhedron();
+    MeshTypes::Polyhedron clip    = mesh_to_intersect.polyhedron();
 
     MeshTypes::Polyhedron out;
     CGAL::Polygon_mesh_processing::corefine_and_compute_intersection(subject, clip, out);
 
     // Convert back to a mesh
     auto vertices_and_faces = FacesAndVerticesFromPolyhedron(out);
-    m_vertices = vertices_and_faces.first;
-    m_faces = vertices_and_faces.second;
+    m_vertices              = vertices_and_faces.first;
+    m_faces                 = vertices_and_faces.second;
 
     updateDims();
 }
@@ -355,15 +344,15 @@ void ClosedMesh::intersection(ClosedMesh mesh_to_intersect) {
 void ClosedMesh::mesh_union(ClosedMesh mesh_to_union) {
     // Convert both to CGAL polyhedrons
     MeshTypes::Polyhedron subject = polyhedron();
-    MeshTypes::Polyhedron clip = mesh_to_union.polyhedron();
+    MeshTypes::Polyhedron clip    = mesh_to_union.polyhedron();
 
     MeshTypes::Polyhedron out;
     CGAL::Polygon_mesh_processing::corefine_and_compute_union(subject, clip, out);
 
     // Convert back to a mesh
     auto vertices_and_faces = FacesAndVerticesFromPolyhedron(out);
-    m_vertices = vertices_and_faces.first;
-    m_faces = vertices_and_faces.second;
+    m_vertices              = vertices_and_faces.first;
+    m_faces                 = vertices_and_faces.second;
 
     updateDims();
 }
@@ -393,7 +382,7 @@ MeshTypes::SurfaceMesh ClosedMesh::extractUpwardFaces() {
         QVector3D normal = QVector3D::crossProduct(points[1] - points[0], points[2] - points[0]).normalized();
         // This face is upward facing
         if (normal.z() > 0.0)
-            segment_property_map[face] = 1; // Set a flag
+            segment_property_map[face] = 1;  // Set a flag
         else
             segment_property_map[face] = 0;
     }
@@ -433,9 +422,9 @@ std::pair<bool, Area> ClosedMesh::crossSectionalArea(Plane plane, QVector<Polygo
     CGAL::Polygon_mesh_slicer<MeshTypes::Polyhedron, MeshTypes::Kernel> slicer(m_representation);
     slicer(plane.toCGALPlane(), std::back_inserter(cross_section));
 
-    Area a = 0;
+    Area a            = 0;
     bool intersecting = false;
-    if (cross_section.size() == 0) // No cross section generated
+    if (cross_section.size() == 0)  // No cross section generated
         a = 0;
     else {
         for (auto section : cross_section) {
@@ -457,8 +446,8 @@ MeshTypes::Polyhedron ClosedMesh::PolyhedronFromVerticesAndFaces(QVector<MeshVer
     return mesh;
 }
 
-std::pair<QVector<MeshVertex>, QVector<MeshFace>>
-ClosedMesh::FacesAndVerticesFromPolyhedron(MeshTypes::Polyhedron& mesh) {
+std::pair<QVector<MeshVertex>, QVector<MeshFace>> ClosedMesh::FacesAndVerticesFromPolyhedron(
+    MeshTypes::Polyhedron& mesh) {
     QVector<MeshFace> mesh_faces;
     mesh_faces.reserve(CGAL::faces(mesh).size());
 
@@ -522,17 +511,13 @@ ClosedMesh::RepairResult ClosedMesh::CleanPolyhedronWithStatus(MeshTypes::Polyhe
         std::vector<PolyhedronHalfedgeDescriptor> non_manifold_vertices;
         CGAL::Polygon_mesh_processing::non_manifold_vertices(polyhedron, std::back_inserter(non_manifold_vertices));
 
-        if (!non_manifold_vertices.empty()) {
-            return RepairResult::kSkippedNonManifoldBoundary;
-        }
+        if (!non_manifold_vertices.empty()) { return RepairResult::kSkippedNonManifoldBoundary; }
 
         RepairResult hole_filling_result = fillBorderHoles(polyhedron);
-        if (hole_filling_result != RepairResult::kSuccess)
-            return hole_filling_result;
+        if (hole_filling_result != RepairResult::kSuccess) return hole_filling_result;
     }
 
-    if (!polyhedron.is_closed())
-        return RepairResult::kRepairLeftOpen;
+    if (!polyhedron.is_closed()) return RepairResult::kRepairLeftOpen;
 
     try {
         if (!CGAL::Polygon_mesh_processing::does_self_intersect(
@@ -563,8 +548,7 @@ ClosedMesh::RepairResult ClosedMesh::CleanPolyhedronWithStatus(MeshTypes::Polyhe
     }
     polyhedron = self_intersection_repair;
 
-    if (!polyhedron.is_closed())
-        return RepairResult::kRepairLeftOpen;
+    if (!polyhedron.is_closed()) return RepairResult::kRepairLeftOpen;
 
     return RepairResult::kSuccess;
 }
@@ -601,10 +585,9 @@ void ClosedMesh::convert() {
 bool ClosedMesh::CheckIntersectingCurves(Plane& plane, QVector<Polygon> boundary_curves) {
     for (Polygon curve : boundary_curves) {
         for (Point p : curve) {
-            if (plane.evaluatePoint(p) >= 0)
-                return true;
+            if (plane.evaluatePoint(p) >= 0) return true;
         }
     }
     return false;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/mesh/mesh_base.cpp
+++ b/src/geometry/mesh/mesh_base.cpp
@@ -39,29 +39,37 @@ MeshBase::MeshBase(const QVector<MeshVertex>& vertices, const QVector<MeshFace>&
 }
 
 MeshBase::MeshBase(const QSharedPointer<MeshBase> mesh) {
-    m_name = mesh->m_name;
-    m_file = mesh->m_file;
-    m_type = mesh->m_type;
-    m_gen_type = mesh->m_gen_type;
-    m_imported_unit = mesh->m_imported_unit;
-    m_vertices = mesh->m_vertices;
+    m_name              = mesh->m_name;
+    m_file              = mesh->m_file;
+    m_type              = mesh->m_type;
+    m_gen_type          = mesh->m_gen_type;
+    m_imported_unit     = mesh->m_imported_unit;
+    m_vertices          = mesh->m_vertices;
     m_vertices_original = m_vertices_aligned = mesh->m_vertices_aligned;
-    m_faces = mesh->m_faces;
+    m_faces                                  = mesh->m_faces;
     m_faces_original = m_faces_aligned = mesh->m_faces_aligned;
-    m_transformation = mesh->m_transformation;
-    m_dimensions = mesh->m_dimensions;
-    m_original_dimensions = mesh->m_original_dimensions;
-    m_min = mesh->m_min;
-    m_max = mesh->m_max;
+    m_transformation                   = mesh->m_transformation;
+    m_dimensions                       = mesh->m_dimensions;
+    m_original_dimensions              = mesh->m_original_dimensions;
+    m_min                              = mesh->m_min;
+    m_max                              = mesh->m_max;
 }
 
-const QVector<MeshVertex> MeshBase::vertices() { return m_vertices; }
+const QVector<MeshVertex> MeshBase::vertices() {
+    return m_vertices;
+}
 
-const QVector<MeshFace> MeshBase::faces() { return m_faces; }
+const QVector<MeshFace> MeshBase::faces() {
+    return m_faces;
+}
 
-const QVector<MeshVertex> MeshBase::originalVertices() { return m_vertices_aligned; }
+const QVector<MeshVertex> MeshBase::originalVertices() {
+    return m_vertices_aligned;
+}
 
-const QVector<MeshFace> MeshBase::originalFaces() { return m_faces_aligned; }
+const QVector<MeshFace> MeshBase::originalFaces() {
+    return m_faces_aligned;
+}
 
 void MeshBase::setTransformation(const QMatrix4x4& matrix) {
     QQuaternion rotation;
@@ -73,7 +81,7 @@ void MeshBase::setTransformation(const QMatrix4x4& matrix) {
     m_transformation = matrix;
 
     m_vertices = m_vertices_aligned;
-    m_faces = m_faces_aligned;
+    m_faces    = m_faces_aligned;
 
     //        QVector3D center = originalCentroid().toQVector3D();
     //        QMatrix4x4 part_center;
@@ -110,9 +118,7 @@ void MeshBase::setTransformations(const QVector<QMatrix4x4> matrixes) {
             this->alignAxis(
                 MathUtils::composeTransformMatrix(translationL, QQuaternion(1, 0, 0, 0), QVector3D(1, 1, 1)));
         }
-        else {
-            this->setTransformation(matrix);
-        }
+        else { this->setTransformation(matrix); }
 
         m_all_transformations.append(matrix);
     }
@@ -123,9 +129,9 @@ void MeshBase::setTransformations(const QVector<QMatrix4x4> matrixes) {
 }
 
 void MeshBase::alignAxis(const QMatrix4x4& matrix) {
-    m_transformation = matrix;
+    m_transformation   = matrix;
     m_vertices_aligned = m_vertices;
-    m_faces_aligned = m_faces;
+    m_faces_aligned    = m_faces;
 
     convert();
     updateDims();
@@ -135,7 +141,7 @@ void MeshBase::alignAxis(const QMatrix4x4& matrix) {
 void MeshBase::resetAlignedAxis(const QMatrix4x4& matrix) {
     m_all_transformations.clear();
 
-    m_transformation = matrix;
+    m_transformation   = matrix;
     m_vertices_aligned = m_vertices = m_vertices_original;
     m_faces_aligned = m_faces = m_faces_original;
 
@@ -145,7 +151,9 @@ void MeshBase::resetAlignedAxis(const QMatrix4x4& matrix) {
     m_original_dimensions = m_dimensions;
 }
 
-const QMatrix4x4& MeshBase::transformation() const { return m_transformation; }
+const QMatrix4x4& MeshBase::transformation() const {
+    return m_transformation;
+}
 
 QVector<QMatrix4x4> MeshBase::transformations() {
     QVector<QMatrix4x4> transformations = m_all_transformations;
@@ -159,30 +167,18 @@ QVector<QMatrix4x4> MeshBase::transformations() {
 void MeshBase::scale(Distance3D bounds) {
     QMatrix4x4 scale_matrix;
     QVector3D scale(1, 1, 1);
-    if (bounds.x < m_dimensions.x) {
-        scale.setX((bounds.x() / m_dimensions.x()));
-    }
-    if (bounds.y < m_dimensions.y) {
-        scale.setY((bounds.y() / m_dimensions.y()));
-    }
-    if (bounds.z < m_dimensions.z) {
-        scale.setZ((bounds.z() / m_dimensions.z()));
-    }
+    if (bounds.x < m_dimensions.x) { scale.setX((bounds.x() / m_dimensions.x())); }
+    if (bounds.y < m_dimensions.y) { scale.setY((bounds.y() / m_dimensions.y())); }
+    if (bounds.z < m_dimensions.z) { scale.setZ((bounds.z() / m_dimensions.z())); }
     scale_matrix.scale(scale);
     this->setTransformation(scale_matrix);
 }
 
 void MeshBase::scaleUniform(Distance3D bounds) {
     double scale_factor = std::numeric_limits<double>::max();
-    if (bounds.x < m_dimensions.x) {
-        scale_factor = std::min(scale_factor, (bounds.x() / m_dimensions.x()));
-    }
-    if (bounds.y < m_dimensions.y) {
-        scale_factor = std::min(scale_factor, (bounds.y() / m_dimensions.y()));
-    }
-    if (bounds.z < m_dimensions.z) {
-        scale_factor = std::min(scale_factor, (bounds.z() / m_dimensions.z()));
-    }
+    if (bounds.x < m_dimensions.x) { scale_factor = std::min(scale_factor, (bounds.x() / m_dimensions.x())); }
+    if (bounds.y < m_dimensions.y) { scale_factor = std::min(scale_factor, (bounds.y() / m_dimensions.y())); }
+    if (bounds.z < m_dimensions.z) { scale_factor = std::min(scale_factor, (bounds.z() / m_dimensions.z())); }
     QMatrix4x4 scale_matrix;
     QVector3D scale(scale_factor, scale_factor, scale_factor);
     scale_matrix.scale(scale);
@@ -191,78 +187,104 @@ void MeshBase::scaleUniform(Distance3D bounds) {
 
 Point MeshBase::centroid() {
     QVector3D center;
-    for (MeshVertex mesh_vertex : m_vertices) {
-        center += mesh_vertex.location;
-    }
+    for (MeshVertex mesh_vertex : m_vertices) { center += mesh_vertex.location; }
     return Point(center / float(m_vertices.size()));
 }
 
 Point MeshBase::originalCentroid() {
     QVector3D center;
-    for (MeshVertex& mesh_vertex : m_vertices_aligned) {
-        center += mesh_vertex.location;
-    }
+    for (MeshVertex& mesh_vertex : m_vertices_aligned) { center += mesh_vertex.location; }
     return Point(center / float(m_vertices_aligned.size()));
 }
 
-Distance3D MeshBase::dimensions() { return m_dimensions; }
+Distance3D MeshBase::dimensions() {
+    return m_dimensions;
+}
 
-Distance3D MeshBase::originalDimensions() { return m_original_dimensions; }
+Distance3D MeshBase::originalDimensions() {
+    return m_original_dimensions;
+}
 
-Point MeshBase::max() { return m_max; }
+Point MeshBase::max() {
+    return m_max;
+}
 
-Point MeshBase::min() { return m_min; }
+Point MeshBase::min() {
+    return m_min;
+}
 
 std::pair<Point, Point> MeshBase::getAxisExtrema(QVector3D vector) {
     Point min, max;
 
-    Plane plane = Plane(m_min, vector);
-    Distance min_distance = plane.distanceToPoint(m_max); // init to max dist
-    Distance max_distance = plane.distanceToPoint(m_min); // init to min dist
+    Plane plane           = Plane(m_min, vector);
+    Distance min_distance = plane.distanceToPoint(m_max);  // init to max dist
+    Distance max_distance = plane.distanceToPoint(m_min);  // init to min dist
     for (MeshVertex vertex : m_vertices) {
         Distance distance = plane.distanceToPoint(vertex.location);
         if (distance < min_distance) {
             min_distance = distance;
-            min = vertex.location;
+            min          = vertex.location;
         }
         else if (distance > max_distance) {
             max_distance = distance;
-            max = vertex.location;
+            max          = vertex.location;
         }
     }
 
     return std::make_pair(min, max);
 }
 
-const QString& MeshBase::name() { return m_name; }
+const QString& MeshBase::name() {
+    return m_name;
+}
 
-void MeshBase::setName(const QString& name) { m_name = name; }
+void MeshBase::setName(const QString& name) {
+    m_name = name;
+}
 
-const QString& MeshBase::path() { return m_file; }
+const QString& MeshBase::path() {
+    return m_file;
+}
 
-void MeshBase::setPath(const QString& path) { m_file = path; }
+void MeshBase::setPath(const QString& path) {
+    m_file = path;
+}
 
-Distance MeshBase::unit() { return m_imported_unit; }
+Distance MeshBase::unit() {
+    return m_imported_unit;
+}
 
-void MeshBase::setUnit(const Distance unit) { m_imported_unit = unit; }
+void MeshBase::setUnit(const Distance unit) {
+    m_imported_unit = unit;
+}
 
-const MeshType MeshBase::type() { return m_type; }
+const MeshType MeshBase::type() {
+    return m_type;
+}
 
-void MeshBase::setType(const MeshType type) { m_type = type; }
+void MeshBase::setType(const MeshType type) {
+    m_type = type;
+}
 
-bool MeshBase::isClosed() { return m_is_closed; }
+bool MeshBase::isClosed() {
+    return m_is_closed;
+}
 
-const MeshGeneratorType MeshBase::genType() { return m_gen_type; }
+const MeshGeneratorType MeshBase::genType() {
+    return m_gen_type;
+}
 
-void MeshBase::setGenType(MeshGeneratorType type) { m_gen_type = type; }
+void MeshBase::setGenType(MeshGeneratorType type) {
+    m_gen_type = type;
+}
 
 std::pair<float*, uint> MeshBase::glVertexArray() {
-    float* vertices_array = new float[9 * m_faces_aligned.size()];
+    float* vertices_array    = new float[9 * m_faces_aligned.size()];
     QVector<MeshVertex> vert = m_vertices_aligned;
 
     int i = 0;
     for (MeshFace mesh_face : m_faces_aligned) {
-        vertices_array[i] = vert.at(mesh_face.vertex_index[0]).location.x();
+        vertices_array[i]     = vert.at(mesh_face.vertex_index[0]).location.x();
         vertices_array[i + 1] = vert.at(mesh_face.vertex_index[0]).location.y();
         vertices_array[i + 2] = vert.at(mesh_face.vertex_index[0]).location.z();
 
@@ -284,7 +306,7 @@ std::pair<float*, uint> MeshBase::glNormalArray() {
 
     int i = 0;
     for (MeshFace mesh_face : m_faces_aligned) {
-        normals_array[i] = mesh_face.normal.x();
+        normals_array[i]     = mesh_face.normal.x();
         normals_array[i + 1] = mesh_face.normal.y();
         normals_array[i + 2] = mesh_face.normal.z();
 
@@ -329,17 +351,14 @@ void MeshBase::updateDims() {
 int MeshBase::GetFaceIdxWithPoints(int idx0, int idx1, int notFaceIdx, QVector<MeshVertex>& vertices) {
     for (unsigned int i = 0; i < vertices[idx0].connected_faces.size(); i++) {
         int f0 = vertices[idx0].connected_faces[i];
-        if (f0 == notFaceIdx)
-            continue;
+        if (f0 == notFaceIdx) continue;
         for (unsigned int j = 0; j < vertices[idx1].connected_faces.size(); j++) {
             int f1 = vertices[idx1].connected_faces[j];
-            if (f1 == notFaceIdx)
-                continue;
-            if (f0 == f1)
-                return f0;
+            if (f1 == notFaceIdx) continue;
+            if (f0 == f1) return f0;
         }
     }
     return -1;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/mesh/mesh_face.cpp
+++ b/src/geometry/mesh/mesh_face.cpp
@@ -5,7 +5,7 @@
 namespace ORNL {
 MeshFace::MeshFace() {
     for (int i = 0; i < 3; i++) {
-        vertex_index[i] = -1;
+        vertex_index[i]         = -1;
         connected_face_index[i] = -1;
     }
 }
@@ -23,4 +23,4 @@ MeshFace::MeshFace(int* vertices, int* connected_faces, QVector3D _normal, bool 
 
     ignore = _ignore;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/mesh/mesh_factory.cpp
+++ b/src/geometry/mesh/mesh_factory.cpp
@@ -107,9 +107,9 @@ ClosedMesh MeshFactory::CreateTriaglePyramidMesh(const Distance& length) {
     vertices.push_back(MeshVertex(QVector3D(0, 0, 0)));
     vertices.push_back(MeshVertex(QVector3D(0, length(), 0)));
     vertices.push_back(MeshVertex(QVector3D(qSqrt(qPow(length(), 2) - qPow(length() / 2.0, 2)), length() / 2.0, 0)));
-    double x = (length() / 2.0) * 0.57735; // tan(30 deg)
-    double y = length() / 2.0;
-    double h = qSqrt(qPow(x, 2) + qPow(y, 2));
+    double x      = (length() / 2.0) * 0.57735;  // tan(30 deg)
+    double y      = length() / 2.0;
+    double h      = qSqrt(qPow(x, 2) + qPow(y, 2));
     double height = qSqrt(qPow(length(), 2) - qPow(h, 2));
     vertices.push_back(MeshVertex(QVector3D(x, y, height)));
 
@@ -166,21 +166,21 @@ ClosedMesh MeshFactory::CreateCylinderMesh(const Distance& radius, const Distanc
     }
 
     int bottom_center_index = vertices.size();
-    vertices.push_back(QVector3D(radius(), radius(), 0)); // Bottom center
+    vertices.push_back(QVector3D(radius(), radius(), 0));  // Bottom center
     int top_center_index = vertices.size();
-    vertices.push_back(QVector3D(radius(), radius(), height())); // Top center
+    vertices.push_back(QVector3D(radius(), radius(), height()));  // Top center
 
     // Side faces
     for (int i = 0; i < resolution; ++i) {
         // Add first triangle
-        int* v1 = new int[3] {i, (i + 1) % resolution, ((i + 1) % resolution) + resolution};
+        int* v1      = new int[3] {i, (i + 1) % resolution, ((i + 1) % resolution) + resolution};
         auto normal1 = QVector3D::crossProduct(vertices[v1[0]].location - vertices[v1[2]].location,
                                                vertices[v1[1]].location - vertices[v1[2]].location)
                            .normalized();
         faces.push_back(MeshFace(v1, new int[3], normal1));
 
         // Add second triangle
-        int* v2 = new int[3] {((i + 1) % resolution) + resolution, i + resolution, i};
+        int* v2      = new int[3] {((i + 1) % resolution) + resolution, i + resolution, i};
         auto normal2 = QVector3D::crossProduct(vertices[v2[0]].location - vertices[v2[2]].location,
                                                vertices[v2[1]].location - vertices[v2[2]].location)
                            .normalized();
@@ -201,8 +201,7 @@ ClosedMesh MeshFactory::CreateCylinderMesh(const Distance& radius, const Distanc
     // Bottom circle faces
     for (int i = resolution; i < (resolution * 2); ++i) {
         int next = i + 1;
-        if (next == resolution * 2)
-            next = resolution;
+        if (next == resolution * 2) next = resolution;
         int* v = new int[3] {i, next, top_center_index};
 
         auto normal = QVector3D::crossProduct(vertices[v[0]].location - vertices[v[2]].location,
@@ -232,7 +231,7 @@ ClosedMesh MeshFactory::CreateConeMesh(const Distance& radius, const Distance& h
     }
 
     int bottom_center_index = vertices.size();
-    vertices.push_back(QVector3D(radius(), radius(), 0)); // Bottom center
+    vertices.push_back(QVector3D(radius(), radius(), 0));  // Bottom center
 
     // Bottom circle faces
     for (int i = 0; i < resolution; ++i) {
@@ -246,7 +245,7 @@ ClosedMesh MeshFactory::CreateConeMesh(const Distance& radius, const Distance& h
     }
 
     int tip_index = vertices.size();
-    vertices.push_back(QVector3D(radius(), radius(), height())); // Tip
+    vertices.push_back(QVector3D(radius(), radius(), height()));  // Tip
 
     // Side faces
     for (int i = 0; i < resolution; ++i) {
@@ -264,4 +263,4 @@ ClosedMesh MeshFactory::CreateConeMesh(const Distance& radius, const Distance& h
     return m;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/mesh/mesh_vertex.cpp
+++ b/src/geometry/mesh/mesh_vertex.cpp
@@ -1,6 +1,7 @@
 #include "geometry/mesh/mesh_vertex.h"
 
 #include <QMatrix4x4>
+
 #include <qvectornd.h>
 
 #include "geometry/mesh/advanced/mesh_types.h"
@@ -11,35 +12,23 @@ MeshVertex::MeshVertex(const QVector3D& location, const QVector3D& normal) : loc
 }
 
 void MeshVertex::transform(const QMatrix4x4& transform) {
-    location = transform * location; // QVector3D(transform * QVector4D(location));
+    location = transform * location;  // QVector3D(transform * QVector4D(location));
 }
 
-MeshTypes::Point_3 MeshVertex::toPoint3() const { return MeshTypes::Point_3(location.x(), location.y(), location.z()); }
+MeshTypes::Point_3 MeshVertex::toPoint3() const {
+    return MeshTypes::Point_3(location.x(), location.y(), location.z());
+}
 
 bool operator<(const MeshVertex& lhs, const MeshVertex& rhs) {
-    if (lhs.location.x() < rhs.location.x()) {
-        return true;
-    }
-    else if (lhs.location.x() > rhs.location.x()) {
-        return false;
-    }
+    if (lhs.location.x() < rhs.location.x()) { return true; }
+    else if (lhs.location.x() > rhs.location.x()) { return false; }
     // lhs.location.x() == rhs.location.x()
-    else if (lhs.location.y() < rhs.location.y()) {
-        return true;
-    }
-    else if (lhs.location.y() > rhs.location.y()) {
-        return false;
-    }
+    else if (lhs.location.y() < rhs.location.y()) { return true; }
+    else if (lhs.location.y() > rhs.location.y()) { return false; }
     // lhs.location.y() == rhs.location.y()
-    else if (lhs.location.z() < rhs.location.z()) {
-        return true;
-    }
-    else if (lhs.location.z() > rhs.location.z()) {
-        return false;
-    }
+    else if (lhs.location.z() < rhs.location.z()) { return true; }
+    else if (lhs.location.z() > rhs.location.z()) { return false; }
     // lhs.location.z() == rhs.location.z()
-    else {
-        return false;
-    }
+    else { return false; }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/mesh/open_mesh.cpp
+++ b/src/geometry/mesh/open_mesh.cpp
@@ -1,5 +1,6 @@
 #include "geometry/mesh/open_mesh.h"
 
+#include <QFileInfo>
 #include <array>
 #include <cstddef>
 #include <iterator>
@@ -24,7 +25,6 @@
 #include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/disable_warnings.h>
-#include <QFileInfo>
 #include <qcontainerfwd.h>
 #include <qfiledevice.h>
 #include <qhashfunctions.h>
@@ -49,16 +49,16 @@ namespace ORNL {
 OpenMesh::OpenMesh() : MeshBase() {}
 
 OpenMesh::OpenMesh(const QVector<MeshVertex>& vertices, const QVector<MeshFace>& faces) : MeshBase(vertices, faces) {
-    m_representation = SurfaceMeshFromVerticesAndFaces(m_vertices, m_faces);
-    m_original_representation = m_representation; // Create a copy
+    m_representation          = SurfaceMeshFromVerticesAndFaces(m_vertices, m_faces);
+    m_original_representation = m_representation;  // Create a copy
     updateDims();
 }
 
 OpenMesh::OpenMesh(const QString& name, const QString& path, const QVector<MeshVertex>& vertices,
                    const QVector<MeshFace>& faces, MeshType type)
     : MeshBase(vertices, faces, name, path, type) {
-    m_representation = SurfaceMeshFromVerticesAndFaces(m_vertices, m_faces);
-    m_original_representation = m_representation; // Create a copy
+    m_representation          = SurfaceMeshFromVerticesAndFaces(m_vertices, m_faces);
+    m_original_representation = m_representation;  // Create a copy
     updateDims();
 }
 
@@ -71,17 +71,19 @@ OpenMesh::OpenMesh(MeshTypes::SurfaceMesh poly, QString name, QString file) : Me
     auto vertices_and_faces = VerticesAndFacesFromSurfaceMesh(m_representation);
     m_vertices_original = m_vertices = m_vertices_aligned = vertices_and_faces.first;
     m_faces_original = m_faces = m_faces_aligned = vertices_and_faces.second;
-    m_original_representation = m_representation;
+    m_original_representation                    = m_representation;
     updateDims();
     m_original_dimensions = m_dimensions;
 }
 
 OpenMesh::OpenMesh(QSharedPointer<OpenMesh> mesh) : MeshBase(mesh) {
-    m_representation = mesh->m_representation;
+    m_representation          = mesh->m_representation;
     m_original_representation = mesh->m_original_representation;
 }
 
-MeshTypes::SurfaceMesh OpenMesh::surface_mesh() { return m_representation; }
+MeshTypes::SurfaceMesh OpenMesh::surface_mesh() {
+    return m_representation;
+}
 
 void OpenMesh::center() {
     //! Compose translation
@@ -153,7 +155,7 @@ MeshTypes::SurfaceMesh OpenMesh::extractUpwardFaces() {
         QVector3D normal = QVector3D::crossProduct(points[1] - points[0], points[2] - points[0]).normalized();
         // This face is upward facing
         if (normal.z() > 0.0)
-            segment_property_map[face] = 1; // Set a flag
+            segment_property_map[face] = 1;  // Set a flag
         else
             segment_property_map[face] = 0;
     }
@@ -178,19 +180,15 @@ std::pair<QVector<Polyline>, QVector<Polygon>> OpenMesh::intersect(Plane plane) 
     QVector<Polygon> result_polygons;
 
     for (auto& cgal_polyline : cgal_polylines) {
-        if (cgal_polyline.front() == cgal_polyline.back()) // Can this be closed into a polygon?
+        if (cgal_polyline.front() == cgal_polyline.back())  // Can this be closed into a polygon?
         {
             Polygon new_polygon;
-            for (auto& point : cgal_polyline) {
-                new_polygon.append(Point::FromCGALPoint(point));
-            }
+            for (auto& point : cgal_polyline) { new_polygon.append(Point::FromCGALPoint(point)); }
             result_polylines.push_back(new_polygon);
         }
         else {
             Polyline new_line;
-            for (auto& point : cgal_polyline) {
-                new_line.append(Point::FromCGALPoint(point));
-            }
+            for (auto& point : cgal_polyline) { new_line.append(Point::FromCGALPoint(point)); }
             result_polylines.push_back(new_line);
         }
     }
@@ -203,8 +201,7 @@ MeshTypes::SurfaceMesh OpenMesh::SurfaceMeshFromVerticesAndFaces(const QVector<M
     typedef MeshTypes::SurfaceMesh::Vertex_index VertexIndex;
     QMap<uint, VertexIndex> points;
 
-    for (uint i = 0, end = vertices.size(); i < end; ++i)
-        points[i] = sm.add_vertex(vertices[i].toPoint3());
+    for (uint i = 0, end = vertices.size(); i < end; ++i) points[i] = sm.add_vertex(vertices[i].toPoint3());
 
     for (auto& face : faces) {
         sm.add_face(points[face.vertex_index[0]], points[face.vertex_index[1]], points[face.vertex_index[2]]);
@@ -212,8 +209,8 @@ MeshTypes::SurfaceMesh OpenMesh::SurfaceMeshFromVerticesAndFaces(const QVector<M
     return sm;
 }
 
-std::pair<QVector<MeshVertex>, QVector<MeshFace>>
-OpenMesh::VerticesAndFacesFromSurfaceMesh(MeshTypes::SurfaceMesh& sm) {
+std::pair<QVector<MeshVertex>, QVector<MeshFace>> OpenMesh::VerticesAndFacesFromSurfaceMesh(
+    MeshTypes::SurfaceMesh& sm) {
     QVector<MeshFace> mesh_faces;
     mesh_faces.reserve(CGAL::faces(sm).size());
 
@@ -272,8 +269,7 @@ QSharedPointer<OpenMesh> OpenMesh::BuildMeshFromPointCloud(const QString& file_p
     else if (suffix == "matrix")
         p = loadMatrixFile(file_path);
 
-    if (p.isEmpty())
-        return nullptr; // No points loaded
+    if (p.isEmpty()) return nullptr;  // No points loaded
 
     std::vector<MeshTypes::Point_3> points(p.begin(), p.end());
     MeshTypes::SurfaceMesh m;
@@ -321,9 +317,9 @@ QVector<MeshTypes::Point_3> OpenMesh::loadMatrixFile(const QString& file_path) {
 QVector<MeshTypes::Point_3> OpenMesh::loadXYZFile(const QString& file_path) {
     QVector<MeshTypes::Point_3> points;
     CGAL::IO::read_points(file_path.toStdString(), std::back_inserter(points));
-    for (auto it = points.begin(); it != points.end(); ++it) // Scale to micron
+    for (auto it = points.begin(); it != points.end(); ++it)  // Scale to micron
         *it = MeshTypes::Point_3(it->x() * 1000, it->y() * 1000, it->z() * 1000);
 
     return points;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/path.cpp
+++ b/src/geometry/path.cpp
@@ -20,83 +20,72 @@
 
 namespace ORNL {
 namespace {
-constexpr double kNumericalTolerance = 1.0e-6;
-constexpr double kPlanarZTolerance = 1.0;
-constexpr double kPi = 3.14159265358979323846;
-constexpr double kMinimumArcSweep = 5.0 * kPi / 180.0;
-constexpr double kMaximumArcSweep = kPi;
+constexpr double kNumericalTolerance     = 1.0e-6;
+constexpr double kPlanarZTolerance       = 1.0;
+constexpr double kPi                     = 3.14159265358979323846;
+constexpr double kMinimumArcSweep        = 5.0 * kPi / 180.0;
+constexpr double kMaximumArcSweep        = kPi;
 constexpr int kDefaultMinimumArcSegments = 3;
 
 struct CircleFit {
     Point center;
     double radius = 0.0;
-    double sweep = 0.0;
-    bool ccw = false;
+    double sweep  = 0.0;
+    bool ccw      = false;
 };
 
 enum class ArcFitResult { kInvalid, kNeedsMoreSweep, kValid };
 
 double normalizedAngleDelta(double delta) {
-    while (delta <= -kPi)
-        delta += 2.0 * kPi;
-    while (delta > kPi)
-        delta -= 2.0 * kPi;
+    while (delta <= -kPi) delta += 2.0 * kPi;
+    while (delta > kPi) delta -= 2.0 * kPi;
     return delta;
 }
 
 bool solve3x3(double matrix[3][4], double solution[3]) {
     for (int column = 0; column < 3; ++column) {
-        int pivot_row = column;
+        int pivot_row      = column;
         double pivot_value = std::abs(matrix[column][column]);
         for (int row = column + 1; row < 3; ++row) {
             const double candidate = std::abs(matrix[row][column]);
             if (candidate > pivot_value) {
                 pivot_value = candidate;
-                pivot_row = row;
+                pivot_row   = row;
             }
         }
 
-        if (pivot_value < kNumericalTolerance)
-            return false;
+        if (pivot_value < kNumericalTolerance) return false;
 
         if (pivot_row != column) {
-            for (int i = column; i < 4; ++i)
-                std::swap(matrix[column][i], matrix[pivot_row][i]);
+            for (int i = column; i < 4; ++i) std::swap(matrix[column][i], matrix[pivot_row][i]);
         }
 
         const double pivot = matrix[column][column];
-        for (int i = column; i < 4; ++i)
-            matrix[column][i] /= pivot;
+        for (int i = column; i < 4; ++i) matrix[column][i] /= pivot;
 
         for (int row = 0; row < 3; ++row) {
-            if (row == column)
-                continue;
+            if (row == column) continue;
 
             const double scale = matrix[row][column];
-            for (int i = column; i < 4; ++i)
-                matrix[row][i] -= scale * matrix[column][i];
+            for (int i = column; i < 4; ++i) matrix[row][i] -= scale * matrix[column][i];
         }
     }
 
-    for (int i = 0; i < 3; ++i)
-        solution[i] = matrix[i][3];
+    for (int i = 0; i < 3; ++i) solution[i] = matrix[i][3];
 
     return true;
 }
 
 void removeTransientSettings(fifojson& settings) {
-    if (!settings.is_array())
-        return;
+    if (!settings.is_array()) return;
 
     for (auto& item : settings) {
-        if (item.is_object())
-            item.erase(SS::kIsRegionStartSegment.toStdString());
+        if (item.is_object()) item.erase(SS::kIsRegionStartSegment.toStdString());
     }
 }
 
 bool settingsCompatible(const QSharedPointer<SettingsBase>& lhs, const QSharedPointer<SettingsBase>& rhs) {
-    if (lhs == nullptr || rhs == nullptr)
-        return lhs == rhs;
+    if (lhs == nullptr || rhs == nullptr) return lhs == rhs;
 
     fifojson lhs_json = lhs->json();
     fifojson rhs_json = rhs->json();
@@ -117,18 +106,14 @@ QSharedPointer<SettingsBase> resolvedArcSettings(const QSharedPointer<SegmentBas
 
 bool lineEligibleForArcFitting(const QSharedPointer<SegmentBase>& segment,
                                const QSharedPointer<SettingsBase>& fallback_settings) {
-    if (dynamic_cast<LineSegment*>(segment.data()) == nullptr)
-        return false;
+    if (dynamic_cast<LineSegment*>(segment.data()) == nullptr) return false;
 
-    if (!segment->isPrintingSegment())
-        return false;
+    if (!segment->isPrintingSegment()) return false;
 
     QSharedPointer<SettingsBase> settings = resolvedArcSettings(segment, fallback_settings);
-    if (settings == nullptr || !settings->setting<bool>(PS::SpecialModes::kEnableArcFitting))
-        return false;
+    if (settings == nullptr || !settings->setting<bool>(PS::SpecialModes::kEnableArcFitting)) return false;
 
-    if (segment->length() <= 0)
-        return false;
+    if (segment->length() <= 0) return false;
 
     return std::abs(segment->start().z() - segment->end().z()) <= kPlanarZTolerance;
 }
@@ -138,15 +123,13 @@ QVector<Point> collectPoints(const QList<QSharedPointer<SegmentBase>>& segments,
     points.reserve(end - begin + 1);
     points.push_back(segments[begin]->start());
 
-    for (int i = begin; i < end; ++i)
-        points.push_back(segments[i]->end());
+    for (int i = begin; i < end; ++i) points.push_back(segments[i]->end());
 
     return points;
 }
 
 bool fitCircle(const QVector<Point>& points, CircleFit& fit) {
-    if (points.size() < 3)
-        return false;
+    if (points.size() < 3) return false;
 
     double mean_x = 0.0;
     double mean_y = 0.0;
@@ -160,15 +143,15 @@ bool fitCircle(const QVector<Point>& points, CircleFit& fit) {
     double uu = 0.0;
     double uv = 0.0;
     double vv = 0.0;
-    double u = 0.0;
-    double v = 0.0;
+    double u  = 0.0;
+    double v  = 0.0;
     double ur = 0.0;
     double vr = 0.0;
-    double r = 0.0;
+    double r  = 0.0;
 
     for (const Point& point : points) {
-        const double local_x = point.x() - mean_x;
-        const double local_y = point.y() - mean_y;
+        const double local_x        = point.x() - mean_x;
+        const double local_y        = point.y() - mean_y;
         const double radius_squared = (local_x * local_x) + (local_y * local_y);
 
         uu += local_x * local_x;
@@ -182,18 +165,16 @@ bool fitCircle(const QVector<Point>& points, CircleFit& fit) {
     }
 
     double matrix[3][4] = {{uu, uv, u, -ur}, {uv, vv, v, -vr}, {u, v, static_cast<double>(points.size()), -r}};
-    double solution[3] = {0.0, 0.0, 0.0};
-    if (!solve3x3(matrix, solution))
-        return false;
+    double solution[3]  = {0.0, 0.0, 0.0};
+    if (!solve3x3(matrix, solution)) return false;
 
-    const double center_x = mean_x - (solution[0] / 2.0);
-    const double center_y = mean_y - (solution[1] / 2.0);
+    const double center_x       = mean_x - (solution[0] / 2.0);
+    const double center_y       = mean_y - (solution[1] / 2.0);
     const double center_local_x = center_x - mean_x;
     const double center_local_y = center_y - mean_y;
     const double radius_squared = (center_local_x * center_local_x) + (center_local_y * center_local_y) - solution[2];
 
-    if (radius_squared <= kNumericalTolerance)
-        return false;
+    if (radius_squared <= kNumericalTolerance) return false;
 
     fit.center = Point(center_x, center_y, points.front().z());
     fit.radius = std::sqrt(radius_squared);
@@ -203,29 +184,25 @@ bool fitCircle(const QVector<Point>& points, CircleFit& fit) {
 
 ArcFitResult validateArcFit(const QVector<Point>& points, double tolerance, CircleFit& fit) {
     const double allowed_error = std::max(tolerance, kNumericalTolerance);
-    const float reference_z = points.front().z();
+    const float reference_z    = points.front().z();
     for (const Point& point : points) {
-        if (std::abs(point.z() - reference_z) > kPlanarZTolerance)
-            return ArcFitResult::kInvalid;
+        if (std::abs(point.z() - reference_z) > kPlanarZTolerance) return ArcFitResult::kInvalid;
 
         const double point_radius = std::hypot(point.x() - fit.center.x(), point.y() - fit.center.y());
-        if (std::abs(point_radius - fit.radius) > allowed_error)
-            return ArcFitResult::kInvalid;
+        if (std::abs(point_radius - fit.radius) > allowed_error) return ArcFitResult::kInvalid;
     }
 
-    if (points.front().distance(points.back()) <= kNumericalTolerance)
-        return ArcFitResult::kInvalid;
+    if (points.front().distance(points.back()) <= kNumericalTolerance) return ArcFitResult::kInvalid;
 
-    double sweep = 0.0;
+    double sweep  = 0.0;
     int direction = 0;
     for (int i = 1, end = points.size(); i < end; ++i) {
         const double previous_angle =
             std::atan2(points[i - 1].y() - fit.center.y(), points[i - 1].x() - fit.center.x());
         const double current_angle = std::atan2(points[i].y() - fit.center.y(), points[i].x() - fit.center.x());
-        const double delta = normalizedAngleDelta(current_angle - previous_angle);
+        const double delta         = normalizedAngleDelta(current_angle - previous_angle);
 
-        if (std::abs(delta) <= kNumericalTolerance)
-            continue;
+        if (std::abs(delta) <= kNumericalTolerance) continue;
 
         const int delta_direction = delta > 0.0 ? 1 : -1;
         if (direction == 0)
@@ -237,16 +214,13 @@ ArcFitResult validateArcFit(const QVector<Point>& points, double tolerance, Circ
     }
 
     fit.sweep = std::abs(sweep);
-    fit.ccw = sweep > 0.0;
+    fit.ccw   = sweep > 0.0;
 
-    if (direction == 0)
-        return ArcFitResult::kInvalid;
+    if (direction == 0) return ArcFitResult::kInvalid;
 
-    if (fit.sweep < kMinimumArcSweep)
-        return ArcFitResult::kNeedsMoreSweep;
+    if (fit.sweep < kMinimumArcSweep) return ArcFitResult::kNeedsMoreSweep;
 
-    if (fit.sweep > kMaximumArcSweep)
-        return ArcFitResult::kInvalid;
+    if (fit.sweep > kMaximumArcSweep) return ArcFitResult::kInvalid;
 
     return ArcFitResult::kValid;
 }
@@ -254,39 +228,49 @@ ArcFitResult validateArcFit(const QVector<Point>& points, double tolerance, Circ
 ArcFitResult tryFitArc(const QList<QSharedPointer<SegmentBase>>& segments, int begin, int end, double tolerance,
                        CircleFit& fit) {
     const QVector<Point> points = collectPoints(segments, begin, end);
-    if (!fitCircle(points, fit))
-        return ArcFitResult::kInvalid;
+    if (!fitCircle(points, fit)) return ArcFitResult::kInvalid;
 
     return validateArcFit(points, tolerance, fit);
 }
 
 QSharedPointer<ArcSegment> createArcSegment(const QSharedPointer<SegmentBase>& source, const Point& start,
                                             const Point& end, const CircleFit& fit) {
-    QSharedPointer<ArcSegment> arc = QSharedPointer<ArcSegment>::create(start, end, fit.center, Angle(fit.sweep),
-                                                                        fit.ccw);
+    QSharedPointer<ArcSegment> arc =
+        QSharedPointer<ArcSegment>::create(start, end, fit.center, Angle(fit.sweep), fit.ccw);
     QSharedPointer<SettingsBase> settings = QSharedPointer<SettingsBase>::create(*source->getSb());
     arc->setSb(settings);
 
     return arc;
 }
-} // namespace
+}  // namespace
 
-void Path::add(const QSharedPointer<SegmentBase>& ps) { m_segments.append(ps); }
-
-void Path::append(const QSharedPointer<SegmentBase>& ps) { m_segments.append(ps); }
-
-void Path::append(Path path) {
-    for (QSharedPointer<SegmentBase> seg : path.getSegments())
-        m_segments.append(seg);
+void Path::add(const QSharedPointer<SegmentBase>& ps) {
+    m_segments.append(ps);
 }
 
-void Path::prepend(const QSharedPointer<SegmentBase>& ps) { m_segments.prepend(ps); }
+void Path::append(const QSharedPointer<SegmentBase>& ps) {
+    m_segments.append(ps);
+}
 
-void Path::insert(int index, const QSharedPointer<SegmentBase>& ps) { m_segments.insert(index, ps); }
+void Path::append(Path path) {
+    for (QSharedPointer<SegmentBase> seg : path.getSegments()) m_segments.append(seg);
+}
 
-void Path::remove(const QSharedPointer<SegmentBase>& ps) { m_segments.removeOne(ps); }
+void Path::prepend(const QSharedPointer<SegmentBase>& ps) {
+    m_segments.prepend(ps);
+}
 
-void Path::removeAt(int index) { m_segments.removeAt(index); }
+void Path::insert(int index, const QSharedPointer<SegmentBase>& ps) {
+    m_segments.insert(index, ps);
+}
+
+void Path::remove(const QSharedPointer<SegmentBase>& ps) {
+    m_segments.removeOne(ps);
+}
+
+void Path::removeAt(int index) {
+    m_segments.removeAt(index);
+}
 
 void Path::reverseSegments() {
     QList<QSharedPointer<SegmentBase>> newSegments;
@@ -304,42 +288,64 @@ Path Path::operator+=(const QSharedPointer<SegmentBase>& ps) {
     return *this;
 }
 
-QList<QSharedPointer<SegmentBase>>::iterator Path::begin() { return m_segments.begin(); }
+QList<QSharedPointer<SegmentBase>>::iterator Path::begin() {
+    return m_segments.begin();
+}
 
-QList<QSharedPointer<SegmentBase>>::iterator Path::end() { return m_segments.end(); }
+QList<QSharedPointer<SegmentBase>>::iterator Path::end() {
+    return m_segments.end();
+}
 
-QList<QSharedPointer<SegmentBase>>::const_iterator Path::begin() const { return m_segments.constBegin(); }
+QList<QSharedPointer<SegmentBase>>::const_iterator Path::begin() const {
+    return m_segments.constBegin();
+}
 
-QList<QSharedPointer<SegmentBase>>::const_iterator Path::end() const { return m_segments.constEnd(); }
+QList<QSharedPointer<SegmentBase>>::const_iterator Path::end() const {
+    return m_segments.constEnd();
+}
 
-QSharedPointer<SegmentBase> Path::operator[](const int index) const { return m_segments[index]; }
+QSharedPointer<SegmentBase> Path::operator[](const int index) const {
+    return m_segments[index];
+}
 
-QSharedPointer<SegmentBase> Path::at(const int index) const { return m_segments[index]; }
+QSharedPointer<SegmentBase> Path::at(const int index) const {
+    return m_segments[index];
+}
 
-QSharedPointer<SegmentBase> Path::front() const { return m_segments.front(); }
+QSharedPointer<SegmentBase> Path::front() const {
+    return m_segments.front();
+}
 
-QSharedPointer<SegmentBase> Path::back() const { return m_segments.back(); }
+QSharedPointer<SegmentBase> Path::back() const {
+    return m_segments.back();
+}
 
-int Path::size() const { return m_segments.size(); }
+int Path::size() const {
+    return m_segments.size();
+}
 
-void Path::move(int from, int to) { m_segments.move(from, to); }
+void Path::move(int from, int to) {
+    m_segments.move(from, to);
+}
 
-void Path::clear() { m_segments.clear(); }
+void Path::clear() {
+    m_segments.clear();
+}
 
-QList<QSharedPointer<SegmentBase>>& Path::getSegments() { return m_segments; }
+QList<QSharedPointer<SegmentBase>>& Path::getSegments() {
+    return m_segments;
+}
 
 Distance Path::calculateLength() {
     Distance totalLength;
-    for (QSharedPointer<SegmentBase> segment : m_segments)
-        totalLength += segment->length();
+    for (QSharedPointer<SegmentBase> segment : m_segments) totalLength += segment->length();
     return totalLength;
 }
 
 Distance Path::calculateLengthNoTravel() {
     Distance totalLength;
     for (QSharedPointer<SegmentBase> segment : m_segments) {
-        if (!segment->isPrintingSegment())
-            continue;
+        if (!segment->isPrintingSegment()) continue;
 
         totalLength += segment->length();
     }
@@ -349,8 +355,7 @@ Distance Path::calculateLengthNoTravel() {
 Distance Path::calculatePrintingLength() {
     Distance totalLength;
     for (QSharedPointer<SegmentBase> segment : m_segments) {
-        if (TravelSegment* ts = dynamic_cast<TravelSegment*>(segment.data()))
-            continue;
+        if (TravelSegment* ts = dynamic_cast<TravelSegment*>(segment.data())) continue;
         totalLength += segment->length();
     }
     return totalLength;
@@ -369,22 +374,19 @@ float Path::getMinZ() {
     float path_min = std::numeric_limits<float>::max();
     for (QSharedPointer<SegmentBase> segment : m_segments) {
         float segment_min = segment->getMinZ();
-        if (segment_min < path_min)
-            path_min = segment_min;
+        if (segment_min < path_min) path_min = segment_min;
     }
     return path_min;
 }
 
 void Path::removeTravels() {
     for (int i = m_segments.size() - 1; i >= 0; --i) {
-        if (TravelSegment* ts = dynamic_cast<TravelSegment*>(m_segments[i].data()))
-            m_segments.removeAt(i);
+        if (TravelSegment* ts = dynamic_cast<TravelSegment*>(m_segments[i].data())) m_segments.removeAt(i);
     }
 }
 
 void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings) {
-    if (m_segments.size() < kDefaultMinimumArcSegments)
-        return;
+    if (m_segments.size() < kDefaultMinimumArcSegments) return;
 
     QList<QSharedPointer<SegmentBase>> fitted_segments;
     fitted_segments.reserve(m_segments.size());
@@ -398,8 +400,7 @@ void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings
         }
 
         int run_end = index + 1;
-        while (run_end < m_segments.size() &&
-               lineEligibleForArcFitting(m_segments[run_end], fallback_settings) &&
+        while (run_end < m_segments.size() && lineEligibleForArcFitting(m_segments[run_end], fallback_settings) &&
                m_segments[run_end - 1]->end() == m_segments[run_end]->start() &&
                settingsCompatible(m_segments[run_end - 1]->getSb(), m_segments[run_end]->getSb())) {
             ++run_end;
@@ -408,13 +409,11 @@ void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings
         int run_index = index;
         while (run_index < run_end) {
             QSharedPointer<SettingsBase> settings = resolvedArcSettings(m_segments[run_index], fallback_settings);
-            Distance tolerance = settings->setting<Distance>(PS::SpecialModes::kArcFittingTolerance);
-            if (tolerance < 0)
-                tolerance = 0.0 * micron;
+            Distance tolerance                    = settings->setting<Distance>(PS::SpecialModes::kArcFittingTolerance);
+            if (tolerance < 0) tolerance = 0.0 * micron;
 
-            const int minimum_segments =
-                std::max(kDefaultMinimumArcSegments,
-                         settings->setting<int>(PS::SpecialModes::kArcFittingMinimumSegmentCount));
+            const int minimum_segments = std::max(
+                kDefaultMinimumArcSegments, settings->setting<int>(PS::SpecialModes::kArcFittingMinimumSegmentCount));
 
             CircleFit best_fit;
             int best_end = -1;
@@ -424,8 +423,7 @@ void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings
                 const ArcFitResult fit_result =
                     tryFitArc(m_segments, run_index, candidate_end, tolerance(), candidate_fit);
                 if (fit_result != ArcFitResult::kValid) {
-                    if (best_end >= 0 || fit_result == ArcFitResult::kInvalid)
-                        break;
+                    if (best_end >= 0 || fit_result == ArcFitResult::kInvalid) break;
 
                     continue;
                 }
@@ -436,7 +434,7 @@ void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings
 
             if (best_end >= 0) {
                 const Point start = m_segments[run_index]->start();
-                const Point end = m_segments[best_end - 1]->end();
+                const Point end   = m_segments[best_end - 1]->end();
                 fitted_segments.push_back(createArcSegment(m_segments[run_index], start, end, best_fit));
                 run_index = best_end;
             }
@@ -452,10 +450,16 @@ void Path::fitCircularArcs(const QSharedPointer<SettingsBase>& fallback_settings
     m_segments = fitted_segments;
 }
 
-bool Path::isClosed() { return m_segments.first()->start() == m_segments.last()->end(); }
+bool Path::isClosed() {
+    return m_segments.first()->start() == m_segments.last()->end();
+}
 
-void Path::setCCW(bool ccw) { m_ccw = ccw; }
+void Path::setCCW(bool ccw) {
+    m_ccw = ccw;
+}
 
-bool Path::getCCW() { return m_ccw; }
+bool Path::getCCW() {
+    return m_ccw;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/path_modifier.cpp
+++ b/src/geometry/path_modifier.cpp
@@ -2,10 +2,10 @@
 
 #include <math.h>
 
-#include <cmath>
-
 #include <QVector>
 #include <QtMath>
+#include <cmath>
+
 #include <qcontainerfwd.h>
 #include <qminmax.h>
 #include <qnumeric.h>
@@ -33,16 +33,16 @@ void copyInitialExtruderSpeed(const QSharedPointer<SettingsBase>& destination,
 }
 
 void copyAdaptedWidthFlag(const QSharedPointer<SettingsBase>& destination, const QSharedPointer<SettingsBase>& source) {
-    if (source->contains(SS::kAdapted)) {
-        destination->setSetting(SS::kAdapted, source->setting<bool>(SS::kAdapted));
-    }
+    if (source->contains(SS::kAdapted)) { destination->setSetting(SS::kAdapted, source->setting<bool>(SS::kAdapted)); }
 }
 
 bool isExtendableLineSegment(const QSharedPointer<SegmentBase>& segment) {
     return segment->isPrintingSegment() && dynamic_cast<LineSegment*>(segment.data()) != nullptr;
 }
 
-bool pointsCoincident(const Point& lhs, const Point& rhs) { return lhs.distance(rhs)() <= 1.0e-4; }
+bool pointsCoincident(const Point& lhs, const Point& rhs) {
+    return lhs.distance(rhs)() <= 1.0e-4;
+}
 
 struct Vector2D {
     double x = 0.0;
@@ -54,34 +54,32 @@ struct SharpCornerGeometry {
     Point sharp_point;
     Point next_cut;
     double previous_cut_parameter = 1.0;
-    double next_cut_parameter = 0.0;
+    double next_cut_parameter     = 0.0;
 };
 
 struct SegmentEndpointUpdates {
     bool has_start = false;
-    bool has_end = false;
+    bool has_end   = false;
     Point start;
     Point end;
     double start_parameter = 0.0;
-    double end_parameter = 1.0;
+    double end_parameter   = 1.0;
 };
 
 struct SharpCornerSettings {
-    bool enabled = false;
-    double threshold_radians = 0.0;
-    double extension_length = 0.0;
+    bool enabled                  = false;
+    double threshold_radians      = 0.0;
+    double extension_length       = 0.0;
     double close_points_threshold = 0.0;
-    double sharpening_leg_length = 0.0;
+    double sharpening_leg_length  = 0.0;
 };
 
 template <typename T>
 T settingWithFallback(const QSharedPointer<SettingsBase>& settings, const QSharedPointer<SettingsBase>& fallback,
                       const QString& key) {
-    if (!settings.isNull() && settings->contains(key))
-        return settings->setting<T>(key);
+    if (!settings.isNull() && settings->contains(key)) return settings->setting<T>(key);
 
-    if (!fallback.isNull())
-        return fallback->setting<T>(key);
+    if (!fallback.isNull()) return fallback->setting<T>(key);
 
     return T();
 }
@@ -97,8 +95,7 @@ SharpCornerSettings sharpCornerSettingsForSegment(const QSharedPointer<SegmentBa
         settingWithFallback<Distance>(segment_settings, fallback, PS::SpecialModes::kSharpCornerClosePointsThreshold);
     Distance sharpening_leg_length =
         settingWithFallback<Distance>(segment_settings, fallback, PS::SpecialModes::kSharpCornerSharpeningLegLength);
-    if (sharpening_leg_length <= 0)
-        sharpening_leg_length = extension_distance;
+    if (sharpening_leg_length <= 0) sharpening_leg_length = extension_distance;
 
     return {
         settingWithFallback<bool>(segment_settings, fallback, PS::SpecialModes::kEnableSharpCornerExtension),
@@ -112,22 +109,23 @@ SharpCornerSettings sharpCornerSettingsForSegment(const QSharedPointer<SegmentBa
 bool sharpCornerEnabledForBothLegs(const QSharedPointer<SegmentBase>& previous_segment,
                                    const QSharedPointer<SegmentBase>& next_segment,
                                    const QSharedPointer<SettingsBase>& fallback, SharpCornerSettings& settings) {
-    settings = sharpCornerSettingsForSegment(previous_segment, fallback);
+    settings                                = sharpCornerSettingsForSegment(previous_segment, fallback);
     const SharpCornerSettings next_settings = sharpCornerSettingsForSegment(next_segment, fallback);
 
     return settings.enabled && next_settings.enabled && settings.threshold_radians > 0.0 &&
            settings.extension_length > 0.0 && settings.sharpening_leg_length > 0.0;
 }
 
-double crossProduct(const Vector2D& lhs, const Vector2D& rhs) { return lhs.x * rhs.y - lhs.y * rhs.x; }
+double crossProduct(const Vector2D& lhs, const Vector2D& rhs) {
+    return lhs.x * rhs.y - lhs.y * rhs.x;
+}
 
 bool normalizedDirection(const Point& start, const Point& end, Vector2D& direction, double& length) {
-    const double x = end.x() - start.x();
-    const double y = end.y() - start.y();
-    length = std::hypot(x, y);
+    const double x              = end.x() - start.x();
+    const double y              = end.y() - start.y();
+    length                      = std::hypot(x, y);
     constexpr double kMinLength = 1.0e-6;
-    if (length < kMinLength)
-        return false;
+    if (length < kMinLength) return false;
 
     direction = {x / length, y / length};
     return true;
@@ -140,20 +138,18 @@ Point pointOnSegment(const Point& start, const Point& end, double parameter) {
 
 bool lineIntersection(const Point& first_start, const Point& first_end, const Point& second_start,
                       const Point& second_end, Point& intersection) {
-    const Vector2D first_axis = {first_end.x() - first_start.x(), first_end.y() - first_start.y()};
-    const Vector2D second_axis = {second_end.x() - second_start.x(), second_end.y() - second_start.y()};
-    const double denominator = crossProduct(first_axis, second_axis);
+    const Vector2D first_axis           = {first_end.x() - first_start.x(), first_end.y() - first_start.y()};
+    const Vector2D second_axis          = {second_end.x() - second_start.x(), second_end.y() - second_start.y()};
+    const double denominator            = crossProduct(first_axis, second_axis);
     constexpr double kParallelTolerance = 1.0e-8;
-    if (std::abs(denominator) < kParallelTolerance)
-        return false;
+    if (std::abs(denominator) < kParallelTolerance) return false;
 
-    const Vector2D start_delta = {second_start.x() - first_start.x(), second_start.y() - first_start.y()};
+    const Vector2D start_delta   = {second_start.x() - first_start.x(), second_start.y() - first_start.y()};
     const double first_parameter = crossProduct(start_delta, second_axis) / denominator;
 
     const double x = first_start.x() + (first_axis.x * first_parameter);
     const double y = first_start.y() + (first_axis.y * first_parameter);
-    if (!std::isfinite(x) || !std::isfinite(y))
-        return false;
+    if (!std::isfinite(x) || !std::isfinite(y)) return false;
 
     intersection = Point(x, y, (first_end.z() + second_start.z()) / 2.0f);
     return true;
@@ -165,8 +161,7 @@ QSharedPointer<SegmentBase> cloneSegmentWithEndpoints(const QSharedPointer<Segme
     segment->setStart(start);
     segment->setEnd(end);
 
-    if (!source->getSb().isNull())
-        segment->setSb(QSharedPointer<SettingsBase>::create(*source->getSb()));
+    if (!source->getSb().isNull()) segment->setSb(QSharedPointer<SettingsBase>::create(*source->getSb()));
 
     return segment;
 }
@@ -178,23 +173,21 @@ bool calculateSharpCornerGeometry(const QSharedPointer<SegmentBase>& previous_se
     Vector2D previous_direction;
     Vector2D next_direction;
     double previous_length = 0.0;
-    double next_length = 0.0;
+    double next_length     = 0.0;
 
     if (!normalizedDirection(previous_segment->start(), previous_segment->end(), previous_direction, previous_length) ||
         !normalizedDirection(next_segment->start(), next_segment->end(), next_direction, next_length)) {
         return false;
     }
 
-    if (previous_length <= sharpening_leg_length || next_length <= sharpening_leg_length)
-        return false;
+    if (previous_length <= sharpening_leg_length || next_length <= sharpening_leg_length) return false;
 
     double cos_theta = (previous_direction.x * next_direction.x) + (previous_direction.y * next_direction.y);
-    cos_theta = qMin(1.0, cos_theta);
-    cos_theta = qMax(-1.0, cos_theta);
+    cos_theta        = qMin(1.0, cos_theta);
+    cos_theta        = qMax(-1.0, cos_theta);
 
     const double corner_angle = M_PI - std::acos(cos_theta);
-    if (corner_angle > threshold_radians)
-        return false;
+    if (corner_angle > threshold_radians) return false;
 
     Point merge_point;
     if (!lineIntersection(previous_segment->start(), previous_segment->end(), next_segment->start(),
@@ -202,18 +195,17 @@ bool calculateSharpCornerGeometry(const QSharedPointer<SegmentBase>& previous_se
         return false;
     }
 
-    const Vector2D extension_direction = {previous_direction.x - next_direction.x,
-                                          previous_direction.y - next_direction.y};
+    const Vector2D extension_direction      = {previous_direction.x - next_direction.x,
+                                               previous_direction.y - next_direction.y};
     const double extension_direction_length = std::hypot(extension_direction.x, extension_direction.y);
-    constexpr double kMinLength = 1.0e-6;
-    if (extension_direction_length < kMinLength)
-        return false;
+    constexpr double kMinLength             = 1.0e-6;
+    if (extension_direction_length < kMinLength) return false;
 
     geometry.previous_cut_parameter = 1.0 - (sharpening_leg_length / previous_length);
-    geometry.next_cut_parameter = sharpening_leg_length / next_length;
+    geometry.next_cut_parameter     = sharpening_leg_length / next_length;
     geometry.previous_cut =
         pointOnSegment(previous_segment->start(), previous_segment->end(), geometry.previous_cut_parameter);
-    geometry.next_cut = pointOnSegment(next_segment->start(), next_segment->end(), geometry.next_cut_parameter);
+    geometry.next_cut    = pointOnSegment(next_segment->start(), next_segment->end(), geometry.next_cut_parameter);
     geometry.sharp_point = Point(
         merge_point.x() + (extension_direction.x / extension_direction_length * extension_length),
         merge_point.y() + (extension_direction.y / extension_direction_length * extension_length), merge_point.z());
@@ -224,8 +216,7 @@ bool calculateSharpCornerGeometry(const QSharedPointer<SegmentBase>& previous_se
 bool canApplyEndUpdate(int segment_index, double parameter, const QVector<bool>& skip_segment,
                        const QVector<SegmentEndpointUpdates>& updates) {
     constexpr double kParameterTolerance = 1.0e-6;
-    if (skip_segment[segment_index] || updates[segment_index].has_end)
-        return false;
+    if (skip_segment[segment_index] || updates[segment_index].has_end) return false;
 
     return !updates[segment_index].has_start ||
            updates[segment_index].start_parameter < parameter - kParameterTolerance;
@@ -234,8 +225,7 @@ bool canApplyEndUpdate(int segment_index, double parameter, const QVector<bool>&
 bool canApplyStartUpdate(int segment_index, double parameter, const QVector<bool>& skip_segment,
                          const QVector<SegmentEndpointUpdates>& updates) {
     constexpr double kParameterTolerance = 1.0e-6;
-    if (skip_segment[segment_index] || updates[segment_index].has_start)
-        return false;
+    if (skip_segment[segment_index] || updates[segment_index].has_start) return false;
 
     return !updates[segment_index].has_end || parameter < updates[segment_index].end_parameter - kParameterTolerance;
 }
@@ -249,12 +239,12 @@ bool applySharpCornerGeometry(Path& path, int previous_index, int next_index, co
         return false;
     }
 
-    updates[previous_index].has_end = true;
-    updates[previous_index].end = geometry.previous_cut;
+    updates[previous_index].has_end       = true;
+    updates[previous_index].end           = geometry.previous_cut;
     updates[previous_index].end_parameter = geometry.previous_cut_parameter;
 
-    updates[next_index].has_start = true;
-    updates[next_index].start = geometry.next_cut;
+    updates[next_index].has_start       = true;
+    updates[next_index].start           = geometry.next_cut;
     updates[next_index].start_parameter = geometry.next_cut_parameter;
 
     insertions_after[previous_index].push_back(
@@ -264,7 +254,7 @@ bool applySharpCornerGeometry(Path& path, int previous_index, int next_index, co
 
     return true;
 }
-} // namespace
+}  // namespace
 
 void PathModifierGenerator::GenerateTravel(Path& path, Point current_location, Velocity velocity) {
     QSharedPointer<TravelSegment> travel_segment =
@@ -283,13 +273,13 @@ void PathModifierGenerator::GenerateTravel(Path& path, Point current_location, V
 void PathModifierGenerator::GenerateOpenLoopLeadIn(Path& path, Distance leadInDistance, Velocity leadInSpeed,
                                                    AngularVelocity leadInExtruderSpeed, bool enableWidthHeight,
                                                    double areaMultiplier) {
-    Point firstPoint = path[0]->start();
+    Point firstPoint  = path[0]->start();
     Point secondPoint = path[0]->end();
-    Distance length = secondPoint.distance(firstPoint);
-    Distance X = firstPoint.x() + (firstPoint.x() - secondPoint.x()) / length() * leadInDistance();
-    Distance Y = firstPoint.y() + (firstPoint.y() - secondPoint.y()) / length() * leadInDistance();
-    Distance Z = firstPoint.z();
-    Point newStart = Point(X, Y, Z);
+    Distance length   = secondPoint.distance(firstPoint);
+    Distance X        = firstPoint.x() + (firstPoint.x() - secondPoint.x()) / length() * leadInDistance();
+    Distance Y        = firstPoint.y() + (firstPoint.y() - secondPoint.y()) / length() * leadInDistance();
+    Distance Z        = firstPoint.z();
+    Point newStart    = Point(X, Y, Z);
 
     QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(newStart, firstPoint);
 
@@ -316,13 +306,13 @@ void PathModifierGenerator::GenerateOpenLoopLeadIn(Path& path, Distance leadInDi
 void PathModifierGenerator::GeneratePrestart(Path& path, Distance prestartDistance, Velocity prestartSpeed,
                                              AngularVelocity prestartExtruderSpeed, bool enableWidthHeight,
                                              double areaMultiplier) {
-    Point firstPoint = path[0]->start();
+    Point firstPoint  = path[0]->start();
     Point secondPoint = path[0]->end();
-    Distance length = secondPoint.distance(firstPoint);
-    Distance X = firstPoint.x() + (firstPoint.x() - secondPoint.x()) / length() * prestartDistance();
-    Distance Y = firstPoint.y() + (firstPoint.y() - secondPoint.y()) / length() * prestartDistance();
-    Distance Z = firstPoint.z();
-    Point newStart = Point(X, Y, Z);
+    Distance length   = secondPoint.distance(firstPoint);
+    Distance X        = firstPoint.x() + (firstPoint.x() - secondPoint.x()) / length() * prestartDistance();
+    Distance Y        = firstPoint.y() + (firstPoint.y() - secondPoint.y()) / length() * prestartDistance();
+    Distance Z        = firstPoint.z();
+    Point newStart    = Point(X, Y, Z);
 
     QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(newStart, firstPoint);
 
@@ -387,7 +377,7 @@ void PathModifierGenerator::GenerateFlyingStart(Path& path, Distance flyingStart
 
             path.insert(0, segment);
         }
-        else // Break the original segment's path into a shorter segment to be used for the flying start
+        else  // Break the original segment's path into a shorter segment to be used for the flying start
         {
             float percentage = 1 - (-flyingStartDistance() / nextSegmentDist());
             // swap the ends and starts?
@@ -442,7 +432,7 @@ void PathModifierGenerator::GenerateInitialStartup(Path& path, Distance startDis
         }
         else {
             float percentage = 1 - (-startDistance() / nextSegmentDist());
-            Point end = Point(
+            Point end        = Point(
                 (1.0 - percentage) * path[currentIndex]->start().x() + percentage * path[currentIndex]->end().x(),
                 (1.0 - percentage) * path[currentIndex]->start().y() + percentage * path[currentIndex]->end().y());
 
@@ -466,10 +456,10 @@ void PathModifierGenerator::GenerateInitialStartup(Path& path, Distance startDis
             // Update Width and Height if using Width and Height mode
             if (enableWidthHeight) {
                 areaMultiplier = qSqrt(areaMultiplier / 100);
-                segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth) *
-                                                             areaMultiplier);
-                segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight) *
-                                                              areaMultiplier);
+                segment->getSb()->setSetting(
+                    SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth) * areaMultiplier);
+                segment->getSb()->setSetting(
+                    SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight) * areaMultiplier);
             }
 
             path.insert(currentIndex, segment);
@@ -483,10 +473,10 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
                                                              Velocity endSpeed, AngularVelocity startExtruderSpeed,
                                                              AngularVelocity endExtruderSpeed, int steps,
                                                              bool enableWidthHeight, double areaMultiplier) {
-    int currentIndex = 0;
-    Distance stepDistance = startDistance / steps;
+    int currentIndex        = 0;
+    Distance stepDistance   = startDistance / steps;
     AngularVelocity rpmStep = (endExtruderSpeed - startExtruderSpeed) / steps;
-    Velocity speedStep = (endSpeed - startSpeed) / steps;
+    Velocity speedStep      = (endSpeed - startSpeed) / steps;
 
     // Loop through once to do the standard initial startup pathing
     while (startDistance > 0) {
@@ -511,7 +501,7 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
         }
         else {
             float percentage = 1 - (-startDistance() / nextSegmentDist());
-            Point end = Point(
+            Point end        = Point(
                 (1.0 - percentage) * path[currentIndex]->start().x() + percentage * path[currentIndex]->end().x(),
                 (1.0 - percentage) * path[currentIndex]->start().y() + percentage * path[currentIndex]->end().y());
 
@@ -536,10 +526,10 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
             // Update Width and Height if using Width and Height mode
             if (enableWidthHeight) {
                 areaMultiplier = qSqrt(areaMultiplier / 100);
-                segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth) *
-                                                             areaMultiplier);
-                segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight) *
-                                                              areaMultiplier);
+                segment->getSb()->setSetting(
+                    SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth) * areaMultiplier);
+                segment->getSb()->setSetting(
+                    SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight) * areaMultiplier);
             }
 
             path.insert(currentIndex, segment);
@@ -554,9 +544,9 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
     AngularVelocity currentExtruderSpeed;
     Velocity currentSpeed;
     for (int j = 1; j < steps; j++) {
-        currentDistance = stepDistance;
+        currentDistance      = stepDistance;
         currentExtruderSpeed = startExtruderSpeed + rpmStep * (j - 1);
-        currentSpeed = startSpeed + speedStep * (j - 1);
+        currentSpeed         = startSpeed + speedStep * (j - 1);
         while (currentDistance > 0) {
             RegionType regionType = path[currentIndex]->getSb()->setting<RegionType>(SS::kRegionType);
 
@@ -570,7 +560,7 @@ void PathModifierGenerator::GenerateInitialStartupWithRampUp(Path& path, Distanc
             }
             else {
                 float percentage = 1 - (-currentDistance() / nextSegmentDist());
-                Point end = Point(
+                Point end        = Point(
                     (1.0 - percentage) * path[currentIndex]->start().x() + percentage * path[currentIndex]->end().x(),
                     (1.0 - percentage) * path[currentIndex]->start().y() + percentage * path[currentIndex]->end().y());
 
@@ -609,12 +599,11 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
                                              Distance slowDownCutoffDistance, Velocity slowDownSpeed,
                                              AngularVelocity extruderSpeed, bool enableWidthHeight,
                                              double areaMultiplier) {
-    int currentIndex = path.size() - 1;
-    bool isClosed = false;
+    int currentIndex      = path.size() - 1;
+    bool isClosed         = false;
     Distance tempDistance = slowDownDistance;
     Point newEnd;
-    if (path[currentIndex]->end() == path[0]->start())
-        isClosed = true;
+    if (path[currentIndex]->end() == path[0]->start()) isClosed = true;
 
     PathModifiers current_mod;
     if (extruderSpeed <= 0)
@@ -624,8 +613,8 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
 
     while (tempDistance > 0 && ((currentIndex >= 0 && !isClosed) || isClosed)) {
         Distance newZIncrement = tempDistance / slowDownDistance * slowDownLiftDistance;
-        newEnd = Point(path[currentIndex]->end().x(), path[currentIndex]->end().y(),
-                       path[currentIndex]->end().z() + newZIncrement);
+        newEnd                 = Point(path[currentIndex]->end().x(), path[currentIndex]->end().y(),
+                                       path[currentIndex]->end().z() + newZIncrement);
 
         // Update start point of the move following this one, so that start points have correct Z value
         if (tempDistance != slowDownDistance && currentIndex + 1 < path.size()) {
@@ -653,7 +642,7 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
         }
         else {
             float percentage = 1 - (-tempDistance() / nextSegmentDist());
-            Point end = Point(
+            Point end        = Point(
                 (1.0 - percentage) * path[currentIndex]->end().x() + percentage * path[currentIndex]->start().x(),
                 (1.0 - percentage) * path[currentIndex]->end().y() + percentage * path[currentIndex]->start().y());
 
@@ -678,23 +667,22 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
             // Update Width and Height if using Width and Height mode
             if (enableWidthHeight) {
                 areaMultiplier = qSqrt(areaMultiplier / 100);
-                segment->getSb()->setSetting(SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth) *
-                                                             areaMultiplier);
-                segment->getSb()->setSetting(SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight) *
-                                                              areaMultiplier);
+                segment->getSb()->setSetting(
+                    SS::kWidth, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth) * areaMultiplier);
+                segment->getSb()->setSetting(
+                    SS::kHeight, path[currentIndex]->getSb()->setting<Distance>(SS::kHeight) * areaMultiplier);
             }
 
             path.insert(currentIndex + 1, segment);
         }
 
         currentIndex -= 1;
-        if (currentIndex < 0)
-            currentIndex = path.size() - 1;
+        if (currentIndex < 0) currentIndex = path.size() - 1;
     }
 
     // Step through loop again if a cutoff distance is needed
     currentIndex = path.size() - 1;
-    current_mod = PathModifiers::kCoasting;
+    current_mod  = PathModifiers::kCoasting;
     while (slowDownCutoffDistance > 0 && ((currentIndex >= 1 && !isClosed) || isClosed)) {
         Distance nextSegmentDist = path[currentIndex]->end().distance(path[currentIndex]->start());
         slowDownCutoffDistance -= nextSegmentDist;
@@ -706,7 +694,7 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
         }
         else {
             float percentage = 1 - (-slowDownCutoffDistance() / nextSegmentDist());
-            Point end = Point(
+            Point end        = Point(
                 (1.0 - percentage) * path[currentIndex]->end().x() + percentage * path[currentIndex]->start().x(),
                 (1.0 - percentage) * path[currentIndex]->end().y() + percentage * path[currentIndex]->start().y(),
                 (1.0 - percentage) * path[currentIndex]->end().z() + percentage * path[currentIndex]->start().z());
@@ -733,8 +721,7 @@ void PathModifierGenerator::GenerateSlowdown(Path& path, Distance slowDownDistan
         }
 
         currentIndex -= 1;
-        if (currentIndex < 0)
-            currentIndex = path.size() - 1;
+        if (currentIndex < 0) currentIndex = path.size() - 1;
     }
 }
 
@@ -745,8 +732,8 @@ void PathModifierGenerator::GenerateLayerLeadIn(Path& path, const Point& leadIn,
 
     for (int i = 0; i < pathSize; i++) {
         firstBuildSegment = path[i];
-        extRate = path[i]->getSb()->setting<int>(SS::kExtruderSpeed);
-        if (extRate <= 0) // If extrusion rate is zero, must be travel move
+        extRate           = path[i]->getSb()->setting<int>(SS::kExtruderSpeed);
+        if (extRate <= 0)  // If extrusion rate is zero, must be travel move
         {
             path[i]->setEnd(leadIn);
             continue;
@@ -775,35 +762,33 @@ void PathModifierGenerator::GenerateTrajectorySlowdown(Path& path, QSharedPointe
     Angle trajactoryAngleThresh = sb->setting<Angle>(ES::Ramping::kTrajectoryAngleThreshold);
 
     // if the threshold angle set to zero ignores the calculations and returns
-    if (trajactoryAngleThresh <= 0)
-        return;
+    if (trajactoryAngleThresh <= 0) return;
 
-    Distance rampDownLength = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleRampDownDistance);
-    Distance rampUpLength = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleRampUpDistance);
-    Velocity speedSlowDown = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleSpeedSlowDown)();
+    Distance rampDownLength               = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleRampDownDistance);
+    Distance rampUpLength                 = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleRampUpDistance);
+    Velocity speedSlowDown                = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleSpeedSlowDown)();
     AngularVelocity extruderSpeedSlowDown = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleExtruderSpeedSlowDown)();
-    Velocity speedUp = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleSpeedUp)();
-    AngularVelocity extruderSpeedUp = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleExtruderSpeedUp)();
+    Velocity speedUp                      = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleSpeedUp)();
+    AngularVelocity extruderSpeedUp       = sb->setting<Distance>(ES::Ramping::kTrajectoryAngleExtruderSpeedUp)();
 
     for (int pathIndex = 0, end = path.size() - 1; pathIndex < end; ++pathIndex) {
-        if (!path[pathIndex]->isPrintingSegment() || !path[pathIndex + 1]->isPrintingSegment())
-            continue;
+        if (!path[pathIndex]->isPrintingSegment() || !path[pathIndex + 1]->isPrintingSegment()) continue;
 
-        Point startPoint = path[pathIndex]->start();
+        Point startPoint      = path[pathIndex]->start();
         Point connectingPoint = path[pathIndex]->end();
-        Point endPoint = path[pathIndex + 1]->end();
+        Point endPoint        = path[pathIndex + 1]->end();
 
-        double seg1X = connectingPoint.x() - startPoint.x();
-        double seg1Y = connectingPoint.y() - startPoint.y();
-        double seg2X = endPoint.x() - connectingPoint.x();
-        double seg2Y = endPoint.y() - connectingPoint.y();
+        double seg1X      = connectingPoint.x() - startPoint.x();
+        double seg1Y      = connectingPoint.y() - startPoint.y();
+        double seg2X      = endPoint.x() - connectingPoint.x();
+        double seg2Y      = endPoint.y() - connectingPoint.y();
         double seg1Length = qSqrt(seg1X * seg1X + seg1Y * seg1Y);
         double seg2Length = qSqrt(seg2X * seg2X + seg2Y * seg2Y);
 
         double cosTheta = (seg1X * seg2X + seg1Y * seg2Y) / (seg1Length * seg2Length);
-        cosTheta = qMin(1.0, cosTheta);
-        cosTheta = qMax(-1.0, cosTheta);
-        double theta = qAbs(M_PI - qAcos(cosTheta));
+        cosTheta        = qMin(1.0, cosTheta);
+        cosTheta        = qMax(-1.0, cosTheta);
+        double theta    = qAbs(M_PI - qAcos(cosTheta));
 
         if (theta < trajactoryAngleThresh) {
             bool segmentSplitted = false;
@@ -826,11 +811,10 @@ void PathModifierGenerator::GenerateTrajectorySlowdown(Path& path, QSharedPointe
 }
 
 void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPointer<SettingsBase> sb) {
-    if (path.size() < 2)
-        return;
+    if (path.size() < 2) return;
 
     const int segmentCount = path.size();
-    const bool isClosed = pointsCoincident(path.front()->start(), path.back()->end());
+    const bool isClosed    = pointsCoincident(path.front()->start(), path.back()->end());
 
     QVector<bool> skipSegment(segmentCount, false);
     QVector<SegmentEndpointUpdates> endpointUpdates(segmentCount);
@@ -839,15 +823,13 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
     bool modifiedPath = false;
     if (segmentCount >= 3) {
         const int firstConnectorIndex = isClosed ? 0 : 1;
-        const int connectorLimit = isClosed ? segmentCount : segmentCount - 1;
+        const int connectorLimit      = isClosed ? segmentCount : segmentCount - 1;
 
         for (int connectorIndex = firstConnectorIndex; connectorIndex < connectorLimit; ++connectorIndex) {
-            if (skipSegment[connectorIndex] || !isExtendableLineSegment(path[connectorIndex])) {
-                continue;
-            }
+            if (skipSegment[connectorIndex] || !isExtendableLineSegment(path[connectorIndex])) { continue; }
 
             const int previousIndex = (connectorIndex + segmentCount - 1) % segmentCount;
-            const int nextIndex = (connectorIndex + 1) % segmentCount;
+            const int nextIndex     = (connectorIndex + 1) % segmentCount;
 
             if (skipSegment[previousIndex] || skipSegment[nextIndex] || previousIndex == nextIndex ||
                 !isExtendableLineSegment(path[previousIndex]) || !isExtendableLineSegment(path[nextIndex])) {
@@ -879,7 +861,7 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
             }
 
             skipSegment[connectorIndex] = true;
-            modifiedPath = true;
+            modifiedPath                = true;
         }
     }
 
@@ -891,12 +873,10 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
             continue;
         }
 
-        if (!pointsCoincident(path[previousIndex]->end(), path[nextIndex]->start()))
-            continue;
+        if (!pointsCoincident(path[previousIndex]->end(), path[nextIndex]->start())) continue;
 
         SharpCornerSettings settings;
-        if (!sharpCornerEnabledForBothLegs(path[previousIndex], path[nextIndex], sb, settings))
-            continue;
+        if (!sharpCornerEnabledForBothLegs(path[previousIndex], path[nextIndex], sb, settings)) continue;
 
         SharpCornerGeometry geometry;
         if (!calculateSharpCornerGeometry(path[previousIndex], path[nextIndex], settings.threshold_radians,
@@ -908,13 +888,11 @@ void PathModifierGenerator::GenerateSharpCornerExtension(Path& path, QSharedPoin
                                                  insertionsAfter);
     }
 
-    if (!modifiedPath)
-        return;
+    if (!modifiedPath) return;
 
     Path sharpenedPath;
     for (int segmentIndex = 0; segmentIndex < segmentCount; ++segmentIndex) {
-        if (skipSegment[segmentIndex])
-            continue;
+        if (skipSegment[segmentIndex]) continue;
 
         Point start =
             endpointUpdates[segmentIndex].has_start ? endpointUpdates[segmentIndex].start : path[segmentIndex]->start();
@@ -937,14 +915,13 @@ void PathModifierGenerator::GenerateTipWipe(Path& path, PathModifiers modifiers,
     tipWipeDistanceCovered = 0;
 
     if (static_cast<int>(modifiers & PathModifiers::kForwardTipWipe) != 0) {
-        int currentIndex = 0;
+        int currentIndex            = 0;
         Distance cumulativeDistance = 0;
-        Distance wipeLength = wipeDistance;
+        Distance wipeLength         = wipeDistance;
         while (wipeDistance > 0) {
             Distance nextSegmentDist = path[currentIndex]->length();
 
-            if (nextSegmentDist == 0)
-                break;
+            if (nextSegmentDist == 0) break;
 
             wipeDistance -= nextSegmentDist;
             cumulativeDistance += nextSegmentDist;
@@ -957,7 +934,7 @@ void PathModifierGenerator::GenerateTipWipe(Path& path, PathModifiers modifiers,
             }
             else {
                 float percentage = 1 - (-wipeDistance() / nextSegmentDist());
-                end = Point(
+                end              = Point(
                     (1.0 - percentage) * path[currentIndex]->start().x() + percentage * path[currentIndex]->end().x(),
                     (1.0 - percentage) * path[currentIndex]->start().y() + percentage * path[currentIndex]->end().y(),
                     path[currentIndex]->end().z() + tipWipeLiftDistance);
@@ -985,7 +962,7 @@ void PathModifierGenerator::GenerateTipWipe(Path& path, PathModifiers modifiers,
         // Find the new X and Y location to wipe to
         Distance new_x = wipeDistance * cos(new_angle) + path[currentIndex]->end().x();
         Distance new_y = wipeDistance * sin(new_angle) + path[currentIndex]->end().y();
-        Point end = Point(new_x, new_y, path[currentIndex]->end().z() + tipWipeLiftDistance);
+        Point end      = Point(new_x, new_y, path[currentIndex]->end().z() + tipWipeLiftDistance);
 
         generateTipWipeSegment(
             path, path[currentIndex]->end(), end, path[currentIndex]->getSb()->setting<Distance>(SS::kWidth),
@@ -996,12 +973,11 @@ void PathModifierGenerator::GenerateTipWipe(Path& path, PathModifiers modifiers,
             path[currentIndex]->getSb()->setting<bool>(SS::kAdapted));
     }
     else {
-        int currentIndex = path.size() - 1;
+        int currentIndex            = path.size() - 1;
         Distance cumulativeDistance = 0;
-        Distance wipeLength = wipeDistance;
-        bool isClosed = false;
-        if (path[currentIndex]->end() == path[0]->start())
-            isClosed = true;
+        Distance wipeLength         = wipeDistance;
+        bool isClosed               = false;
+        if (path[currentIndex]->end() == path[0]->start()) isClosed = true;
 
         while (wipeDistance > 0 && ((currentIndex >= 0 && !isClosed) || isClosed)) {
             Distance nextSegmentDist = path[currentIndex]->end().distance(path[currentIndex]->start());
@@ -1015,7 +991,7 @@ void PathModifierGenerator::GenerateTipWipe(Path& path, PathModifiers modifiers,
             }
             else {
                 float percentage = 1 - (-wipeDistance() / nextSegmentDist());
-                end = Point(
+                end              = Point(
                     (1.0 - percentage) * path[currentIndex]->end().x() + percentage * path[currentIndex]->start().x(),
                     (1.0 - percentage) * path[currentIndex]->end().y() + percentage * path[currentIndex]->start().y(),
                     path[currentIndex]->start().z() + tipWipeLiftDistance);
@@ -1030,8 +1006,7 @@ void PathModifierGenerator::GenerateTipWipe(Path& path, PathModifiers modifiers,
                 path[currentIndex]->getSb()->setting<bool>(SS::kAdapted));
 
             currentIndex -= 1;
-            if (currentIndex < 0)
-                currentIndex = path.size() - 1;
+            if (currentIndex < 0) currentIndex = path.size() - 1;
         }
     }
 }
@@ -1040,16 +1015,15 @@ void PathModifierGenerator::GenerateForwardTipWipeOpenLoop(Path& path, PathModif
                                                            Velocity wipeSpeed, AngularVelocity extruderSpeed,
                                                            Distance tipWipeLiftDistance, Distance tipWipeCutoffDistance,
                                                            bool clearTipWipDistanceCovered) {
-    if (clearTipWipDistanceCovered)
-        tipWipeDistanceCovered = 0;
+    if (clearTipWipDistanceCovered) tipWipeDistanceCovered = 0;
 
     int currentIndex = path.size() - 1;
-    Distance length = path[currentIndex]->end().distance(path[currentIndex]->start());
-    Distance X = path[currentIndex]->end().x() +
-                 (path[currentIndex]->end().x() - path[currentIndex]->start().x()) / length() * wipeDistance();
-    Distance Y = path[currentIndex]->end().y() +
-                 (path[currentIndex]->end().y() - path[currentIndex]->start().y()) / length() * wipeDistance();
-    Distance Z = path[currentIndex]->end().z() + tipWipeLiftDistance;
+    Distance length  = path[currentIndex]->end().distance(path[currentIndex]->start());
+    Distance X       = path[currentIndex]->end().x() +
+                       (path[currentIndex]->end().x() - path[currentIndex]->start().x()) / length() * wipeDistance();
+    Distance Y       = path[currentIndex]->end().y() +
+                       (path[currentIndex]->end().y() - path[currentIndex]->start().y()) / length() * wipeDistance();
+    Distance Z       = path[currentIndex]->end().z() + tipWipeLiftDistance;
     Point end(X, Y, Z);
 
     generateTipWipeSegment(
@@ -1067,7 +1041,7 @@ void PathModifierGenerator::GenerateSpiralLift(Path& path, Distance spiralWidth,
 
     if (supportsG3) {
         const Angle spiral_angle = 355.0f * degree;
-        const Angle end_angle = (360.0f * degree) - spiral_angle;
+        const Angle end_angle    = (360.0f * degree) - spiral_angle;
         Point spiral_start_point(startPoint.x() + spiralWidth, startPoint.y(), startPoint.z());
         Point spiral_end_point(startPoint.x() + spiralWidth * qCos(end_angle()),
                                startPoint.y() + spiralWidth * qSin(end_angle()), startPoint.z() + spiralHeight);
@@ -1149,35 +1123,31 @@ void PathModifierGenerator::GenerateRamp(Path& path, bool& segmentSplitted, int 
                                          PathModifiers pathModifiers, Distance rampLength, Velocity speed,
                                          AngularVelocity extruderSpeed) {
     Distance rampLengthCovered = 0;
-    int endIndex = path.size() - 1;
-    bool rampDown = pathModifiers == PathModifiers::kRampingDown;
+    int endIndex               = path.size() - 1;
+    bool rampDown              = pathModifiers == PathModifiers::kRampingDown;
 
     while (rampLengthCovered < rampLength) {
         if (rampDown) {
-            if (segmentIndex < 0)
-                break;
+            if (segmentIndex < 0) break;
         }
         else {
-            if (segmentIndex > endIndex)
-                break;
+            if (segmentIndex > endIndex) break;
         }
 
         QSharedPointer<SegmentBase> segment = path[segmentIndex];
 
         PathModifiers segPM = segment->getSb()->setting<PathModifiers>(SS::kPathModifiers);
-        if (segPM == PathModifiers::kRampingUp || segPM == PathModifiers::kRampingDown)
-            break;
+        if (segPM == PathModifiers::kRampingUp || segPM == PathModifiers::kRampingDown) break;
 
         if (segment->length() > (rampLength - rampLengthCovered)) {
             double newPDist = ((rampLength - rampLengthCovered) / segment->length())();
-            if (!rampDown)
-                newPDist = 1 - newPDist;
+            if (!rampDown) newPDist = 1 - newPDist;
 
             Point startP = segment->start();
-            Point endP = segment->end();
-            Point newPV = Point((startP.x() - endP.x()) * newPDist, (startP.y() - endP.y()) * newPDist,
-                                (startP.z() - endP.z()) * newPDist);
-            Point newP = Point(endP.x() + newPV.x(), endP.y() + newPV.y(), endP.z() + newPV.z());
+            Point endP   = segment->end();
+            Point newPV  = Point((startP.x() - endP.x()) * newPDist, (startP.y() - endP.y()) * newPDist,
+                                 (startP.z() - endP.z()) * newPDist);
+            Point newP   = Point(endP.x() + newPV.x(), endP.y() + newPV.y(), endP.z() + newPV.z());
 
             segment->setEnd(newP);
 
@@ -1233,9 +1203,7 @@ void PathModifierGenerator::generateTipWipeSegment(Path& path, Point start, Poin
     if (tipWipeCutoffDistance > 0) {
         Distance length = end.distance(start);
 
-        if (tipWipeDistanceCovered >= tipWipeCutoffDistance) {
-            extruder_speed = 0;
-        }
+        if (tipWipeDistanceCovered >= tipWipeCutoffDistance) { extruder_speed = 0; }
         else if (tipWipeDistanceCovered() + length() - tipWipeCutoffDistance() > 0.09) {
             auto ratio = (tipWipeCutoffDistance() - tipWipeDistanceCovered()) / length();
             Point hopPoint(start.x() + ((end.x() - start.x()) * ratio), start.y() + ((end.y() - start.y()) * ratio),
@@ -1244,7 +1212,7 @@ void PathModifierGenerator::generateTipWipeSegment(Path& path, Point start, Poin
             writeSegment(path, start, hopPoint, width, height, speed, acceleration, extruder_speed, regionType,
                          pathModifiers, materialNumber, adapted);
 
-            start = hopPoint;
+            start          = hopPoint;
             extruder_speed = 0;
         }
 
@@ -1256,4 +1224,4 @@ void PathModifierGenerator::generateTipWipeSegment(Path& path, Point start, Poin
 }
 
 Distance PathModifierGenerator::tipWipeDistanceCovered = 0;
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/pattern_generator.cpp
+++ b/src/geometry/pattern_generator.cpp
@@ -47,8 +47,7 @@ QVector<Polyline> PatternGenerator::GenerateLines(PolygonList geometry, Distance
     //! Unrotate polygons
     for (int i = 0; i < cutlines.size(); i++) {
         cutlines[i] = cutlines[i].rotate(-rotation);
-        if (i % 2 == 0)
-            cutlines[i] = cutlines[i].reverse();
+        if (i % 2 == 0) cutlines[i] = cutlines[i].reverse();
     }
 
     return cutlines;
@@ -79,16 +78,13 @@ QVector<Polyline> PatternGenerator::GenerateConcentric(PolygonList& geometry, Di
         for (Polygon polygon : path_line) {
             Polyline polyline;
             polyline.reserve(polygon.size());
-            for (Point point : polygon) {
-                polyline << point;
-            }
+            for (Point point : polygon) { polyline << point; }
             cutlines.append(polyline);
         }
         path_line = path_line.offset(-lineSpacing);
     }
 
-    if (path_line.size() != 0)
-        geometry = path_line.offset(-beadWidth / 2);
+    if (path_line.size() != 0) geometry = path_line.offset(-beadWidth / 2);
 
     return cutlines;
 }
@@ -116,7 +112,7 @@ QVector<Polyline> PatternGenerator::GenerateTriangles(PolygonList geometry, Dist
 
         //! The space left over after all the max number of cutlines are generated
         Distance freeSpace = (max.toDistance3D().x - min.toDistance3D().x) % lineSpacing;
-        int cutCount = ceil(((max.toDistance3D().x - min.toDistance3D().x) / lineSpacing)());
+        int cutCount       = ceil(((max.toDistance3D().x - min.toDistance3D().x) / lineSpacing)());
 
         //! \note Always ensure that there is an odd number of lines so that there is always a line intersecting the
         //! center
@@ -124,9 +120,7 @@ QVector<Polyline> PatternGenerator::GenerateTriangles(PolygonList geometry, Dist
             --cutCount;
             freeSpace += lineSpacing;
         }
-        if (cutCount < 0) {
-            cutCount = 0;
-        }
+        if (cutCount < 0) { cutCount = 0; }
 
         //! start at the bounding box's minimum x value and go all the way to the bounding box's maximum x value.
         //! As we go along, every "line_spacing" distance we intersect the polygons with the grid lines
@@ -144,9 +138,7 @@ QVector<Polyline> PatternGenerator::GenerateTriangles(PolygonList geometry, Dist
         //! Unrotate polygons
         for (int i = 0; i < cutlines.size(); i++) {
             cutlines[i] = cutlines[i].rotate(-rotation);
-            if (i % 2 == 0) {
-                cutlines[i] = cutlines[i].reverse();
-            }
+            if (i % 2 == 0) { cutlines[i] = cutlines[i].reverse(); }
         }
 
         result.append(cutlines);
@@ -177,15 +169,13 @@ QVector<Polyline> PatternGenerator::GenerateHexagonsAndTriangles(PolygonList geo
         QVector<Polyline> cutlines;
 
         Distance freeSpace = (max.toDistance3D().x - min.toDistance3D().x) % lineSpacing;
-        int cutCount = ceil(((max.toDistance3D().x - min.toDistance3D().x) / lineSpacing)());
+        int cutCount       = ceil(((max.toDistance3D().x - min.toDistance3D().x) / lineSpacing)());
 
         if (cutCount % 2 == 1) {
             --cutCount;
             freeSpace += lineSpacing;
         }
-        if (cutCount < 0) {
-            cutCount = 0;
-        }
+        if (cutCount < 0) { cutCount = 0; }
 
         for (Distance x = min.toDistance3D().x + (freeSpace / 2); x < max.toDistance3D().x; x += lineSpacing) {
             // create the grid lines
@@ -198,9 +188,7 @@ QVector<Polyline> PatternGenerator::GenerateHexagonsAndTriangles(PolygonList geo
 
         for (int i = 0; i < cutlines.size(); i++) {
             cutlines[i] = cutlines[i].rotate(-rotation);
-            if (i % 2 == 0) {
-                cutlines[i] = cutlines[i].reverse();
-            }
+            if (i % 2 == 0) { cutlines[i] = cutlines[i].reverse(); }
         }
 
         result.append(cutlines);
@@ -225,7 +213,7 @@ QVector<Polyline> PatternGenerator::GenerateHoneyComb(PolygonList geometry, Dist
     }
 
     //! \note r^2 = 3/4 * R^2 is used to find the radius of a circumscribed polygon from a supplied side length
-    Distance verticalLineSpacing = sqrt(((lineSpacing * lineSpacing) * 0.75)) * 2;
+    Distance verticalLineSpacing   = sqrt(((lineSpacing * lineSpacing) * 0.75)) * 2;
     Distance horizontalLineSpacing = lineSpacing;
 
     QVector<Polyline> cutlines;
@@ -243,8 +231,7 @@ QVector<Polyline> PatternGenerator::GenerateHoneyComb(PolygonList geometry, Dist
         for (int xCount = 0; xCount < (xCutCount * 4); xCount++) {
             switch (xCount % 4) {
                 case 0: {
-                    if (xCount == 0)
-                        row << currentLocation;
+                    if (xCount == 0) row << currentLocation;
                     currentLocation = Point(currentLocation.x() + horizontalLineSpacing, currentLocation.y());
                     row << currentLocation;
                     break;
@@ -277,12 +264,8 @@ QVector<Polyline> PatternGenerator::GenerateHoneyComb(PolygonList geometry, Dist
             }
         }
 
-        if (yCount % 2) {
-            currentLocation = Point(min.x(), currentLocation.y() + beadWidth);
-        }
-        else {
-            currentLocation = Point(min.x(), currentLocation.y() + verticalLineSpacing + beadWidth);
-        }
+        if (yCount % 2) { currentLocation = Point(min.x(), currentLocation.y() + beadWidth); }
+        else { currentLocation = Point(min.x(), currentLocation.y() + verticalLineSpacing + beadWidth); }
 
         cutlines += geometry & row;
     }
@@ -290,9 +273,7 @@ QVector<Polyline> PatternGenerator::GenerateHoneyComb(PolygonList geometry, Dist
     //! \note Rotate back our cutlines to match the rotation
     for (int i = 0; i < cutlines.size(); i++) {
         cutlines[i] = cutlines[i].rotate(-rotation);
-        if (i % 2 == 0) {
-            cutlines[i] = cutlines[i].reverse();
-        }
+        if (i % 2 == 0) { cutlines[i] = cutlines[i].reverse(); }
     }
 
     return cutlines;
@@ -301,7 +282,7 @@ QVector<Polyline> PatternGenerator::GenerateHoneyComb(PolygonList geometry, Dist
 QVector<Polyline> PatternGenerator::GenerateRadialHatch(PolygonList geometry, Point center, Distance lineSpacing,
                                                         Angle sector_rotation, Angle infill_rotation) {
     PolygonList geometry_oriented = geometry.rotateAround(center, sector_rotation);
-    geometry_oriented = geometry_oriented.rotate(infill_rotation);
+    geometry_oriented             = geometry_oriented.rotate(infill_rotation);
 
     //! Get the bounding box for the polygons. outline_minimum is the minimum
     Point outline_minimum = geometry_oriented.min();
@@ -343,4 +324,4 @@ QVector<Polyline> PatternGenerator::GenerateRadialHatch(PolygonList geometry, Po
     }
     return cutlines;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/plane.cpp
+++ b/src/geometry/plane.cpp
@@ -12,12 +12,12 @@ namespace ORNL {
 Plane::Plane() {}
 
 Plane::Plane(const Point& point, const QVector3D& normal) {
-    m_point = point;
+    m_point         = point;
     m_normal_vector = normal;
 }
 
 Plane::Plane(Point p0, Point p1, Point p2) {
-    m_point = p0;
+    m_point         = p0;
     m_normal_vector = QVector3D::crossProduct((p1 - p0).toQVector3D(), ((p2 - p0).toQVector3D()));
     m_normal_vector.normalize();
 }
@@ -29,28 +29,46 @@ Plane::Plane(MeshTypes::Plane_3& plane) {
     m_normal_vector.normalize();
 }
 
-Point Plane::point() { return m_point; }
+Point Plane::point() {
+    return m_point;
+}
 
-Point Plane::point() const { return m_point; }
+Point Plane::point() const {
+    return m_point;
+}
 
-QVector3D Plane::normal() { return m_normal_vector; }
+QVector3D Plane::normal() {
+    return m_normal_vector;
+}
 
-QVector3D Plane::normal() const { return m_normal_vector; }
+QVector3D Plane::normal() const {
+    return m_normal_vector;
+}
 
-void Plane::point(const Point& point) { m_point = point; }
+void Plane::point(const Point& point) {
+    m_point = point;
+}
 
-void Plane::normal(const QVector3D normal) { m_normal_vector = normal; }
+void Plane::normal(const QVector3D normal) {
+    m_normal_vector = normal;
+}
 
 void Plane::rotate(const QQuaternion& quaternion) {
     m_normal_vector = quaternion.rotatedVector(m_normal_vector);
     m_normal_vector.normalize();
 }
 
-void Plane::shiftX(double x) { m_point.x(m_point.x() + x); }
+void Plane::shiftX(double x) {
+    m_point.x(m_point.x() + x);
+}
 
-void Plane::shiftY(double y) { m_point.y(m_point.y() + y); }
+void Plane::shiftY(double y) {
+    m_point.y(m_point.y() + y);
+}
 
-void Plane::shiftZ(double z) { m_point.z(m_point.z() + z); }
+void Plane::shiftZ(double z) {
+    m_point.z(m_point.z() + z);
+}
 
 void Plane::shiftAlongNormal(double d) {
     QVector3D n = m_normal_vector;
@@ -74,7 +92,9 @@ double Plane::evaluatePoint(Point point) {
     return (m_normal_vector.x() * dx) + (m_normal_vector.y() * dy) + (m_normal_vector.z() * dz);
 }
 
-double Plane::distanceToPoint(Point point) { return evaluatePoint(point) / m_normal_vector.length(); }
+double Plane::distanceToPoint(Point point) {
+    return evaluatePoint(point) / m_normal_vector.length();
+}
 
 MeshTypes::Plane_3 Plane::toCGALPlane() {
     m_normal_vector.normalize();
@@ -91,5 +111,7 @@ bool Plane::isEqual(const Plane& rhs, double epsilon) {
            qAbs(QVector3D::dotProduct(m_normal_vector, QVector3D(diff.x(), diff.y(), diff.z()))) <= epsilon;
 }
 
-bool Plane::operator==(const Plane& rhs) { return isEqual(rhs, 0.01); }
-} // namespace ORNL
+bool Plane::operator==(const Plane& rhs) {
+    return isEqual(rhs, 0.01);
+}
+}  // namespace ORNL

--- a/src/geometry/point.cpp
+++ b/src/geometry/point.cpp
@@ -101,9 +101,9 @@ Point Point::fromQVector3D(const QVector3D& p) {
 }
 
 Point::Point(const Point& p) {
-    m_x = p.m_x;
-    m_y = p.m_y;
-    m_z = p.m_z;
+    m_x  = p.m_x;
+    m_y  = p.m_y;
+    m_z  = p.m_z;
     m_sb = p.m_sb;
 }
 
@@ -121,13 +121,14 @@ Point Point::round(Point p) {
     return p;
 }
 
-Distance Point::distance() const { return qSqrt(qPow(m_x, 2) + qPow(m_y, 2) + qPow(m_z, 2)); }
+Distance Point::distance() const {
+    return qSqrt(qPow(m_x, 2) + qPow(m_y, 2) + qPow(m_z, 2));
+}
 
 // normalizes the x,y and z values of the point to be between 0 and 1
 Point Point::normal(Distance len) {
     Distance _len = (*this).distance();
-    if (_len < 1 * micron)
-        return Point(len, 0);
+    if (_len < 1 * micron) return Point(len, 0);
     return (*this) * len.to(micron) / _len.to(micron);
 }
 
@@ -135,7 +136,9 @@ Distance Point::distance(const Point& rhs) const {
     return qSqrt(qPow(rhs.m_x - m_x, 2) + qPow(rhs.m_y - m_y, 2) + qPow(rhs.m_z - m_z, 2));
 }
 
-float Point::dot(const Point& rhs) const { return m_x * rhs.m_x + m_y * rhs.m_y + m_z * rhs.m_z; }
+float Point::dot(const Point& rhs) const {
+    return m_x * rhs.m_x + m_y * rhs.m_y + m_z * rhs.m_z;
+}
 
 float Point::dot(const Point& lhs, const Point& rhs) {
     return lhs.m_x * rhs.m_x + lhs.m_y * rhs.m_y + lhs.m_z * rhs.m_z;
@@ -145,7 +148,9 @@ Point Point::cross(const Point& rhs) const {
     return Point(m_y * rhs.m_z - m_z * rhs.m_y, m_z * rhs.m_x - m_x * rhs.m_z, m_x * rhs.m_y - m_y * rhs.m_x);
 }
 
-Point Point::rotate(Angle angle, QVector3D axis) { return rotateAround({0, 0, 0}, angle, axis); }
+Point Point::rotate(Angle angle, QVector3D axis) {
+    return rotateAround({0, 0, 0}, angle, axis);
+}
 
 Point Point::rotateAround(Point center, Angle angle, QVector3D axis) {
     QVector3D c = center.toQVector3D();
@@ -164,29 +169,49 @@ void Point::moveTowards(const Point& target, const Distance dist) {
     *this += vector;
 }
 
-bool Point::shorterThan(Distance rhs) const { return distance() < rhs; }
+bool Point::shorterThan(Distance rhs) const {
+    return distance() < rhs;
+}
 
 ClipperLib2::IntPoint Point::toIntPoint() const {
     return ClipperLib2::IntPoint(static_cast<long long>(m_x), static_cast<long long>(m_y));
 }
 
-Distance2D Point::toDistance2D() const { return Distance2D(m_x, m_y); }
+Distance2D Point::toDistance2D() const {
+    return Distance2D(m_x, m_y);
+}
 
-Distance3D Point::toDistance3D() const { return Distance3D(m_x, m_y, m_z); }
+Distance3D Point::toDistance3D() const {
+    return Distance3D(m_x, m_y, m_z);
+}
 
-QPoint Point::toQPoint() const { return QPoint(static_cast<int>(m_x), static_cast<int>(m_y)); }
+QPoint Point::toQPoint() const {
+    return QPoint(static_cast<int>(m_x), static_cast<int>(m_y));
+}
 
-ORNL::Point::operator QPointF() const { return QPointF(m_x, m_y); }
+ORNL::Point::operator QPointF() const {
+    return QPointF(m_x, m_y);
+}
 
-QVector2D Point::toQVector2D() const { return QVector2D(m_x, m_y); }
+QVector2D Point::toQVector2D() const {
+    return QVector2D(m_x, m_y);
+}
 
-QVector3D Point::toQVector3D() const { return QVector3D(m_x, m_y, m_z); }
+QVector3D Point::toQVector3D() const {
+    return QVector3D(m_x, m_y, m_z);
+}
 
-MeshTypes::Kernel::Point_3 Point::toCartesian3D() const { return MeshTypes::Kernel::Point_3(m_x, m_y, m_z); }
+MeshTypes::Kernel::Point_3 Point::toCartesian3D() const {
+    return MeshTypes::Kernel::Point_3(m_x, m_y, m_z);
+}
 
-MeshTypes::Vector_3 Point::toVector_3() const { return MeshTypes::Vector_3(m_x, m_y, m_z); }
+MeshTypes::Vector_3 Point::toVector_3() const {
+    return MeshTypes::Vector_3(m_x, m_y, m_z);
+}
 
-Point Point::operator+(const Point& rhs) { return Point(m_x + rhs.m_x, m_y + rhs.m_y, m_z + rhs.m_z); }
+Point Point::operator+(const Point& rhs) {
+    return Point(m_x + rhs.m_x, m_y + rhs.m_y, m_z + rhs.m_z);
+}
 
 Point Point::operator+=(const Point& rhs) {
     m_x += rhs.m_x;
@@ -195,7 +220,9 @@ Point Point::operator+=(const Point& rhs) {
     return *this;
 }
 
-Point Point::operator-(const Point& rhs) { return Point(m_x - rhs.m_x, m_y - rhs.m_y, m_z - rhs.m_z); }
+Point Point::operator-(const Point& rhs) {
+    return Point(m_x - rhs.m_x, m_y - rhs.m_y, m_z - rhs.m_z);
+}
 
 Point Point::operator-=(const Point& rhs) {
     m_x -= rhs.m_x;
@@ -204,9 +231,13 @@ Point Point::operator-=(const Point& rhs) {
     return *this;
 }
 
-Point Point::operator*(const float rhs) const { return Point(rhs * m_x, rhs * m_y, rhs * m_z); }
+Point Point::operator*(const float rhs) const {
+    return Point(rhs * m_x, rhs * m_y, rhs * m_z);
+}
 
-Point Point::operator*(const float rhs) { return Point(rhs * m_x, rhs * m_y, rhs * m_z); }
+Point Point::operator*(const float rhs) {
+    return Point(rhs * m_x, rhs * m_y, rhs * m_z);
+}
 
 Point Point::operator*=(const float rhs) {
     m_x *= rhs;
@@ -215,7 +246,9 @@ Point Point::operator*=(const float rhs) {
     return *this;
 }
 
-Point Point::operator/(const float rhs) { return Point(m_x / rhs, m_y / rhs, m_z / rhs); }
+Point Point::operator/(const float rhs) {
+    return Point(m_x / rhs, m_y / rhs, m_z / rhs);
+}
 
 Point Point::operator/=(const float m) {
     m_x /= m;
@@ -233,33 +266,61 @@ bool Point::operator!=(const Point& rhs) {
            MathUtils::notEquals(m_z, rhs.m_z);
 }
 
-float Point::x() { return m_x; }
+float Point::x() {
+    return m_x;
+}
 
-float Point::x() const { return m_x; }
+float Point::x() const {
+    return m_x;
+}
 
-void Point::x(float x) { m_x = x; }
+void Point::x(float x) {
+    m_x = x;
+}
 
-void Point::x(const Distance& x) { m_x = x(); }
+void Point::x(const Distance& x) {
+    m_x = x();
+}
 
-float Point::y() { return m_y; }
+float Point::y() {
+    return m_y;
+}
 
-float Point::y() const { return m_y; }
+float Point::y() const {
+    return m_y;
+}
 
-void Point::y(float y) { m_y = y; }
+void Point::y(float y) {
+    m_y = y;
+}
 
-void Point::y(const Distance& y) { m_y = y(); }
+void Point::y(const Distance& y) {
+    m_y = y();
+}
 
-float Point::z() { return m_z; }
+float Point::z() {
+    return m_z;
+}
 
-float Point::z() const { return m_z; }
+float Point::z() const {
+    return m_z;
+}
 
-void Point::z(float z) { m_z = z; }
+void Point::z(float z) {
+    m_z = z;
+}
 
-void Point::z(const Distance& z) { m_z = z(); }
+void Point::z(const Distance& z) {
+    m_z = z();
+}
 
-void Point::setSettings(QSharedPointer<SettingsBase> sb) { m_sb = sb; }
+void Point::setSettings(QSharedPointer<SettingsBase> sb) {
+    m_sb = sb;
+}
 
-QSharedPointer<SettingsBase> Point::getSettings() { return m_sb; }
+QSharedPointer<SettingsBase> Point::getSettings() {
+    return m_sb;
+}
 
 QString Point::toCSVString() {
     return QString(QString::number(m_x) + "," + QString::number(m_y) + "," + QString::number(m_z));
@@ -270,7 +331,9 @@ Point operator*(const QMatrix4x4& lhs, const Point& rhs) {
     return Point(lhs * p);
 }
 
-Point operator*(const float lhs, Point& rhs) { return rhs * lhs; }
+Point operator*(const float lhs, Point& rhs) {
+    return rhs * lhs;
+}
 
 Point operator+(const Point& lhs, const Point& rhs) {
     return Point(lhs.x() + rhs.x(), lhs.y() + rhs.y(), lhs.z() + rhs.z());
@@ -291,29 +354,15 @@ bool operator!=(const Point& lhs, const Point& rhs) {
 }
 
 bool operator<(const Point& lhs, const Point& rhs) {
-    if (lhs.x() < rhs.x()) {
-        return true;
-    }
-    else if (lhs.x() > rhs.x()) {
-        return false;
-    }
+    if (lhs.x() < rhs.x()) { return true; }
+    else if (lhs.x() > rhs.x()) { return false; }
     // lhs.location.x() == rhs.location.x()
-    else if (lhs.y() < rhs.y()) {
-        return true;
-    }
-    else if (lhs.y() > rhs.y()) {
-        return false;
-    }
+    else if (lhs.y() < rhs.y()) { return true; }
+    else if (lhs.y() > rhs.y()) { return false; }
     // lhs.location.y() == rhs.location.y()
-    else if (lhs.z() < rhs.z()) {
-        return true;
-    }
-    else if (lhs.z() > rhs.z()) {
-        return false;
-    }
+    else if (lhs.z() < rhs.z()) { return true; }
+    else if (lhs.z() > rhs.z()) { return false; }
     // lhs.location.z() == rhs.location.z()
-    else {
-        return false;
-    }
+    else { return false; }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/polygon.cpp
+++ b/src/geometry/polygon.cpp
@@ -21,19 +21,17 @@ Polygon::Polygon(const QVector<Point>& path) : QVector<Point>(path) {}
 
 Polygon::Polygon(const ClipperLib2::Path& path) {
     reserve(path.size());
-    for (const ClipperLib2::IntPoint& point : path) {
-        append(point);
-    }
+    for (const ClipperLib2::IntPoint& point : path) { append(point); }
 }
 
 Polygon::Polygon(const Path& path) {
     reserve(path.size());
-    for (int i = 0; i < path.size(); i++) {
-        append(path.at(i)->start());
-    }
+    for (int i = 0; i < path.size(); i++) { append(path.at(i)->start()); }
 }
 
-bool Polygon::orientation() const { return ClipperLib2::Orientation((*this)()); }
+bool Polygon::orientation() const {
+    return ClipperLib2::Orientation((*this)());
+}
 
 PolygonList Polygon::offset(const Distance& distance, const ClipperLib2::JoinType& joinType) const {
     ClipperLib2::Paths paths;
@@ -53,22 +51,18 @@ int64_t Polygon::polygonLength() const {
     return rv;
 }
 
-Point Polygon::boundingRectCenter() const { return (this->min() + this->max()) / 2.0; }
+Point Polygon::boundingRectCenter() const {
+    return (this->min() + this->max()) / 2.0;
+}
 
 Point Polygon::min() const {
     Point rv(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
     for (const Point& point : *this) {
-        if (point.x() < rv.x()) {
-            rv.x(point.x());
-        }
+        if (point.x() < rv.x()) { rv.x(point.x()); }
 
-        if (point.y() < rv.y()) {
-            rv.y(point.y());
-        }
+        if (point.y() < rv.y()) { rv.y(point.y()); }
 
-        if (point.z() < rv.z()) {
-            rv.z(point.z());
-        }
+        if (point.z() < rv.z()) { rv.z(point.z()); }
     }
     return rv;
 }
@@ -77,17 +71,11 @@ Point Polygon::max() const {
     Point rv(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(),
              std::numeric_limits<float>::lowest());
     for (const Point& point : *this) {
-        if (point.x() > rv.x()) {
-            rv.x(point.x());
-        }
+        if (point.x() > rv.x()) { rv.x(point.x()); }
 
-        if (point.y() > rv.y()) {
-            rv.y(point.y());
-        }
+        if (point.y() > rv.y()) { rv.y(point.y()); }
 
-        if (point.z() > rv.z()) {
-            rv.z(point.z());
-        }
+        if (point.z() > rv.z()) { rv.z(point.z()); }
     }
     return rv;
 }
@@ -96,26 +84,20 @@ Polygon Polygon::rotateAround(const Point& center, const Angle& rotation_angle, 
     Polygon polygon;
     polygon.reserve(this->size());
 
-    for (Point point : *this) {
-        polygon.append(point.rotateAround(center, rotation_angle, axis));
-    }
+    for (Point point : *this) { polygon.append(point.rotateAround(center, rotation_angle, axis)); }
     return polygon;
 }
 
 Polygon Polygon::translate(const QVector3D& shift) {
     Polygon shifted_polygon;
     shifted_polygon.reserve(size());
-    for (const Point& point : *this) {
-        shifted_polygon.append(point + shift.toPoint());
-    }
+    for (const Point& point : *this) { shifted_polygon.append(point + shift.toPoint()); }
     return shifted_polygon;
 }
 
 bool Polygon::inside(const Point& point, const bool& border_result) const {
     int res = ClipperLib2::PointInPolygon(point.toIntPoint(), (*this)());
-    if (res == -1) {
-        return border_result;
-    }
+    if (res == -1) { return border_result; }
     return res == 1;
 }
 
@@ -131,15 +113,17 @@ bool Polygon::overlaps(const Polygon& p) {
     return !solution.empty();
 }
 
-Area Polygon::area() const { return Area(ClipperLib2::Area((*this)())); }
+Area Polygon::area() const {
+    return Area(ClipperLib2::Area((*this)()));
+}
 
 Point Polygon::closestPointTo(const Point& rhs) const {
-    Point ret = rhs;
+    Point ret         = rhs;
     Distance bestDist = Distance(std::numeric_limits<float>::max());
     for (const Point& point : (*this)) {
         Distance dist = rhs.distance(point);
         if (dist < bestDist) {
-            ret = point;
+            ret      = point;
             bestDist = dist;
         }
     }
@@ -153,10 +137,8 @@ Polygon Polygon::simplify(const Angle& tolerance) {
     Point prev = operator[](size() - 1);
     for (int i = 0; i < size(); i++) {
         current = (*this)[i];
-        next = (*this)[(i + 1) % size()];
-        if (!MathUtils::nearCollinear(prev, current, next, tolerance)) {
-            polygon.append(current);
-        }
+        next    = (*this)[(i + 1) % size()];
+        if (!MathUtils::nearCollinear(prev, current, next, tolerance)) { polygon.append(current); }
         prev = current;
     }
     polygon.squeeze();
@@ -167,8 +149,7 @@ Polyline Polygon::toPolyline() {
     Polyline newLine;
     newLine.reserve(this->size());
 
-    for (auto it = this->begin(), end = this->end(); it != end; ++it)
-        newLine.push_back(*it);
+    for (auto it = this->begin(), end = this->end(); it != end; ++it) newLine.push_back(*it);
 
     newLine.push_back(this->at(0));
 
@@ -180,7 +161,7 @@ QVector<Polyline> Polygon::getEdges() const {
 
     for (size_t i = 0; i < size(); ++i) {
         const Point& start = this->at(i);
-        const Point& end = this->at((i + 1) % size());
+        const Point& end   = this->at((i + 1) % size());
         edges += Polyline({start, end});
     }
 
@@ -269,9 +250,7 @@ QVector<Polyline> Polygon::operator&(const Polyline& rhs) {
     ClipperLib2::OpenPathsFromPolyTree(poly_tree, paths);
 
     QVector<Polyline> rv;
-    for (ClipperLib2::Path path : paths) {
-        rv += Polyline(path);
-    }
+    for (ClipperLib2::Path path : paths) { rv += Polyline(path); }
     return rv;
 }
 
@@ -299,22 +278,22 @@ PolygonList Polygon::operator^(const Polygon& rhs) {
 
 ClipperLib2::Path Polygon::operator()() const {
     ClipperLib2::Path path;
-    for (Point point : (*this)) {
-        path.push_back(point.toIntPoint());
-    }
+    for (Point point : (*this)) { path.push_back(point.toIntPoint()); }
     return path;
 }
 
 bool Polygon::operator==(const Polygon& rhs) const {
-    if (rhs.size() != this->size()) // they both must be the same size
+    if (rhs.size() != this->size())  // they both must be the same size
         return false;
 
     for (int index = 0; index < this->size(); index++) {
-        if (this->at(index) != rhs[index]) // The points differ
+        if (this->at(index) != rhs[index])  // The points differ
             return false;
     }
     return true;
 }
 
-ClipperLib2::Path Polygon::getPath() { return this->operator()(); }
-} // namespace ORNL
+ClipperLib2::Path Polygon::getPath() {
+    return this->operator()();
+}
+}  // namespace ORNL

--- a/src/geometry/polygon_list.cpp
+++ b/src/geometry/polygon_list.cpp
@@ -1,10 +1,10 @@
 
 #include "geometry/polygon_list.h"
 
+#include <QPolygon>
 #include <cstdint>
 #include <limits>
 
-#include <QPolygon>
 #include <clipper.hpp>
 #include <qpoint.h>
 #include <qtypes.h>
@@ -37,7 +37,7 @@ PolygonList PolygonList::offset(Distance distance, Distance real_offset, Clipper
         paths.clear();
         clipper.Clear();
         clipper.AddPaths(polygons(), joinType, ClipperLib2::etClosedPolygon);
-        clipper.Execute(paths, -distance() + 10); //! +10 buffer
+        clipper.Execute(paths, -distance() + 10);  //! +10 buffer
         PolygonList reversed_offset_geometry(paths);
 
         PolygonList lost_geometry = original_geometry - reversed_offset_geometry;
@@ -50,9 +50,7 @@ bool PolygonList::inside(Point p, bool border_result) const {
     int poly_count_inside = 0;
     for (ClipperLib2::Path poly : (*this)()) {
         const int is_inside_this_poly = ClipperLib2::PointInPolygon(p.toIntPoint(), poly);
-        if (is_inside_this_poly == -1) {
-            return border_result;
-        }
+        if (is_inside_this_poly == -1) { return border_result; }
         poly_count_inside += is_inside_this_poly;
     }
     return (poly_count_inside % 2) == 1;
@@ -91,9 +89,7 @@ PolygonList PolygonList::externalPolygonBoundaries() const {
     PolygonList boundaries;
 
     for (const PolygonList& part : splitIntoParts()) {
-        if (!part.isEmpty()) {
-            boundaries.append(part.first());
-        }
+        if (!part.isEmpty()) { boundaries.append(part.first()); }
     }
 
     return boundaries;
@@ -103,9 +99,7 @@ PolygonList PolygonList::internalPolygonBoundaries() const {
     PolygonList boundaries;
 
     for (const PolygonList& part : splitIntoParts()) {
-        for (int i = 1; i < part.size(); ++i) {
-            boundaries.append(part[i]);
-        }
+        for (int i = 1; i < part.size(); ++i) { boundaries.append(part[i]); }
     }
 
     return boundaries;
@@ -119,9 +113,7 @@ QVector<PolygonList> PolygonList::splitIntoParts(bool unionAll) const {
     if (unionAll) {
         clipper.Execute(ClipperLib2::ctUnion, resultPolyTree, ClipperLib2::pftNonZero, ClipperLib2::pftNonZero);
     }
-    else {
-        clipper.Execute(ClipperLib2::ctUnion, resultPolyTree);
-    }
+    else { clipper.Execute(ClipperLib2::ctUnion, resultPolyTree); }
 
     splitIntoParts_processPolyTreeNode(&resultPolyTree, result);
 
@@ -137,8 +129,7 @@ void PolygonList::splitIntoParts_processPolyTreeNode(ClipperLib2::PolyNode* node
             part += child->Childs[i]->Contour;
             splitIntoParts_processPolyTreeNode(child->Childs[i], ret);
         }
-        if (part.size() > 0)
-            ret.push_back(part);
+        if (part.size() > 0) ret.push_back(part);
     }
 }
 
@@ -156,9 +147,7 @@ PolygonList PolygonList::removeDegenerateVertices() {
         bool isChanged = false;
         for (int idx = 0; idx < poly.size(); idx++) {
             Point& last = (result.size() == 0) ? poly.back() : result.back();
-            if (idx + 1 == poly.size() && result.size() == 0) {
-                break;
-            }
+            if (idx + 1 == poly.size() && result.size() == 0) { break; }
             Point& next = (idx + 1 == poly.size()) ? result[0] : poly[idx + 1];
             // lines are in the opposite direction
             if (isDegenerate(last, poly[idx], next)) {
@@ -168,20 +157,16 @@ PolygonList PolygonList::removeDegenerateVertices() {
                     result.pop_back();
                 }
             }
-            else {
-                result += (poly[idx]);
-            }
+            else { result += (poly[idx]); }
         }
 
         if (isChanged) {
-            if (result.size() > 2) {
-                ret[poly_idx] = result;
-            }
+            if (result.size() > 2) { ret[poly_idx] = result; }
             else {
                 ret.remove(poly_idx);
-                poly_idx--; // effectively the next iteration has the same
-                            // poly_idx (referring to a new poly which is
-                            // not yet processed)
+                poly_idx--;  // effectively the next iteration has the same
+                             // poly_idx (referring to a new poly which is
+                             // not yet processed)
             }
         }
     }
@@ -196,17 +181,11 @@ Point PolygonList::min() const {
         if (p.area()() > 0) {
             Point temp_min = p.min();
 
-            if (temp_min.x() < rv.x()) {
-                rv.x(temp_min.x());
-            }
+            if (temp_min.x() < rv.x()) { rv.x(temp_min.x()); }
 
-            if (temp_min.y() < rv.y()) {
-                rv.y(temp_min.y());
-            }
+            if (temp_min.y() < rv.y()) { rv.y(temp_min.y()); }
 
-            if (temp_min.z() < rv.z()) {
-                rv.z(temp_min.z());
-            }
+            if (temp_min.z() < rv.z()) { rv.z(temp_min.z()); }
         }
     }
     return rv;
@@ -221,23 +200,19 @@ Point PolygonList::max() const {
         if (p.area()() > 0) {
             Point temp_min = p.max();
 
-            if (temp_min.x() > rv.x()) {
-                rv.x(temp_min.x());
-            }
+            if (temp_min.x() > rv.x()) { rv.x(temp_min.x()); }
 
-            if (temp_min.y() > rv.y()) {
-                rv.y(temp_min.y());
-            }
+            if (temp_min.y() > rv.y()) { rv.y(temp_min.y()); }
 
-            if (temp_min.z() > rv.z()) {
-                rv.z(temp_min.z());
-            }
+            if (temp_min.z() > rv.z()) { rv.z(temp_min.z()); }
         }
     }
     return rv;
 }
 
-Point PolygonList::boundingRectCenter() const { return (max() + min()) / 2.0; }
+Point PolygonList::boundingRectCenter() const {
+    return (max() + min()) / 2.0;
+}
 
 PolygonList PolygonList::rotate(const Angle& angle, const QVector3D& axis) {
     return rotateAround({0, 0, 0}, angle, axis);
@@ -245,106 +220,138 @@ PolygonList PolygonList::rotate(const Angle& angle, const QVector3D& axis) {
 
 PolygonList PolygonList::rotateAround(const Point& center, const Angle& angle, const QVector3D& axis) {
     PolygonList rv;
-    for (const Polygon& polygon : *this) {
-        rv += polygon.rotateAround(center, angle, axis);
-    }
+    for (const Polygon& polygon : *this) { rv += polygon.rotateAround(center, angle, axis); }
     return rv;
 }
 
 int64_t PolygonList::totalLength() {
     int64_t total_length = 0;
-    for (Polygon polygon : (*this)) {
-        total_length += polygon.polygonLength();
-    }
+    for (Polygon polygon : (*this)) { total_length += polygon.polygonLength(); }
 
     return total_length;
 }
 
 Area PolygonList::totalArea() {
     Area total_area;
-    for (Polygon poly : *this) {
-        total_area += poly.area();
-    }
+    for (Polygon poly : *this) { total_area += poly.area(); }
     return total_area;
 }
 
 bool PolygonList::operator==(const PolygonList& rhs) const {
     PolygonList pl1 = *this;
     PolygonList pl2 = rhs;
-    if ((pl1 - pl2).isEmpty() && ((pl2) - (pl1)).isEmpty()) {
-        return true;
-    }
-    else {
-        return false;
-    }
+    if ((pl1 - pl2).isEmpty() && ((pl2) - (pl1)).isEmpty()) { return true; }
+    else { return false; }
 }
 
 bool PolygonList::operator!=(const PolygonList& rhs) const {
     PolygonList pl1 = *this;
     PolygonList pl2 = rhs;
-    if ((pl1 - pl2).isEmpty() && ((pl2) - (pl1)).isEmpty()) {
-        return false;
-    }
-    else {
-        return true;
-    }
+    if ((pl1 - pl2).isEmpty() && ((pl2) - (pl1)).isEmpty()) { return false; }
+    else { return true; }
 }
 
-PolygonList PolygonList::operator+(const PolygonList& rhs) { return _add(rhs); }
+PolygonList PolygonList::operator+(const PolygonList& rhs) {
+    return _add(rhs);
+}
 
-PolygonList PolygonList::operator+(const Polygon& rhs) { return _add(rhs); }
+PolygonList PolygonList::operator+(const Polygon& rhs) {
+    return _add(rhs);
+}
 
-PolygonList PolygonList::operator+=(const PolygonList& rhs) { return _add_to_this(rhs); }
+PolygonList PolygonList::operator+=(const PolygonList& rhs) {
+    return _add_to_this(rhs);
+}
 
-PolygonList PolygonList::operator+=(const Polygon& rhs) { return _add_to_this(rhs); }
+PolygonList PolygonList::operator+=(const Polygon& rhs) {
+    return _add_to_this(rhs);
+}
 
-PolygonList PolygonList::operator-(const PolygonList& rhs) const { return _subtract(rhs); }
+PolygonList PolygonList::operator-(const PolygonList& rhs) const {
+    return _subtract(rhs);
+}
 
-PolygonList PolygonList::operator-(const Polygon& rhs) const { return _subtract(rhs); }
+PolygonList PolygonList::operator-(const Polygon& rhs) const {
+    return _subtract(rhs);
+}
 
-PolygonList PolygonList::operator-=(const PolygonList& rhs) { return _subtract_from_this(rhs); }
+PolygonList PolygonList::operator-=(const PolygonList& rhs) {
+    return _subtract_from_this(rhs);
+}
 
-PolygonList PolygonList::operator-=(const Polygon& rhs) { return _subtract_from_this(rhs); }
+PolygonList PolygonList::operator-=(const Polygon& rhs) {
+    return _subtract_from_this(rhs);
+}
 
-PolygonList PolygonList::operator<<(const PolygonList& rhs) { return _add(rhs); }
+PolygonList PolygonList::operator<<(const PolygonList& rhs) {
+    return _add(rhs);
+}
 
-PolygonList PolygonList::operator<<(const Polygon& rhs) { return _add(rhs); }
+PolygonList PolygonList::operator<<(const Polygon& rhs) {
+    return _add(rhs);
+}
 
-PolygonList PolygonList::operator|(const PolygonList& rhs) { return _add(rhs); }
+PolygonList PolygonList::operator|(const PolygonList& rhs) {
+    return _add(rhs);
+}
 
-PolygonList PolygonList::operator|(const Polygon& rhs) { return _add(rhs); }
+PolygonList PolygonList::operator|(const Polygon& rhs) {
+    return _add(rhs);
+}
 
-PolygonList PolygonList::operator|=(const PolygonList& rhs) { return _add_to_this(rhs); }
+PolygonList PolygonList::operator|=(const PolygonList& rhs) {
+    return _add_to_this(rhs);
+}
 
-PolygonList PolygonList::operator|=(const Polygon& rhs) { return _add_to_this(rhs); }
+PolygonList PolygonList::operator|=(const Polygon& rhs) {
+    return _add_to_this(rhs);
+}
 
-PolygonList PolygonList::operator&(const PolygonList& rhs) { return _intersect(rhs); }
+PolygonList PolygonList::operator&(const PolygonList& rhs) {
+    return _intersect(rhs);
+}
 
-PolygonList PolygonList::operator&(const Polygon& rhs) { return _intersect(rhs); }
+PolygonList PolygonList::operator&(const Polygon& rhs) {
+    return _intersect(rhs);
+}
 
-QVector<Polyline> PolygonList::operator&(const Polyline& rhs) { return _intersect(rhs); }
+QVector<Polyline> PolygonList::operator&(const Polyline& rhs) {
+    return _intersect(rhs);
+}
 
-PolygonList PolygonList::operator&=(const PolygonList& rhs) { return _intersect_with_this(rhs); }
+PolygonList PolygonList::operator&=(const PolygonList& rhs) {
+    return _intersect_with_this(rhs);
+}
 
-PolygonList PolygonList::operator&=(const Polygon& rhs) { return _intersect_with_this(rhs); }
+PolygonList PolygonList::operator&=(const Polygon& rhs) {
+    return _intersect_with_this(rhs);
+}
 
-PolygonList PolygonList::operator^(const PolygonList& rhs) { return _xor(rhs); }
+PolygonList PolygonList::operator^(const PolygonList& rhs) {
+    return _xor(rhs);
+}
 
-PolygonList PolygonList::operator^(const Polygon& rhs) { return _xor(rhs); }
+PolygonList PolygonList::operator^(const Polygon& rhs) {
+    return _xor(rhs);
+}
 
-PolygonList PolygonList::operator^=(const PolygonList& rhs) { return _xor_with_this(rhs); }
+PolygonList PolygonList::operator^=(const PolygonList& rhs) {
+    return _xor_with_this(rhs);
+}
 
-PolygonList PolygonList::operator^=(const Polygon& rhs) { return _xor_with_this(rhs); }
+PolygonList PolygonList::operator^=(const Polygon& rhs) {
+    return _xor_with_this(rhs);
+}
 
-PolygonList::PolygonList(const ClipperLib2::Paths& paths) { clipperLoad(paths); }
+PolygonList::PolygonList(const ClipperLib2::Paths& paths) {
+    clipperLoad(paths);
+}
 
 void PolygonList::clipperLoad(const ClipperLib2::Paths& paths) {
     clear();
     for (ClipperLib2::Path path : paths) {
         Polygon polygon;
-        for (ClipperLib2::IntPoint point : path) {
-            polygon += Point(point);
-        }
+        for (ClipperLib2::IntPoint point : path) { polygon += Point(point); }
         append(polygon);
     }
 }
@@ -353,9 +360,7 @@ ClipperLib2::Paths PolygonList::operator()() const {
     ClipperLib2::Paths paths;
     for (const Polygon& polygon : *this) {
         ClipperLib2::Path path;
-        for (Point point : polygon) {
-            path.push_back(point.toIntPoint());
-        }
+        for (Point point : polygon) { path.push_back(point.toIntPoint()); }
         paths.push_back(path);
     }
     return paths;
@@ -469,9 +474,7 @@ QVector<Polyline> PolygonList::_intersect(const Polyline& polyline) {
     ClipperLib2::OpenPathsFromPolyTree(poly_tree, paths);
 
     QVector<Polyline> rv;
-    for (ClipperLib2::Path path : paths) {
-        rv += Polyline(path);
-    }
+    for (ClipperLib2::Path path : paths) { rv += Polyline(path); }
     return rv;
 }
 
@@ -543,17 +546,14 @@ PolygonList PolygonList::_xor_with_this(const PolygonList& other) {
 
 Area PolygonList::netArea() {
     Area a;
-    for (Polygon p : *this) {
-        a = a + p.area();
-    }
+    for (Polygon p : *this) { a = a + p.area(); }
     return a;
 }
 
 void PolygonList::addAll(QVector<Polygon> polygons) {
     ClipperLib2::Clipper clipper;
     ClipperLib2::Paths paths;
-    for (Polygon poly : polygons)
-        clipper.AddPath(poly.getPath(), ClipperLib2::ptSubject, true);
+    for (Polygon poly : polygons) clipper.AddPath(poly.getPath(), ClipperLib2::ptSubject, true);
     clipper.Execute(ClipperLib2::ctUnion, paths, ClipperLib2::pftEvenOdd, ClipperLib2::pftEvenOdd);
     clipperLoad(paths);
 }
@@ -563,9 +563,7 @@ QVector<QPolygon> PolygonList::toQPolygons() const {
 
     for (const Polygon& poly : *this) {
         QPolygon cpoly;
-        for (const Point& point : poly) {
-            cpoly.push_back(point.toQPoint());
-        }
+        for (const Point& point : poly) { cpoly.push_back(point.toQPoint()); }
         ret.push_back(cpoly);
     }
 
@@ -582,10 +580,8 @@ QRect PolygonList::boundingRect() const {
 QVector<Polyline> PolygonList::getEdges() const {
     QVector<Polyline> edges;
 
-    for (const Polygon& poly : *this) {
-        edges += poly.getEdges();
-    }
+    for (const Polygon& poly : *this) { edges += poly.getEdges(); }
 
     return edges;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/polyline.cpp
+++ b/src/geometry/polyline.cpp
@@ -19,35 +19,29 @@
 #include "units/unit.h"
 
 namespace ORNL {
-Polyline::Polyline(const QVector<Point>& path) { QVector<Point>::operator+=(path); }
+Polyline::Polyline(const QVector<Point>& path) {
+    QVector<Point>::operator+=(path);
+}
 
 Polyline::Polyline(const QVector<ClipperLib2::IntPoint>& path) {
-    for (ClipperLib2::IntPoint p : path) {
-        append(Point(p));
-    }
+    for (ClipperLib2::IntPoint p : path) { append(Point(p)); }
 }
 
 Polyline::Polyline(const ClipperLib2::Path& path) {
-    for (ClipperLib2::IntPoint p : path) {
-        append(Point(p));
-    }
+    for (ClipperLib2::IntPoint p : path) { append(Point(p)); }
 }
 
 Polyline::Polyline(const std::vector<MeshTypes::Point_3>& cgal_polyline) {
-    for (auto p : cgal_polyline) {
-        append(Point(p));
-    }
+    for (auto p : cgal_polyline) { append(Point(p)); }
 }
 
 Polyline::Polyline(const QVector<QPair<double, double>>& pts) {
-    for (auto pt : pts) {
-        append(Point(pt.first, pt.second));
-    }
+    for (auto pt : pts) { append(Point(pt.first, pt.second)); }
 }
 
 Distance Polyline::length() const {
     Distance this_length = Distance(0);
-    Point p0 = operator[](0);
+    Point p0             = operator[](0);
     for (int i = 1; i < size(); i++) {
         Point p1 = operator[](i);
         this_length += p1.distance(p0);
@@ -66,32 +60,24 @@ Polyline Polyline::concatenate(Polyline rhs, bool this_end_point, bool rhs_end_p
             }
         }
         else {
-            for (const Point& point : rhs) {
-                concatenated_polyline.append(point);
-            }
+            for (const Point& point : rhs) { concatenated_polyline.append(point); }
         }
-    } //! if this_end_point != rhs_end_point
+    }  //! if this_end_point != rhs_end_point
     else {
         if (this_end_point == true) {
-            for (const Point& point : rhs) {
-                concatenated_polyline.prepend(point);
-            }
+            for (const Point& point : rhs) { concatenated_polyline.prepend(point); }
         }
         else {
-            for (int i = rhs.size() - 1; i >= 0; --i) {
-                concatenated_polyline.append(rhs[i]);
-            }
+            for (int i = rhs.size() - 1; i >= 0; --i) { concatenated_polyline.append(rhs[i]); }
         }
-    } //! if this_end_point == rhs_end_point
+    }  //! if this_end_point == rhs_end_point
 
     return concatenated_polyline;
 }
 
 Polyline Polyline::reverse() {
     Polyline reversed_polyline;
-    for (Point& point : *this) {
-        reversed_polyline.prepend(point);
-    }
+    for (Point& point : *this) { reversed_polyline.prepend(point); }
     return reversed_polyline;
 }
 
@@ -101,12 +87,12 @@ bool Polyline::shorterThan(Distance check_length) const {
 }
 
 Point Polyline::closestPointTo(const Point& rhs) const {
-    Point ret = rhs;
+    Point ret         = rhs;
     Distance bestDist = Distance(std::numeric_limits<float>::max());
     for (Point point : (*this)) {
         Distance dist = rhs.distance(point);
         if (dist < bestDist) {
-            ret = point;
+            ret      = point;
             bestDist = dist;
         }
     }
@@ -124,29 +110,22 @@ Polyline Polyline::simplify(Distance tol) {
     psimpl::simplify_douglas_peucker<2>(polyline.begin(), polyline.end(), tol(), std::back_inserter(result));
 
     Polyline simplified;
-    for (uint n = 0, end = result.size(); n < end; n += 2)
-        simplified.append(Point(result[n], result[n + 1]));
+    for (uint n = 0, end = result.size(); n < end; n += 2) simplified.append(Point(result[n], result[n + 1]));
 
     return simplified;
 }
 
 Polyline Polyline::removeShortSegments(Distance min_segment_length, bool closed) const {
-    if (min_segment_length <= 0 || size() < 2) {
-        return *this;
-    }
+    if (min_segment_length <= 0 || size() < 2) { return *this; }
 
     Polyline cleaned(*this);
     const bool repeats_start = closed && cleaned.size() > 1 && cleaned.first() == cleaned.last();
-    if (repeats_start) {
-        cleaned.removeLast();
-    }
+    if (repeats_start) { cleaned.removeLast(); }
 
     const int min_points = closed ? 3 : 2;
-    if (cleaned.size() < min_points) {
-        return Polyline();
-    }
+    if (cleaned.size() < min_points) { return Polyline(); }
 
-    auto pointAfter = [](int index, int point_count) { return (index + 1) % point_count; };
+    auto pointAfter  = [](int index, int point_count) { return (index + 1) % point_count; };
     auto pointBefore = [](int index, int point_count) { return (index + point_count - 1) % point_count; };
 
     auto replacementLength = [&](int remove_index) {
@@ -156,29 +135,23 @@ Polyline Polyline::removeShortSegments(Distance min_segment_length, bool closed)
 
     bool removed_point = true;
     while (removed_point && cleaned.size() > min_points) {
-        removed_point = false;
+        removed_point           = false;
         const int segment_count = closed ? cleaned.size() : cleaned.size() - 1;
 
         for (int segment_index = 0; segment_index < segment_count; ++segment_index) {
             const int next_index = pointAfter(segment_index, cleaned.size());
-            if (cleaned[segment_index].distance(cleaned[next_index]) >= min_segment_length) {
-                continue;
-            }
+            if (cleaned[segment_index].distance(cleaned[next_index]) >= min_segment_length) { continue; }
 
             int remove_index = next_index;
             if (closed) {
                 remove_index =
                     replacementLength(segment_index) <= replacementLength(next_index) ? segment_index : next_index;
             }
-            else if (segment_index == 0) {
-                remove_index = next_index;
-            }
-            else if (next_index == cleaned.size() - 1) {
-                remove_index = segment_index;
-            }
+            else if (segment_index == 0) { remove_index = next_index; }
+            else if (next_index == cleaned.size() - 1) { remove_index = segment_index; }
             else {
                 const Distance remove_segment_start_length = cleaned[segment_index - 1].distance(cleaned[next_index]);
-                const Distance remove_segment_end_length = cleaned[segment_index].distance(cleaned[next_index + 1]);
+                const Distance remove_segment_end_length   = cleaned[segment_index].distance(cleaned[next_index + 1]);
                 remove_index = remove_segment_start_length <= remove_segment_end_length ? segment_index : next_index;
             }
 
@@ -188,30 +161,22 @@ Polyline Polyline::removeShortSegments(Distance min_segment_length, bool closed)
         }
     }
 
-    if (cleaned.size() < min_points) {
-        return Polyline();
-    }
+    if (cleaned.size() < min_points) { return Polyline(); }
 
     const int segment_count = closed ? cleaned.size() : cleaned.size() - 1;
     for (int segment_index = 0; segment_index < segment_count; ++segment_index) {
         const int next_index = pointAfter(segment_index, cleaned.size());
-        if (cleaned[segment_index].distance(cleaned[next_index]) < min_segment_length) {
-            return Polyline();
-        }
+        if (cleaned[segment_index].distance(cleaned[next_index]) < min_segment_length) { return Polyline(); }
     }
 
-    if (repeats_start) {
-        cleaned.push_back(cleaned.first());
-    }
+    if (repeats_start) { cleaned.push_back(cleaned.first()); }
 
     return cleaned;
 }
 
 Polygon Polyline::close() {
     Polygon ret(operator()());
-    if (ret.back() == ret.front()) {
-        ret.pop_back();
-    }
+    if (ret.back() == ret.front()) { ret.pop_back(); }
     return ret;
 }
 
@@ -280,24 +245,20 @@ Polyline Polyline::rotateAround(Point center, Angle rotation_angle, QVector3D ax
 bool Polyline::inside(const Point& point, bool border_result) const {
     if (this->first() == this->last()) {
         int res = ClipperLib2::PointInPolygon(point.toIntPoint(), (*this)());
-        if (res == -1) {
-            return border_result;
-        }
+        if (res == -1) { return border_result; }
         return res == 1;
     }
     return false;
 }
 
-bool Polyline::orientation() const { return ClipperLib2::Orientation((*this)()); }
+bool Polyline::orientation() const {
+    return ClipperLib2::Orientation((*this)());
+}
 
 Polyline Polyline::operator+(Polyline rhs) {
-    if (last() == rhs.first()) {
-        rhs.removeFirst();
-    }
+    if (last() == rhs.first()) { rhs.removeFirst(); }
     Polyline polyline(*this);
-    for (int i = 0; i < rhs.size(); i++) {
-        polyline.push_back(rhs[i]);
-    }
+    for (int i = 0; i < rhs.size(); i++) { polyline.push_back(rhs[i]); }
     return polyline;
 }
 
@@ -308,12 +269,8 @@ Polyline Polyline::operator+(const Point& rhs) {
 }
 
 Polyline& Polyline::operator+=(Polyline rhs) {
-    if (this->size() > 0 && last() == rhs.first()) {
-        rhs.removeFirst();
-    }
-    for (int i = 0; i < rhs.size(); i++) {
-        push_back(rhs[i]);
-    }
+    if (this->size() > 0 && last() == rhs.first()) { rhs.removeFirst(); }
+    for (int i = 0; i < rhs.size(); i++) { push_back(rhs[i]); }
     return *this;
 }
 
@@ -332,9 +289,7 @@ QVector<Polyline> Polyline::operator-(const Polygon& rhs) {
     ClipperLib2::OpenPathsFromPolyTree(poly_tree, paths);
 
     QVector<Polyline> rv;
-    for (ClipperLib2::Path path : paths) {
-        rv += Polyline(path);
-    }
+    for (ClipperLib2::Path path : paths) { rv += Polyline(path); }
     return rv;
 }
 
@@ -348,26 +303,18 @@ QVector<Polyline> Polyline::operator-(const PolygonList& rhs) {
     ClipperLib2::OpenPathsFromPolyTree(poly_tree, paths);
 
     QVector<Polyline> rv;
-    for (ClipperLib2::Path path : paths) {
-        rv += Polyline(path);
-    }
+    for (ClipperLib2::Path path : paths) { rv += Polyline(path); }
     return rv;
 }
 
 Point Polyline::min() const {
     Point rv(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max());
     for (const Point& point : *this) {
-        if (point.x() < rv.x()) {
-            rv.x(point.x());
-        }
+        if (point.x() < rv.x()) { rv.x(point.x()); }
 
-        if (point.y() < rv.y()) {
-            rv.y(point.y());
-        }
+        if (point.y() < rv.y()) { rv.y(point.y()); }
 
-        if (point.z() < rv.z()) {
-            rv.z(point.z());
-        }
+        if (point.z() < rv.z()) { rv.z(point.z()); }
     }
     return rv;
 }
@@ -376,17 +323,11 @@ Point Polyline::max() const {
     Point rv(std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(),
              std::numeric_limits<float>::lowest());
     for (const Point& point : *this) {
-        if (point.x() > rv.x()) {
-            rv.x(point.x());
-        }
+        if (point.x() > rv.x()) { rv.x(point.x()); }
 
-        if (point.y() > rv.y()) {
-            rv.y(point.y());
-        }
+        if (point.y() > rv.y()) { rv.y(point.y()); }
 
-        if (point.z() > rv.z()) {
-            rv.z(point.z());
-        }
+        if (point.z() > rv.z()) { rv.z(point.z()); }
     }
     return rv;
 }
@@ -398,9 +339,7 @@ QVector<Point> Polyline::operator&(const Polyline& rhs) {
 
 ClipperLib2::Path Polyline::operator()() const {
     ClipperLib2::Path path;
-    for (Point p : (*this)) {
-        path.push_back(p.toIntPoint());
-    }
+    for (Point p : (*this)) { path.push_back(p.toIntPoint()); }
     return path;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/segment_base.cpp
+++ b/src/geometry/segment_base.cpp
@@ -30,91 +30,131 @@ SegmentBase::SegmentBase(Point start, Point end)
                             PathModifiers::kSpiralLift;
 }
 
-Point SegmentBase::start() const { return m_start; }
+Point SegmentBase::start() const {
+    return m_start;
+}
 
-Point SegmentBase::midpoint() const { return (m_start + m_end) / 2.; }
+Point SegmentBase::midpoint() const {
+    return (m_start + m_end) / 2.;
+}
 
-Point SegmentBase::end() const { return m_end; }
+Point SegmentBase::end() const {
+    return m_end;
+}
 
-uint SegmentBase::layerNumber() { return m_layer_num; }
+uint SegmentBase::layerNumber() {
+    return m_layer_num;
+}
 
-uint SegmentBase::lineNumber() { return m_line_num; }
+uint SegmentBase::lineNumber() {
+    return m_line_num;
+}
 
-float SegmentBase::displayWidth() { return m_display_width; }
+float SegmentBase::displayWidth() {
+    return m_display_width;
+}
 
-float SegmentBase::displayHeight() { return m_display_height; }
+float SegmentBase::displayHeight() {
+    return m_display_height;
+}
 
-SegmentDisplayType SegmentBase::displayType() { return m_display_type; }
+SegmentDisplayType SegmentBase::displayType() {
+    return m_display_type;
+}
 
-QColor SegmentBase::color() { return m_color; }
+QColor SegmentBase::color() {
+    return m_color;
+}
 
-bool SegmentBase::depositionActive() const { return m_deposition_active; }
+bool SegmentBase::depositionActive() const {
+    return m_deposition_active;
+}
 
-void SegmentBase::setDepositionActive(bool deposition_active) { m_deposition_active = deposition_active; }
+void SegmentBase::setDepositionActive(bool deposition_active) {
+    m_deposition_active = deposition_active;
+}
 
 void SegmentBase::setCylindricalBeadCenter(const Point& center) {
-    m_cylindrical_bead_center = center;
+    m_cylindrical_bead_center     = center;
     m_has_cylindrical_bead_center = true;
 }
 
-void SegmentBase::clearCylindricalBeadCenter() { m_has_cylindrical_bead_center = false; }
+void SegmentBase::clearCylindricalBeadCenter() {
+    m_has_cylindrical_bead_center = false;
+}
 
-bool SegmentBase::hasCylindricalBeadCenter() const { return m_has_cylindrical_bead_center; }
+bool SegmentBase::hasCylindricalBeadCenter() const {
+    return m_has_cylindrical_bead_center;
+}
 
-Point SegmentBase::cylindricalBeadCenter() const { return m_cylindrical_bead_center; }
+Point SegmentBase::cylindricalBeadCenter() const {
+    return m_cylindrical_bead_center;
+}
 
 void SegmentBase::setDisplayInfo(float display_width, float display_length, float display_height,
                                  SegmentDisplayType type, QColor color, uint line_num, uint layer_num) {
-    m_display_width = display_width;
+    m_display_width  = display_width;
     m_display_length = display_length;
     m_display_height = display_height;
-    m_display_type = type;
-    m_color = color;
-    m_line_num = line_num;
-    m_layer_num = layer_num;
+    m_display_type   = type;
+    m_color          = color;
+    m_line_num       = line_num;
+    m_layer_num      = layer_num;
 }
 
-void SegmentBase::setDisplayWidth(float display_width) { m_display_width = display_width; }
+void SegmentBase::setDisplayWidth(float display_width) {
+    m_display_width = display_width;
+}
 
-void SegmentBase::setDisplayHeight(float display_height) { m_display_height = display_height; }
+void SegmentBase::setDisplayHeight(float display_height) {
+    m_display_height = display_height;
+}
 
 void SegmentBase::createGraphic(std::vector<float>& vertices, std::vector<float>& normals, std::vector<float>& colors) {
     // NOP
 }
 
-void SegmentBase::setStart(Point start) { m_start = start; }
+void SegmentBase::setStart(Point start) {
+    m_start = start;
+}
 
-void SegmentBase::setEnd(Point end) { m_end = end; }
+void SegmentBase::setEnd(Point end) {
+    m_end = end;
+}
 
-void SegmentBase::reverse() { std::swap(m_start, m_end); }
+void SegmentBase::reverse() {
+    std::swap(m_start, m_end);
+}
 
-QSharedPointer<SettingsBase> SegmentBase::getSb() const { return m_sb; }
+QSharedPointer<SettingsBase> SegmentBase::getSb() const {
+    return m_sb;
+}
 
-void SegmentBase::setSb(const QSharedPointer<SettingsBase>& sb) { m_sb = sb; }
+void SegmentBase::setSb(const QSharedPointer<SettingsBase>& sb) {
+    m_sb = sb;
+}
 
 void SegmentBase::rotate(QQuaternion rotation) {
     // rotate each point
-    QVector3D start_vec = m_start.toQVector3D();
+    QVector3D start_vec    = m_start.toQVector3D();
     QVector3D result_start = rotation.rotatedVector(start_vec);
-    m_start = Point(result_start);
+    m_start                = Point(result_start);
 
-    QVector3D end_vec = m_end.toQVector3D();
+    QVector3D end_vec    = m_end.toQVector3D();
     QVector3D result_end = rotation.rotatedVector(end_vec);
-    m_end = Point(result_end);
+    m_end                = Point(result_end);
 
     if (m_has_cylindrical_bead_center) {
-        QVector3D center_vec = m_cylindrical_bead_center.toQVector3D();
-        QVector3D result_center = rotation.rotatedVector(center_vec);
+        QVector3D center_vec      = m_cylindrical_bead_center.toQVector3D();
+        QVector3D result_center   = rotation.rotatedVector(center_vec);
         m_cylindrical_bead_center = Point(result_center);
     }
 }
 
 void SegmentBase::shift(Point shift) {
     m_start = m_start + shift;
-    m_end = m_end + shift;
-    if (m_has_cylindrical_bead_center) {
-        m_cylindrical_bead_center = m_cylindrical_bead_center + shift;
-    }
+    m_end   = m_end + shift;
+    if (m_has_cylindrical_bead_center) { m_cylindrical_bead_center = m_cylindrical_bead_center + shift; }
 }
 
 bool SegmentBase::isPrintingSegment() {
@@ -125,5 +165,7 @@ bool SegmentBase::isPrintingSegment() {
     return true;
 }
 
-Distance SegmentBase::length() { return m_start.distance(m_end); }
-} // namespace ORNL
+Distance SegmentBase::length() {
+    return m_start.distance(m_end);
+}
+}  // namespace ORNL

--- a/src/geometry/segments/arc.cpp
+++ b/src/geometry/segments/arc.cpp
@@ -34,17 +34,17 @@ ArcSegment::ArcSegment(Point start, Point middle, Point end) : SegmentBase(start
         case 0:
             throw IllegalArgumentException(
                 "Cannot construct an ArcSegment from collinear start, middle, and end points");
-        case 1: // Clockwise
+        case 1:  // Clockwise
             m_ccw = false;
             break;
-        case -1: // Counter-clockwise
+        case -1:  // Counter-clockwise
             m_ccw = true;
             break;
     }
 
-    m_start = start;
+    m_start  = start;
     m_center = CalculateCenter(start, middle, end);
-    m_end = end;
+    m_end    = end;
 
     updateAngle();
 }
@@ -66,24 +66,33 @@ void ArcSegment::createGraphic(std::vector<float>& vertices, std::vector<float>&
                                 colors, normals);
 }
 
-QSharedPointer<SegmentBase> ArcSegment::clone() const { return QSharedPointer<ArcSegment>::create(*this); }
+QSharedPointer<SegmentBase> ArcSegment::clone() const {
+    return QSharedPointer<ArcSegment>::create(*this);
+}
 
-Point ArcSegment::center() const { return m_center; }
+Point ArcSegment::center() const {
+    return m_center;
+}
 
-Angle ArcSegment::angle() const { return m_angle; }
+Angle ArcSegment::angle() const {
+    return m_angle;
+}
 
-void ArcSegment::setAngle(const Angle& angle) { m_angle = angle; }
+void ArcSegment::setAngle(const Angle& angle) {
+    m_angle = angle;
+}
 
-bool ArcSegment::counterclockwise() const { return m_ccw; }
+bool ArcSegment::counterclockwise() const {
+    return m_ccw;
+}
 
 QString ArcSegment::writeGCode(QSharedPointer<WriterBase> writer) {
-    Velocity speed = this->getSb()->setting<Velocity>(SS::kSpeed);
-    int extruderSpeed = this->getSb()->setting<int>(SS::kExtruderSpeed);
-    RegionType regionType = this->getSb()->setting<RegionType>(SS::kRegionType);
+    Velocity speed          = this->getSb()->setting<Velocity>(SS::kSpeed);
+    int extruderSpeed       = this->getSb()->setting<int>(SS::kExtruderSpeed);
+    RegionType regionType   = this->getSb()->setting<RegionType>(SS::kRegionType);
     PathModifiers modifiers = this->getSb()->setting<PathModifiers>(SS::kPathModifiers);
-    const QString gcode = writer->writeArc(m_start, m_end, m_center, m_angle, m_ccw, this->getSb());
-    if (!gcode.isEmpty())
-        writer->setCurrentPosition(m_end);
+    const QString gcode     = writer->writeArc(m_start, m_end, m_center, m_angle, m_ccw, this->getSb());
+    if (!gcode.isEmpty()) writer->setCurrentPosition(m_end);
     return gcode;
 }
 
@@ -104,24 +113,24 @@ float ArcSegment::getMinZ() {
 Distance ArcSegment::length() {
     const double planar_radius = std::hypot(m_start.x() - m_center.x(), m_start.y() - m_center.y());
     const double planar_length = m_angle() * planar_radius;
-    const double z_delta = m_end.z() - m_start.z();
+    const double z_delta       = m_end.z() - m_start.z();
     return Distance(std::hypot(planar_length, z_delta));
 }
 
 Point ArcSegment::CalculateCenter(const Point& start, const Point& middle, const Point& end) {
-    const double ax = start.x() - end.x();
-    const double ay = start.y() - end.y();
-    const double bx = middle.x() - end.x();
-    const double by = middle.y() - end.y();
-    const double determinant = 2.0 * ((ax * by) - (ay * bx));
-    const double scale = qMax(1.0, qMax(qMax(qAbs(ax), qAbs(ay)), qMax(qAbs(bx), qAbs(by))));
+    const double ax                    = start.x() - end.x();
+    const double ay                    = start.y() - end.y();
+    const double bx                    = middle.x() - end.x();
+    const double by                    = middle.y() - end.y();
+    const double determinant           = 2.0 * ((ax * by) - (ay * bx));
+    const double scale                 = qMax(1.0, qMax(qMax(qAbs(ax), qAbs(ay)), qMax(qAbs(bx), qAbs(by))));
     const double determinant_tolerance = std::numeric_limits<double>::epsilon() * scale * scale * 16.0;
 
     if (qFuzzyIsNull(determinant) || qAbs(determinant) <= determinant_tolerance) {
         throw IllegalArgumentException("Cannot calculate an arc center from collinear or near-collinear points");
     }
 
-    const double start_offset_squared = (ax * ax) + (ay * ay);
+    const double start_offset_squared  = (ax * ax) + (ay * ay);
     const double middle_offset_squared = (bx * bx) + (by * by);
     const double x = end.x() + ((by * start_offset_squared) - (ay * middle_offset_squared)) / determinant;
     const double y = end.y() + ((ax * middle_offset_squared) - (bx * start_offset_squared)) / determinant;
@@ -134,16 +143,16 @@ Distance ArcSegment::Radius(const Point& a, const Point& b, const Point& c) {
 }
 
 double ArcSegment::SignedCurvature(const Point& a, const Point& b, const Point& c) {
-    double li = a.distance(b)();
+    double li  = a.distance(b)();
     double li1 = b.distance(c)();
-    double qi = a.distance(c)();
+    double qi  = a.distance(c)();
 
-    QVector3D li_v = b.toQVector3D() - a.toQVector3D();
+    QVector3D li_v  = b.toQVector3D() - a.toQVector3D();
     QVector3D li1_v = c.toQVector3D() - b.toQVector3D();
 
     double det = QVector3D::crossProduct(li_v, li1_v).z();
 
-    double numerator = 2 * det;
+    double numerator   = 2 * det;
     double denominator = li * li1 * qi;
 
     return numerator / denominator;
@@ -162,15 +171,14 @@ void ArcSegment::updateAngle() {
     else
         m_angle = Angle(b - a);
 
-    if (m_angle <= 0)
-        m_angle = (2.0f * M_PI) + m_angle;
+    if (m_angle <= 0) m_angle = (2.0f * M_PI) + m_angle;
 }
 
 void ArcSegment::rotate(QQuaternion rotation) {
     // rotate each point
-    QVector3D center_vec = m_center.toQVector3D();
+    QVector3D center_vec    = m_center.toQVector3D();
     QVector3D result_center = rotation.rotatedVector(center_vec);
-    m_center = Point(result_center);
+    m_center                = Point(result_center);
 
     SegmentBase::rotate(rotation);
 }
@@ -180,4 +188,4 @@ void ArcSegment::shift(Point shift) {
 
     SegmentBase::shift(shift);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/segments/bezier.cpp
+++ b/src/geometry/segments/bezier.cpp
@@ -37,12 +37,11 @@ Point BezierSegment::getPointAlong(double t) {
 
 Distance BezierSegment::length() {
     const int approx_segments = 1000;
-    Distance length = 0.0;
-    Point last = m_start;
+    Distance length           = 0.0;
+    Point last                = m_start;
     Point next;
 
     for (double increment = (1.0 / approx_segments), t = increment; t <= 1.0; t += increment) {
-
         next = this->getPointAlong(t);
         length += last.distance(next);
         last = next;
@@ -53,12 +52,9 @@ Distance BezierSegment::length() {
 float BezierSegment::getMinZ() {
     float min = m_start.z();
 
-    if (min < m_control_a.z())
-        min = m_control_a.z();
-    if (min < m_control_b.z())
-        min = m_control_b.z();
-    if (min < m_end.z())
-        min = m_end.z();
+    if (min < m_control_a.z()) min = m_control_a.z();
+    if (min < m_control_b.z()) min = m_control_b.z();
+    if (min < m_end.z()) min = m_end.z();
 
     return min;
 }
@@ -68,7 +64,9 @@ QString BezierSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     return {};
 }
 
-QSharedPointer<SegmentBase> BezierSegment::clone() const { return QSharedPointer<BezierSegment>::create(*this); }
+QSharedPointer<SegmentBase> BezierSegment::clone() const {
+    return QSharedPointer<BezierSegment>::create(*this);
+}
 
 QPair<BezierSegment, Distance> BezierSegment::Fit(int start_index, int end_index, Path& path) {
     Point p1 = path[start_index]->start();
@@ -76,8 +74,7 @@ QPair<BezierSegment, Distance> BezierSegment::Fit(int start_index, int end_index
 
     // Compute the ground truth
     BSpline spline(p1);
-    for (int i = start_index; i <= end_index; ++i)
-        spline.append(path[i]->end());
+    for (int i = start_index; i <= end_index; ++i) spline.append(path[i]->end());
 
     // Determine control points for new curve
     double t0 = 0.49;
@@ -101,7 +98,7 @@ QPair<BezierSegment, Distance> BezierSegment::Fit(int start_index, int end_index
     Point numer_part = p_t1 - (p1 * t11) - (p4 * t14);
 
     Point p3_numerator = (p_t0 - (p1 * t01) - (p4 * t04)) - (numer_part * (t02 / t12));
-    Point p3 = p3_numerator / (t03 - ((t02 * t13) / t12));
+    Point p3           = p3_numerator / (t03 - ((t02 * t13) / t12));
 
     Point p2 = (numer_part - (p3 * t13)) / t12;
 
@@ -125,7 +122,7 @@ QPair<Point, Point> BezierSegment::ComputeControlPoints(Point& a, Point& b, Poin
     Distance d_ab = a.distance(b);
     Distance d_bc = b.distance(c);
 
-    double first_scale = smoothing * (d_ab() / (d_ab + d_bc)());
+    double first_scale  = smoothing * (d_ab() / (d_ab + d_bc)());
     double second_scale = smoothing * (d_bc() / (d_ab + d_bc)());
 
     Point first_control((b.x() - first_scale * (c.x() - a.x())), (b.y() - first_scale * (c.y() - a.y())));
@@ -135,19 +132,23 @@ QPair<Point, Point> BezierSegment::ComputeControlPoints(Point& a, Point& b, Poin
     return QPair<Point, Point>(first_control, second_control);
 }
 
-void BezierSegment::setControlA(Point& control) { m_control_a = control; }
+void BezierSegment::setControlA(Point& control) {
+    m_control_a = control;
+}
 
-void BezierSegment::setControlB(Point& control) { m_control_b = control; }
+void BezierSegment::setControlB(Point& control) {
+    m_control_b = control;
+}
 
 void BezierSegment::rotate(QQuaternion rotation) {
     // rotate each point
-    QVector3D control_a_vec = m_control_a.toQVector3D();
+    QVector3D control_a_vec    = m_control_a.toQVector3D();
     QVector3D result_control_a = rotation.rotatedVector(control_a_vec);
-    m_control_a = Point(result_control_a);
+    m_control_a                = Point(result_control_a);
 
-    QVector3D control_b_vec = m_control_b.toQVector3D();
+    QVector3D control_b_vec    = m_control_b.toQVector3D();
     QVector3D result_control_b = rotation.rotatedVector(control_b_vec);
-    m_control_b = Point(result_control_b);
+    m_control_b                = Point(result_control_b);
 
     SegmentBase::rotate(rotation);
 }
@@ -158,4 +159,4 @@ void BezierSegment::shift(Point shift) {
 
     SegmentBase::shift(shift);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/segments/line.cpp
+++ b/src/geometry/segments/line.cpp
@@ -27,21 +27,18 @@ void LineSegment::createGraphic(std::vector<float>& vertices, std::vector<float>
                                    m_end.toQVector3D(), m_color, vertices, colors, normals);
 }
 
-QSharedPointer<SegmentBase> LineSegment::clone() const { return QSharedPointer<LineSegment>::create(*this); }
+QSharedPointer<SegmentBase> LineSegment::clone() const {
+    return QSharedPointer<LineSegment>::create(*this);
+}
 
 QString LineSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     const QString gcode = writer->writeLine(m_start, m_end, this->getSb());
-    if (!gcode.isEmpty())
-        writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty()) writer->setCurrentPosition(m_end);
     return gcode;
 }
 
 float LineSegment::getMinZ() {
-    if (m_start.z() < m_end.z()) {
-        return m_start.z();
-    }
-    else {
-        return m_end.z();
-    }
+    if (m_start.z() < m_end.z()) { return m_start.z(); }
+    else { return m_end.z(); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/segments/scan.cpp
+++ b/src/geometry/segments/scan.cpp
@@ -17,21 +17,24 @@ ScanSegment::ScanSegment(Point start, Point end) : SegmentBase(start, end) {
     // NOP
 }
 
-QSharedPointer<SegmentBase> ScanSegment::clone() const { return QSharedPointer<ScanSegment>::create(*this); }
+QSharedPointer<SegmentBase> ScanSegment::clone() const {
+    return QSharedPointer<ScanSegment>::create(*this);
+}
 
 QString ScanSegment::writeGCode(QSharedPointer<WriterBase> writer) {
-    Velocity speed = this->getSb()->setting<Velocity>(SS::kSpeed);
+    Velocity speed      = this->getSb()->setting<Velocity>(SS::kSpeed);
     const QString gcode = writer->writeScan(m_end, speed, m_on_off);
-    if (!gcode.isEmpty())
-        writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty()) writer->setCurrentPosition(m_end);
     return gcode;
 }
 
-void ScanSegment::setDataCollection(bool on) { m_on_off = on; }
+void ScanSegment::setDataCollection(bool on) {
+    m_on_off = on;
+}
 
 float ScanSegment::getMinZ() {
     // don't want this min to impact the min for an entire layer, but still need to return something
     // so return the largest possible number
     return std::numeric_limits<float>::max();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/segments/travel.cpp
+++ b/src/geometry/segments/travel.cpp
@@ -14,16 +14,19 @@ TravelSegment::TravelSegment(Point start, Point end, TravelLiftType liftType)
     // NOP
 }
 
-QSharedPointer<SegmentBase> TravelSegment::clone() const { return QSharedPointer<TravelSegment>::create(*this); }
+QSharedPointer<SegmentBase> TravelSegment::clone() const {
+    return QSharedPointer<TravelSegment>::create(*this);
+}
 
 QString TravelSegment::writeGCode(QSharedPointer<WriterBase> writer) {
     const QString gcode = writer->writeTravel(m_start, m_end, m_lift_type, this->getSb());
-    if (!gcode.isEmpty())
-        writer->setCurrentPosition(m_end);
+    if (!gcode.isEmpty()) writer->setCurrentPosition(m_end);
     return gcode;
 }
 
-void TravelSegment::setLiftType(TravelLiftType newLiftType) { m_lift_type = newLiftType; }
+void TravelSegment::setLiftType(TravelLiftType newLiftType) {
+    m_lift_type = newLiftType;
+}
 
 float TravelSegment::getMinZ() {
     if (m_start.z() < m_end.z())
@@ -31,4 +34,4 @@ float TravelSegment::getMinZ() {
     else
         return m_end.z();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/geometry/settings_polygon.cpp
+++ b/src/geometry/settings_polygon.cpp
@@ -13,9 +13,7 @@ SettingsPolygon::SettingsPolygon(QVector<Polygon> geometry, QSharedPointer<Setti
     m_sb = sb;
 
     // Set geometry from cs.
-    if (!geometry.isEmpty()) {
-        this->addAll(geometry);
-    }
+    if (!geometry.isEmpty()) { this->addAll(geometry); }
 }
 
 QVector<Point> SettingsPolygon::clipLine(Point start, Point end) const {
@@ -47,7 +45,11 @@ QVector<Point> SettingsPolygon::clipLine(Point start, Point end) const {
     return rv;
 }
 
-QSharedPointer<SettingsBase> SettingsPolygon::getSettings() { return m_sb; }
+QSharedPointer<SettingsBase> SettingsPolygon::getSettings() {
+    return m_sb;
+}
 
-QSharedPointer<SettingsBase> SettingsPolygon::getSettings() const { return m_sb; }
-} // namespace ORNL
+QSharedPointer<SettingsBase> SettingsPolygon::getSettings() const {
+    return m_sb;
+}
+}  // namespace ORNL

--- a/src/graphics/base_view.cpp
+++ b/src/graphics/base_view.cpp
@@ -6,6 +6,7 @@
 #include <QFileDialog>
 #include <QKeyEvent>
 #include <QMouseEvent>
+
 #include <qmatrix4x4.h>
 #include <qnamespace.h>
 #include <qopenglshaderprogram.h>
@@ -25,7 +26,7 @@
 namespace ORNL {
 namespace {
 constexpr float kKeyboardRotateDegrees = 5.0f;
-constexpr float kKeyboardPanNdcStep = 0.10f;
+constexpr float kKeyboardPanNdcStep    = 0.10f;
 
 bool isArrowKey(int key) {
     return key == Qt::Key_Left || key == Qt::Key_Right || key == Qt::Key_Up || key == Qt::Key_Down;
@@ -50,7 +51,7 @@ bool hasCameraPanModifier(Qt::KeyboardModifiers modifiers) {
     return modifiers.testFlag(Qt::ShiftModifier) || modifiers.testFlag(Qt::ControlModifier) ||
            modifiers.testFlag(Qt::AltModifier);
 }
-} // namespace
+}  // namespace
 
 BaseView::BaseView(QWidget* parent) : QOpenGLWidget(parent) {
     // Initalize camera projection.
@@ -61,7 +62,7 @@ BaseView::BaseView(QWidget* parent) : QOpenGLWidget(parent) {
     m_projection.perspective(Constants::OpenGL::kFov, aspect, Constants::OpenGL::kNearPlane,
                              Constants::OpenGL::kFarPlane);
 
-    m_camera = QSharedPointer<CameraManager>::create(); // Manager for camera/view matrix
+    m_camera = QSharedPointer<CameraManager>::create();  // Manager for camera/view matrix
     m_shader_program.reset(new QOpenGLShaderProgram());
     this->setMouseTracking(true);
     this->setFocusPolicy(Qt::StrongFocus);
@@ -143,12 +144,8 @@ void BaseView::mouseMoveEvent(QMouseEvent* e) {
         }
 
         case (Qt::RightButton): {
-            if (e->modifiers() == Qt::ControlModifier) {
-                this->handleControlModifiedRightMove(ndc_mouse_pos);
-            }
-            else {
-                this->handleRightMove(ndc_mouse_pos);
-            }
+            if (e->modifiers() == Qt::ControlModifier) { this->handleControlModifiedRightMove(ndc_mouse_pos); }
+            else { this->handleRightMove(ndc_mouse_pos); }
             break;
         }
 
@@ -198,7 +195,7 @@ void BaseView::keyPressEvent(QKeyEvent* e) {
     if (hasCameraPanModifier(e->modifiers())) {
         QMatrix4x4 view = m_camera->viewMatrix();
         QVector3D right = QVector3D(view(0, 0), view(0, 1), view(0, 2));
-        QVector3D up = QVector3D(view(1, 0), view(1, 1), view(1, 2));
+        QVector3D up    = QVector3D(view(1, 0), view(1, 1), view(1, 2));
 
         right.setZ(0);
         up.setZ(0);
@@ -221,12 +218,12 @@ void BaseView::keyPressEvent(QKeyEvent* e) {
 
 void BaseView::zoomIn() {
     m_camera->zoom(10);
-    this->update(); // Need to repaint with new view matrix
+    this->update();  // Need to repaint with new view matrix
 }
 
 void BaseView::zoomOut() {
     m_camera->zoom(-10);
-    this->update(); // Need to repaint with new view matrix
+    this->update();  // Need to repaint with new view matrix
 }
 
 void BaseView::resetZoom() {
@@ -241,7 +238,7 @@ void BaseView::resetCamera() {
     m_camera->panAbsolute(QVector3D(0, 0, 0));
     m_focus->scaleAbsolute(QVector3D(1, 1, 1));
 
-    this->update(); // Need to repaint with new model matrices
+    this->update();  // Need to repaint with new model matrices
 }
 
 void BaseView::setTopView() {
@@ -274,19 +271,33 @@ void BaseView::setIsoView() {
     this->handleWheelForward(QPointF(), 120 * 20);
 }
 
-void BaseView::addObject(QSharedPointer<GraphicsObject> object) { m_render_objects.append(object); }
+void BaseView::addObject(QSharedPointer<GraphicsObject> object) {
+    m_render_objects.append(object);
+}
 
-void BaseView::removeObject(QSharedPointer<GraphicsObject> object) { m_render_objects.removeOne(object); }
+void BaseView::removeObject(QSharedPointer<GraphicsObject> object) {
+    m_render_objects.removeOne(object);
+}
 
-void BaseView::setProjectionMatrix(QMatrix4x4 projection) { m_projection = projection; }
+void BaseView::setProjectionMatrix(QMatrix4x4 projection) {
+    m_projection = projection;
+}
 
-QSharedPointer<CameraManager> BaseView::camera() { return m_camera; }
+QSharedPointer<CameraManager> BaseView::camera() {
+    return m_camera;
+}
 
-QMatrix4x4 BaseView::projectionMatrix() { return m_projection; }
+QMatrix4x4 BaseView::projectionMatrix() {
+    return m_projection;
+}
 
-QMatrix4x4 BaseView::viewMatrix() { return m_camera->viewMatrix(); }
+QMatrix4x4 BaseView::viewMatrix() {
+    return m_camera->viewMatrix();
+}
 
-QSharedPointer<QOpenGLShaderProgram> BaseView::shaderProgram() { return m_shader_program; }
+QSharedPointer<QOpenGLShaderProgram> BaseView::shaderProgram() {
+    return m_shader_program;
+}
 
 void BaseView::handleMidClick(QPointF mouse_ndc_pos) {
     m_camera->setDragStart(mouse_ndc_pos);
@@ -326,7 +337,7 @@ void BaseView::handleMidMove(QPointF mouse_ndc_pos) {
 void BaseView::handleRightMove(QPointF mouse_ndc_pos) {
     m_camera->rotateFromPoint(mouse_ndc_pos);
 
-    this->update(); // Repaint because view matrix has changed
+    this->update();  // Repaint because view matrix has changed
 }
 
 void BaseView::handleRightLeftMove(QPointF mouse_nds_pos) {
@@ -375,16 +386,18 @@ void BaseView::translateCamera(QVector3D v, bool absolute) {
     }
 }
 
-void BaseView::rotateCamera(QVector2D screen_delta) { m_camera->rotateByScreenDelta(screen_delta); }
+void BaseView::rotateCamera(QVector2D screen_delta) {
+    m_camera->rotateByScreenDelta(screen_delta);
+}
 
 void BaseView::initializeGL() {
     // Required for OpenGL to work
     this->initializeOpenGLFunctions();
 
-    this->setupStyle(); // color background
+    this->setupStyle();  // color background
 
-    this->glEnable(GL_CULL_FACE);  // Cull polygons based on winding
-    this->glEnable(GL_DEPTH_TEST); // Depth comparisons so stuff behind other polygons not shown
+    this->glEnable(GL_CULL_FACE);   // Cull polygons based on winding
+    this->glEnable(GL_DEPTH_TEST);  // Depth comparisons so stuff behind other polygons not shown
 
     this->glEnable(GL_BLEND);
     this->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -396,15 +409,15 @@ void BaseView::initializeGL() {
     m_shader_program->link();
     m_shader_program->bind();
 
-    m_shader_locs.projection = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kProjectionName);
-    m_shader_locs.view = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kViewName);
+    m_shader_locs.projection     = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kProjectionName);
+    m_shader_locs.view           = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kViewName);
     m_shader_locs.lighting_color = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kLightingColorName);
-    m_shader_locs.lighting_pos = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kLightingPositionName);
-    m_shader_locs.camera_pos = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kCameraPositionName);
+    m_shader_locs.lighting_pos   = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kLightingPositionName);
+    m_shader_locs.camera_pos     = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kCameraPositionName);
     m_shader_locs.ambient_strength = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kAmbientStrengthName);
     m_shader_locs.using_solid_wireframe_mode =
         m_shader_program->uniformLocation(Constants::OpenGL::Shader::kUsingSolidWireframeModeName);
-    m_shader_locs.stack_axis = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kStackingAxisName);
+    m_shader_locs.stack_axis     = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kStackingAxisName);
     m_shader_locs.overhang_angle = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kOverhangAngleName);
     m_shader_locs.using_overhang_mode = m_shader_program->uniformLocation(Constants::OpenGL::Shader::kOverhangModeName);
     m_shader_locs.rendering_part_object =
@@ -454,9 +467,7 @@ void BaseView::paintGL() {
 
     QQueue<QSharedPointer<GraphicsObject>> goQueue;
     // Add objects to the render queue first
-    for (auto& go : m_render_objects) {
-        go->addToRenderQueue(goQueue);
-    }
+    for (auto& go : m_render_objects) { go->addToRenderQueue(goQueue); }
 
     // Then render objects in queue
     while (!goQueue.isEmpty()) {
@@ -484,4 +495,4 @@ QPointF BaseView::normalizeWidgetPos(QPointF widget_pos) {
     normalized_device_pos.setY(1.0 - 2.0 * widget_pos.y() / this->height());
     return normalized_device_pos;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/graphics_object.cpp
+++ b/src/graphics/graphics_object.cpp
@@ -2,14 +2,14 @@
 
 #include <GL/gl.h>
 
+#include <QOpenGLShaderProgram>
+#include <QStack>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <tuple>
 #include <vector>
 
-#include <QOpenGLShaderProgram>
-#include <QStack>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qimage.h>
@@ -37,8 +37,7 @@ GraphicsObject::GraphicsObject(BaseView* view, const std::vector<float>& vertice
 }
 
 GraphicsObject::~GraphicsObject() {
-    if (m_view.isNull() || m_view->context() == nullptr)
-        return;
+    if (m_view.isNull() || m_view->context() == nullptr) return;
 
     m_view->makeCurrent();
 
@@ -51,9 +50,7 @@ GraphicsObject::~GraphicsObject() {
 }
 
 void GraphicsObject::render() {
-
-    if (m_state.hidden)
-        return;
+    if (m_state.hidden) return;
     m_view->shaderProgram()->setUniformValue(m_shader_locs.usingSolidWireframeMode, this->getSolidWireFrameMode());
 
     // Draw to front of screen if on top or underneath.
@@ -94,19 +91,21 @@ void GraphicsObject::render() {
     // qDebug() << m_view->glGetError();
 
     // Restore global rendering values.
-    if (m_state.ontop || m_state.underneath)
-        m_view->glDepthRange(0.01, 0.99);
-    if (m_state.billboard)
-        m_view->shaderProgram()->setUniformValue(m_shader_locs.ambient, 0.4f);
+    if (m_state.ontop || m_state.underneath) m_view->glDepthRange(0.01, 0.99);
+    if (m_state.billboard) m_view->shaderProgram()->setUniformValue(m_shader_locs.ambient, 0.4f);
 }
 
 void GraphicsObject::configureUniforms() {
     m_view->shaderProgram()->setUniformValue(m_shader_locs.renderingPartObject, false);
 }
 
-BaseView* GraphicsObject::view() { return m_view.data(); }
+BaseView* GraphicsObject::view() {
+    return m_view.data();
+}
 
-QVector<QVector3D> GraphicsObject::minimumBoundingBox() { return m_transformed_mbb; }
+QVector<QVector3D> GraphicsObject::minimumBoundingBox() {
+    return m_transformed_mbb;
+}
 
 bool GraphicsObject::doesMBBIntersect(QSharedPointer<GraphicsObject> go) {
     QVector3D min = this->minimum();
@@ -123,7 +122,9 @@ bool GraphicsObject::doesMBBIntersect(QSharedPointer<GraphicsObject> go) {
     return false;
 }
 
-QVector3D GraphicsObject::center() { return (m_transformed_mbb[MBB_MIN] + m_transformed_mbb[MBB_MAX]) / 2; }
+QVector3D GraphicsObject::center() {
+    return (m_transformed_mbb[MBB_MIN] + m_transformed_mbb[MBB_MAX]) / 2;
+}
 
 QVector3D GraphicsObject::minimum() {
     QVector3D min;
@@ -165,9 +166,9 @@ void GraphicsObject::setTransformationInternal(QMatrix4x4 mtrx, bool propagate) 
     if (propagate) {
         for (auto& c : this->children()) {
             // Get new child position and propagate.
-            QMatrix4x4 child_tfm = c->transformation();
+            QMatrix4x4 child_tfm    = c->transformation();
             QMatrix4x4 relative_tfm = m_transform.inverted() * child_tfm;
-            QMatrix4x4 new_tfm = mtrx * relative_tfm;
+            QMatrix4x4 new_tfm      = mtrx * relative_tfm;
 
             // Using external function to decompose here.
             c->setTransformation(new_tfm, true);
@@ -177,9 +178,7 @@ void GraphicsObject::setTransformationInternal(QMatrix4x4 mtrx, bool propagate) 
     m_transform = mtrx;
 
     // Update bounding cube.
-    for (int i = 0; i < m_mbb.size(); i++) {
-        m_transformed_mbb[i] = mtrx * m_mbb[i];
-    }
+    for (int i = 0; i < m_mbb.size(); i++) { m_transformed_mbb[i] = mtrx * m_mbb[i]; }
 
     if (!m_state.in_callback) {
         m_state.in_callback = true;
@@ -241,13 +240,21 @@ void GraphicsObject::scale(QVector3D s, bool propagate) {
     this->setTransformationInternal(new_tfm, propagate);
 }
 
-QMatrix4x4 GraphicsObject::transformation() { return m_transform; }
+QMatrix4x4 GraphicsObject::transformation() {
+    return m_transform;
+}
 
-QVector3D GraphicsObject::translation() { return m_translation; }
+QVector3D GraphicsObject::translation() {
+    return m_translation;
+}
 
-QQuaternion GraphicsObject::rotation() { return m_rotation; }
+QQuaternion GraphicsObject::rotation() {
+    return m_rotation;
+}
 
-QVector3D GraphicsObject::scaling() { return m_scale; }
+QVector3D GraphicsObject::scaling() {
+    return m_scale;
+}
 
 std::vector<Triangle> GraphicsObject::triangles() {
     // 3 vertices specify a triangle, but each vertex refers to 3 floats
@@ -266,30 +273,36 @@ std::vector<Triangle> GraphicsObject::triangles() {
     return triangles;
 }
 
-const std::vector<float>& GraphicsObject::vertices() { return m_vertices; }
+const std::vector<float>& GraphicsObject::vertices() {
+    return m_vertices;
+}
 
-const std::vector<float>& GraphicsObject::normals() { return m_normals; }
+const std::vector<float>& GraphicsObject::normals() {
+    return m_normals;
+}
 
-const std::vector<float>& GraphicsObject::colors() { return m_colors; }
+const std::vector<float>& GraphicsObject::colors() {
+    return m_colors;
+}
 
-QSharedPointer<GraphicsObject> GraphicsObject::parent() { return m_parent; }
+QSharedPointer<GraphicsObject> GraphicsObject::parent() {
+    return m_parent;
+}
 
-QSet<QSharedPointer<GraphicsObject>> GraphicsObject::children() { return m_children; }
+QSet<QSharedPointer<GraphicsObject>> GraphicsObject::children() {
+    return m_children;
+}
 
 QSet<QSharedPointer<GraphicsObject>> GraphicsObject::allChildren() {
     QSet<QSharedPointer<GraphicsObject>> ret;
 
     QStack<QSharedPointer<GraphicsObject>> queue;
-    for (auto& child : m_children) {
-        queue.push(child);
-    }
+    for (auto& child : m_children) { queue.push(child); }
 
     while (!queue.empty()) {
         QSharedPointer<GraphicsObject> go = queue.pop();
 
-        for (auto& go_child : go->children()) {
-            queue.push(go_child);
-        }
+        for (auto& go_child : go->children()) { queue.push(go_child); }
 
         ret.insert(go);
     }
@@ -305,39 +318,56 @@ void GraphicsObject::adoptChild(QSharedPointer<GraphicsObject> child) {
 }
 
 void GraphicsObject::orphanChild(QSharedPointer<GraphicsObject> child) {
-    if (child.isNull())
-        return;
+    if (child.isNull()) return;
     child->m_parent = nullptr;
     m_children.remove(child);
 
     this->orphanChildCallback(child);
 }
 
-void GraphicsObject::lock() { m_state.locked = true; }
+void GraphicsObject::lock() {
+    m_state.locked = true;
+}
 
-void GraphicsObject::unlock() { m_state.locked = false; }
+void GraphicsObject::unlock() {
+    m_state.locked = false;
+}
 
-void GraphicsObject::setLocked(bool lock) { m_state.locked = lock; }
+void GraphicsObject::setLocked(bool lock) {
+    m_state.locked = lock;
+}
 
-bool GraphicsObject::locked() { return m_state.locked; }
+bool GraphicsObject::locked() {
+    return m_state.locked;
+}
 
-void GraphicsObject::hide() { m_state.hidden = true; }
+void GraphicsObject::hide() {
+    m_state.hidden = true;
+}
 
-void GraphicsObject::show() { m_state.hidden = false; }
+void GraphicsObject::show() {
+    m_state.hidden = false;
+}
 
-void GraphicsObject::setHidden(bool hide) { m_state.hidden = hide; }
+void GraphicsObject::setHidden(bool hide) {
+    m_state.hidden = hide;
+}
 
-bool GraphicsObject::hidden() { return m_state.hidden; }
+bool GraphicsObject::hidden() {
+    return m_state.hidden;
+}
 
-void GraphicsObject::setBillboarding(bool state) { m_state.billboard = state; }
+void GraphicsObject::setBillboarding(bool state) {
+    m_state.billboard = state;
+}
 
 void GraphicsObject::setOnTop(bool state) {
     m_state.underneath = false;
-    m_state.ontop = state;
+    m_state.ontop      = state;
 }
 
 void GraphicsObject::setUnderneath(bool state) {
-    m_state.ontop = false;
+    m_state.ontop      = false;
     m_state.underneath = state;
 }
 
@@ -348,12 +378,12 @@ GraphicsObject::GraphicsObject() {
 void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertices, const std::vector<float>& normals,
                                 const std::vector<float>& colors, const ushort render_mode,
                                 const std::vector<float>& uv, const QImage texture) {
-    m_view = view;
+    m_view        = view;
     m_render_mode = render_mode;
 
     QSharedPointer<QOpenGLShaderProgram> program = m_view->shaderProgram();
     // Get shader locations.
-    m_shader_locs.model = m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kModelName);
+    m_shader_locs.model   = m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kModelName);
     m_shader_locs.ambient = m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kAmbientStrengthName);
     m_shader_locs.overhangAngle =
         m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kOverhangAngleName);
@@ -362,9 +392,9 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
     m_shader_locs.renderingPartObject =
         m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kRenderingPartObjectName);
     m_shader_locs.vertice = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kPositionName);
-    m_shader_locs.normal = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kNormalName);
-    m_shader_locs.color = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kColorName);
-    m_shader_locs.uv = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kUVName);
+    m_shader_locs.normal  = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kNormalName);
+    m_shader_locs.color   = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kColorName);
+    m_shader_locs.uv      = m_view->shaderProgram()->attributeLocation(Constants::OpenGL::Shader::kUVName);
     m_shader_locs.usingSolidWireframeMode =
         m_view->shaderProgram()->uniformLocation(Constants::OpenGL::Shader::kUsingSolidWireframeModeName);
 
@@ -373,9 +403,9 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
     m_view->shaderProgram()->bind();
 
     m_vertices = vertices;
-    m_normals = normals;
-    m_colors = colors;
-    m_uv = uv;
+    m_normals  = normals;
+    m_colors   = colors;
+    m_uv       = uv;
 
     m_texture = QSharedPointer<QOpenGLTexture>::create(texture);
     m_texture->setMinificationFilter(QOpenGLTexture::Nearest);
@@ -396,9 +426,7 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
     m_view->shaderProgram()->setAttributeBuffer(m_shader_locs.vertice, GL_FLOAT, 0, 3);
 
     // Normals
-    if (!m_normals.size()) {
-        m_normals.resize(m_vertices.size(), 0);
-    }
+    if (!m_normals.size()) { m_normals.resize(m_vertices.size(), 0); }
     m_nbo.create();
     m_nbo.setUsagePattern(QOpenGLBuffer::StaticDraw);
     m_nbo.bind();
@@ -407,9 +435,7 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
     m_view->shaderProgram()->setAttributeBuffer(m_shader_locs.normal, GL_FLOAT, 0, 3);
 
     // Colors
-    if (!m_colors.size()) {
-        m_normals.resize((m_vertices.size() / 3) * 4, 0);
-    }
+    if (!m_colors.size()) { m_normals.resize((m_vertices.size() / 3) * 4, 0); }
     m_cbo.create();
     m_cbo.setUsagePattern(QOpenGLBuffer::DynamicDraw);
     m_cbo.bind();
@@ -424,9 +450,7 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
         // map to 0,0 for the remaining vertices.
         int uv_float_count = (m_vertices.size() / 3) * 2;
         m_uv.resize(uv_float_count);
-        for (int i = m_uv.size(); i < uv_float_count; i++) {
-            m_uv[i] = 0.0f;
-        }
+        for (int i = m_uv.size(); i < uv_float_count; i++) { m_uv[i] = 0.0f; }
     }
 
     m_tbo.create();
@@ -480,15 +504,25 @@ void GraphicsObject::populateGL(BaseView* view, const std::vector<float>& vertic
     std::tie(m_translation, m_rotation, m_scale) = MathUtils::decomposeTransformMatrix(m_transform);
 }
 
-void GraphicsObject::draw() { m_view->glDrawArrays(renderMode(), 0, m_vertices.size() / 3); }
+void GraphicsObject::draw() {
+    m_view->glDrawArrays(renderMode(), 0, m_vertices.size() / 3);
+}
 
-bool GraphicsObject::getSolidWireFrameMode() { return m_state.is_solid_wireframe; }
+bool GraphicsObject::getSolidWireFrameMode() {
+    return m_state.is_solid_wireframe;
+}
 
-void GraphicsObject::setSolidWireFrameMode(bool state) { m_state.is_solid_wireframe = state; }
+void GraphicsObject::setSolidWireFrameMode(bool state) {
+    m_state.is_solid_wireframe = state;
+}
 
-bool GraphicsObject::getWireFrameMode() { return m_state.is_wireframe; }
+bool GraphicsObject::getWireFrameMode() {
+    return m_state.is_wireframe;
+}
 
-void GraphicsObject::setWireFrameMode(bool state) { m_state.is_wireframe = state; }
+void GraphicsObject::setWireFrameMode(bool state) {
+    m_state.is_wireframe = state;
+}
 
 void GraphicsObject::setTransparency(uint trans) {
     m_transparency = trans;
@@ -500,7 +534,9 @@ void GraphicsObject::setTransparency(uint trans) {
     this->paint(m_color);
 }
 
-uint GraphicsObject::transparency() { return m_transparency; }
+uint GraphicsObject::transparency() {
+    return m_transparency;
+}
 
 void GraphicsObject::replaceVertices(std::vector<float>& vertices) {
     m_vertices = vertices;
@@ -651,42 +687,47 @@ void GraphicsObject::orphanChildCallback(QSharedPointer<GraphicsObject> child) {
     // Does nothing by default.
 }
 
-QSharedPointer<QOpenGLTexture>& GraphicsObject::texture() { return m_texture; }
+QSharedPointer<QOpenGLTexture>& GraphicsObject::texture() {
+    return m_texture;
+}
 
-QSharedPointer<QOpenGLVertexArrayObject>& GraphicsObject::vao() { return m_vao; }
+QSharedPointer<QOpenGLVertexArrayObject>& GraphicsObject::vao() {
+    return m_vao;
+}
 
-ushort& GraphicsObject::renderMode() { return m_render_mode; }
+ushort& GraphicsObject::renderMode() {
+    return m_render_mode;
+}
 
-bool& GraphicsObject::solidWireFrameMode() { return m_state.is_solid_wireframe; }
+bool& GraphicsObject::solidWireFrameMode() {
+    return m_state.is_solid_wireframe;
+}
 
-bool& GraphicsObject::wireFrameMode() { return m_state.is_wireframe; }
+bool& GraphicsObject::wireFrameMode() {
+    return m_state.is_wireframe;
+}
 
 void GraphicsObject::addToRenderQueue(QQueue<QSharedPointer<GraphicsObject>>& renderQueue) {
-
     // First add each of this objects children to the render queue
-    for (auto& c : m_children) {
-        c->addToRenderQueue(renderQueue);
-    }
+    for (auto& c : m_children) { c->addToRenderQueue(renderQueue); }
 
     QSharedPointer<PartObject> p = this->sharedFromThis().dynamicCast<PartObject>();
     // If this graphics object is a part and its transparent, put it to the back of the render queue,
     // otherwise, put it to the front.
-    if (p && p->transparency() < 255) {
-        renderQueue.append(this->sharedFromThis());
-    }
-    else {
-        renderQueue.prepend(this->sharedFromThis());
-    }
+    if (p && p->transparency() < 255) { renderQueue.append(this->sharedFromThis()); }
+    else { renderQueue.prepend(this->sharedFromThis()); }
 }
 
-void GraphicsObject::paint(QColor color) { this->paint(color, 0); }
+void GraphicsObject::paint(QColor color) {
+    this->paint(color, 0);
+}
 
 void GraphicsObject::paint(QColor color, uint whence, long count) {
     // TODO: move this to shaders.
     uint stop = (count == -1) ? m_colors.size() : whence + count;
 
     for (int i = whence; i < stop; i += 4) {
-        m_colors[i] = color.redF();
+        m_colors[i]     = color.redF();
         m_colors[i + 1] = color.greenF();
         m_colors[i + 2] = color.blueF();
         m_colors[i + 3] = color.alphaF();
@@ -698,4 +739,4 @@ void GraphicsObject::paint(QColor color, uint whence, long count) {
     m_cbo.release();
 }
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/graphics/objects/arrow_object.cpp
+++ b/src/graphics/objects/arrow_object.cpp
@@ -16,7 +16,7 @@
 namespace ORNL {
 ArrowObject::ArrowObject(BaseView* view, QVector3D begin, QVector3D end, QColor color) {
     m_begin = begin;
-    m_end = end;
+    m_end   = end;
     m_color = color;
 
     this->initArrow(view);
@@ -25,7 +25,7 @@ ArrowObject::ArrowObject(BaseView* view, QVector3D begin, QVector3D end, QColor 
 ArrowObject::ArrowObject(BaseView* view, QSharedPointer<GraphicsObject> begin, QSharedPointer<GraphicsObject> end,
                          QColor color) {
     m_begin = begin->center();
-    m_end = end->center();
+    m_end   = end->center();
     m_color = color;
 
     m_head_tracking = end;
@@ -61,11 +61,10 @@ void ArrowObject::setEnd(QVector3D end) {
 }
 
 void ArrowObject::updateEndpoints() {
-    if (m_head_tracking.isNull() || m_tail_tracking.isNull())
-        return;
+    if (m_head_tracking.isNull() || m_tail_tracking.isNull()) return;
 
     m_begin = m_tail_tracking->center();
-    m_end = m_head_tracking->center();
+    m_end   = m_head_tracking->center();
 
     float len = m_begin.distanceToPoint(m_end);
 
@@ -124,7 +123,7 @@ void ArrowObject::initArrow(BaseView* view) {
 }
 
 QMatrix4x4 ArrowObject::findTransform(QVector3D begin, QVector3D end) {
-    QVector3D dir_vec = end - begin;
+    QVector3D dir_vec   = end - begin;
     QVector3D start_vec = QVector3D(begin.distanceToPoint(end), 0, 0);
 
     QQuaternion rotation = QQuaternion::rotationTo(start_vec, dir_vec);
@@ -136,4 +135,4 @@ QMatrix4x4 ArrowObject::findTransform(QVector3D begin, QVector3D end) {
     return tfm;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/axes_object.cpp
+++ b/src/graphics/objects/axes_object.cpp
@@ -2,9 +2,9 @@
 
 #include <math.h>
 
+#include <QtMath>
 #include <vector>
 
-#include <QtMath>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qmatrix4x4.h>
@@ -81,4 +81,4 @@ void AxesObject::updateDimensions(float axis_length) {
     this->scaleAbsolute(
         QVector3D(axis_length / m_starting_length, axis_length / m_starting_length, axis_length / m_starting_length));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/cube/plane_object.cpp
+++ b/src/graphics/objects/cube/plane_object.cpp
@@ -14,9 +14,9 @@ PlaneObject::PlaneObject(BaseView* view, float length, float width, QColor color
 PlaneObject::PlaneObject(BaseView* view, float length, float width, float height, QColor color)
     : CubeObject(view, length, width, height, color) {
     m_starting_length = length;
-    m_starting_width = width;
+    m_starting_width  = width;
     m_starting_height = height;
-    m_color = color;
+    m_color           = color;
 }
 
 void PlaneObject::setLockedRotationQuaternion(const QQuaternion& rotation) {
@@ -24,16 +24,19 @@ void PlaneObject::setLockedRotationQuaternion(const QQuaternion& rotation) {
     this->rotateAbsolute(m_locked_rotation);
 }
 
-void PlaneObject::setLockedRotation(bool lock) { m_rotation_toggle = lock; }
+void PlaneObject::setLockedRotation(bool lock) {
+    m_rotation_toggle = lock;
+}
 
-void PlaneObject::updateDimensions(float length, float width) { updateDimensions(length, width, m_starting_height); }
+void PlaneObject::updateDimensions(float length, float width) {
+    updateDimensions(length, width, m_starting_height);
+}
 
 void PlaneObject::updateDimensions(float length, float width, float height) {
     this->scaleAbsolute(QVector3D(length / m_starting_length, width / m_starting_width, height / m_starting_height));
 }
 
 void PlaneObject::transformationCallback() {
-    if (m_rotation_toggle)
-        this->rotateAbsolute(m_locked_rotation);
+    if (m_rotation_toggle) this->rotateAbsolute(m_locked_rotation);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/cube_object.cpp
+++ b/src/graphics/objects/cube_object.cpp
@@ -1,8 +1,8 @@
 #include "graphics/objects/cube_object.h"
 
+#include <QPainter>
 #include <vector>
 
-#include <QPainter>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qimage.h>
@@ -16,7 +16,7 @@ namespace ORNL {
 CubeObject::CubeObject(BaseView* view, float length, float width, float height, QColor color, ushort render_mode,
                        const QVector<QImage>& textures) {
     m_length = length;
-    m_width = width;
+    m_width  = width;
     m_height = height;
 
     m_textures = textures;
@@ -27,17 +27,13 @@ CubeObject::CubeObject(BaseView* view, float length, float width, float height, 
     std::vector<float> uv;
 
     // Fill out rest of textures with blank textures.
-    for (int i = m_textures.size(); i < 6; i++) {
-        m_textures.append(QImage(":/textures/blank_texture.png"));
-    }
+    for (int i = m_textures.size(); i < 6; i++) { m_textures.append(QImage(":/textures/blank_texture.png")); }
 
     // Face pixel size - should be square.
     uint fps = 0;
     for (QImage& texture : m_textures) {
-        if (texture.size().width() > fps)
-            fps = texture.size().width();
-        if (texture.size().height() > fps)
-            fps = texture.size().height();
+        if (texture.size().width() > fps) fps = texture.size().width();
+        if (texture.size().height() > fps) fps = texture.size().height();
     }
 
     // Stitch together textures for a cube map.
@@ -78,4 +74,4 @@ CubeObject::CubeObject(BaseView* view, float length, float width, float height, 
     this->populateGL(view, vertices, normals, colors, render_mode, uv, result);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/cylinder/cylinder_plane_object.cpp
+++ b/src/graphics/objects/cylinder/cylinder_plane_object.cpp
@@ -10,16 +10,16 @@ namespace ORNL {
 CylinderPlaneObject::CylinderPlaneObject(BaseView* view, float radius, QColor color)
     : CylinderPlaneObject(view, radius, 0, color) {
     m_starting_outer_radius = radius;
-    m_color = color;
+    m_color                 = color;
 }
 
 CylinderPlaneObject::CylinderPlaneObject(ORNL::BaseView* view, float outer_radius, float inner_radius, QColor color)
     : CylinderObject(view, outer_radius, inner_radius, 0.1, color) {
     m_starting_outer_radius = outer_radius;
-    m_color = color;
+    m_color                 = color;
 }
 
 void CylinderPlaneObject::updateDimensions(float outer_radius, float inner_radius) {
     this->scaleAbsolute(QVector3D(outer_radius / m_starting_outer_radius, outer_radius / m_starting_outer_radius, 1));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/cylinder_object.cpp
+++ b/src/graphics/objects/cylinder_object.cpp
@@ -18,7 +18,7 @@ CylinderObject::CylinderObject(BaseView* view, float radius, float height, QColo
 CylinderObject::CylinderObject(BaseView* view, float outer_radius, float inner_radius, float height, QColor color) {
     m_outer_radius = outer_radius;
     m_inner_radius = inner_radius;
-    m_height = height;
+    m_height       = height;
 
     std::vector<float> vertices;
     std::vector<float> normals;
@@ -28,4 +28,4 @@ CylinderObject::CylinderObject(BaseView* view, float outer_radius, float inner_r
 
     this->populateGL(view, vertices, normals, colors);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/gcode_object.cpp
+++ b/src/graphics/objects/gcode_object.cpp
@@ -2,6 +2,7 @@
 
 #include <GL/gl.h>
 
+#include <QOpenGLShaderProgram>
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -9,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include <QOpenGLShaderProgram>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qlist.h>
@@ -32,17 +32,15 @@
 namespace ORNL {
 namespace {
 //! @brief Vertex counts emitted by ShapeFactory for each full bead mesh segment type.
-constexpr qsizetype kLinearBeadVertexCount = 120;
-constexpr qsizetype kCurvedBeadVertexCount = 1980;
+constexpr qsizetype kLinearBeadVertexCount   = 120;
+constexpr qsizetype kCurvedBeadVertexCount   = 1980;
 constexpr double kLightweightArcSegmentAngle = (2.0 * 3.14159265358979323846) / 48.0;
-constexpr double kLightweightArcEpsilon = 1.0e-6;
+constexpr double kLightweightArcEpsilon      = 1.0e-6;
 
 //! @brief Counts display segments before GL buffer construction so oversized gcode can use a lighter path.
 qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
     qsizetype count = 0;
-    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
-        count += layer.size();
-    }
+    for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) { count += layer.size(); }
     return count;
 }
 
@@ -50,9 +48,7 @@ qsizetype countSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gco
 bool hasMeshSegments(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode) {
     for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
         for (const QSharedPointer<SegmentBase>& segment : layer) {
-            if (!static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
-                return true;
-            }
+            if (!static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) { return true; }
         }
     }
 
@@ -64,9 +60,7 @@ qsizetype countTravelSegments(const QVector<QVector<QSharedPointer<SegmentBase>>
     qsizetype count = 0;
     for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
         for (const QSharedPointer<SegmentBase>& segment : layer) {
-            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
-                ++count;
-            }
+            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) { ++count; }
         }
     }
 
@@ -101,9 +95,7 @@ void appendLightweightLineEdge(const QVector3D& start, const QVector3D& end, con
 
 int lightweightArcSegmentCount(const ArcSegment& arc) {
     const double sweep = arc.angle()();
-    if (!std::isfinite(sweep) || sweep <= kLightweightArcEpsilon) {
-        return 1;
-    }
+    if (!std::isfinite(sweep) || sweep <= kLightweightArcEpsilon) { return 1; }
 
     return std::max(1, static_cast<int>(std::ceil(sweep / kLightweightArcSegmentAngle)));
 }
@@ -111,11 +103,11 @@ int lightweightArcSegmentCount(const ArcSegment& arc) {
 //! @brief Appends a curved GL_LINES approximation for an arc segment.
 void appendLightweightArc(const ArcSegment& arc, const QColor& color, std::vector<float>& vertices,
                           std::vector<float>& normals, std::vector<float>& colors) {
-    const Point start = arc.start();
-    const Point center = arc.center();
-    const Point end = arc.end();
+    const Point start   = arc.start();
+    const Point center  = arc.center();
+    const Point end     = arc.end();
     const double radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    const double sweep = arc.angle()();
+    const double sweep  = arc.angle()();
 
     if (!std::isfinite(radius) || !std::isfinite(sweep) || radius <= kLightweightArcEpsilon ||
         sweep <= kLightweightArcEpsilon) {
@@ -123,19 +115,17 @@ void appendLightweightArc(const ArcSegment& arc, const QColor& color, std::vecto
         return;
     }
 
-    const int segment_count = lightweightArcSegmentCount(arc);
-    const double start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const int segment_count   = lightweightArcSegmentCount(arc);
+    const double start_angle  = std::atan2(start.y() - center.y(), start.x() - center.x());
     const double signed_sweep = arc.counterclockwise() ? sweep : -sweep;
-    const double z_delta = end.z() - start.z();
+    const double z_delta      = end.z() - start.z();
 
     QVector3D previous = start.toQVector3D();
     for (int i = 1; i <= segment_count; ++i) {
         QVector3D current;
-        if (i == segment_count) {
-            current = end.toQVector3D();
-        }
+        if (i == segment_count) { current = end.toQVector3D(); }
         else {
-            const double t = static_cast<double>(i) / static_cast<double>(segment_count);
+            const double t     = static_cast<double>(i) / static_cast<double>(segment_count);
             const double angle = start_angle + (signed_sweep * t);
             current = QVector3D(center.x() + (radius * std::cos(angle)), center.y() + (radius * std::sin(angle)),
                                 start.z() + (z_delta * t));
@@ -158,28 +148,22 @@ void appendLightweightLine(const QSharedPointer<SegmentBase>& segment, std::vect
     appendLightweightLineEdge(segment->start().toQVector3D(), segment->end().toQVector3D(), color, vertices, normals,
                               colors);
 }
-} // namespace
+}  // namespace
 
 qsizetype GCodeObject::estimateTrueWidthVertexCount(const QVector<QVector<QSharedPointer<SegmentBase>>>& gcode,
                                                     qsizetype limit) {
     qsizetype count = 0;
     for (const QVector<QSharedPointer<SegmentBase>>& layer : gcode) {
         for (const QSharedPointer<SegmentBase>& segment : layer) {
-            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) {
-                continue;
-            }
+            if (static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel)) { continue; }
 
             if (dynamic_cast<ArcSegment*>(segment.data()) != nullptr ||
                 dynamic_cast<BezierSegment*>(segment.data()) != nullptr) {
                 count += kCurvedBeadVertexCount;
             }
-            else {
-                count += kLinearBeadVertexCount;
-            }
+            else { count += kLinearBeadVertexCount; }
 
-            if (count > limit) {
-                return count;
-            }
+            if (count > limit) { return count; }
         }
     }
 
@@ -199,17 +183,15 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
 
     m_segment_info_control = segmentInfoControl;
     m_updates_segment_info = update_segment_info;
-    if (m_updates_segment_info && !m_segment_info_control.isNull()) {
-        m_segment_info_control->setGCode(gcode);
-    }
+    if (m_updates_segment_info && !m_segment_info_control.isNull()) { m_segment_info_control->setGCode(gcode); }
 
-    const qsizetype segment_count = countSegments(gcode);
-    const qsizetype vertex_threshold = true_width_vertex_threshold < 0 ? 0 : true_width_vertex_threshold;
-    const bool true_widths_requested = use_true_widths && preview_mode != GCodePreviewMode::kThinLines;
+    const qsizetype segment_count     = countSegments(gcode);
+    const qsizetype vertex_threshold  = true_width_vertex_threshold < 0 ? 0 : true_width_vertex_threshold;
+    const bool true_widths_requested  = use_true_widths && preview_mode != GCodePreviewMode::kThinLines;
     const bool auto_threshold_limited = preview_mode != GCodePreviewMode::kTrueWidths;
     const qsizetype estimate_limit = auto_threshold_limited ? vertex_threshold : std::numeric_limits<qsizetype>::max();
     const qsizetype mesh_vertex_count = true_widths_requested ? estimateTrueWidthVertexCount(gcode, estimate_limit) : 0;
-    m_lightweight_lines = !true_widths_requested || (auto_threshold_limited && mesh_vertex_count > vertex_threshold);
+    m_lightweight_lines   = !true_widths_requested || (auto_threshold_limited && mesh_vertex_count > vertex_threshold);
     m_primary_render_mode = (m_lightweight_lines || !hasMeshSegments(gcode)) ? GL_LINES : GL_TRIANGLES;
 
     if (m_lightweight_lines) {
@@ -241,11 +223,11 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
 
         for (auto& segment : layer) {
             QSharedPointer<SegmentDisplayMeta> seg_meta = QSharedPointer<SegmentDisplayMeta>::create();
-            seg_meta->layer = segment->layerNumber();
-            seg_meta->line = segment->lineNumber();
-            seg_meta->type = segment->displayType();
-            seg_meta->original_color = segment->color();
-            seg_meta->current_color = segment->color();
+            seg_meta->layer                             = segment->layerNumber();
+            seg_meta->line                              = segment->lineNumber();
+            seg_meta->type                              = segment->displayType();
+            seg_meta->original_color                    = segment->color();
+            seg_meta->current_color                     = segment->color();
 
             const bool render_as_line =
                 m_lightweight_lines || static_cast<bool>(segment->displayType() & SegmentDisplayType::kTravel);
@@ -257,9 +239,7 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
                 if (render_as_line) {
                     appendLightweightLine(segment, primary_vertices, primary_normals, primary_colors);
                 }
-                else {
-                    segment->createGraphic(primary_vertices, primary_normals, primary_colors);
-                }
+                else { segment->createGraphic(primary_vertices, primary_normals, primary_colors); }
                 seg_meta->length = (primary_vertices.size() / 3) - seg_meta->offset;
             }
             else {
@@ -268,8 +248,7 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
                 seg_meta->length = (travel_line_vertices.size() / 3) - seg_meta->offset;
             }
 
-            if (static_cast<bool>(seg_meta->type & m_hidden_type))
-                seg_meta->hidden = true;
+            if (static_cast<bool>(seg_meta->type & m_hidden_type)) seg_meta->hidden = true;
 
             layer_meta.push_back(seg_meta);
         }
@@ -277,10 +256,10 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
         m_segments.push_back(layer_meta);
     }
 
-    m_low_layer = 0;
+    m_low_layer  = 0;
     m_high_layer = gcode.size() - 1;
 
-    m_low_segment = 0;
+    m_low_segment  = 0;
     m_high_segment = visibleSegmentCount();
 
     this->populateGL(view, primary_vertices, primary_normals, primary_colors, m_primary_render_mode);
@@ -288,14 +267,11 @@ GCodeObject::GCodeObject(BaseView* view, QVector<QVector<QSharedPointer<SegmentB
 }
 
 GCodeObject::~GCodeObject() {
-    if (m_view.isNull() || m_view->context() == nullptr)
-        return;
+    if (m_view.isNull() || m_view->context() == nullptr) return;
 
     m_view->makeCurrent();
 
-    if (!m_travel_line_vao.isNull()) {
-        m_travel_line_vao->destroy();
-    }
+    if (!m_travel_line_vao.isNull()) { m_travel_line_vao->destroy(); }
 
     m_travel_line_vbo.destroy();
     m_travel_line_nbo.destroy();
@@ -305,13 +281,11 @@ GCodeObject::~GCodeObject() {
 
 void GCodeObject::populateTravelLineGL(BaseView* view, const std::vector<float>& vertices,
                                        const std::vector<float>& normals, const std::vector<float>& colors) {
-    if (vertices.empty()) {
-        return;
-    }
+    if (vertices.empty()) { return; }
 
     m_travel_line_vertices = vertices;
-    m_travel_line_normals = normals;
-    m_travel_line_colors = colors;
+    m_travel_line_normals  = normals;
+    m_travel_line_colors   = colors;
     m_travel_line_uv.resize((m_travel_line_vertices.size() / 3) * 2, 0.0f);
 
     view->makeCurrent();
@@ -373,11 +347,10 @@ void GCodeObject::hideSegmentType(SegmentDisplayType type, bool hide) {
 
 void GCodeObject::showSegments(uint low_segment, uint high_segment) {
     uint max = visibleSegmentCount();
-    if (low_segment < 0 || high_segment > max)
-        return;
+    if (low_segment < 0 || high_segment > max) return;
 
     m_high_segment = high_segment;
-    m_low_segment = low_segment;
+    m_low_segment  = low_segment;
 
     uint count = 0;
     for (int i = m_low_layer; i <= m_high_layer; i++) {
@@ -386,35 +359,38 @@ void GCodeObject::showSegments(uint low_segment, uint high_segment) {
                 static_cast<bool>(m_segments[i][j]->type & m_hidden_type)) {
                 m_segments[i][j]->hidden = true;
             }
-            else {
-                m_segments[i][j]->hidden = false;
-            }
+            else { m_segments[i][j]->hidden = false; }
             ++count;
         }
     }
 }
 
-void GCodeObject::showLowSegment(uint low_segment) { this->showSegments(low_segment, m_high_segment); }
+void GCodeObject::showLowSegment(uint low_segment) {
+    this->showSegments(low_segment, m_high_segment);
+}
 
-void GCodeObject::showHighSegment(uint high_segment) { this->showSegments(m_low_segment, high_segment); }
+void GCodeObject::showHighSegment(uint high_segment) {
+    this->showSegments(m_low_segment, high_segment);
+}
 
 void GCodeObject::showLayers(uint low_layer, uint high_layer) {
-    if (low_layer < 0 || high_layer > m_segments.size())
-        return;
+    if (low_layer < 0 || high_layer > m_segments.size()) return;
 
-    m_low_layer = low_layer;
+    m_low_layer  = low_layer;
     m_high_layer = high_layer;
 }
 
-void GCodeObject::showLow(uint low_layer) { this->showLayers(low_layer, m_high_layer); }
+void GCodeObject::showLow(uint low_layer) {
+    this->showLayers(low_layer, m_high_layer);
+}
 
-void GCodeObject::showHigh(uint high_layer) { this->showLayers(m_low_layer, high_layer); }
+void GCodeObject::showHigh(uint high_layer) {
+    this->showLayers(m_low_layer, high_layer);
+}
 
 void GCodeObject::selectSegment(uint line_number) {
-
     for (auto& layer : m_segments) {
-        if (layer.isEmpty() || layer.back()->line < line_number)
-            continue;
+        if (layer.isEmpty() || layer.back()->line < line_number) continue;
 
         for (auto& seg : layer) {
             if (seg->line == line_number) {
@@ -432,7 +408,6 @@ void GCodeObject::selectSegment(uint line_number) {
 }
 
 void GCodeObject::deselectSegment(uint line_number) {
-
     if (m_selected_segments.contains(line_number)) {
         QSharedPointer<SegmentDisplayMeta> seg_meta = m_selected_segments[line_number];
         m_selected_segments.remove(line_number);
@@ -462,7 +437,6 @@ QList<int> GCodeObject::deselectAll() {
 }
 
 void GCodeObject::highlightSegment(uint line_number) {
-
     if (!m_highlighted_segment.isNull()) {
         if (m_highlighted_segment->line == line_number)
             return;
@@ -472,8 +446,7 @@ void GCodeObject::highlightSegment(uint line_number) {
 
     QSharedPointer<SegmentDisplayMeta> seg_meta;
     for (auto& layer : m_segments) {
-        if (layer.isEmpty() || layer.back()->line < line_number)
-            continue;
+        if (layer.isEmpty() || layer.back()->line < line_number) continue;
 
         for (auto& seg : layer) {
             if (seg->line == line_number) {
@@ -499,37 +472,36 @@ search_break:
 uint GCodeObject::visibleSegmentCount() {
     uint sum = 0;
 
-    for (uint i = m_low_layer; i <= m_high_layer; i++) {
-        sum += m_segments[i].size();
-    }
+    for (uint i = m_low_layer; i <= m_high_layer; i++) { sum += m_segments[i].size(); }
 
     return sum;
 }
 
-bool GCodeObject::isCurrentlySelected(int line_num) { return m_selected_segments.contains(line_num); }
+bool GCodeObject::isCurrentlySelected(int line_num) {
+    return m_selected_segments.contains(line_num);
+}
 
-bool GCodeObject::isLightweight() const { return m_lightweight_lines; }
+bool GCodeObject::isLightweight() const {
+    return m_lightweight_lines;
+}
 
 const QVector<std::pair<uint, std::vector<Triangle>>> GCodeObject::segmentTriangles() {
     QVector<std::pair<uint, std::vector<Triangle>>> ret;
 
-    if (m_primary_render_mode != GL_TRIANGLES) {
-        return ret;
-    }
+    if (m_primary_render_mode != GL_TRIANGLES) { return ret; }
 
-    QMatrix4x4 transform = this->transformation();
+    QMatrix4x4 transform           = this->transformation();
     const std::vector<float>& vert = this->vertices();
 
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
         for (QSharedPointer<SegmentDisplayMeta> seg : m_segments[i]) {
-            if (seg->hidden || seg->buffer != SegmentRenderBuffer::kPrimary)
-                continue;
+            if (seg->hidden || seg->buffer != SegmentRenderBuffer::kPrimary) continue;
             // For each segment, get its triangles.
             std::vector<Triangle> seg_tri;
             Triangle current_triangle;
 
             uint seg_start = seg->offset * 3;
-            uint seg_end = (seg->offset + seg->length) * 3;
+            uint seg_end   = (seg->offset + seg->length) * 3;
 
             for (uint i = seg_start; i < seg_end; i += 9) {
                 current_triangle.a = transform * QVector3D(vert[i + 0], vert[i + 1], vert[i + 2]);
@@ -554,19 +526,17 @@ const QVector<std::pair<uint, std::pair<QVector3D, QVector3D>>> GCodeObject::seg
 
     for (uint i = m_low_layer; i <= m_high_layer; i++) {
         for (QSharedPointer<SegmentDisplayMeta> seg : m_segments[i]) {
-            if (seg->hidden)
-                continue;
-            if (seg->buffer == SegmentRenderBuffer::kPrimary && m_primary_render_mode != GL_LINES)
-                continue;
+            if (seg->hidden) continue;
+            if (seg->buffer == SegmentRenderBuffer::kPrimary && m_primary_render_mode != GL_LINES) continue;
 
             const std::vector<float>& vert =
                 seg->buffer == SegmentRenderBuffer::kTravelLine ? m_travel_line_vertices : this->vertices();
             uint seg_start = seg->offset * 3;
-            uint seg_end = (seg->offset + seg->length) * 3;
+            uint seg_end   = (seg->offset + seg->length) * 3;
 
             for (uint i = seg_start; i + 5 < seg_end; i += 6) {
                 QVector3D start = transform * QVector3D(vert[i + 0], vert[i + 1], vert[i + 2]);
-                QVector3D end = transform * QVector3D(vert[i + 3], vert[i + 4], vert[i + 5]);
+                QVector3D end   = transform * QVector3D(vert[i + 3], vert[i + 4], vert[i + 5]);
                 ret.push_back(std::make_pair(seg->line, std::make_pair(start, end)));
             }
         }
@@ -593,9 +563,7 @@ void GCodeObject::drawBufferRuns(SegmentRenderBuffer buffer, ushort render_mode)
                 continue;
             }
 
-            if (run_length > 0 && run_offset + run_length == segment->offset) {
-                run_length += segment->length;
-            }
+            if (run_length > 0 && run_offset + run_length == segment->offset) { run_length += segment->length; }
             else {
                 drawRun();
                 run_offset = segment->offset;
@@ -610,9 +578,7 @@ void GCodeObject::drawBufferRuns(SegmentRenderBuffer buffer, ushort render_mode)
 void GCodeObject::draw() {
     drawBufferRuns(SegmentRenderBuffer::kPrimary, m_primary_render_mode);
 
-    if (m_travel_line_vao.isNull()) {
-        return;
-    }
+    if (m_travel_line_vao.isNull()) { return; }
 
     this->vao()->release();
     m_travel_line_vao->bind();
@@ -622,9 +588,7 @@ void GCodeObject::draw() {
 }
 
 void GCodeObject::updateTravelLineColors(std::vector<float>& colors, uint whence) {
-    if (m_travel_line_vao.isNull()) {
-        return;
-    }
+    if (m_travel_line_vao.isNull()) { return; }
 
     m_travel_line_cbo.bind();
 
@@ -657,8 +621,6 @@ void GCodeObject::paintSegment(QSharedPointer<GCodeObject::SegmentDisplayMeta> s
     if (seg_meta->buffer == SegmentRenderBuffer::kTravelLine) {
         updateTravelLineColors(new_colors, seg_meta->offset * 4);
     }
-    else {
-        this->updateColors(new_colors, seg_meta->offset * 4);
-    }
+    else { this->updateColors(new_colors, seg_meta->offset * 4); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/grid_object.cpp
+++ b/src/graphics/objects/grid_object.cpp
@@ -15,10 +15,10 @@ namespace ORNL {
 
 GridObject::GridObject(BaseView* view, float length, float width, float x_grid, float y_grid, QColor color) {
     m_length = length;
-    m_width = width;
+    m_width  = width;
     m_x_grid = x_grid;
     m_y_grid = y_grid;
-    m_color = color;
+    m_color  = color;
 
     std::vector<float> vertices;
     std::vector<float> colors;
@@ -34,7 +34,7 @@ GridObject::GridObject(BaseView* view, float length, float width, float x_grid, 
 
 void GridObject::updateDimensions(float length, float width, float x_grid, float y_grid) {
     m_length = length;
-    m_width = width;
+    m_width  = width;
 
     m_x_grid = (x_grid > 0) ? x_grid : m_x_grid;
     m_y_grid = (y_grid > 0) ? y_grid : m_y_grid;
@@ -76,4 +76,4 @@ std::vector<Triangle> GridObject::triangles() {
     return triangles;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/part_object.cpp
+++ b/src/graphics/objects/part_object.cpp
@@ -34,7 +34,7 @@
 
 namespace ORNL {
 namespace {
-constexpr float kFeatureEdgeCosThreshold = 0.9063078f; // 25 degrees.
+constexpr float kFeatureEdgeCosThreshold      = 0.9063078f;  // 25 degrees.
 constexpr float kFeatureEdgePositionTolerance = 1.0f;
 //! \brief Base opacity for feature-edge lines when the parent part is fully opaque.
 constexpr float kFeatureEdgeAlpha = 0.35f;
@@ -59,12 +59,14 @@ struct TriangleDepth {
 
 //! \brief Graphics object wrapper that exposes repainting for the feature-edge overlay.
 class FeatureEdgeObject : public GraphicsObject {
-  public:
+   public:
     using GraphicsObject::GraphicsObject;
 
     //! \brief Repaints every feature-edge vertex with the supplied display color.
     //! \param color Color and alpha to apply to the overlay lines.
-    void setEdgeColor(QColor color) { this->paint(color); }
+    void setEdgeColor(QColor color) {
+        this->paint(color);
+    }
 };
 
 std::array<long long, 3> vertexKey(const QVector3D& vertex) {
@@ -75,10 +77,9 @@ std::array<long long, 3> vertexKey(const QVector3D& vertex) {
 
 std::array<long long, 6> edgeKey(const QVector3D& start, const QVector3D& end) {
     const std::array<long long, 3> start_key = vertexKey(start);
-    const std::array<long long, 3> end_key = vertexKey(end);
+    const std::array<long long, 3> end_key   = vertexKey(end);
 
-    if (end_key < start_key)
-        return {end_key[0], end_key[1], end_key[2], start_key[0], start_key[1], start_key[2]};
+    if (end_key < start_key) return {end_key[0], end_key[1], end_key[2], start_key[0], start_key[1], start_key[2]};
 
     return {start_key[0], start_key[1], start_key[2], end_key[0], end_key[1], end_key[2]};
 }
@@ -104,26 +105,22 @@ void appendTriangleData(const std::vector<float>& source, size_t triangle_index,
 }
 
 bool isFeatureEdge(const QVector<EdgeSample>& edge_samples) {
-    if (edge_samples.size() == 1)
-        return true;
+    if (edge_samples.size() == 1) return true;
 
     for (int i = 0; i < edge_samples.size(); ++i) {
         QVector3D first_normal = edge_samples[i].normal.normalized();
 
-        if (first_normal.isNull())
-            continue;
+        if (first_normal.isNull()) continue;
 
         for (int j = i + 1; j < edge_samples.size(); ++j) {
             QVector3D second_normal = edge_samples[j].normal.normalized();
 
-            if (second_normal.isNull())
-                continue;
+            if (second_normal.isNull()) continue;
 
             float edge_angle_cos = std::fabs(QVector3D::dotProduct(first_normal, second_normal));
-            edge_angle_cos = std::max(-1.0f, std::min(1.0f, edge_angle_cos));
+            edge_angle_cos       = std::max(-1.0f, std::min(1.0f, edge_angle_cos));
 
-            if (edge_angle_cos <= kFeatureEdgeCosThreshold)
-                return true;
+            if (edge_angle_cos <= kFeatureEdgeCosThreshold) return true;
         }
     }
 
@@ -137,7 +134,7 @@ void appendFeatureEdge(std::vector<float>& edge_vertices, const QVector<MeshVert
         return;
 
     const QVector3D start = vertices[edge_sample.start_index].location * Constants::OpenGL::kObjectToView;
-    const QVector3D end = vertices[edge_sample.end_index].location * Constants::OpenGL::kObjectToView;
+    const QVector3D end   = vertices[edge_sample.end_index].location * Constants::OpenGL::kObjectToView;
 
     edge_vertices.push_back(start.x());
     edge_vertices.push_back(start.y());
@@ -149,7 +146,7 @@ void appendFeatureEdge(std::vector<float>& edge_vertices, const QVector<MeshVert
 
 bool isValidFaceEdge(const QVector<MeshVertex>& vertices, const MeshFace& face, int edge_index) {
     const int start_index = face.vertex_index[edge_index];
-    const int end_index = face.vertex_index[(edge_index + 1) % 3];
+    const int end_index   = face.vertex_index[(edge_index + 1) % 3];
 
     return start_index >= 0 && start_index < vertices.size() && end_index >= 0 && end_index < vertices.size();
 }
@@ -160,13 +157,12 @@ std::map<std::array<long long, 6>, QVector<EdgeSample>> buildEdgeMap(const QVect
 
     for (const MeshFace& face : faces) {
         for (int edge_index = 0; edge_index < 3; ++edge_index) {
-            if (!isValidFaceEdge(vertices, face, edge_index))
-                continue;
+            if (!isValidFaceEdge(vertices, face, edge_index)) continue;
 
-            const int start_index = face.vertex_index[edge_index];
-            const int end_index = face.vertex_index[(edge_index + 1) % 3];
+            const int start_index  = face.vertex_index[edge_index];
+            const int end_index    = face.vertex_index[(edge_index + 1) % 3];
             const QVector3D& start = vertices[start_index].location;
-            const QVector3D& end = vertices[end_index].location;
+            const QVector3D& end   = vertices[end_index].location;
 
             edge_map[edgeKey(start, end)].push_back({start_index, end_index, face.normal});
         }
@@ -176,16 +172,15 @@ std::map<std::array<long long, 6>, QVector<EdgeSample>> buildEdgeMap(const QVect
 }
 
 std::vector<float> buildFeatureEdgeVertices(QSharedPointer<MeshBase> mesh) {
-    const QVector<MeshVertex> vertices = mesh->originalVertices();
-    const QVector<MeshFace> faces = mesh->originalFaces();
+    const QVector<MeshVertex> vertices                                     = mesh->originalVertices();
+    const QVector<MeshFace> faces                                          = mesh->originalFaces();
     const std::map<std::array<long long, 6>, QVector<EdgeSample>> edge_map = buildEdgeMap(vertices, faces);
 
     std::vector<float> edge_vertices;
     edge_vertices.reserve(faces.size() * 6);
 
     for (auto edge_iter = edge_map.cbegin(); edge_iter != edge_map.cend(); ++edge_iter) {
-        if (isFeatureEdge(edge_iter->second))
-            appendFeatureEdge(edge_vertices, vertices, edge_iter->second.first());
+        if (isFeatureEdge(edge_iter->second)) appendFeatureEdge(edge_vertices, vertices, edge_iter->second.first());
     }
 
     return edge_vertices;
@@ -194,13 +189,10 @@ std::vector<float> buildFeatureEdgeVertices(QSharedPointer<MeshBase> mesh) {
 QSharedPointer<GraphicsObject> createFeatureEdgeObject(BaseView* view, QSharedPointer<MeshBase> mesh) {
     std::vector<float> edge_vertices = buildFeatureEdgeVertices(mesh);
 
-    if (edge_vertices.empty())
-        return QSharedPointer<GraphicsObject>();
+    if (edge_vertices.empty()) return QSharedPointer<GraphicsObject>();
 
     std::vector<float> edge_normals(edge_vertices.size(), 0.0f);
-    for (size_t i = 2; i < edge_normals.size(); i += 3) {
-        edge_normals[i] = 1.0f;
-    }
+    for (size_t i = 2; i < edge_normals.size(); i += 3) { edge_normals[i] = 1.0f; }
 
     const QColor edge_color = featureEdgeColor(255);
     std::vector<float> edge_colors;
@@ -226,10 +218,10 @@ QSharedPointer<GraphicsObject> createSlicingCylinderPreviewObject(BaseView* view
 
     return QSharedPointer<GraphicsObject>::create(view, vertices, normals, colors);
 }
-} // namespace
+}  // namespace
 
 PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mode) {
-    m_part = p;
+    m_part                        = p;
     QSharedPointer<MeshBase> mesh = p->rootMesh();
 
     // Vertices
@@ -237,11 +229,11 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
     unsigned int vert_size;
 
     std::tie(vert_float, vert_size) = mesh->glVertexArray();
-    std::vector<float> vertices = std::vector<float>(vert_float, vert_float + (vert_size / sizeof(float)));
+    std::vector<float> vertices     = std::vector<float>(vert_float, vert_float + (vert_size / sizeof(float)));
 
     // Scale to OpenGL space
     for (int i = 0; i < vert_size / sizeof(float); i += 3) {
-        vertices[i] = (vertices[i]) * Constants::OpenGL::kObjectToView;
+        vertices[i]     = (vertices[i]) * Constants::OpenGL::kObjectToView;
         vertices[i + 1] = (vertices[i + 1]) * Constants::OpenGL::kObjectToView;
         vertices[i + 2] = (vertices[i + 2]) * Constants::OpenGL::kObjectToView;
     }
@@ -258,15 +250,15 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
     switch (mesh->type()) {
         case (MeshType::kSupport):
         case (MeshType::kBuild):
-            m_base_color = Constants::Colors::kLightBlue;
+            m_base_color     = Constants::Colors::kLightBlue;
             m_selected_color = Constants::Colors::kGreen;
             break;
         case (MeshType::kClipping):
-            m_base_color = Constants::Colors::kRed;
+            m_base_color     = Constants::Colors::kRed;
             m_selected_color = Constants::Colors::kOrange;
             break;
         case (MeshType::kSettings):
-            m_base_color = Constants::Colors::kBlue;
+            m_base_color     = Constants::Colors::kBlue;
             m_selected_color = Constants::Colors::kPurple;
             break;
     }
@@ -277,7 +269,7 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
     std::vector<float> colors;
     colors.resize(totalColors);
     for (int i = 0; i < totalColors; i += 4) {
-        colors[i] = m_base_color.redF();
+        colors[i]     = m_base_color.redF();
         colors[i + 1] = m_base_color.greenF();
         colors[i + 2] = m_base_color.blueF();
         colors[i + 3] = m_base_color.alphaF();
@@ -302,9 +294,9 @@ PartObject::PartObject(BaseView* view, QSharedPointer<Part> p, ushort render_mod
 
     // Make axis.
     float length = this->maximum().x() - this->minimum().x();
-    float width = this->maximum().y() - this->minimum().y();
-    float depth = this->maximum().z() - this->minimum().z();
-    auto goax = QSharedPointer<AxesObject>::create(this->view(), std::fmax(std::fmax(length, width), depth));
+    float width  = this->maximum().y() - this->minimum().y();
+    float depth  = this->maximum().z() - this->minimum().z();
+    auto goax    = QSharedPointer<AxesObject>::create(this->view(), std::fmax(std::fmax(length, width), depth));
     goax->setOnTop(true);
     goax->hide();
 
@@ -361,8 +353,7 @@ void PartObject::draw() {
 
         m_view->glDrawArrays(renderMode(), 0, m_vertices.size() / 3);
 
-        if (sort_for_transparency)
-            m_view->glDepthMask(GL_TRUE);
+        if (sort_for_transparency) m_view->glDepthMask(GL_TRUE);
 
         if (!getSolidWireFrameMode() && !m_feature_edge_object.isNull()) {
             m_view->glDepthFunc(GL_LEQUAL);
@@ -434,23 +425,27 @@ void PartObject::unselect() {
     m_selected = false;
 }
 
-void PartObject::highlight() { this->paint(m_color.lighter()); }
+void PartObject::highlight() {
+    this->paint(m_color.lighter());
+}
 
-void PartObject::unhighlight() { this->paint(m_color); }
+void PartObject::unhighlight() {
+    this->paint(m_color);
+}
 
 void PartObject::setMeshTypeColor(MeshType type) {
     switch (type) {
         case (MeshType::kSupport):
         case (MeshType::kBuild):
-            m_base_color = Constants::Colors::kLightBlue;
+            m_base_color     = Constants::Colors::kLightBlue;
             m_selected_color = Constants::Colors::kGreen;
             break;
         case (MeshType::kClipping):
-            m_base_color = Constants::Colors::kRed;
+            m_base_color     = Constants::Colors::kRed;
             m_selected_color = Constants::Colors::kOrange;
             break;
         case (MeshType::kSettings):
-            m_base_color = Constants::Colors::kBlue;
+            m_base_color     = Constants::Colors::kBlue;
             m_selected_color = Constants::Colors::kPurple;
             break;
     }
@@ -465,24 +460,34 @@ void PartObject::setRenderMode(ushort mode) {
     render();
 }
 
-void PartObject::setSolidWireFrameMode(bool state) { solidWireFrameMode() = state; }
+void PartObject::setSolidWireFrameMode(bool state) {
+    solidWireFrameMode() = state;
+}
 
-QSharedPointer<ArrowObject> PartObject::arrow() { return m_arrow_object; }
+QSharedPointer<ArrowObject> PartObject::arrow() {
+    return m_arrow_object;
+}
 
-QSharedPointer<TextObject> PartObject::label() { return m_label_object; }
+QSharedPointer<TextObject> PartObject::label() {
+    return m_label_object;
+}
 
-QSharedPointer<AxesObject> PartObject::axes() { return m_axes_object; }
+QSharedPointer<AxesObject> PartObject::axes() {
+    return m_axes_object;
+}
 
-QSharedPointer<PlaneObject> PartObject::plane() { return m_plane_object; }
+QSharedPointer<PlaneObject> PartObject::plane() {
+    return m_plane_object;
+}
 
-QSharedPointer<GraphicsObject> PartObject::slicingCylinder() { return m_slicing_cylinder_object; }
+QSharedPointer<GraphicsObject> PartObject::slicingCylinder() {
+    return m_slicing_cylinder_object;
+}
 
 QSharedPointer<PlaneObject> PartObject::layerSettingsRangePlane(int index) {
     index = std::max(index, 0);
 
-    while (m_layer_settings_range_objects.size() <= index) {
-        this->createLayerSettingsRangePlane();
-    }
+    while (m_layer_settings_range_objects.size() <= index) { this->createLayerSettingsRangePlane(); }
 
     return m_layer_settings_range_objects[index];
 }
@@ -492,9 +497,9 @@ QVector<QSharedPointer<PlaneObject>> PartObject::layerSettingsRangePlanes() cons
 }
 
 QSharedPointer<PlaneObject> PartObject::createLayerSettingsRangePlane() {
-    float length = this->maximum().x() - this->minimum().x();
-    float width = this->maximum().y() - this->minimum().y();
-    float depth = this->maximum().z() - this->minimum().z();
+    float length  = this->maximum().x() - this->minimum().x();
+    float width   = this->maximum().y() - this->minimum().y();
+    float depth   = this->maximum().z() - this->minimum().z();
     float max_dim = std::fmax(length, std::fmax(width, depth));
     max_dim += max_dim * 0.20f;
     max_dim = std::fmax(max_dim, 1.0f);
@@ -529,9 +534,13 @@ void PartObject::setOverhangAngle(Angle a) {
         this->paint(m_color);
 }
 
-QString PartObject::name() { return m_part->name(); }
+QString PartObject::name() {
+    return m_part->name();
+}
 
-QSharedPointer<Part> PartObject::part() { return m_part; }
+QSharedPointer<Part> PartObject::part() {
+    return m_part;
+}
 
 void PartObject::overhangUpdate() {
     this->view()->shaderProgram()->bind();
@@ -555,7 +564,7 @@ void PartObject::sortTrianglesForTransparency() {
     std::vector<TriangleDepth> triangle_depths;
     triangle_depths.reserve(triangle_count);
     for (size_t triangle_index = 0; triangle_index < triangle_count; ++triangle_index) {
-        const size_t offset = triangle_index * kTrianglePositionFloatCount;
+        const size_t offset    = triangle_index * kTrianglePositionFloatCount;
         const QVector3D center = (QVector3D(m_vertices[offset], m_vertices[offset + 1], m_vertices[offset + 2]) +
                                   QVector3D(m_vertices[offset + 3], m_vertices[offset + 4], m_vertices[offset + 5]) +
                                   QVector3D(m_vertices[offset + 6], m_vertices[offset + 7], m_vertices[offset + 8])) /
@@ -585,23 +594,18 @@ void PartObject::sortTrianglesForTransparency() {
 }
 
 void PartObject::updateFeatureEdgeAppearance() {
-    if (m_feature_edge_object.isNull())
-        return;
+    if (m_feature_edge_object.isNull()) return;
 
     QSharedPointer<FeatureEdgeObject> feature_edge_object = m_feature_edge_object.dynamicCast<FeatureEdgeObject>();
-    if (!feature_edge_object.isNull())
-        feature_edge_object->setEdgeColor(featureEdgeColor(m_transparency));
+    if (!feature_edge_object.isNull()) feature_edge_object->setEdgeColor(featureEdgeColor(m_transparency));
 }
 
 void PartObject::transformationCallback() {
-    if (!m_feature_edge_object.isNull())
-        m_feature_edge_object->setTransformation(this->transformation(), false);
+    if (!m_feature_edge_object.isNull()) m_feature_edge_object->setTransformation(this->transformation(), false);
 
-    if (!m_arrow_object.isNull())
-        m_arrow_object->updateEndpoints();
+    if (!m_arrow_object.isNull()) m_arrow_object->updateEndpoints();
     for (auto& goc : m_part_children) {
-        if (!goc->arrow().isNull())
-            goc->arrow()->updateEndpoints();
+        if (!goc->arrow().isNull()) goc->arrow()->updateEndpoints();
     }
 
     QVector3D label_pos = this->center();
@@ -611,19 +615,17 @@ void PartObject::transformationCallback() {
     m_plane_object->scaleAbsolute(QVector3D(this->scaling().x(), this->scaling().y(), 1));
 
     float length = this->minimumBoundingBox()[MBB_FLB].distanceToPoint(this->minimumBoundingBox()[MBB_FRB]);
-    float width = this->minimumBoundingBox()[MBB_FLB].distanceToPoint(this->minimumBoundingBox()[MBB_BLB]);
-    float depth = this->minimumBoundingBox()[MBB_FLT].distanceToPoint(this->minimumBoundingBox()[MBB_FLB]);
+    float width  = this->minimumBoundingBox()[MBB_FLB].distanceToPoint(this->minimumBoundingBox()[MBB_BLB]);
+    float depth  = this->minimumBoundingBox()[MBB_FLT].distanceToPoint(this->minimumBoundingBox()[MBB_FLB]);
     m_axes_object->updateDimensions(std::fmax(std::fmax(length, width), depth));
 
-    if (m_overhang_shown)
-        this->overhangUpdate();
+    if (m_overhang_shown) this->overhangUpdate();
 }
 
 void PartObject::adoptChildCallback(QSharedPointer<GraphicsObject> child) {
     // We only care about new part objects.
     QSharedPointer<PartObject> goc = child.dynamicCast<PartObject>();
-    if (goc.isNull())
-        return;
+    if (goc.isNull()) return;
 
     m_part_children.insert(goc);
 
@@ -640,8 +642,7 @@ void PartObject::adoptChildCallback(QSharedPointer<GraphicsObject> child) {
 void PartObject::orphanChildCallback(QSharedPointer<GraphicsObject> child) {
     // We only care about removed part objects.
     QSharedPointer<PartObject> goc = child.dynamicCast<PartObject>();
-    if (goc.isNull())
-        return;
+    if (goc.isNull()) return;
 
     m_part_children.remove(goc);
 
@@ -657,7 +658,6 @@ void PartObject::paint(QColor color) {
 
     this->GraphicsObject::paint(color);
     this->updateFeatureEdgeAppearance();
-    if (m_overhang_shown)
-        this->overhangUpdate();
+    if (m_overhang_shown) this->overhangUpdate();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/printer/cartesian_printer_object.cpp
+++ b/src/graphics/objects/printer/cartesian_printer_object.cpp
@@ -37,7 +37,7 @@ CartesianPrinterObject::CartesianPrinterObject(BaseView* view, QSharedPointer<Se
     this->populateGL(view, vertices, tmp_norm, colors, GL_LINES);
 
     float length = m_max.x() - m_min.x();
-    float width = m_max.y() - m_min.y();
+    float width  = m_max.y() - m_min.y();
 
     // Axes
     auto goax = QSharedPointer<AxesObject>::create(view, std::fmin(length, width) * 0.4);
@@ -49,7 +49,7 @@ CartesianPrinterObject::CartesianPrinterObject(BaseView* view, QSharedPointer<Se
     gopl->translate(m_floor_center);
     gopl->setUnderneath(true);
 
-    m_axes = goax;
+    m_axes        = goax;
     m_floor_plane = gopl;
 
     this->adoptChild(goax);
@@ -60,7 +60,9 @@ CartesianPrinterObject::CartesianPrinterObject(BaseView* view, QSharedPointer<Se
     this->updateSeams();
 }
 
-QVector3D CartesianPrinterObject::printerCenter() { return this->translation() + m_floor_center; }
+QVector3D CartesianPrinterObject::printerCenter() {
+    return this->translation() + m_floor_center;
+}
 
 QList<QSharedPointer<PartObject>> CartesianPrinterObject::externalParts() {
     QList<QSharedPointer<PartObject>> ret;
@@ -69,8 +71,7 @@ QList<QSharedPointer<PartObject>> CartesianPrinterObject::externalParts() {
 
     for (auto& child : this->allChildren()) {
         auto gop = child.dynamicCast<PartObject>();
-        if (gop.isNull())
-            continue;
+        if (gop.isNull()) continue;
 
         QVector3D partMin = gop->minimum();
         QVector3D partMax = gop->maximum();
@@ -90,18 +91,18 @@ QList<QSharedPointer<PartObject>> CartesianPrinterObject::externalParts() {
 void CartesianPrinterObject::updateMembers() {
     QSharedPointer<SettingsBase> sb = this->getSettings();
 
-    m_x_grid = 0;
+    m_x_grid        = 0;
     m_x_grid_offset = 0;
-    m_y_grid = 0;
+    m_y_grid        = 0;
     m_y_grid_offset = 0;
 
     if (sb->setting<bool>(PRS::Dimensions::kEnableGridX)) {
-        m_x_grid = sb->setting<float>(PRS::Dimensions::kGridXDistance);
+        m_x_grid        = sb->setting<float>(PRS::Dimensions::kGridXDistance);
         m_x_grid_offset = sb->setting<float>(PRS::Dimensions::kGridXOffset);
     }
 
     if (sb->setting<bool>(PRS::Dimensions::kEnableGridY)) {
-        m_y_grid = sb->setting<float>(PRS::Dimensions::kGridYDistance);
+        m_y_grid        = sb->setting<float>(PRS::Dimensions::kGridYDistance);
         m_y_grid_offset = sb->setting<float>(PRS::Dimensions::kGridYOffset);
     }
 
@@ -159,7 +160,7 @@ void CartesianPrinterObject::updateGeometry() {
     this->translateAbsolute(QVector3D(0, 0, 0));
 
     float length = m_max.x() - m_min.x();
-    float width = m_max.y() - m_min.y();
+    float width  = m_max.y() - m_min.y();
 
     m_axes->updateDimensions(std::fmin(length, width) * 0.4);
     m_floor_plane->updateDimensions(length, width);
@@ -169,4 +170,4 @@ void CartesianPrinterObject::updateGeometry() {
 
     this->translateAbsolute(translation);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/printer/cylindrical_printer_object.cpp
+++ b/src/graphics/objects/printer/cylindrical_printer_object.cpp
@@ -44,7 +44,7 @@ CylindricalPrinterObject::CylindricalPrinterObject(BaseView* view, QSharedPointe
     gopl->translate(m_floor_center);
     gopl->setUnderneath(true);
 
-    m_axes = goax;
+    m_axes        = goax;
     m_floor_plane = gopl;
 
     this->adoptChild(goax);
@@ -57,20 +57,21 @@ CylindricalPrinterObject::CylindricalPrinterObject(BaseView* view, QSharedPointe
     this->updateSeams();
 }
 
-QVector3D CylindricalPrinterObject::printerCenter() { return m_floor_center + this->translation(); }
+QVector3D CylindricalPrinterObject::printerCenter() {
+    return m_floor_center + this->translation();
+}
 
 QList<QSharedPointer<PartObject>> CylindricalPrinterObject::externalParts() {
     QList<QSharedPointer<PartObject>> ret;
 
-    float printerMinZ = this->minimum().z();
-    float printerMaxZ = this->maximum().z();
+    float printerMinZ   = this->minimum().z();
+    float printerMaxZ   = this->maximum().z();
     float radiusSquared = m_radius * m_radius;
-    QVector3D origin = this->printerCenter();
+    QVector3D origin    = this->printerCenter();
 
     for (auto& child : this->allChildren()) {
         auto gop = child.dynamicCast<PartObject>();
-        if (gop.isNull())
-            continue;
+        if (gop.isNull()) continue;
 
         QVector3D partMin = gop->minimum();
         QVector3D partMax = gop->maximum();
@@ -159,4 +160,4 @@ void CylindricalPrinterObject::updateGeometry() {
 
     this->translateAbsolute(translation);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/printer/printer_object.cpp
+++ b/src/graphics/objects/printer/printer_object.cpp
@@ -2,14 +2,14 @@
 
 #include <math.h>
 
+#include <QMatrix4x4>
+#include <QPointF>
+#include <QVector>
 #include <algorithm>
 #include <limits>
 #include <tuple>
 #include <vector>
 
-#include <QMatrix4x4>
-#include <QPointF>
-#include <QVector>
 #include <qcolor.h>
 #include <qmath.h>
 #include <qsharedpointer.h>
@@ -25,12 +25,12 @@
 namespace ORNL {
 namespace {
 constexpr float kMinimumOptimizationGuideLength = 1.5f;
-constexpr float kOptimizationGuidePrinterScale = 0.5f;
+constexpr float kOptimizationGuidePrinterScale  = 0.5f;
 
 QSharedPointer<GraphicsObject> createOptimizationGuide(BaseView* view, QColor color) {
     const std::vector<float> vertices = {-0.5f, 0.0f, 0.0f, 0.5f, 0.0f, 0.0f};
-    const std::vector<float> colors = {color.redF(), color.greenF(), color.blueF(), color.alphaF(),
-                                       color.redF(), color.greenF(), color.blueF(), color.alphaF()};
+    const std::vector<float> colors   = {color.redF(), color.greenF(), color.blueF(), color.alphaF(),
+                                         color.redF(), color.greenF(), color.blueF(), color.alphaF()};
     const std::vector<float> normals;
 
     auto guide = QSharedPointer<GraphicsObject>::create(view, vertices, normals, colors, GL_LINES);
@@ -67,9 +67,7 @@ QVector3D optimizationGuideDirection(const QSharedPointer<SettingsBase>& sb) {
         direction = QVector3D(sb->setting<float>(PS::Slicing::kSlicePlaneNormalX),
                               sb->setting<float>(PS::Slicing::kSlicePlaneNormalY),
                               sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ));
-        if (direction.isNull()) {
-            direction = QVector3D(0.0f, 0.0f, 1.0f);
-        }
+        if (direction.isNull()) { direction = QVector3D(0.0f, 0.0f, 1.0f); }
     }
 
     direction.normalize();
@@ -109,7 +107,7 @@ void hideOptimizationAnchor(const QSharedPointer<SeamObject>& marker, const QSha
     marker->hide();
     guide->hide();
 }
-} // namespace
+}  // namespace
 
 void PrinterObject::updateFromSettings(QSharedPointer<SettingsBase> sb) {
     m_sb = sb;
@@ -141,15 +139,13 @@ PrinterObject::OptimizationPointPick PrinterObject::pickOptimizationPoint(const 
     float nearest = std::numeric_limits<float>::infinity();
     OptimizationPointPick picked;
     for (const OptimizationPointPick& candidate : candidates) {
-        if (!candidate.isValid() || candidate.object->hidden()) {
-            continue;
-        }
+        if (!candidate.isValid() || candidate.object->hidden()) { continue; }
 
         const float distance =
             PartPicker::pickDistance(projection, view, mouse_ndc_pos, candidate.object->triangles(), ortho);
         if (distance < nearest) {
             nearest = distance;
-            picked = candidate;
+            picked  = candidate;
         }
     }
 
@@ -162,14 +158,10 @@ bool PrinterObject::bedIntersection(const QMatrix4x4& projection, const QMatrix4
     QVector3D direction;
     std::tie(start, direction) = PartPicker::getDirectionAndStart(projection, mouse_ndc_pos, view, ortho);
 
-    if (qFuzzyIsNull(direction.z())) {
-        return false;
-    }
+    if (qFuzzyIsNull(direction.z())) { return false; }
 
     const float distance = (this->printerCenter().z() - start.z()) / direction.z();
-    if (distance < 0.0f) {
-        return false;
-    }
+    if (distance < 0.0f) { return false; }
 
     intersection = start + (distance * direction);
     return true;
@@ -178,12 +170,12 @@ bool PrinterObject::bedIntersection(const QMatrix4x4& projection, const QMatrix4
 float PrinterObject::getDefaultZoom() {
     if (m_printer_max_dims.y() > m_printer_max_dims.z()) {
         float offset = (0.5 * m_printer_max_dims.y()) / qTan((1.0 / 2.0) * M_PI);
-        float base = offset + (m_printer_max_dims.x()) - printerCenter().x();
+        float base   = offset + (m_printer_max_dims.x()) - printerCenter().x();
         return base / qTan((3.0 / 18.0) * M_PI);
     }
     else {
         float offset = (0.5 * m_printer_max_dims.z()) / qCos((3.0 / 18.0) * M_PI);
-        float base = offset + (m_printer_max_dims.x()) - printerCenter().x();
+        float base   = offset + (m_printer_max_dims.x()) - printerCenter().x();
         return base / qTan((3.0 / 18.0) * M_PI);
     }
 }
@@ -208,8 +200,8 @@ void PrinterObject::updateSeams() {
         optionalPathOrderUsesCustomLocation(m_sb->setting<int>(PS::Optimizations::kPerimeterPathOrder)) ||
         optionalPathOrderUsesCustomLocation(m_sb->setting<int>(PS::Optimizations::kInsetPathOrder)) ||
         optionalPathOrderUsesCustomLocation(m_sb->setting<int>(PS::Optimizations::kSkinPathOrder));
-    bool secondPointEnabled = m_sb->setting<bool>(PS::Optimizations::kEnableSecondCustomLocation);
-    const float bed_z = this->printerCenter().z();
+    bool secondPointEnabled         = m_sb->setting<bool>(PS::Optimizations::kEnableSecondCustomLocation);
+    const float bed_z               = this->printerCenter().z();
     const QVector3D guide_direction = optimizationGuideDirection(m_sb);
     const float max_printer_dimension =
         std::max(std::max(m_printer_max_dims.x(), m_printer_max_dims.y()), m_printer_max_dims.z());
@@ -224,9 +216,7 @@ void PrinterObject::updateSeams() {
         showOptimizationAnchor(m_seams.custom_island_opt, m_seams.custom_island_guide, translation, guide_direction,
                                guide_length);
     }
-    else {
-        hideOptimizationAnchor(m_seams.custom_island_opt, m_seams.custom_island_guide);
-    }
+    else { hideOptimizationAnchor(m_seams.custom_island_opt, m_seams.custom_island_guide); }
 
     if (path_order_uses_custom) {
         const QVector3D translation = optimizationPointTranslation(m_sb, PS::Optimizations::kCustomPathXLocation,
@@ -236,9 +226,7 @@ void PrinterObject::updateSeams() {
         showOptimizationAnchor(m_seams.custom_path_opt, m_seams.custom_path_guide, translation, guide_direction,
                                guide_length);
     }
-    else {
-        hideOptimizationAnchor(m_seams.custom_path_opt, m_seams.custom_path_guide);
-    }
+    else { hideOptimizationAnchor(m_seams.custom_path_opt, m_seams.custom_path_guide); }
 
     if (usesCustomPointLocation(pointOrder)) {
         const QVector3D translation = optimizationPointTranslation(m_sb, PS::Optimizations::kCustomPointXLocation,
@@ -256,9 +244,7 @@ void PrinterObject::updateSeams() {
             showOptimizationAnchor(m_seams.custom_point_second_opt, m_seams.custom_point_second_guide,
                                    secondTranslation, guide_direction, guide_length);
         }
-        else {
-            hideOptimizationAnchor(m_seams.custom_point_second_opt, m_seams.custom_point_second_guide);
-        }
+        else { hideOptimizationAnchor(m_seams.custom_point_second_opt, m_seams.custom_point_second_guide); }
     }
     else {
         hideOptimizationAnchor(m_seams.custom_point_opt, m_seams.custom_point_guide);
@@ -266,26 +252,30 @@ void PrinterObject::updateSeams() {
     }
 }
 
-void PrinterObject::setSettings(QSharedPointer<SettingsBase> sb) { m_sb = sb; }
+void PrinterObject::setSettings(QSharedPointer<SettingsBase> sb) {
+    m_sb = sb;
+}
 
-QSharedPointer<SettingsBase> PrinterObject::getSettings() { return m_sb; }
+QSharedPointer<SettingsBase> PrinterObject::getSettings() {
+    return m_sb;
+}
 
 void PrinterObject::createSeams() {
     const QColor island_color =
         PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kPerimeter);
-    const QColor path_color = PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kSkin);
+    const QColor path_color  = PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kSkin);
     const QColor point_color = PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kInset);
     const QColor second_point_color =
         PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kInfill);
 
-    m_seams.custom_island_opt = QSharedPointer<SeamObject>::create(this->view(), island_color);
-    m_seams.custom_path_opt = QSharedPointer<SeamObject>::create(this->view(), path_color);
-    m_seams.custom_point_opt = QSharedPointer<SeamObject>::create(this->view(), point_color);
+    m_seams.custom_island_opt       = QSharedPointer<SeamObject>::create(this->view(), island_color);
+    m_seams.custom_path_opt         = QSharedPointer<SeamObject>::create(this->view(), path_color);
+    m_seams.custom_point_opt        = QSharedPointer<SeamObject>::create(this->view(), point_color);
     m_seams.custom_point_second_opt = QSharedPointer<SeamObject>::create(this->view(), second_point_color);
 
-    m_seams.custom_island_guide = createOptimizationGuide(this->view(), island_color);
-    m_seams.custom_path_guide = createOptimizationGuide(this->view(), path_color);
-    m_seams.custom_point_guide = createOptimizationGuide(this->view(), point_color);
+    m_seams.custom_island_guide       = createOptimizationGuide(this->view(), island_color);
+    m_seams.custom_path_guide         = createOptimizationGuide(this->view(), path_color);
+    m_seams.custom_point_guide        = createOptimizationGuide(this->view(), point_color);
     m_seams.custom_point_second_guide = createOptimizationGuide(this->view(), second_point_color);
 
     this->adoptChild(m_seams.custom_island_opt);
@@ -303,7 +293,11 @@ void PrinterObject::createSeams() {
     hideOptimizationAnchor(m_seams.custom_point_second_opt, m_seams.custom_point_second_guide);
 }
 
-bool PrinterObject::isTrueVolume() { return m_is_true_volume; }
+bool PrinterObject::isTrueVolume() {
+    return m_is_true_volume;
+}
 
-PrinterObject::PrinterObject(bool is_true_volume) { m_is_true_volume = is_true_volume; }
-} // namespace ORNL
+PrinterObject::PrinterObject(bool is_true_volume) {
+    m_is_true_volume = is_true_volume;
+}
+}  // namespace ORNL

--- a/src/graphics/objects/sphere/seam_object.cpp
+++ b/src/graphics/objects/sphere/seam_object.cpp
@@ -11,4 +11,4 @@ namespace ORNL {
 SeamObject::SeamObject(BaseView* view, QColor color) : SphereObject(view, .25, color, GL_TRIANGLES) {
     this->setOnTop(true);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/sphere_object.cpp
+++ b/src/graphics/objects/sphere_object.cpp
@@ -21,4 +21,4 @@ SphereObject::SphereObject(BaseView* view, float radius, QColor color, ushort re
 
     this->populateGL(view, vertices, normals, colors, render_mode);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/objects/text_object.cpp
+++ b/src/graphics/objects/text_object.cpp
@@ -2,9 +2,9 @@
 
 #include <GL/gl.h>
 
+#include <QPainter>
 #include <vector>
 
-#include <QPainter>
 #include <qhashfunctions.h>
 #include <qimage.h>
 #include <qmatrix4x4.h>
@@ -84,4 +84,4 @@ void TextObject::setText(QString str) {
 
     this->replaceTexture(result);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/support/camera_manager.cpp
+++ b/src/graphics/support/camera_manager.cpp
@@ -1,8 +1,8 @@
 #include "graphics/support/camera_manager.h"
 
+#include <QtMath>
 #include <cmath>
 
-#include <QtMath>
 #include <qmatrix4x4.h>
 #include <qpoint.h>
 #include <qvectornd.h>
@@ -12,17 +12,21 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
-CameraManager::CameraManager() { this->reset(); }
+CameraManager::CameraManager() {
+    this->reset();
+}
 
 void CameraManager::reset() {
     this->rotateAbsolute(QVector2D(0, -70));
-    m_pan = QVector3D(0, 0, 0);
-    m_zoom = m_default_zoom;
+    m_pan       = QVector3D(0, 0, 0);
+    m_zoom      = m_default_zoom;
     m_wheel_pos = 0.0;
     updateViewMatrix();
 }
 
-void CameraManager::setDragStart(QPointF ndc_pos) { m_drag_start = ndc_pos; }
+void CameraManager::setDragStart(QPointF ndc_pos) {
+    m_drag_start = ndc_pos;
+}
 
 void CameraManager::rotate(const QVector2D dr) {
     m_pitch += -90 + dr.x();
@@ -33,7 +37,7 @@ void CameraManager::rotate(const QVector2D dr) {
 
 void CameraManager::rotateAbsolute(const QVector2D r) {
     m_pitch = -90 + r.x();
-    m_yaw = r.y();
+    m_yaw   = r.y();
 
     this->updateViewMatrix();
 }
@@ -52,7 +56,7 @@ void CameraManager::zoom(float delta) {
     delta /= 8.75;
     m_wheel_pos += delta;
     double y_offset = log10(m_default_zoom) / log10(kZoomBase);
-    m_zoom = powf(kZoomBase, (-(m_wheel_pos - y_offset)));
+    m_zoom          = powf(kZoomBase, (-(m_wheel_pos - y_offset)));
 
     this->updateViewMatrix();
 }
@@ -69,7 +73,7 @@ QVector3D CameraManager::translateFromPoint(QPointF ndc_pos) {
     // Use view matrix to get camera's up and right vectors, so that we can
     // translate in the direction of those vectors.
     QVector3D right = QVector3D(m_view(0, 0), m_view(0, 1), m_view(0, 2));
-    QVector3D up = QVector3D(m_view(1, 0), m_view(1, 1), m_view(1, 2));
+    QVector3D up    = QVector3D(m_view(1, 0), m_view(1, 1), m_view(1, 2));
 
     // Project onto the XY plane and normalize.
     right.setZ(0);
@@ -88,11 +92,17 @@ QVector3D CameraManager::translateFromPoint(QPointF ndc_pos) {
     return translation;
 }
 
-void CameraManager::setViewMatrix(QMatrix4x4 mtrx) { m_view = mtrx; }
+void CameraManager::setViewMatrix(QMatrix4x4 mtrx) {
+    m_view = mtrx;
+}
 
-const QMatrix4x4& CameraManager::viewMatrix() { return m_view; }
+const QMatrix4x4& CameraManager::viewMatrix() {
+    return m_view;
+}
 
-const QVector3D CameraManager::cameraTranslation() { return m_camera_translation + m_pan; }
+const QVector3D CameraManager::cameraTranslation() {
+    return m_camera_translation + m_pan;
+}
 
 void CameraManager::pan(QVector3D dt) {
     m_pan -= dt;
@@ -104,16 +114,22 @@ void CameraManager::panAbsolute(QVector3D pos) {
     updateViewMatrix();
 }
 
-QVector3D CameraManager::getPan() { return m_pan; }
+QVector3D CameraManager::getPan() {
+    return m_pan;
+}
 
-float CameraManager::getZoom() { return m_zoom; }
+float CameraManager::getZoom() {
+    return m_zoom;
+}
 
 void CameraManager::setDefaultZoom(double value) {
     m_default_zoom = value;
-    m_max_zoom = m_default_zoom * 1.5;
+    m_max_zoom     = m_default_zoom * 1.5;
 }
 
-float CameraManager::getDefaultZoom() { return m_default_zoom; }
+float CameraManager::getDefaultZoom() {
+    return m_default_zoom;
+}
 
 void CameraManager::updateViewMatrix() {
     // Limit as approaching -180, being collinear with up vector causes render failure.
@@ -125,4 +141,4 @@ void CameraManager::updateViewMatrix() {
     m_view.lookAt(m_camera_translation, m_pan, QVector3D(0, 0, 1));
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/support/part_picker.cpp
+++ b/src/graphics/support/part_picker.cpp
@@ -53,10 +53,9 @@ std::tuple<float, Triangle> PartPicker::pickDistanceAndTriangle(const QMatrix4x4
     return std::make_tuple(std::get<0>(ret), std::get<1>(ret));
 }
 
-std::tuple<float, Triangle, QVector3D>
-PartPicker::pickDistanceTriangleAndIntersection(const QMatrix4x4& projection, const QMatrix4x4& view,
-                                                QPointF ndc_mouse_pos, const std::vector<Triangle>& triangles,
-                                                bool ortho) {
+std::tuple<float, Triangle, QVector3D> PartPicker::pickDistanceTriangleAndIntersection(
+    const QMatrix4x4& projection, const QMatrix4x4& view, QPointF ndc_mouse_pos, const std::vector<Triangle>& triangles,
+    bool ortho) {
     QVector3D start_pos;
     QVector3D dir;
 
@@ -81,7 +80,7 @@ std::tuple<float, Triangle, QVector3D> PartPicker::castRay(const QVector3D& s, c
         float dist_to_triangle = findDistanceToTriangle(s, v, tri);
 
         if (min_dist > dist_to_triangle) {
-            min_dist = dist_to_triangle;
+            min_dist          = dist_to_triangle;
             selected_triangle = tri;
         }
     }
@@ -95,12 +94,12 @@ float PartPicker::findDistanceToTriangle(const QVector3D& ray_start, const QVect
     const float epsilon = std::numeric_limits<float>::epsilon();
     QVector3D edge1;
     QVector3D edge2;
-    QVector3D p, q; // vectors with no real physical meaning, but used to solve equation
+    QVector3D p, q;  // vectors with no real physical meaning, but used to solve equation
     float denominator;
     float distance = std::numeric_limits<float>::infinity();
-    float u, v;          // coordinate of intersection in barycentric coordinate system, must be in interval [0,1]
-    QVector3D transform; // will represent moving one of the triangle's vertices to the origin of the barycentric
-                         // coordinate system
+    float u, v;           // coordinate of intersection in barycentric coordinate system, must be in interval [0,1]
+    QVector3D transform;  // will represent moving one of the triangle's vertices to the origin of the barycentric
+                          // coordinate system
 
     // This is Moller-Trumbore
 
@@ -109,52 +108,44 @@ float PartPicker::findDistanceToTriangle(const QVector3D& ray_start, const QVect
 
     // I say *should* because I didn't actually check the math, but these edges
     // work in practice.
-    edge1 = triangle.b - triangle.a;
-    edge2 = triangle.c - triangle.a;
-    p = QVector3D::crossProduct(ray_dir, edge2);
+    edge1       = triangle.b - triangle.a;
+    edge2       = triangle.c - triangle.a;
+    p           = QVector3D::crossProduct(ray_dir, edge2);
     denominator = QVector3D::dotProduct(edge1, p);
 
     // If denominator is less than zero, that means the triangle faces away
     // from our ray and should be culled
 
     // If denominator is (close to) zero, that means the ray and triangle are parallel
-    if (denominator < epsilon) {
-        return distance;
-    }
+    if (denominator < epsilon) { return distance; }
 
     transform = ray_start - triangle.a;
 
     // u and v are the barycentric coordinates whose sum should not
     // exceed 1 and neither of which should be negative
     u = QVector3D::dotProduct(transform, p) / denominator;
-    if ((u < 0) || (u > 1)) {
-        return distance;
-    }
+    if ((u < 0) || (u > 1)) { return distance; }
 
     q = QVector3D::crossProduct(transform, edge1);
     v = QVector3D::dotProduct(ray_dir, q) / denominator;
-    if ((v < 0) || (u + v > 1)) {
-        return distance;
-    }
+    if ((v < 0) || (u + v > 1)) { return distance; }
 
     // Finally, we can compute how far along the ray we intersect with the triangle
     distance = QVector3D::dotProduct(q, edge2) / denominator;
 
     // If distance is negative, that means the triangle that we "hit" is *behind*
     // us, and we don't care if we "hit" something behind us, so just return
-    if (distance < epsilon) {
-        return std::numeric_limits<float>::infinity();
-    }
+    if (distance < epsilon) { return std::numeric_limits<float>::infinity(); }
     return distance;
 }
 
 std::tuple<QVector3D, QVector3D> PartPicker::getDirectionAndStart(const QMatrix4x4& projection, QPointF ndc_mouse_pos,
                                                                   const QMatrix4x4& view, bool ortho) {
-    QVector4D p_near_ndc = QVector4D(ndc_mouse_pos.x(), ndc_mouse_pos.y(), -1, 1); // z near = -1
-    QVector4D p_far_ndc = QVector4D(ndc_mouse_pos.x(), ndc_mouse_pos.y(), 1, 1);   // z far = 1
+    QVector4D p_near_ndc = QVector4D(ndc_mouse_pos.x(), ndc_mouse_pos.y(), -1, 1);  // z near = -1
+    QVector4D p_far_ndc  = QVector4D(ndc_mouse_pos.x(), ndc_mouse_pos.y(), 1, 1);   // z far = 1
 
     QVector4D p_near_h = view.inverted() * projection.inverted() * p_near_ndc;
-    QVector4D p_far_h = view.inverted() * projection.inverted() * p_far_ndc;
+    QVector4D p_far_h  = view.inverted() * projection.inverted() * p_far_ndc;
 
     QVector3D p0, p1;
     if (ortho) {
@@ -167,4 +158,4 @@ std::tuple<QVector3D, QVector3D> PartPicker::getDirectionAndStart(const QMatrix4
     }
     return std::make_tuple(p0, (p1 - p0).normalized());
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/support/shape_factory.cpp
+++ b/src/graphics/support/shape_factory.cpp
@@ -1,14 +1,13 @@
 #include "graphics/support/shape_factory.h"
 
+#include <QMatrix4x4>
+#include <QVector2D>
+#include <QVector4D>
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
 #include <vector>
-
-#include <QMatrix4x4>
-#include <QVector2D>
-#include <QVector4D>
 
 #include "geometry/segments/bezier.h"
 #include "managers/settings/settings_manager.h"
@@ -16,18 +15,18 @@
 
 namespace ORNL {
 namespace {
-constexpr float kPi = 3.14159265358979323846f;
-constexpr float kTwoPi = 2.0f * kPi;
-constexpr float kVectorEpsilon = 1.0e-6f;
+constexpr float kPi                   = 3.14159265358979323846f;
+constexpr float kTwoPi                = 2.0f * kPi;
+constexpr float kVectorEpsilon        = 1.0e-6f;
 constexpr float kVectorEpsilonSquared = kVectorEpsilon * kVectorEpsilon;
 
-constexpr int kCylinderSegments = 50;
-constexpr int kConeSlices = 50;
-constexpr int kSphereMinSectorCount = 3;
-constexpr int kSphereMinStackCount = 2;
-constexpr int kCurveSegments = 32;
+constexpr int kCylinderSegments            = 50;
+constexpr int kConeSlices                  = 50;
+constexpr int kSphereMinSectorCount        = 3;
+constexpr int kSphereMinStackCount         = 2;
+constexpr int kCurveSegments               = 32;
 constexpr int kBuildVolumeCylinderSegments = 100;
-constexpr int kBuildVolumeVerticalLines = 6;
+constexpr int kBuildVolumeVerticalLines    = 6;
 
 struct Rgba {
     float r;
@@ -36,15 +35,15 @@ struct Rgba {
     float a;
 
     explicit Rgba(const QColor& color)
-        : r(static_cast<float>(color.redF())), g(static_cast<float>(color.greenF())),
-          b(static_cast<float>(color.blueF())), a(static_cast<float>(color.alphaF())) {}
+        : r(static_cast<float>(color.redF())),
+          g(static_cast<float>(color.greenF())),
+          b(static_cast<float>(color.blueF())),
+          a(static_cast<float>(color.alphaF())) {}
 };
 
 void reserveAdditional(std::vector<float>& values, std::size_t count) {
     const std::size_t required_capacity = values.size() + count;
-    if (required_capacity <= values.capacity()) {
-        return;
-    }
+    if (required_capacity <= values.capacity()) { return; }
 
     const std::size_t grown_capacity = values.capacity() == 0 ? required_capacity : values.capacity() * 2;
     values.reserve(std::max(required_capacity, grown_capacity));
@@ -85,9 +84,7 @@ void appendColor(std::vector<float>& colors, const Rgba& rgba) {
 
 QVector3D faceNormal(const QVector3D& v0, const QVector3D& v1, const QVector3D& v2) {
     QVector3D normal = QVector3D::crossProduct(v1 - v0, v2 - v0);
-    if (normal.lengthSquared() > kVectorEpsilonSquared) {
-        normal.normalize();
-    }
+    if (normal.lengthSquared() > kVectorEpsilonSquared) { normal.normalize(); }
     return normal;
 }
 
@@ -114,9 +111,7 @@ void appendLine(const QVector3D& start, const QVector3D& end, const Rgba& rgba, 
 }
 
 std::size_t countLoopValues(float value, float limit, float step) {
-    if (!std::isfinite(value) || !std::isfinite(limit) || !std::isfinite(step) || step <= 0.0f) {
-        return 0;
-    }
+    if (!std::isfinite(value) || !std::isfinite(limit) || !std::isfinite(step) || step <= 0.0f) { return 0; }
 
     std::size_t count = 0;
     while (value < limit) {
@@ -127,22 +122,18 @@ std::size_t countLoopValues(float value, float limit, float step) {
 }
 
 std::vector<QVector2D> squishedBeadProfile(float width, float height, unsigned int quads_per_side) {
-    if (width <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return {};
-    }
+    if (width <= kVectorEpsilon || height <= kVectorEpsilon) { return {}; }
 
     const bool rectangular_prism = height > width;
     const float radius = rectangular_prism
                              ? std::sqrt(((width / 2.0f) * (width / 2.0f)) + ((height / 2.0f) * (height / 2.0f)))
                              : width / 2.0f;
-    if (radius <= kVectorEpsilon) {
-        return {};
-    }
+    if (radius <= kVectorEpsilon) { return {}; }
 
     const unsigned int resolved_quads_per_side = rectangular_prism ? 1 : std::max(1u, quads_per_side);
-    const unsigned int vertices_per_arc = resolved_quads_per_side + 1;
-    const float theta_start = -std::asin(std::clamp((height / 2.0f) / radius, -1.0f, 1.0f));
-    const float theta_end = -theta_start;
+    const unsigned int vertices_per_arc        = resolved_quads_per_side + 1;
+    const float theta_start                    = -std::asin(std::clamp((height / 2.0f) / radius, -1.0f, 1.0f));
+    const float theta_end                      = -theta_start;
     const float theta_increment = (theta_end - theta_start) / static_cast<float>(resolved_quads_per_side);
 
     std::vector<QVector2D> profile;
@@ -150,15 +141,13 @@ std::vector<QVector2D> squishedBeadProfile(float width, float height, unsigned i
 
     for (unsigned int i = 0; i < vertices_per_arc; ++i) {
         const float theta = theta_start + (static_cast<float>(i) * theta_increment);
-        const float x = radius * std::cos(theta);
-        const float y = radius * std::sin(theta);
+        const float x     = radius * std::cos(theta);
+        const float y     = radius * std::sin(theta);
 
         profile.emplace_back(x, y);
     }
 
-    for (unsigned int i = 0; i < vertices_per_arc; ++i) {
-        profile.emplace_back(-profile[i].x(), -profile[i].y());
-    }
+    for (unsigned int i = 0; i < vertices_per_arc; ++i) { profile.emplace_back(-profile[i].x(), -profile[i].y()); }
 
     return profile;
 }
@@ -167,43 +156,29 @@ QVector3D displaySliceNormal() {
     QVector3D normal = {GSM->getGlobal()->setting<float>(PS::Slicing::kSlicePlaneNormalX),
                         GSM->getGlobal()->setting<float>(PS::Slicing::kSlicePlaneNormalY),
                         GSM->getGlobal()->setting<float>(PS::Slicing::kSlicePlaneNormalZ)};
-    if (normal.lengthSquared() <= kVectorEpsilonSquared) {
-        normal = QVector3D(0.0f, 0.0f, 1.0f);
-    }
-    else {
-        normal.normalize();
-    }
+    if (normal.lengthSquared() <= kVectorEpsilonSquared) { normal = QVector3D(0.0f, 0.0f, 1.0f); }
+    else { normal.normalize(); }
 
     return normal;
 }
 
 bool beadFrameForTangentAndNormal(QVector3D tangent, QVector3D normal_hint, QVector3D& binormal, QVector3D& normal) {
-    if (tangent.lengthSquared() <= kVectorEpsilonSquared) {
-        return false;
-    }
+    if (tangent.lengthSquared() <= kVectorEpsilonSquared) { return false; }
     tangent.normalize();
 
-    if (normal_hint.lengthSquared() <= kVectorEpsilonSquared) {
-        normal_hint = displaySliceNormal();
-    }
-    else {
-        normal_hint.normalize();
-    }
+    if (normal_hint.lengthSquared() <= kVectorEpsilonSquared) { normal_hint = displaySliceNormal(); }
+    else { normal_hint.normalize(); }
 
     binormal = QVector3D::crossProduct(tangent, normal_hint);
     if (binormal.lengthSquared() <= kVectorEpsilonSquared) {
-        normal = (std::fabs(tangent.x()) < 0.9f) ? QVector3D(1.0f, 0.0f, 0.0f) : QVector3D(0.0f, 1.0f, 0.0f);
+        normal   = (std::fabs(tangent.x()) < 0.9f) ? QVector3D(1.0f, 0.0f, 0.0f) : QVector3D(0.0f, 1.0f, 0.0f);
         binormal = QVector3D::crossProduct(tangent, normal);
     }
-    if (binormal.lengthSquared() <= kVectorEpsilonSquared) {
-        return false;
-    }
+    if (binormal.lengthSquared() <= kVectorEpsilonSquared) { return false; }
     binormal.normalize();
 
     normal = QVector3D::crossProduct(binormal, tangent);
-    if (normal.lengthSquared() <= kVectorEpsilonSquared) {
-        return false;
-    }
+    if (normal.lengthSquared() <= kVectorEpsilonSquared) { return false; }
     normal.normalize();
 
     return true;
@@ -215,9 +190,7 @@ bool beadFrameForTangent(QVector3D tangent, QVector3D& binormal, QVector3D& norm
 
 QVector3D radialNormalForPoint(const QVector3D& point, const QVector3D& cylinder_axis) {
     QVector3D normal(point.x() - cylinder_axis.x(), point.y() - cylinder_axis.y(), 0.0f);
-    if (normal.lengthSquared() > kVectorEpsilonSquared) {
-        normal.normalize();
-    }
+    if (normal.lengthSquared() > kVectorEpsilonSquared) { normal.normalize(); }
 
     return normal;
 }
@@ -227,9 +200,7 @@ void appendSweptBeadMesh(float width, float height, CenterAt center_at, TangentA
                          const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                          std::vector<float>& normals) {
     const std::vector<QVector2D> profile = squishedBeadProfile(width, height, 4);
-    if (profile.empty()) {
-        return;
-    }
+    if (profile.empty()) { return; }
 
     const std::size_t profile_size = profile.size();
     const Rgba rgba(color);
@@ -240,13 +211,11 @@ void appendSweptBeadMesh(float width, float height, CenterAt center_at, TangentA
                                                       std::vector<QVector3D>(profile_size));
 
     for (int ring_index = 0; ring_index <= kCurveSegments; ++ring_index) {
-        const float t = static_cast<float>(ring_index) / static_cast<float>(kCurveSegments);
+        const float t          = static_cast<float>(ring_index) / static_cast<float>(kCurveSegments);
         const QVector3D center = center_at(t);
         QVector3D binormal;
         QVector3D normal;
-        if (!beadFrameForTangentAndNormal(tangent_at(t), normal_at(t), binormal, normal)) {
-            return;
-        }
+        if (!beadFrameForTangentAndNormal(tangent_at(t), normal_at(t), binormal, normal)) { return; }
 
         centers[ring_index] = center;
         for (std::size_t i = 0; i < profile_size; ++i) {
@@ -293,32 +262,30 @@ float arcSweepAngle(const Point& start, const Point& center, const Point& end, b
     }
 
     const float start_angle = std::atan2(center.x() - start.x(), center.y() - start.y());
-    const float end_angle = std::atan2(center.x() - end.x(), center.y() - end.y());
+    const float end_angle   = std::atan2(center.x() - end.x(), center.y() - end.y());
 
     float angle = counterclockwise ? start_angle - end_angle : end_angle - start_angle;
-    if (angle < 0.0f) {
-        angle += kTwoPi;
-    }
+    if (angle < 0.0f) { angle += kTwoPi; }
 
     return angle;
 }
-} // namespace
+}  // namespace
 
 void ShapeFactory::appendBox(float length, float width, float height, const QMatrix4x4& transform, const QColor& color,
                              std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
     const float half_length = length / 2.0f;
-    const float half_width = width / 2.0f;
+    const float half_width  = width / 2.0f;
     const float half_height = height / 2.0f;
 
     const std::array<QVector3D, 8> corner_vertices = {
-        transform * QVector3D(-half_length, -half_width, half_height),  // back  left  top
-        transform * QVector3D(half_length, -half_width, half_height),   // back  right top
-        transform * QVector3D(half_length, half_width, half_height),    // front right top
-        transform * QVector3D(-half_length, half_width, half_height),   // front left  top
-        transform * QVector3D(-half_length, -half_width, -half_height), // back  left  bottom
-        transform * QVector3D(half_length, -half_width, -half_height),  // back  right bottom
-        transform * QVector3D(half_length, half_width, -half_height),   // front right bottom
-        transform * QVector3D(-half_length, half_width, -half_height),  // front left  bottom
+        transform * QVector3D(-half_length, -half_width, half_height),   // back  left  top
+        transform * QVector3D(half_length, -half_width, half_height),    // back  right top
+        transform * QVector3D(half_length, half_width, half_height),     // front right top
+        transform * QVector3D(-half_length, half_width, half_height),    // front left  top
+        transform * QVector3D(-half_length, -half_width, -half_height),  // back  left  bottom
+        transform * QVector3D(half_length, -half_width, -half_height),   // back  right bottom
+        transform * QVector3D(half_length, half_width, -half_height),    // front right bottom
+        transform * QVector3D(-half_length, half_width, -half_height),   // front left  bottom
     };
 
     static constexpr std::array<std::array<int, 3>, 12> kTriangles = {
@@ -351,10 +318,10 @@ void ShapeFactory::appendSplineBead(float width, float height, const Point& star
                                     std::vector<float>& normals) {
     BezierSegment curve(start, control_a, control_b, end);
     const double increment = 1.0 / static_cast<double>(kCurveSegments);
-    auto center_at = [&curve](float t) { return curve.getPointAlong(t).toQVector3D(); };
-    auto tangent_at = [&curve, increment](float t) {
+    auto center_at         = [&curve](float t) { return curve.getPointAlong(t).toQVector3D(); };
+    auto tangent_at        = [&curve, increment](float t) {
         const double previous = std::max(0.0, static_cast<double>(t) - increment);
-        const double next = std::min(1.0, static_cast<double>(t) + increment);
+        const double next     = std::min(1.0, static_cast<double>(t) + increment);
         return curve.getPointAlong(next).toQVector3D() - curve.getPointAlong(previous).toQVector3D();
     };
 
@@ -364,23 +331,21 @@ void ShapeFactory::appendSplineBead(float width, float height, const Point& star
 void ShapeFactory::appendCylinder(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                                   std::vector<float>& vertices, std::vector<float>& colors,
                                   std::vector<float>& normals) {
-    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return;
-    }
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) { return; }
 
     std::array<QVector3D, kCylinderSegments> top_vertices;
     std::array<QVector3D, kCylinderSegments> bottom_vertices;
     const float theta_increment = kTwoPi / static_cast<float>(kCylinderSegments);
 
     for (int i = 0; i < kCylinderSegments; ++i) {
-        const float theta = static_cast<float>(i) * theta_increment;
-        const float x = radius * std::cos(theta);
-        const float y = radius * std::sin(theta);
-        top_vertices[i] = transform * QVector3D(x, y, height);
+        const float theta  = static_cast<float>(i) * theta_increment;
+        const float x      = radius * std::cos(theta);
+        const float y      = radius * std::sin(theta);
+        top_vertices[i]    = transform * QVector3D(x, y, height);
         bottom_vertices[i] = transform * QVector3D(x, y, 0.0f);
     }
 
-    const QVector3D top_center = transform * QVector3D(0.0f, 0.0f, height);
+    const QVector3D top_center    = transform * QVector3D(0.0f, 0.0f, height);
     const QVector3D bottom_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
     const Rgba rgba(color);
     reserveTriangleMesh(vertices, colors, normals, static_cast<std::size_t>(kCylinderSegments) * 4);
@@ -403,15 +368,15 @@ void ShapeFactory::appendSphere(float radius, int sector_count, int stack_count,
     }
 
     const float sector_step = kTwoPi / static_cast<float>(sector_count);
-    const float stack_step = kPi / static_cast<float>(stack_count);
+    const float stack_step  = kPi / static_cast<float>(stack_count);
 
     std::vector<QVector3D> tmp_vertices;
     tmp_vertices.reserve(static_cast<std::size_t>(stack_count + 1) * static_cast<std::size_t>(sector_count + 1));
 
     for (int i = 0; i <= stack_count; ++i) {
         const float stack_angle = (kPi / 2.0f) - (static_cast<float>(i) * stack_step);
-        const float xy = radius * std::cos(stack_angle);
-        const float z = radius * std::sin(stack_angle);
+        const float xy          = radius * std::cos(stack_angle);
+        const float z           = radius * std::sin(stack_angle);
 
         for (int j = 0; j <= sector_count; ++j) {
             const float sector_angle = static_cast<float>(j) * sector_step;
@@ -434,12 +399,8 @@ void ShapeFactory::appendSphere(float radius, int sector_count, int stack_count,
             const QVector3D& v3 = tmp_vertices[vi1 + 1];
             const QVector3D& v4 = tmp_vertices[vi2 + 1];
 
-            if (i == 0) {
-                appendTriangleData(v1, v2, v4, rgba, vertices, colors, normals);
-            }
-            else if (i == (stack_count - 1)) {
-                appendTriangleData(v1, v2, v3, rgba, vertices, colors, normals);
-            }
+            if (i == 0) { appendTriangleData(v1, v2, v4, rgba, vertices, colors, normals); }
+            else if (i == (stack_count - 1)) { appendTriangleData(v1, v2, v3, rgba, vertices, colors, normals); }
             else {
                 appendTriangleData(v1, v2, v3, rgba, vertices, colors, normals);
                 appendTriangleData(v3, v2, v4, rgba, vertices, colors, normals);
@@ -458,9 +419,7 @@ void ShapeFactory::appendLinearBead(float width, float length, float height, con
     }
 
     const std::vector<QVector2D> profile = squishedBeadProfile(width, height, quads_per_side);
-    if (profile.empty()) {
-        return;
-    }
+    if (profile.empty()) { return; }
 
     const QMatrix4x4 transform = computeLinearBeadTransform(start, end);
 
@@ -469,11 +428,11 @@ void ShapeFactory::appendLinearBead(float width, float length, float height, con
     std::vector<QVector3D> bottom_vertices(vertices_per_side);
 
     for (std::size_t i = 0; i < vertices_per_side; ++i) {
-        top_vertices[i] = transform * QVector3D(profile[i].x(), profile[i].y(), length);
+        top_vertices[i]    = transform * QVector3D(profile[i].x(), profile[i].y(), length);
         bottom_vertices[i] = transform * QVector3D(profile[i].x(), profile[i].y(), 0.0f);
     }
 
-    const QVector3D top_center = transform * QVector3D(0.0f, 0.0f, length);
+    const QVector3D top_center    = transform * QVector3D(0.0f, 0.0f, length);
     const QVector3D bottom_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
     const Rgba rgba(color);
     reserveTriangleMesh(vertices, colors, normals, vertices_per_side * 4);
@@ -491,7 +450,7 @@ void ShapeFactory::appendRadialLinearBead(float width, float length, float heigh
                                           const QVector3D& end, const QVector3D& cylinder_axis, const QColor& color,
                                           std::vector<float>& vertices, std::vector<float>& colors,
                                           std::vector<float>& normals, unsigned int quads_per_side) {
-    const QVector3D midpoint = (start + end) / 2.0f;
+    const QVector3D midpoint      = (start + end) / 2.0f;
     const QVector3D radial_normal = radialNormalForPoint(midpoint, cylinder_axis);
     if (radial_normal.lengthSquared() <= kVectorEpsilonSquared) {
         appendLinearBead(width, length, height, start, end, color, vertices, colors, normals, quads_per_side);
@@ -504,9 +463,7 @@ void ShapeFactory::appendRadialLinearBead(float width, float length, float heigh
     }
 
     const std::vector<QVector2D> profile = squishedBeadProfile(width, height, quads_per_side);
-    if (profile.empty()) {
-        return;
-    }
+    if (profile.empty()) { return; }
 
     const QMatrix4x4 transform = computeLinearBeadTransform(start, end, radial_normal);
 
@@ -515,11 +472,11 @@ void ShapeFactory::appendRadialLinearBead(float width, float length, float heigh
     std::vector<QVector3D> bottom_vertices(vertices_per_side);
 
     for (std::size_t i = 0; i < vertices_per_side; ++i) {
-        top_vertices[i] = transform * QVector3D(profile[i].x(), profile[i].y(), length);
+        top_vertices[i]    = transform * QVector3D(profile[i].x(), profile[i].y(), length);
         bottom_vertices[i] = transform * QVector3D(profile[i].x(), profile[i].y(), 0.0f);
     }
 
-    const QVector3D top_center = transform * QVector3D(0.0f, 0.0f, length);
+    const QVector3D top_center    = transform * QVector3D(0.0f, 0.0f, length);
     const QVector3D bottom_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
     const Rgba rgba(color);
     reserveTriangleMesh(vertices, colors, normals, vertices_per_side * 4);
@@ -535,19 +492,17 @@ void ShapeFactory::appendRadialLinearBead(float width, float length, float heigh
 
 void ShapeFactory::appendCone(float radius, float height, const QMatrix4x4& transform, const QColor& color,
                               std::vector<float>& vertices, std::vector<float>& colors, std::vector<float>& normals) {
-    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return;
-    }
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) { return; }
 
     std::array<QVector3D, kConeSlices> perimeter_vertices;
     const float theta_increment = kTwoPi / static_cast<float>(kConeSlices);
 
     for (int i = 0; i < kConeSlices; ++i) {
-        const float theta = static_cast<float>(i) * theta_increment;
+        const float theta     = static_cast<float>(i) * theta_increment;
         perimeter_vertices[i] = transform * QVector3D(radius * std::sin(theta), radius * std::cos(theta), 0.0f);
     }
 
-    const QVector3D tip = transform * QVector3D(0.0f, 0.0f, height);
+    const QVector3D tip         = transform * QVector3D(0.0f, 0.0f, height);
     const QVector3D base_center = transform * QVector3D(0.0f, 0.0f, 0.0f);
     const Rgba rgba(color);
     reserveTriangleMesh(vertices, colors, normals, static_cast<std::size_t>(kConeSlices) * 2);
@@ -659,28 +614,22 @@ void ShapeFactory::appendBuildVolumeBoxLines(const QVector3D& min, const QVector
 void ShapeFactory::appendBuildVolumeCylinderLines(float radius, float height, float x_grid_dist, float y_grid_dist,
                                                   const QColor& color, std::vector<float>& vertices,
                                                   std::vector<float>& colors) {
-    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return;
-    }
+    if (radius <= kVectorEpsilon || height <= kVectorEpsilon) { return; }
 
     const float theta_increment = kTwoPi / static_cast<float>(kBuildVolumeCylinderSegments);
-    const float vertical_step = kTwoPi / static_cast<float>(kBuildVolumeVerticalLines);
-    const float r_squared = radius * radius;
+    const float vertical_step   = kTwoPi / static_cast<float>(kBuildVolumeVerticalLines);
+    const float r_squared       = radius * radius;
 
     std::size_t line_count = (static_cast<std::size_t>(kBuildVolumeCylinderSegments) * 2) + kBuildVolumeVerticalLines;
-    if (x_grid_dist > 0.0f) {
-        line_count += countLoopValues(-radius, radius + kVectorEpsilon, x_grid_dist);
-    }
-    if (y_grid_dist > 0.0f) {
-        line_count += countLoopValues(-radius, radius + kVectorEpsilon, y_grid_dist);
-    }
+    if (x_grid_dist > 0.0f) { line_count += countLoopValues(-radius, radius + kVectorEpsilon, x_grid_dist); }
+    if (y_grid_dist > 0.0f) { line_count += countLoopValues(-radius, radius + kVectorEpsilon, y_grid_dist); }
 
     const Rgba rgba(color);
     reserveLineMesh(vertices, colors, line_count);
 
     for (float current_height : std::array<float, 2> {0.0f, height}) {
         for (int i = 0; i < kBuildVolumeCylinderSegments; ++i) {
-            const float theta = static_cast<float>(i) * theta_increment;
+            const float theta      = static_cast<float>(i) * theta_increment;
             const float next_theta = static_cast<float>(i + 1) * theta_increment;
             appendLine(QVector3D(radius * std::cos(theta), radius * std::sin(theta), current_height),
                        QVector3D(radius * std::cos(next_theta), radius * std::sin(next_theta), current_height), rgba,
@@ -690,8 +639,8 @@ void ShapeFactory::appendBuildVolumeCylinderLines(float radius, float height, fl
 
     for (int i = 0; i < kBuildVolumeVerticalLines; ++i) {
         const float theta = static_cast<float>(i) * vertical_step;
-        const float x = radius * std::cos(theta);
-        const float y = radius * std::sin(theta);
+        const float x     = radius * std::cos(theta);
+        const float y     = radius * std::sin(theta);
         appendLine(QVector3D(x, y, 0.0f), QVector3D(x, y, height), rgba, vertices, colors);
     }
 
@@ -722,9 +671,7 @@ QMatrix4x4 ShapeFactory::computeLinearBeadTransform(const QVector3D& start, cons
     QVector3D tangent = end - start;
     QVector3D binormal;
     QVector3D normal;
-    if (!beadFrameForTangentAndNormal(tangent, normal_hint, binormal, normal)) {
-        return transform;
-    }
+    if (!beadFrameForTangentAndNormal(tangent, normal_hint, binormal, normal)) { return transform; }
 
     tangent.normalize();
 
@@ -742,14 +689,12 @@ void ShapeFactory::appendArcBead(float width, float height, const Point& start, 
                                  bool is_ccw, const QColor& color, std::vector<float>& vertices,
                                  std::vector<float>& colors, std::vector<float>& normals) {
     const float major_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    if (major_radius <= kVectorEpsilon || width <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return;
-    }
+    if (major_radius <= kVectorEpsilon || width <= kVectorEpsilon || height <= kVectorEpsilon) { return; }
 
-    const float start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
-    const float sweep_angle = arcSweepAngle(start, center, end, is_ccw);
+    const float start_angle  = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const float sweep_angle  = arcSweepAngle(start, center, end, is_ccw);
     const float signed_sweep = is_ccw ? sweep_angle : -sweep_angle;
-    const float z_delta = end.z() - start.z();
+    const float z_delta      = end.z() - start.z();
 
     auto center_at = [start, center, major_radius, start_angle, signed_sweep, z_delta](float t) {
         const float angle = start_angle + (signed_sweep * t);
@@ -770,14 +715,12 @@ void ShapeFactory::appendRadialArcBead(float width, float height, const Point& s
                                        const QColor& color, std::vector<float>& vertices, std::vector<float>& colors,
                                        std::vector<float>& normals) {
     const float major_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    if (major_radius <= kVectorEpsilon || width <= kVectorEpsilon || height <= kVectorEpsilon) {
-        return;
-    }
+    if (major_radius <= kVectorEpsilon || width <= kVectorEpsilon || height <= kVectorEpsilon) { return; }
 
-    const float start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
-    const float sweep_angle = arcSweepAngle(start, center, end, is_ccw);
+    const float start_angle  = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const float sweep_angle  = arcSweepAngle(start, center, end, is_ccw);
     const float signed_sweep = is_ccw ? sweep_angle : -sweep_angle;
-    const float z_delta = end.z() - start.z();
+    const float z_delta      = end.z() - start.z();
 
     auto center_at = [start, center, major_radius, start_angle, signed_sweep, z_delta](float t) {
         const float angle = start_angle + (signed_sweep * t);
@@ -794,4 +737,4 @@ void ShapeFactory::appendRadialArcBead(float width, float height, const Point& s
     appendSweptBeadMesh(width, height, center_at, tangent_at, normal_at, color, vertices, colors, normals);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -45,8 +45,8 @@ struct LinePickResult {
 
 LinePickResult projectLineHit(const QPointF& point, const QPointF& start, const QPointF& end, float start_depth,
                               float end_depth) {
-    const float dx = end.x() - start.x();
-    const float dy = end.y() - start.y();
+    const float dx             = end.x() - start.x();
+    const float dy             = end.y() - start.y();
     const float length_squared = (dx * dx) + (dy * dy);
 
     if (length_squared <= std::numeric_limits<float>::epsilon()) {
@@ -56,33 +56,31 @@ LinePickResult projectLineHit(const QPointF& point, const QPointF& start, const 
     }
 
     float t = ((point.x() - start.x()) * dx + (point.y() - start.y()) * dy) / length_squared;
-    t = MathUtils::clamp(0.0f, t, 1.0f);
+    t       = MathUtils::clamp(0.0f, t, 1.0f);
 
     const float projected_x = start.x() + (t * dx);
     const float projected_y = start.y() + (t * dy);
-    const float point_dx = point.x() - projected_x;
-    const float point_dy = point.y() - projected_y;
-    const float depth = start_depth + (t * (end_depth - start_depth));
+    const float point_dx    = point.x() - projected_x;
+    const float point_dy    = point.y() - projected_y;
+    const float depth       = start_depth + (t * (end_depth - start_depth));
     return {(point_dx * point_dx) + (point_dy * point_dy), depth};
 }
 
 bool projectToNdc(const QMatrix4x4& projection, const QMatrix4x4& view, const QVector3D& point, QPointF& ndc,
                   float& depth) {
     const QVector4D clip = projection * view * QVector4D(point, 1.0f);
-    if (qFuzzyIsNull(clip.w())) {
-        return false;
-    }
+    if (qFuzzyIsNull(clip.w())) { return false; }
 
     const QVector3D projected = clip.toVector3DAffine();
-    ndc = QPointF(projected.x(), projected.y());
-    depth = projected.z();
+    ndc                       = QPointF(projected.x(), projected.y());
+    depth                     = projected.z();
     return true;
 }
-} // namespace
+}  // namespace
 
 GCodeView::GCodeView(QSharedPointer<SettingsBase> sb, QSharedPointer<GCodeInfoControl> segmentInfoControl) {
-    m_sb = sb;
-    m_segment_info_control = segmentInfoControl;
+    m_sb                      = sb;
+    m_segment_info_control    = segmentInfoControl;
     m_use_true_segment_widths = PreferencesManager::getInstance()->getUseTrueWidthsPreference();
 }
 
@@ -148,29 +146,21 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     }
 
     m_true_width_overlay_key_valid = false;
-    m_gcode = gcode;
+    m_gcode                        = gcode;
 
     if (m_state.ortho) {
         m_state.zoom_factor = 1.0f;
         this->resizeGL(this->width(), this->height());
     }
 
-    if (gcode.isEmpty()) {
-        m_gcode_object = nullptr;
-    }
+    if (gcode.isEmpty()) { m_gcode_object = nullptr; }
     else {
-        if (m_state.low_layer >= gcode.size()) {
-            m_state.low_layer = gcode.size() - 1;
-        }
-        if (m_state.high_layer >= gcode.size()) {
-            m_state.high_layer = gcode.size() - 1;
-        }
-        if (m_state.high_layer < m_state.low_layer) {
-            m_state.high_layer = m_state.low_layer;
-        }
+        if (m_state.low_layer >= gcode.size()) { m_state.low_layer = gcode.size() - 1; }
+        if (m_state.high_layer >= gcode.size()) { m_state.high_layer = gcode.size() - 1; }
+        if (m_state.high_layer < m_state.low_layer) { m_state.high_layer = m_state.low_layer; }
 
         QSharedPointer<PreferencesManager> preferences = PreferencesManager::getInstance();
-        m_gcode_object = QSharedPointer<GCodeObject>::create(
+        m_gcode_object                                 = QSharedPointer<GCodeObject>::create(
             this, gcode, m_segment_info_control, m_use_true_segment_widths,
             preferences->getGCodePreviewModePreference(), preferences->getGCodePreviewVertexThresholdPreference());
         m_gcode_object->showLayers(m_state.low_layer, m_state.high_layer);
@@ -188,9 +178,7 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     }
     updateHoverTracking();
 
-    if (m_state.showing_ghosts) {
-        rebuildGhosts();
-    }
+    if (m_state.showing_ghosts) { rebuildGhosts(); }
 
     this->update();
     updateSegmentInfoViewMatrix();
@@ -199,9 +187,7 @@ void GCodeView::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
 bool GCodeView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
     auto picked =
         m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, m_state.ortho);
-    if (!picked.isValid()) {
-        return false;
-    }
+    if (!picked.isValid()) { return false; }
 
     QVector3D bed_intersection;
     if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection,
@@ -209,11 +195,11 @@ bool GCodeView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
         return false;
     }
 
-    m_state.dragging_seam = true;
-    m_state.dragged_seam = picked.object;
+    m_state.dragging_seam          = true;
+    m_state.dragged_seam           = picked.object;
     m_state.dragged_seam_x_setting = picked.x_setting;
     m_state.dragged_seam_y_setting = picked.y_setting;
-    m_state.dragged_seam_offset = picked.object->translation() - bed_intersection;
+    m_state.dragged_seam_offset    = picked.object->translation() - bed_intersection;
 
     emit optimizationPointDragStarted(picked.x_setting, picked.y_setting);
 
@@ -222,9 +208,7 @@ bool GCodeView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
 }
 
 bool GCodeView::updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish) {
-    if (!m_state.dragging_seam || m_state.dragged_seam.isNull()) {
-        return false;
-    }
+    if (!m_state.dragging_seam || m_state.dragged_seam.isNull()) { return false; }
 
     QVector3D bed_intersection;
     if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection,
@@ -240,18 +224,14 @@ bool GCodeView::updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish) 
     if (finish) {
         emit optimizationPointDragFinished(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
     }
-    else {
-        emit optimizationPointDragged(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
-    }
+    else { emit optimizationPointDragged(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y); }
 
     this->update();
     return true;
 }
 
 void GCodeView::finishOptimizationPointDrag(QPointF mouse_ndc_pos) {
-    if (!m_state.dragging_seam) {
-        return;
-    }
+    if (!m_state.dragging_seam) { return; }
 
     if (!updateOptimizationPointDrag(mouse_ndc_pos, true) && !m_state.dragged_seam.isNull()) {
         const QVector3D translation = m_state.dragged_seam->translation();
@@ -272,13 +252,10 @@ void GCodeView::finishOptimizationPointDrag(QPointF mouse_ndc_pos) {
 void GCodeView::hideSegmentType(SegmentDisplayType type, bool hidden) {
     m_state.hidden_type = (hidden) ? (m_state.hidden_type | type) : (m_state.hidden_type & ~type);
 
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     m_gcode_object->hideSegmentType(type, hidden);
-    if (!m_true_width_overlay_object.isNull()) {
-        m_true_width_overlay_object->hideSegmentType(type, hidden);
-    }
+    if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->hideSegmentType(type, hidden); }
 
     this->update();
 }
@@ -298,16 +275,12 @@ void GCodeView::clearGhosts() {
         return;
     }
 
-    for (auto ghost : m_ghosted_parts) {
-        m_printer->orphanChild(ghost);
-    }
+    for (auto ghost : m_ghosted_parts) { m_printer->orphanChild(ghost); }
     m_ghosted_parts.clear();
 }
 
 void GCodeView::rebuildGhosts() {
-    if (m_meta_model.isNull() || m_printer.isNull()) {
-        return;
-    }
+    if (m_meta_model.isNull() || m_printer.isNull()) { return; }
 
     clearGhosts();
 
@@ -324,28 +297,22 @@ void GCodeView::rebuildGhosts() {
 
 void GCodeView::clearTrueWidthOverlay() {
     if (!m_true_width_overlay_object.isNull()) {
-        if (!m_gcode_object.isNull()) {
-            m_gcode_object->orphanChild(m_true_width_overlay_object);
-        }
+        if (!m_gcode_object.isNull()) { m_gcode_object->orphanChild(m_true_width_overlay_object); }
         m_true_width_overlay_object.reset();
     }
 }
 
 QVector<QVector<QSharedPointer<SegmentBase>>> GCodeView::visiblePrintableGCodeSubset() const {
     QVector<QVector<QSharedPointer<SegmentBase>>> subset;
-    if (m_gcode.isEmpty()) {
-        return subset;
-    }
+    if (m_gcode.isEmpty()) { return subset; }
 
-    const uint low_layer = std::min(m_state.low_layer, static_cast<uint>(m_gcode.size() - 1));
+    const uint low_layer  = std::min(m_state.low_layer, static_cast<uint>(m_gcode.size() - 1));
     const uint high_layer = std::min(m_state.high_layer, static_cast<uint>(m_gcode.size() - 1));
-    if (low_layer > high_layer) {
-        return subset;
-    }
+    if (low_layer > high_layer) { return subset; }
 
-    const uint high_segment = m_state.high_segment == std::numeric_limits<uint>::max()
-                                  ? std::numeric_limits<uint>::max()
-                                  : std::max(m_state.low_segment, m_state.high_segment);
+    const uint high_segment    = m_state.high_segment == std::numeric_limits<uint>::max()
+                                     ? std::numeric_limits<uint>::max()
+                                     : std::max(m_state.low_segment, m_state.high_segment);
     uint visible_segment_index = 0;
 
     for (uint layer_index = low_layer; layer_index <= high_layer; ++layer_index) {
@@ -363,9 +330,7 @@ QVector<QVector<QSharedPointer<SegmentBase>>> GCodeView::visiblePrintableGCodeSu
             ++visible_segment_index;
         }
 
-        if (!layer_subset.isEmpty()) {
-            subset.push_back(layer_subset);
-        }
+        if (!layer_subset.isEmpty()) { subset.push_back(layer_subset); }
     }
 
     return subset;
@@ -379,40 +344,32 @@ void GCodeView::refreshTrueWidthOverlay() {
     }
 
     QSharedPointer<PreferencesManager> preferences = PreferencesManager::getInstance();
-    const GCodePreviewMode preview_mode = preferences->getGCodePreviewModePreference();
-    const int vertex_threshold = preferences->getGCodePreviewVertexThresholdPreference();
+    const GCodePreviewMode preview_mode            = preferences->getGCodePreviewModePreference();
+    const int vertex_threshold                     = preferences->getGCodePreviewVertexThresholdPreference();
 
     TrueWidthOverlayKey key;
-    key.low_layer = m_state.low_layer;
-    key.high_layer = m_state.high_layer;
-    key.low_segment = m_state.low_segment;
-    key.high_segment = m_state.high_segment;
-    key.preview_mode = preview_mode;
+    key.low_layer        = m_state.low_layer;
+    key.high_layer       = m_state.high_layer;
+    key.low_segment      = m_state.low_segment;
+    key.high_segment     = m_state.high_segment;
+    key.preview_mode     = preview_mode;
     key.vertex_threshold = vertex_threshold;
-    key.use_true_widths = m_use_true_segment_widths;
+    key.use_true_widths  = m_use_true_segment_widths;
 
-    if (m_true_width_overlay_key_valid && key == m_true_width_overlay_key) {
-        return;
-    }
+    if (m_true_width_overlay_key_valid && key == m_true_width_overlay_key) { return; }
 
     clearTrueWidthOverlay();
-    m_true_width_overlay_key = key;
+    m_true_width_overlay_key       = key;
     m_true_width_overlay_key_valid = true;
 
-    if (preview_mode == GCodePreviewMode::kThinLines) {
-        return;
-    }
+    if (preview_mode == GCodePreviewMode::kThinLines) { return; }
 
     QVector<QVector<QSharedPointer<SegmentBase>>> visible_gcode = visiblePrintableGCodeSubset();
-    if (visible_gcode.isEmpty()) {
-        return;
-    }
+    if (visible_gcode.isEmpty()) { return; }
 
     const qsizetype estimated_vertices =
         GCodeObject::estimateTrueWidthVertexCount(visible_gcode, static_cast<qsizetype>(vertex_threshold));
-    if (estimated_vertices > vertex_threshold) {
-        return;
-    }
+    if (estimated_vertices > vertex_threshold) { return; }
 
     m_true_width_overlay_object = QSharedPointer<GCodeObject>::create(
         this, visible_gcode, m_segment_info_control, true, GCodePreviewMode::kTrueWidths, vertex_threshold, false);
@@ -426,14 +383,10 @@ void GCodeView::refreshTrueWidthOverlay() {
 uint GCodeView::pickVisibleSegment(const QPointF& mouse_ndc_pos) {
     if (!m_true_width_overlay_object.isNull()) {
         const uint overlay_line_num = this->pickSegment(mouse_ndc_pos, m_true_width_overlay_object);
-        if (overlay_line_num != 0) {
-            return overlay_line_num;
-        }
+        if (overlay_line_num != 0) { return overlay_line_num; }
     }
 
-    if (m_gcode_object.isNull()) {
-        return 0;
-    }
+    if (m_gcode_object.isNull()) { return 0; }
 
     return this->pickSegment(mouse_ndc_pos, m_gcode_object);
 }
@@ -442,9 +395,7 @@ void GCodeView::updateSegmentWidths(bool use_true_width) {
     clear();
     m_use_true_segment_widths = use_true_width;
 
-    if (!m_gcode.isEmpty()) {
-        addGCode(m_gcode);
-    }
+    if (!m_gcode.isEmpty()) { addGCode(m_gcode); }
 }
 
 void GCodeView::initView() {
@@ -470,19 +421,14 @@ void GCodeView::initView() {
 }
 
 void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
-    if (beginOptimizationPointDrag(mouse_ndc_pos)) {
-        return;
-    }
+    if (beginOptimizationPointDrag(mouse_ndc_pos)) { return; }
 
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     uint picked_line_num = this->pickVisibleSegment(mouse_ndc_pos);
 
     if (picked_line_num == 0) {
-        if (!m_true_width_overlay_object.isNull()) {
-            m_true_width_overlay_object->deselectAll();
-        }
+        if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->deselectAll(); }
         emit updateSelectedSegments(QList<int>(), m_gcode_object->deselectAll());
     }
     else {
@@ -495,9 +441,7 @@ void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
         }
         else {
             m_gcode_object->selectSegment(picked_line_num);
-            if (!m_true_width_overlay_object.isNull()) {
-                m_true_width_overlay_object->selectSegment(picked_line_num);
-            }
+            if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->selectSegment(picked_line_num); }
             emit updateSelectedSegments(QList<int> {(int)picked_line_num - 1}, QList<int> {});
         }
     }
@@ -505,15 +449,11 @@ void GCodeView::handleLeftClick(QPointF mouse_ndc_pos) {
 }
 
 void GCodeView::handleLeftMove(QPointF mouse_ndc_pos) {
-    if (m_state.dragging_seam) {
-        updateOptimizationPointDrag(mouse_ndc_pos, false);
-    }
+    if (m_state.dragging_seam) { updateOptimizationPointDrag(mouse_ndc_pos, false); }
 }
 
 void GCodeView::handleLeftRelease(QPointF mouse_ndc_pos) {
-    if (m_state.dragging_seam) {
-        finishOptimizationPointDrag(mouse_ndc_pos);
-    }
+    if (m_state.dragging_seam) { finishOptimizationPointDrag(mouse_ndc_pos); }
 }
 
 void GCodeView::handleLeftDoubleClick(QPointF mouse_ndc_pos) {
@@ -524,12 +464,8 @@ void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
     auto picked_seam =
         m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, m_state.ortho);
     if (picked_seam.isValid()) {
-        if (!m_gcode_object.isNull()) {
-            m_gcode_object->highlightSegment(0);
-        }
-        if (!m_true_width_overlay_object.isNull()) {
-            m_true_width_overlay_object->highlightSegment(0);
-        }
+        if (!m_gcode_object.isNull()) { m_gcode_object->highlightSegment(0); }
+        if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->highlightSegment(0); }
 
         this->setCursor(QCursor(Qt::OpenHandCursor));
         this->update();
@@ -538,15 +474,12 @@ void GCodeView::handleMouseMove(QPointF mouse_ndc_pos) {
 
     this->setCursor(QCursor(Qt::ArrowCursor));
 
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     uint picked_line_num = this->pickVisibleSegment(mouse_ndc_pos);
 
     m_gcode_object->highlightSegment(picked_line_num);
-    if (!m_true_width_overlay_object.isNull()) {
-        m_true_width_overlay_object->highlightSegment(picked_line_num);
-    }
+    if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->highlightSegment(picked_line_num); }
 
     this->update();
 }
@@ -600,8 +533,7 @@ void GCodeView::translateCamera(QVector3D v, bool absolute) {
 }
 
 void GCodeView::rotateCamera(QVector2D screen_delta) {
-    if (!m_state.ortho)
-        this->BaseView::rotateCamera(screen_delta);
+    if (!m_state.ortho) this->BaseView::rotateCamera(screen_delta);
 }
 
 void GCodeView::resizeGL(int width, int height) {
@@ -613,12 +545,10 @@ void GCodeView::resizeGL(int width, int height) {
     // (Re)Initalize camera projection.
     QMatrix4x4 projection;
 
-    if (width <= 0 || height <= 0) {
-        return;
-    }
+    if (width <= 0 || height <= 0) { return; }
 
-    const float scale = std::pow(24.0f, m_state.zoom_factor);
-    const float half_width = static_cast<float>(width) / scale;
+    const float scale       = std::pow(24.0f, m_state.zoom_factor);
+    const float half_width  = static_cast<float>(width) / scale;
     const float half_height = static_cast<float>(height) / scale;
 
     projection.setToIdentity();
@@ -633,14 +563,14 @@ void GCodeView::resizeGL(int width, int height) {
 
 uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeObject> gog) {
     float min_triangle_dist = Constants::Limits::Maximums::kMaxFloat;
-    float min_pick_depth = std::numeric_limits<float>::infinity();
-    uint picked_seg = 0;
+    float min_pick_depth    = std::numeric_limits<float>::infinity();
+    uint picked_seg         = 0;
 
     auto tris = gog->segmentTriangles();
 
     for (auto& tri : tris) {
-        const auto pick = PartPicker::pickDistanceAndIntersection(this->projectionMatrix(), this->viewMatrix(),
-                                                                  mouse_ndc_pos, tri.second, m_state.ortho);
+        const auto pick  = PartPicker::pickDistanceAndIntersection(this->projectionMatrix(), this->viewMatrix(),
+                                                                   mouse_ndc_pos, tri.second, m_state.ortho);
         const float dist = std::get<0>(pick);
 
         if (dist < min_triangle_dist) {
@@ -648,8 +578,8 @@ uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeOb
             float depth = min_pick_depth;
             projectToNdc(this->projectionMatrix(), this->viewMatrix(), std::get<1>(pick), ndc, depth);
             min_triangle_dist = dist;
-            min_pick_depth = depth;
-            picked_seg = tri.first;
+            min_pick_depth    = depth;
+            picked_seg        = tri.first;
         }
     }
 
@@ -667,7 +597,7 @@ uint GCodeView::pickSegment(const QPointF& mouse_ndc_pos, QSharedPointer<GCodeOb
         const LinePickResult line_hit = projectLineHit(mouse_ndc_pos, start_ndc, end_ndc, start_depth, end_depth);
         if (line_hit.distance_squared <= kLinePickToleranceSquared && line_hit.depth < min_pick_depth) {
             min_pick_depth = line_hit.depth;
-            picked_seg = line.first;
+            picked_seg     = line.first;
         }
     }
 
@@ -712,9 +642,7 @@ void GCodeView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
 
         m_printer = new_printer;
     }
-    else {
-        m_printer->updateFromSettings(m_sb);
-    }
+    else { m_printer->updateFromSettings(m_sb); }
 
     m_camera->setDefaultZoom(m_printer->getDefaultZoom());
     this->resetCamera();
@@ -735,8 +663,7 @@ void GCodeView::updateOptimizationSettings(QSharedPointer<SettingsBase> sb) {
 }
 
 void GCodeView::setLowLayer(uint low_layer) {
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     m_gcode_object->showLow(low_layer);
     m_state.low_layer = low_layer;
@@ -751,8 +678,7 @@ void GCodeView::setLowLayer(uint low_layer) {
 }
 
 void GCodeView::setHighLayer(uint high_layer) {
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     m_gcode_object->showHigh(high_layer);
     m_state.high_layer = high_layer;
@@ -767,8 +693,7 @@ void GCodeView::setHighLayer(uint high_layer) {
 }
 
 void GCodeView::setLowSegment(uint low_segment) {
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     m_gcode_object->showLowSegment(low_segment);
     m_state.low_segment = low_segment;
@@ -780,8 +705,7 @@ void GCodeView::setLowSegment(uint low_segment) {
 }
 
 void GCodeView::setHighSegment(uint high_segment) {
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     m_gcode_object->showHighSegment(high_segment);
     m_state.high_segment = high_segment;
@@ -793,21 +717,16 @@ void GCodeView::setHighSegment(uint high_segment) {
 }
 
 void GCodeView::updateSegments(QList<int> linesToAdd, QList<int> linesToRemove) {
-    if (m_gcode_object.isNull())
-        return;
+    if (m_gcode_object.isNull()) return;
 
     for (int line_num : linesToAdd) {
         m_gcode_object->selectSegment(line_num + 1);
-        if (!m_true_width_overlay_object.isNull()) {
-            m_true_width_overlay_object->selectSegment(line_num + 1);
-        }
+        if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->selectSegment(line_num + 1); }
     }
 
     for (int line_num : linesToRemove) {
         m_gcode_object->deselectSegment(line_num + 1);
-        if (!m_true_width_overlay_object.isNull()) {
-            m_true_width_overlay_object->deselectSegment(line_num + 1);
-        }
+        if (!m_true_width_overlay_object.isNull()) { m_true_width_overlay_object->deselectSegment(line_num + 1); }
     }
 
     this->update();
@@ -841,14 +760,10 @@ void GCodeView::setMeta(QSharedPointer<PartMetaModel> meta) {
 
 void GCodeView::showGhosts(bool show) {
     m_state.showing_ghosts = show;
-    if (show && m_ghosted_parts.isEmpty()) {
-        rebuildGhosts();
-    }
+    if (show && m_ghosted_parts.isEmpty()) { rebuildGhosts(); }
 
     for (auto ghost : m_ghosted_parts) {
-        if (show) {
-            ghost->show();
-        }
+        if (show) { ghost->show(); }
         else
             ghost->hide();
     }
@@ -863,12 +778,11 @@ void GCodeView::resetCamera() {
     this->translateCamera(
         QVector3D(m_printer->printerCenter().x(), m_printer->printerCenter().y(), m_printer->minimum().z()), true);
 
-    this->update(); // Need to repaint with new model matrices
+    this->update();  // Need to repaint with new model matrices
     updateSegmentInfoViewMatrix();
 }
 
 void GCodeView::updateSegmentInfoViewMatrix() {
-    if (!m_segment_info_control.isNull())
-        m_segment_info_control->setViewMatrix(this->viewMatrix());
+    if (!m_segment_info_control.isNull()) m_segment_info_control->setViewMatrix(this->viewMatrix());
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -2,14 +2,14 @@
 
 #include <math.h>
 
+#include <QMessageBox>
+#include <QStack>
+#include <QToolTip>
 #include <algorithm>
 #include <cmath>
 #include <limits>
 #include <vector>
 
-#include <QMessageBox>
-#include <QStack>
-#include <QToolTip>
 #include <qcolor.h>
 #include <qcursor.h>
 #include <qevent.h>
@@ -55,10 +55,10 @@
 namespace ORNL {
 namespace {
 constexpr float kMinimumLayerSettingsRangeThickness = 0.01f;
-constexpr float kMinimumSlicingCylinderHeight = 0.01f;
-constexpr float kMeasurementMarkerRadius = 0.025f;
-constexpr float kMeasurementLabelLift = 0.08f;
-constexpr float kMeasurementLabelScale = 0.08f;
+constexpr float kMinimumSlicingCylinderHeight       = 0.01f;
+constexpr float kMeasurementMarkerRadius            = 0.025f;
+constexpr float kMeasurementLabelLift               = 0.08f;
+constexpr float kMeasurementLabelScale              = 0.08f;
 
 QString asciiDistanceUnitText(QString unit_text) {
     unit_text.replace(Constants::Units::kMicron, "um");
@@ -70,11 +70,11 @@ QString asciiDistanceUnitText(QString unit_text) {
 bool isFinitePoint(const QVector3D& point) {
     return std::isfinite(point.x()) && std::isfinite(point.y()) && std::isfinite(point.z());
 }
-} // namespace
+}  // namespace
 
 PartView::PartView(QSharedPointer<SettingsBase> sb) {
     m_menu = new RightClickMenu(this);
-    m_sb = sb;
+    m_sb   = sb;
 }
 
 void PartView::setModel(QSharedPointer<PartMetaModel> m) {
@@ -96,9 +96,7 @@ QList<QSharedPointer<Part>> PartView::floatingParts() {
     QVector3D printerFloor = m_printer->printerCenter();
 
     for (auto& gop : m_part_objects) {
-        if (!MathUtils::glEquals(gop->minimum().z(), printerFloor.z())) {
-            result.push_back(gop->part());
-        }
+        if (!MathUtils::glEquals(gop->minimum().z(), printerFloor.z())) { result.push_back(gop->part()); }
     }
 
     return result;
@@ -108,17 +106,13 @@ QList<QSharedPointer<Part>> PartView::externalParts() {
     QList<QSharedPointer<PartObject>> ret = m_printer->externalParts();
     QList<QSharedPointer<Part>> result;
 
-    for (auto& gop : ret) {
-        result.append(gop->part());
-    }
+    for (auto& gop : ret) { result.append(gop->part()); }
 
     return result;
 }
 
 void PartView::showLabels(bool show) {
-    for (auto& gop : m_part_objects) {
-        gop->label()->setHidden(!show);
-    }
+    for (auto& gop : m_part_objects) { gop->label()->setHidden(!show); }
 
     m_state.names_shown = show;
 
@@ -126,9 +120,7 @@ void PartView::showLabels(bool show) {
 }
 
 void PartView::showSlicingPlanes(bool show) {
-    if (show) {
-        updateSlicingSettings(m_sb);
-    }
+    if (show) { updateSlicingSettings(m_sb); }
 
     m_state.planes_shown = show;
     updateSlicingGeometryPreviews();
@@ -143,14 +135,12 @@ void PartView::showLayerSettingsRange(bool show) {
 
 void PartView::setLayerSettingsRanges(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges) {
     m_state.layer_settings_range_part = part;
-    m_state.layer_settings_ranges = layer_ranges;
+    m_state.layer_settings_ranges     = layer_ranges;
     updateLayerSettingsRangePlane();
 }
 
 void PartView::showOverhang(bool show) {
-    for (auto& gop : m_part_objects) {
-        gop->showOverhang(show);
-    }
+    for (auto& gop : m_part_objects) { gop->showOverhang(show); }
 
     m_state.overhangs_shown = show;
 
@@ -173,8 +163,8 @@ void PartView::setupAlignment(QVector3D plane) {
 }
 
 void PartView::setMeasurementMode(bool enabled) {
-    m_state.measuring = enabled;
-    m_state.aligning = false;
+    m_state.measuring             = enabled;
+    m_state.aligning              = false;
     m_state.has_measurement_start = false;
 
     if (enabled) {
@@ -218,8 +208,7 @@ void PartView::dropPart(QSharedPointer<PartObject> gop) {
         for (uint i = 0; i < 3; i++) {
             QVector3D pt = t[i];
 
-            if (pt.z() < z_sub)
-                z_sub = pt.z();
+            if (pt.z() < z_sub) z_sub = pt.z();
         }
     }
 
@@ -245,20 +234,18 @@ restart_check:
 
 bool PartView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
     auto picked = m_printer->pickOptimizationPoint(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos);
-    if (!picked.isValid()) {
-        return false;
-    }
+    if (!picked.isValid()) { return false; }
 
     QVector3D bed_intersection;
     if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection)) {
         return false;
     }
 
-    m_state.dragging_seam = true;
-    m_state.dragged_seam = picked.object;
+    m_state.dragging_seam          = true;
+    m_state.dragged_seam           = picked.object;
     m_state.dragged_seam_x_setting = picked.x_setting;
     m_state.dragged_seam_y_setting = picked.y_setting;
-    m_state.dragged_seam_offset = picked.object->translation() - bed_intersection;
+    m_state.dragged_seam_offset    = picked.object->translation() - bed_intersection;
 
     emit optimizationPointDragStarted(picked.x_setting, picked.y_setting);
 
@@ -267,9 +254,7 @@ bool PartView::beginOptimizationPointDrag(QPointF mouse_ndc_pos) {
 }
 
 bool PartView::updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish) {
-    if (!m_state.dragging_seam || m_state.dragged_seam.isNull()) {
-        return false;
-    }
+    if (!m_state.dragging_seam || m_state.dragged_seam.isNull()) { return false; }
 
     QVector3D bed_intersection;
     if (!m_printer->bedIntersection(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, bed_intersection)) {
@@ -284,18 +269,14 @@ bool PartView::updateOptimizationPointDrag(QPointF mouse_ndc_pos, bool finish) {
     if (finish) {
         emit optimizationPointDragFinished(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
     }
-    else {
-        emit optimizationPointDragged(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y);
-    }
+    else { emit optimizationPointDragged(m_state.dragged_seam_x_setting, x, m_state.dragged_seam_y_setting, y); }
 
     this->update();
     return true;
 }
 
 void PartView::finishOptimizationPointDrag(QPointF mouse_ndc_pos) {
-    if (!m_state.dragging_seam) {
-        return;
-    }
+    if (!m_state.dragging_seam) { return; }
 
     if (!updateOptimizationPointDrag(mouse_ndc_pos, true) && !m_state.dragged_seam.isNull()) {
         const QVector3D translation = m_state.dragged_seam->translation();
@@ -332,7 +313,7 @@ void PartView::centerSelectedParts() {
 
     // Compute the offset to move the center of the bounding box to the printer center.
     QVector3D offset = m_printer->printerCenter() - group_center;
-    offset.setZ(0.0f); // Do not move the parts in the z direction.
+    offset.setZ(0.0f);  // Do not move the parts in the z direction.
 
     // Move the selected parts.
     for (const auto& gop : m_selected_objects) {
@@ -414,15 +395,13 @@ void PartView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
 
         m_printer = new_printer;
     }
-    else {
-        m_printer->updateFromSettings(m_sb);
-    }
+    else { m_printer->updateFromSettings(m_sb); }
 
     QVector3D max = m_printer->maximum();
     QVector3D min = m_printer->minimum();
 
     // For low plane, extend distance by 20% and select max.
-    float width_diff = (max.x() * 1.2) - max.x();
+    float width_diff  = (max.x() * 1.2) - max.x();
     float length_diff = (max.y() * 1.2) - max.y();
 
     float diff = 0;
@@ -433,7 +412,7 @@ void PartView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
         diff = length_diff;
 
     float length = (max.x() - min.x()) + (2 * diff);
-    float width = (max.y() - min.y()) + (2 * diff);
+    float width  = (max.y() - min.y()) + (2 * diff);
 
     m_low_plane->updateDimensions(length, width, length / 50, width / 50);
     m_low_plane->translateAbsolute(m_printer->printerCenter());
@@ -457,9 +436,7 @@ void PartView::updateOptimizationSettings(QSharedPointer<SettingsBase> sb) {
 void PartView::updateOverhangSettings(QSharedPointer<SettingsBase> sb) {
     m_sb = sb;
 
-    for (auto& gop : m_part_objects) {
-        gop->setOverhangAngle(m_sb->setting<Angle>(PS::Support::kThresholdAngle));
-    }
+    for (auto& gop : m_part_objects) { gop->setOverhangAngle(m_sb->setting<Angle>(PS::Support::kThresholdAngle)); }
 
     this->update();
 }
@@ -504,13 +481,13 @@ void PartView::initView() {
     QVector3D min = m_printer->minimum();
 
     // For low plane, extend distance by 20% and select max.
-    float width_diff = (max.x() * 1.2) - max.x();
+    float width_diff  = (max.x() * 1.2) - max.x();
     float length_diff = (max.y() * 1.2) - max.y();
 
     float diff = (width_diff > length_diff) ? width_diff : length_diff;
 
     float length = (max.x() - min.x()) + (2 * diff);
-    float width = (max.y() - min.y()) + (2 * diff);
+    float width  = (max.y() - min.y()) + (2 * diff);
 
     QColor c = Constants::Colors::kRed;
     c.setAlpha(102);
@@ -529,13 +506,9 @@ void PartView::initView() {
 }
 
 void PartView::handleLeftClick(QPointF mouse_ndc_pos) {
-    if (m_state.measuring && handleMeasurementClick(mouse_ndc_pos)) {
-        return;
-    }
+    if (m_state.measuring && handleMeasurementClick(mouse_ndc_pos)) { return; }
 
-    if (beginOptimizationPointDrag(mouse_ndc_pos)) {
-        return;
-    }
+    if (beginOptimizationPointDrag(mouse_ndc_pos)) { return; }
 
     auto picked_part = this->pickPart(mouse_ndc_pos, m_part_objects);
     if (!picked_part.isNull()) {
@@ -545,8 +518,7 @@ void PartView::handleLeftClick(QPointF mouse_ndc_pos) {
                                                            picked_part->triangles());
 
             if (!(picked_tri.a == QVector3D() && picked_tri.b == QVector3D() && picked_tri.c == QVector3D())) {
-                if (!picked_part->locked())
-                    this->alignPart(picked_part, picked_tri, m_state.align_plane_norm);
+                if (!picked_part->locked()) this->alignPart(picked_part, picked_tri, m_state.align_plane_norm);
             }
 
             m_state.aligning = false;
@@ -554,9 +526,7 @@ void PartView::handleLeftClick(QPointF mouse_ndc_pos) {
             this->setCursor(QCursor(Qt::ArrowCursor));
         }
         // If not see if we hit a selected object.
-        else if (m_selected_objects.contains(picked_part)) {
-            m_state.translating = true;
-        }
+        else if (m_selected_objects.contains(picked_part)) { m_state.translating = true; }
 
         return;
     }
@@ -605,12 +575,8 @@ void PartView::handleLeftDoubleClick(QPointF mouse_ndc_pos) {
         for (auto& gop : m_part_objects) {
             auto item = m_model->lookupByGraphic(gop);
 
-            if (!item->isSelected() && m_selected_objects.contains(gop)) {
-                item->setSelected(true);
-            }
-            else if (item->isSelected() && !m_selected_objects.contains(gop)) {
-                item->setSelected(false);
-            }
+            if (!item->isSelected() && m_selected_objects.contains(gop)) { item->setSelected(true); }
+            else if (item->isSelected() && !m_selected_objects.contains(gop)) { item->setSelected(false); }
         }
         this->permitModel();
     }
@@ -629,7 +595,7 @@ void PartView::handleLeftRelease(QPointF mouse_ndc_pos) {
     m_state.part_trans_start.clear();
 
     this->permitModel();
-    m_state.blocking = false;
+    m_state.blocking    = false;
     m_state.translating = false;
 
     this->blockModel();
@@ -650,10 +616,8 @@ void PartView::handleLeftMove(QPointF mouse_ndc_pos) {
         return;
     }
 
-    if (m_selected_objects.empty())
-        return;
-    if (!m_state.translating)
-        return;
+    if (m_selected_objects.empty()) return;
+    if (!m_state.translating) return;
 
     if (!m_state.blocking) {
         this->blockModel();
@@ -676,12 +640,9 @@ void PartView::handleLeftMove(QPointF mouse_ndc_pos) {
     QVector3D intersect = std::get<1>(PartPicker::pickDistanceAndIntersection(
         this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, m_low_plane->triangles()));
     // If there's no intersection, there is no move.
-    if (std::fabs(intersect.x()) == Constants::Limits::Maximums::kInfFloat)
-        return;
-    if (std::fabs(intersect.y()) == Constants::Limits::Maximums::kInfFloat)
-        return;
-    if (std::fabs(intersect.z()) == Constants::Limits::Maximums::kInfFloat)
-        return;
+    if (std::fabs(intersect.x()) == Constants::Limits::Maximums::kInfFloat) return;
+    if (std::fabs(intersect.y()) == Constants::Limits::Maximums::kInfFloat) return;
+    if (std::fabs(intersect.z()) == Constants::Limits::Maximums::kInfFloat) return;
 
     intersect.setZ(0);
 
@@ -689,9 +650,7 @@ void PartView::handleLeftMove(QPointF mouse_ndc_pos) {
         // Save the start of this transform.
         m_state.translate_start = intersect;
 
-        for (auto& gop : m_selected_objects) {
-            m_state.part_trans_start[gop] = gop->translation();
-        }
+        for (auto& gop : m_selected_objects) { m_state.part_trans_start[gop] = gop->translation(); }
     }
 
     // Actual translation.
@@ -754,7 +713,7 @@ void PartView::handleRightMove(QPointF mouse_ndc_pos) {
     QMatrix4x4 view_mtrx = this->viewMatrix();
 
     QVector3D right = QVector3D(view_mtrx(0, 0), view_mtrx(0, 1), view_mtrx(0, 2));
-    QVector3D up = QVector3D(0, 0, 1);
+    QVector3D up    = QVector3D(0, 0, 1);
 
     right.setZ(0);
     right.normalize();
@@ -776,9 +735,7 @@ void PartView::handleRightMove(QPointF mouse_ndc_pos) {
 
 void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
     if (m_state.rotating) {
-        if (m_state.right_click_timer.elapsed() < 250) {
-            m_menu->show(global_pos, m_model->selectedItems());
-        }
+        if (m_state.right_click_timer.elapsed() < 250) { m_menu->show(global_pos, m_model->selectedItems()); }
 
         m_state.rotating = false;
         m_state.blocking = false;
@@ -794,7 +751,7 @@ void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
             }
 
             QQuaternion r = gop->rotation();
-            QVector3D er = r.toEulerAngles();
+            QVector3D er  = r.toEulerAngles();
 
             // Snap to intervals of 15 degrees.
             er.setX(MathUtils::snap(er.x(), 15));
@@ -841,9 +798,7 @@ void PartView::handleRightRelease(QPointF mouse_ndc_pos, QPointF global_pos) {
         updateSlicingGeometryPreviews();
         this->update();
     }
-    else {
-        this->BaseView::handleRightRelease(mouse_ndc_pos, global_pos);
-    }
+    else { this->BaseView::handleRightRelease(mouse_ndc_pos, global_pos); }
 }
 
 void PartView::handleMouseMove(QPointF mouse_ndc_pos) {
@@ -875,12 +830,8 @@ void PartView::handleMouseMove(QPointF mouse_ndc_pos) {
 
     QCursor c = QCursor(Qt::ArrowCursor);
 
-    if (m_state.aligning) {
-        c = QCursor(Qt::PointingHandCursor);
-    }
-    else if (m_selected_objects.contains(picked_part)) {
-        c = QCursor(Qt::OpenHandCursor);
-    }
+    if (m_state.aligning) { c = QCursor(Qt::PointingHandCursor); }
+    else if (m_selected_objects.contains(picked_part)) { c = QCursor(Qt::OpenHandCursor); }
 
     // Highlighting of objects.
     if (m_state.highlighted_part.isNull() && !picked_part.isNull()) {
@@ -913,13 +864,16 @@ void PartView::handleWheelBackward(QPointF mouse_ndc_pos, float delta) {
     this->update();
 }
 
-void PartView::handleMidClick(QPointF mouse_ndc_pos) { this->BaseView::handleMidClick(mouse_ndc_pos); }
+void PartView::handleMidClick(QPointF mouse_ndc_pos) {
+    this->BaseView::handleMidClick(mouse_ndc_pos);
+}
 
-void PartView::handleMidRelease(QPointF mouse_ndc_pos) { this->BaseView::handleMidRelease(mouse_ndc_pos); }
+void PartView::handleMidRelease(QPointF mouse_ndc_pos) {
+    this->BaseView::handleMidRelease(mouse_ndc_pos);
+}
 
 bool PartView::handleKeyPress(QKeyEvent* e) {
-    if (!m_state.measuring || e->key() != Qt::Key_Escape)
-        return false;
+    if (!m_state.measuring || e->key() != Qt::Key_Escape) return false;
 
     clearMeasurement();
     emit measurementReadoutChanged("Measurement cleared");
@@ -933,7 +887,7 @@ void PartView::resetCamera() {
 
     this->translateCamera(m_printer->printerCenter(), true);
 
-    this->update(); // Need to repaint with new model matrices
+    this->update();  // Need to repaint with new model matrices
 }
 
 void PartView::modelSelectionUpdate(QSharedPointer<PartMetaItem> pm) {
@@ -965,16 +919,15 @@ void PartView::modelAdditionUpdate(QSharedPointer<PartMetaItem> pm) {
 
             PreferenceChoice should_shift = PreferencesManager::getInstance()->getFileShiftPreference();
             if (should_shift == PreferenceChoice::kAsk) {
-                if (QMessageBox::question(this, "Warning",
-                                          "Do you wish to shift " + gop->part()->name() +
-                                              " so that it does not intersect current parts?",
-                                          QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
+                if (QMessageBox::question(
+                        this, "Warning",
+                        "Do you wish to shift " + gop->part()->name() + " so that it does not intersect current parts?",
+                        QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
                     should_shift = PreferenceChoice::kPerformAutomatically;
                 else
                     should_shift = PreferenceChoice::kSkipAutomatically;
             }
-            if (should_shift == PreferenceChoice::kPerformAutomatically)
-                this->shiftPart(gop);
+            if (should_shift == PreferenceChoice::kPerformAutomatically) this->shiftPart(gop);
         }
     }
 
@@ -986,11 +939,9 @@ void PartView::modelAdditionUpdate(QSharedPointer<PartMetaItem> pm) {
     // Sub object visibility.
     gop->setOverhangAngle(m_sb->setting<Angle>(PS::Support::kThresholdAngle));
     gop->plane()->setLockedRotationQuaternion(slicingPlaneRotation());
-    if (m_state.overhangs_shown)
-        gop->showOverhang(true);
+    if (m_state.overhangs_shown) gop->showOverhang(true);
     updateSlicingGeometryPreview(gop);
-    if (m_state.names_shown)
-        gop->label()->show();
+    if (m_state.names_shown) gop->label()->show();
     updateLayerSettingsRangePlane();
 
     this->blockModel();
@@ -1006,7 +957,7 @@ void PartView::modelAdditionUpdate(QSharedPointer<PartMetaItem> pm) {
 
 void PartView::modelReloadUpdate(QSharedPointer<PartMetaItem> pm) {
     QSharedPointer<PartObject> gop = pm->graphicsPart();
-    auto tfm = gop->transformation();
+    auto tfm                       = gop->transformation();
 
     modelRemovalUpdate(pm);
     pm->setGraphicsPart(nullptr);
@@ -1040,8 +991,7 @@ void PartView::modelRemovalUpdate(QSharedPointer<PartMetaItem> pm) {
 
     m_printer->orphanChild(gop);
 
-    if (m_state.highlighted_part == gop)
-        m_state.highlighted_part = nullptr;
+    if (m_state.highlighted_part == gop) m_state.highlighted_part = nullptr;
 
     updateLayerSettingsRangePlane();
 
@@ -1049,16 +999,14 @@ void PartView::modelRemovalUpdate(QSharedPointer<PartMetaItem> pm) {
 }
 
 void PartView::modelParentingUpdate(QSharedPointer<PartMetaItem> pm) {
-    QSharedPointer<PartMetaItem> parent_pm = pm->parent();
-    QSharedPointer<PartObject> parent_pm_gop = (parent_pm.isNull()) ? nullptr : parent_pm->graphicsPart();
-    QSharedPointer<PartObject> gop = pm->graphicsPart();
+    QSharedPointer<PartMetaItem> parent_pm    = pm->parent();
+    QSharedPointer<PartObject> parent_pm_gop  = (parent_pm.isNull()) ? nullptr : parent_pm->graphicsPart();
+    QSharedPointer<PartObject> gop            = pm->graphicsPart();
     QSharedPointer<GraphicsObject> parent_gop = pm->graphicsPart()->parent();
 
     gop->unselect();
-    if (parent_gop.dynamicCast<PartObject>())
-        parent_gop.dynamicCast<PartObject>()->unselect();
-    if (parent_pm_gop != nullptr)
-        parent_pm_gop->unselect();
+    if (parent_gop.dynamicCast<PartObject>()) parent_gop.dynamicCast<PartObject>()->unselect();
+    if (parent_pm_gop != nullptr) parent_pm_gop->unselect();
 
     // If the parent of the graphics part is not the same as the graphics part for this update, then
     // its parent has changed. It needs to be removed from the old parent and added to the new one.
@@ -1155,8 +1103,8 @@ void PartView::alignPart(QSharedPointer<PartObject> gop, Triangle tri, QVector3D
     local_c = gop->transformation().inverted() * tri.c;
 
     // Find the triangle normal
-    edge1 = local_b - local_a;
-    edge2 = local_c - local_a;
+    edge1        = local_b - local_a;
+    edge2        = local_c - local_a;
     surface_norm = QVector3D::crossProduct(edge1, edge2);
     surface_norm.normalize();
 
@@ -1172,35 +1120,23 @@ void PartView::alignPart(QSharedPointer<PartObject> gop, Triangle tri, QVector3D
     acos_arg = std::max(
         std::min(QVector3D::dotProduct(surface_norm, floor_norm) / (surface_norm.length() * floor_norm.length()), 1.0f),
         -1.0f);
-    asin_arg = std::max(std::min(axis.length() / (surface_norm.length() * floor_norm.length()), 1.0f), -1.0f);
+    asin_arg   = std::max(std::min(axis.length() / (surface_norm.length() * floor_norm.length()), 1.0f), -1.0f);
     acos_angle = qAcos(acos_arg);
     asin_angle = qAsin(asin_arg);
 
     // Get correct value and sign of angle from what we know about
     // range of asin and acos
-    if (acos_angle < M_PI_2 && asin_angle < 0.0f) {
-        angle = asin_angle;
-    }
-    else if (acos_angle > M_PI_2 && asin_angle > 0.0f) {
-        angle = acos_angle;
-    }
-    else if (acos_angle > M_PI_2 && asin_angle < 0.0f) {
-        angle = -acos_angle;
-    }
-    else {
-        angle = acos_angle;
-    }
+    if (acos_angle < M_PI_2 && asin_angle < 0.0f) { angle = asin_angle; }
+    else if (acos_angle > M_PI_2 && asin_angle > 0.0f) { angle = acos_angle; }
+    else if (acos_angle > M_PI_2 && asin_angle < 0.0f) { angle = -acos_angle; }
+    else { angle = acos_angle; }
 
     // If axis is zero, this means the surface norm and floor norm are parallel or antiparallel
     if (qAbs(axis.x()) < 0.01 && qAbs(axis.y()) < 0.01 && qAbs(axis.z()) < 0.01) {
         // Parallel, so don't do rotate
-        if (acos_arg > 0) {
-            angle = 0.0f;
-        }
+        if (acos_arg > 0) { angle = 0.0f; }
         // Antiparallel, so axis doesn't really matter. Arbitrarily choose local x-axis
-        else {
-            axis = QVector3D(1, 0, 0);
-        }
+        else { axis = QVector3D(1, 0, 0); }
     }
     QQuaternion rotation = QQuaternion::fromAxisAndAngle(axis, qRadiansToDegrees(angle));
     gop->rotate(rotation);
@@ -1212,8 +1148,7 @@ void PartView::alignPart(QSharedPointer<PartObject> gop, Triangle tri, QVector3D
         for (uint i = 0; i < 3; i++) {
             QVector3D pt = t[i];
 
-            if (pt.z() < z_sub)
-                z_sub = pt.z();
+            if (pt.z() < z_sub) z_sub = pt.z();
         }
     }
 
@@ -1240,7 +1175,7 @@ QSharedPointer<PartObject> PartView::pickPart(const QPointF& mouse_ndc_pos,
             PartPicker::pickDistance(this->projectionMatrix(), this->viewMatrix(), mouse_ndc_pos, gop->triangles());
 
         if (dist < min_dist) {
-            min_dist = dist;
+            min_dist    = dist;
             picked_part = gop;
         }
     }
@@ -1262,12 +1197,10 @@ QSharedPointer<PartObject> PartView::findObject(QString name) {
 }
 
 QSharedPointer<PartObject> PartView::findObject(QSharedPointer<Part> part) {
-    if (part.isNull())
-        return nullptr;
+    if (part.isNull()) return nullptr;
 
     for (auto& go : m_part_objects) {
-        if (go->part() == part)
-            return go;
+        if (go->part() == part) return go;
     }
 
     return nullptr;
@@ -1283,8 +1216,8 @@ bool PartView::handleMeasurementClick(QPointF mouse_ndc_pos) {
     if (!m_state.has_measurement_start) {
         clearMeasurement();
 
-        m_state.measurement_start = picked_point;
-        m_state.has_measurement_start = true;
+        m_state.measurement_start        = picked_point;
+        m_state.has_measurement_start    = true;
         m_state.measurement_start_marker = createMeasurementMarker(picked_point);
         addObject(m_state.measurement_start_marker);
 
@@ -1296,8 +1229,8 @@ bool PartView::handleMeasurementClick(QPointF mouse_ndc_pos) {
     clearMeasurementPreview();
 
     m_state.measurement_end_marker = createMeasurementMarker(picked_point);
-    m_state.measurement_line = createMeasurementLine(m_state.measurement_start, picked_point);
-    m_state.measurement_label = createMeasurementLabel(m_state.measurement_start, picked_point);
+    m_state.measurement_line       = createMeasurementLine(m_state.measurement_start, picked_point);
+    m_state.measurement_label      = createMeasurementLabel(m_state.measurement_start, picked_point);
 
     addObject(m_state.measurement_line);
     addObject(m_state.measurement_end_marker);
@@ -1316,22 +1249,20 @@ bool PartView::handleMeasurementClick(QPointF mouse_ndc_pos) {
 
 void PartView::updateMeasurementPreview(QPointF mouse_ndc_pos) {
     if (!m_state.has_measurement_start) {
-        if (clearMeasurementPreview())
-            this->update();
+        if (clearMeasurementPreview()) this->update();
         return;
     }
 
     QVector3D picked_point;
     if (!pickMeasurementPoint(mouse_ndc_pos, picked_point)) {
-        if (clearMeasurementPreview())
-            this->update();
+        if (clearMeasurementPreview()) this->update();
         emit measurementReadoutChanged("Select second measurement point");
         return;
     }
 
     clearMeasurementPreview();
 
-    m_state.measurement_preview_line = createMeasurementLine(m_state.measurement_start, picked_point);
+    m_state.measurement_preview_line  = createMeasurementLine(m_state.measurement_start, picked_point);
     m_state.measurement_preview_label = createMeasurementLabel(m_state.measurement_start, picked_point);
     addObject(m_state.measurement_preview_line);
     addObject(m_state.measurement_preview_label);
@@ -1344,7 +1275,7 @@ void PartView::updateMeasurementPreview(QPointF mouse_ndc_pos) {
 
 bool PartView::clearMeasurementPreview() {
     bool removed = removeMeasurementObject(m_state.measurement_preview_line);
-    removed = removeMeasurementObject(m_state.measurement_preview_label) || removed;
+    removed      = removeMeasurementObject(m_state.measurement_preview_label) || removed;
     return removed;
 }
 
@@ -1353,21 +1284,19 @@ bool PartView::pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& poi
     QVector3D closest_point;
 
     for (auto& gop : m_part_objects) {
-        auto pick = PartPicker::pickDistanceTriangleAndIntersection(this->projectionMatrix(), this->viewMatrix(),
-                                                                    mouse_ndc_pos, gop->triangles());
+        auto pick        = PartPicker::pickDistanceTriangleAndIntersection(this->projectionMatrix(), this->viewMatrix(),
+                                                                           mouse_ndc_pos, gop->triangles());
         const float dist = std::get<0>(pick);
         const QVector3D intersect = std::get<2>(pick);
-        if (!std::isfinite(dist) || !isFinitePoint(intersect))
-            continue;
+        if (!std::isfinite(dist) || !isFinitePoint(intersect)) continue;
 
         if (dist < min_dist) {
-            min_dist = dist;
+            min_dist      = dist;
             closest_point = intersect;
         }
     }
 
-    if (!std::isfinite(min_dist))
-        return false;
+    if (!std::isfinite(min_dist)) return false;
 
     point = closest_point;
     return true;
@@ -1375,22 +1304,20 @@ bool PartView::pickMeasurementPoint(const QPointF& mouse_ndc_pos, QVector3D& poi
 
 void PartView::clearMeasurement() {
     bool removed = clearMeasurementPreview();
-    removed = removeMeasurementObject(m_state.measurement_start_marker) || removed;
-    removed = removeMeasurementObject(m_state.measurement_end_marker) || removed;
-    removed = removeMeasurementObject(m_state.measurement_line) || removed;
-    removed = removeMeasurementObject(m_state.measurement_label) || removed;
+    removed      = removeMeasurementObject(m_state.measurement_start_marker) || removed;
+    removed      = removeMeasurementObject(m_state.measurement_end_marker) || removed;
+    removed      = removeMeasurementObject(m_state.measurement_line) || removed;
+    removed      = removeMeasurementObject(m_state.measurement_label) || removed;
 
     m_state.has_measurement_start = false;
-    m_state.measurement_start = QVector3D();
+    m_state.measurement_start     = QVector3D();
     emit measurementReadoutChanged(QString());
 
-    if (removed)
-        this->update();
+    if (removed) this->update();
 }
 
 bool PartView::removeMeasurementObject(QSharedPointer<GraphicsObject>& object) {
-    if (object.isNull())
-        return false;
+    if (object.isNull()) return false;
 
     removeObject(object);
     object.reset();
@@ -1406,9 +1333,9 @@ QSharedPointer<GraphicsObject> PartView::createMeasurementMarker(const QVector3D
 
 QSharedPointer<GraphicsObject> PartView::createMeasurementLine(const QVector3D& start, const QVector3D& end) {
     std::vector<float> vertices = {start.x(), start.y(), start.z(), end.x(), end.y(), end.z()};
-    std::vector<float> normals = {0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f};
+    std::vector<float> normals  = {0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f};
 
-    QColor color = Constants::Colors::kYellow;
+    QColor color              = Constants::Colors::kYellow;
     std::vector<float> colors = {color.redF(), color.greenF(), color.blueF(), color.alphaF(),
                                  color.redF(), color.greenF(), color.blueF(), color.alphaF()};
 
@@ -1418,7 +1345,7 @@ QSharedPointer<GraphicsObject> PartView::createMeasurementLine(const QVector3D& 
 }
 
 QSharedPointer<GraphicsObject> PartView::createMeasurementLabel(const QVector3D& start, const QVector3D& end) {
-    const QVector3D midpoint = (start + end) / 2.0f + QVector3D(0.0f, 0.0f, kMeasurementLabelLift);
+    const QVector3D midpoint      = (start + end) / 2.0f + QVector3D(0.0f, 0.0f, kMeasurementLabelLift);
     const double distance_microns = start.distanceToPoint(end) * Constants::OpenGL::kViewToObject;
 
     auto label = QSharedPointer<TextObject>::create(this, formatMeasurementDistance(distance_microns, true),
@@ -1430,9 +1357,8 @@ QSharedPointer<GraphicsObject> PartView::createMeasurementLabel(const QVector3D&
 
 QString PartView::formatMeasurementDistance(double microns, bool ascii_units) const {
     const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
-    QString unit_text = PreferencesManager::getInstance()->getDistanceUnitText();
-    if (ascii_units)
-        unit_text = asciiDistanceUnitText(unit_text);
+    QString unit_text   = PreferencesManager::getInstance()->getDistanceUnitText();
+    if (ascii_units) unit_text = asciiDistanceUnitText(unit_text);
 
     return QString("%1 %2").arg(QString::number(Distance(microns).to(unit), 'f', 3), unit_text);
 }
@@ -1452,16 +1378,14 @@ QQuaternion PartView::slicingPlaneRotation() const {
 
 QSharedPointer<SettingsBase> PartView::slicingSettingsForPart(QSharedPointer<Part> part) const {
     QSharedPointer<SettingsBase> part_sb = QSharedPointer<SettingsBase>::create(*m_sb);
-    if (!part.isNull())
-        part_sb->populate(part->getSb());
+    if (!part.isNull()) part_sb->populate(part->getSb());
 
     return part_sb;
 }
 
 bool PartView::cylindricalSlicingPreviewGeometry(QSharedPointer<PartObject> gop, QVector3D& base_center, float& radius,
                                                  float& height) const {
-    if (gop.isNull() || gop->part().isNull() || gop->part()->rootMesh().isNull() || m_printer.isNull())
-        return false;
+    if (gop.isNull() || gop->part().isNull() || gop->part()->rootMesh().isNull() || m_printer.isNull()) return false;
 
     QSharedPointer<SettingsBase> part_sb = slicingSettingsForPart(gop->part());
     const CylinderAxisSource axis_mode =
@@ -1479,22 +1403,18 @@ bool PartView::cylindricalSlicingPreviewGeometry(QSharedPointer<PartObject> gop,
     }
 
     const std::vector<Triangle> triangles = gop->triangles();
-    if (triangles.empty())
-        return false;
+    if (triangles.empty()) return false;
 
     float max_z = std::numeric_limits<float>::lowest();
     for (const Triangle& triangle : triangles) {
-        for (const QVector3D& point : {triangle.a, triangle.b, triangle.c}) {
-            max_z = std::max(max_z, point.z());
-        }
+        for (const QVector3D& point : {triangle.a, triangle.b, triangle.c}) { max_z = std::max(max_z, point.z()); }
     }
 
     Distance initial_radius = part_sb->setting<Distance>(PS::Slicing::kCylinderInnerRadius);
-    if (initial_radius < 0)
-        initial_radius = 0.0 * micron;
+    if (initial_radius < 0) initial_radius = 0.0 * micron;
 
-    radius = initial_radius() * Constants::OpenGL::kObjectToView;
-    Distance cylinder_height = part_sb->setting<Distance>(PS::Slicing::kCylinderHeight);
+    radius                         = initial_radius() * Constants::OpenGL::kObjectToView;
+    Distance cylinder_height       = part_sb->setting<Distance>(PS::Slicing::kCylinderHeight);
     const float build_volume_min_z = m_printer->minimum().z();
     height = cylinder_height > 0 ? cylinder_height() * Constants::OpenGL::kObjectToView : max_z - build_volume_min_z;
     height = std::max(height, kMinimumSlicingCylinderHeight);
@@ -1504,15 +1424,12 @@ bool PartView::cylindricalSlicingPreviewGeometry(QSharedPointer<PartObject> gop,
 }
 
 void PartView::updateSlicingGeometryPreview(QSharedPointer<PartObject> gop) {
-    if (gop.isNull())
-        return;
+    if (gop.isNull()) return;
 
     gop->plane()->hide();
-    if (!gop->slicingCylinder().isNull())
-        gop->slicingCylinder()->hide();
+    if (!gop->slicingCylinder().isNull()) gop->slicingCylinder()->hide();
 
-    if (!m_state.planes_shown)
-        return;
+    if (!m_state.planes_shown) return;
 
     const SlicingMode slicing_mode = static_cast<SlicingMode>(m_sb->setting<int>(PS::Slicing::kSlicingMode));
     switch (slicing_mode) {
@@ -1542,9 +1459,7 @@ void PartView::updateSlicingGeometryPreview(QSharedPointer<PartObject> gop) {
 }
 
 void PartView::updateSlicingGeometryPreviews() {
-    for (auto& gop : m_part_objects) {
-        updateSlicingGeometryPreview(gop);
-    }
+    for (auto& gop : m_part_objects) { updateSlicingGeometryPreview(gop); }
 }
 
 void PartView::updateLayerSettingsRangePlane() {
@@ -1572,9 +1487,9 @@ void PartView::updateLayerSettingsRangePlane() {
     slicing_vector.normalize();
     const QQuaternion rotation = slicingPlaneRotation();
 
-    float length = gop->maximum().x() - gop->minimum().x();
-    float width = gop->maximum().y() - gop->minimum().y();
-    float depth = gop->maximum().z() - gop->minimum().z();
+    float length  = gop->maximum().x() - gop->minimum().x();
+    float width   = gop->maximum().y() - gop->minimum().y();
+    float depth   = gop->maximum().z() - gop->minimum().z();
     float max_dim = std::fmax(length, std::fmax(width, depth));
     max_dim += max_dim * 0.20f;
 
@@ -1582,8 +1497,7 @@ void PartView::updateLayerSettingsRangePlane() {
     for (const QPair<int, int>& layer_range : m_state.layer_settings_ranges) {
         QVector3D center;
         float thickness = 0.0f;
-        if (!layerSettingsRangeGeometry(gop, layer_range.first, layer_range.second, center, thickness))
-            continue;
+        if (!layerSettingsRangeGeometry(gop, layer_range.first, layer_range.second, center, thickness)) continue;
 
         QSharedPointer<PlaneObject> range_plane = gop->layerSettingsRangePlane(visible_plane_index);
         range_plane->updateDimensions(max_dim, max_dim, thickness);
@@ -1599,34 +1513,28 @@ void PartView::updateLayerSettingsRangePlane() {
 
 void PartView::hideLayerSettingsRangePlanes() {
     for (auto& gop : m_part_objects) {
-        for (auto& range_plane : gop->layerSettingsRangePlanes()) {
-            range_plane->hide();
-        }
+        for (auto& range_plane : gop->layerSettingsRangePlanes()) { range_plane->hide(); }
     }
 }
 
 bool PartView::layerSettingsRangeGeometry(QSharedPointer<PartObject> gop, int low_layer, int high_layer,
                                           QVector3D& center, float& thickness) const {
-    if (gop.isNull() || gop->part().isNull() || gop->part()->rootMesh().isNull())
-        return false;
+    if (gop.isNull() || gop->part().isNull() || gop->part()->rootMesh().isNull()) return false;
 
-    const int low = qMin(low_layer, high_layer);
+    const int low  = qMin(low_layer, high_layer);
     const int high = qMax(low_layer, high_layer);
-    if (low < 0 || high < low)
-        return false;
+    if (low < 0 || high < low) return false;
 
     QVector3D slicing_vector = {m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalX),
                                 m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalY),
                                 m_sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ)};
-    if (slicing_vector.isNull())
-        return false;
+    if (slicing_vector.isNull()) return false;
     slicing_vector.normalize();
 
     std::vector<Triangle> triangles = gop->triangles();
-    if (triangles.empty())
-        return false;
+    if (triangles.empty()) return false;
 
-    bool initialized = false;
+    bool initialized      = false;
     double min_projection = 0.0;
     double max_projection = 0.0;
 
@@ -1635,24 +1543,18 @@ bool PartView::layerSettingsRangeGeometry(QSharedPointer<PartObject> gop, int lo
         for (const QVector3D& point : points) {
             const double projection = QVector3D::dotProduct(point, slicing_vector);
 
-            if (!initialized || projection < min_projection) {
-                min_projection = projection;
-            }
+            if (!initialized || projection < min_projection) { min_projection = projection; }
 
-            if (!initialized || projection > max_projection) {
-                max_projection = projection;
-            }
+            if (!initialized || projection > max_projection) { max_projection = projection; }
 
             initialized = true;
         }
     }
 
-    if (!initialized)
-        return false;
+    if (!initialized) return false;
 
     const double part_height = max_projection - min_projection;
-    if (part_height <= 0.0)
-        return false;
+    if (part_height <= 0.0) return false;
 
     Distance base_layer_height;
     if (gop->part()->getSb()->contains(PS::Layer::kLayerHeight))
@@ -1663,16 +1565,14 @@ bool PartView::layerSettingsRangeGeometry(QSharedPointer<PartObject> gop, int lo
     const auto normal_height = [](Distance layer_height) { return layer_height() * Constants::OpenGL::kObjectToView; };
 
     const double base_layer_normal_height = normal_height(base_layer_height);
-    if (base_layer_normal_height <= 0.0)
-        return false;
+    if (base_layer_normal_height <= 0.0) return false;
 
     const QMap<uint, QSharedPointer<SettingsRange>> ranges = gop->part()->getSettingsRanges();
     const auto layer_normal_height = [&ranges, &normal_height, base_layer_normal_height](int layer) {
         QSharedPointer<SettingsRange> selected_range;
         for (auto i = ranges.begin(), end = ranges.end(); i != end; ++i) {
             QSharedPointer<SettingsRange> range = i.value();
-            if (!range->includesIndex(layer))
-                continue;
+            if (!range->includesIndex(layer)) continue;
 
             if (selected_range.isNull()) {
                 selected_range = range;
@@ -1691,39 +1591,36 @@ bool PartView::layerSettingsRangeGeometry(QSharedPointer<PartObject> gop, int lo
         return base_layer_normal_height;
     };
 
-    double current_height = 0.0;
+    double current_height        = 0.0;
     double selected_start_height = 0.0;
-    double selected_end_height = 0.0;
-    bool found_start = false;
-    bool found_end = false;
+    double selected_end_height   = 0.0;
+    bool found_start             = false;
+    bool found_end               = false;
 
     for (int layer = 0; layer <= high; ++layer) {
         if (layer == low) {
             selected_start_height = current_height;
-            found_start = true;
+            found_start           = true;
         }
 
         current_height += layer_normal_height(layer);
 
         if (layer == high) {
             selected_end_height = current_height;
-            found_end = true;
+            found_end           = true;
             break;
         }
 
-        if (current_height > part_height && layer < low)
-            return false;
+        if (current_height > part_height && layer < low) return false;
     }
 
-    if (!found_start || !found_end)
-        return false;
+    if (!found_start || !found_end) return false;
 
     selected_start_height = std::min(selected_start_height, part_height);
-    selected_end_height = std::min(selected_end_height, part_height);
-    if (selected_end_height <= selected_start_height)
-        return false;
+    selected_end_height   = std::min(selected_end_height, part_height);
+    if (selected_end_height <= selected_start_height) return false;
 
-    const double center_height = (selected_start_height + selected_end_height) / 2.0;
+    const double center_height     = (selected_start_height + selected_end_height) / 2.0;
     const double center_projection = min_projection + center_height;
 
     center = gop->center();
@@ -1747,4 +1644,4 @@ void PartView::permitModel() {
     QObject::connect(m_model.get(), &PartMetaModel::parentingUpdate, this, &PartView::modelParentingUpdate);
     QObject::connect(m_model.get(), &PartMetaModel::transformUpdate, this, &PartView::modelTranformUpdate);
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <QApplication>
 #include <QCommandLineParser>
 #include <QStyleFactory>
+
 #include <nlohmann/json_fwd.hpp>
 #include <qcontainerfwd.h>
 #include <qcoreapplication.h>

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -1,5 +1,8 @@
 #include "managers/preferences_manager.h"
 
+#include <QDir>
+#include <QStandardPaths>
+#include <QString>
 #include <algorithm>
 #include <list>
 #include <map>
@@ -7,9 +10,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <QDir>
-#include <QStandardPaths>
-#include <QString>
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qcoreapplication.h>
@@ -30,7 +30,7 @@
 
 namespace ORNL {
 namespace {
-constexpr int kVisualizationColorMigrationVersion = 1;
+constexpr int kVisualizationColorMigrationVersion            = 1;
 constexpr const char* kVisualizationColorMigrationVersionKey = "visualization_color_migration_version";
 
 /*!
@@ -62,14 +62,10 @@ QColor parseVisualizationColor(const std::string& colorText, bool& valid) {
     QString text = QString::fromStdString(colorText).trimmed();
     QColor color(text);
 
-    if (!color.isValid() && !text.startsWith("#")) {
-        color = QColor(QString("#") + text);
-    }
+    if (!color.isValid() && !text.startsWith("#")) { color = QColor(QString("#") + text); }
 
     valid = color.isValid();
-    if (valid) {
-        color.setAlpha(255);
-    }
+    if (valid) { color.setAlpha(255); }
 
     return color;
 }
@@ -83,10 +79,8 @@ bool visualizationColorMatches(const std::string& colorText, const QColor& expec
 bool replaceStaleVisualizationColor(std::unordered_map<std::string, std::string>& visualizationColorsHex,
                                     VisualizationColors color, const std::vector<QColor>& staleColors) {
     const std::string name = VisualizationColorsName(color).toStdString();
-    auto colorIt = visualizationColorsHex.find(name);
-    if (colorIt == visualizationColorsHex.end()) {
-        return false;
-    }
+    auto colorIt           = visualizationColorsHex.find(name);
+    if (colorIt == visualizationColorsHex.end()) { return false; }
 
     for (const QColor& staleColor : staleColors) {
         if (visualizationColorMatches(colorIt->second, staleColor)) {
@@ -102,42 +96,58 @@ bool migrateVisualizationColorDefaults(std::unordered_map<std::string, std::stri
     bool migrated = false;
 
     // Carry forward revised arc defaults for users who ran pre-release builds with these stale values persisted.
-    migrated |= replaceStaleVisualizationColor(
-        visualizationColorsHex, VisualizationColors::kInsetArc,
-        {QColor(255, 179, 0, 255), QColor(102, 224, 255, 255)});
-    migrated |= replaceStaleVisualizationColor(
-        visualizationColorsHex, VisualizationColors::kPerimeterArc,
-        {QColor(255, 0, 204, 255), QColor(0, 85, 255, 255)});
+    migrated |= replaceStaleVisualizationColor(visualizationColorsHex, VisualizationColors::kInsetArc,
+                                               {QColor(255, 179, 0, 255), QColor(102, 224, 255, 255)});
+    migrated |= replaceStaleVisualizationColor(visualizationColorsHex, VisualizationColors::kPerimeterArc,
+                                               {QColor(255, 0, 204, 255), QColor(0, 85, 255, 255)});
 
     return migrated;
 }
-} // namespace
+}  // namespace
 
 QSharedPointer<PreferencesManager> PreferencesManager::m_singleton = QSharedPointer<PreferencesManager>();
 
 QSharedPointer<PreferencesManager> PreferencesManager::getInstance() {
-    if (m_singleton.isNull()) {
-        m_singleton.reset(new PreferencesManager());
-    }
+    if (m_singleton.isNull()) { m_singleton.reset(new PreferencesManager()); }
     return m_singleton;
 }
 
 PreferencesManager::PreferencesManager()
-    : m_import_unit(mm), m_distance_unit(in), m_velocity_unit(in / s), m_acceleration_unit(in / s / s),
-      m_density_unit(g / cm / cm / cm), m_angle_unit(deg), m_time_unit(s), m_temperature_unit(K), m_voltage_unit(V),
-      m_mass_unit(kg), m_project_shift_preference(PreferenceChoice::kAsk),
-      m_file_shift_preference(PreferenceChoice::kPerformAutomatically), m_align_preference(PreferenceChoice::kAsk),
-      m_hide_travel_preference(false), m_hide_support_preference(false), m_use_true_widths_preference(true),
-      m_gcode_preview_mode_preference(GCodePreviewMode::kAuto), m_gcode_preview_vertex_threshold_preference(5000000),
+    : m_import_unit(mm),
+      m_distance_unit(in),
+      m_velocity_unit(in / s),
+      m_acceleration_unit(in / s / s),
+      m_density_unit(g / cm / cm / cm),
+      m_angle_unit(deg),
+      m_time_unit(s),
+      m_temperature_unit(K),
+      m_voltage_unit(V),
+      m_mass_unit(kg),
+      m_project_shift_preference(PreferenceChoice::kAsk),
+      m_file_shift_preference(PreferenceChoice::kPerformAutomatically),
+      m_align_preference(PreferenceChoice::kAsk),
+      m_hide_travel_preference(false),
+      m_hide_support_preference(false),
+      m_use_true_widths_preference(true),
+      m_gcode_preview_mode_preference(GCodePreviewMode::kAuto),
+      m_gcode_preview_vertex_threshold_preference(5000000),
       m_disabled_setting_visibility_preference(DisabledSettingVisibility::kGrey),
-      m_warn_unsaved_project_on_close_preference(true), m_themeName(ThemeName::kLightMode),
-      m_theme(static_cast<int>(m_themeName)), m_rotation_unit(RotationUnit::kPitchRollYaw), m_dirty(false),
-      m_is_maximized(false), m_window_size(-1, -1), m_window_pos(-1, -1), m_use_implicit_transforms(false),
-      m_always_drop_parts(false), m_layer_lag(100), m_segment_lag(10),
+      m_warn_unsaved_project_on_close_preference(true),
+      m_themeName(ThemeName::kLightMode),
+      m_theme(static_cast<int>(m_themeName)),
+      m_rotation_unit(RotationUnit::kPitchRollYaw),
+      m_dirty(false),
+      m_is_maximized(false),
+      m_window_size(-1, -1),
+      m_window_pos(-1, -1),
+      m_use_implicit_transforms(false),
+      m_always_drop_parts(false),
+      m_layer_lag(100),
+      m_segment_lag(10),
       m_visualization_color_migration_version(kVisualizationColorMigrationVersion) {
-    m_hidden_settings["Printer"] = std::list<std::string>();
-    m_hidden_settings["Material"] = std::list<std::string>();
-    m_hidden_settings["Profile"] = std::list<std::string>();
+    m_hidden_settings["Printer"]      = std::list<std::string>();
+    m_hidden_settings["Material"]     = std::list<std::string>();
+    m_hidden_settings["Profile"]      = std::list<std::string>();
     m_hidden_settings["Experimental"] = std::list<std::string>();
     setDefaultVisualizationColors({});
 }
@@ -149,7 +159,7 @@ QColor PreferencesManager::getVisualizationColor(VisualizationColors color) {
 
 void PreferencesManager::setVisualizationColor(QString name, QColor value) {
     m_visualization_qcolors[name.toStdString()] = value;
-    m_dirty = true;
+    m_dirty                                     = true;
 }
 
 QColor PreferencesManager::revertVisualizationColor(QString name) {
@@ -158,7 +168,7 @@ QColor PreferencesManager::revertVisualizationColor(QString name) {
         VisualizationColors colorEnum = (VisualizationColors)i;
         if (VisualizationColorsName(colorEnum) == name) {
             m_visualization_qcolors[name.toStdString()] = VisualizationColorsDefaults(colorEnum);
-            m_dirty = true;
+            m_dirty                                     = true;
             break;
         }
     }
@@ -199,7 +209,7 @@ void PreferencesManager::setDefaultVisualizationColors(
     if (m_visualization_color_migration_version < kVisualizationColorMigrationVersion) {
         migrateVisualizationColorDefaults(migratedVisualizationColorsHex);
         m_visualization_color_migration_version = kVisualizationColorMigrationVersion;
-        m_dirty = true;
+        m_dirty                                 = true;
     }
 
     m_visualization_qcolors.clear();
@@ -212,9 +222,7 @@ void PreferencesManager::setDefaultVisualizationColors(
 
     for (const auto& color : migratedVisualizationColorsHex) {
         VisualizationColors colorEnum;
-        if (!visualizationColorFromName(color.first, colorEnum)) {
-            continue;
-        }
+        if (!visualizationColorFromName(color.first, colorEnum)) { continue; }
 
         if (color.second.empty()) {
             m_dirty = true;
@@ -241,9 +249,8 @@ void PreferencesManager::importPreferences(QString filepath) {
     if (file.exists()) {
         file.open(QIODevice::ReadOnly);
         QString preferences = file.readAll();
-        fifojson j = json::parse(preferences.toStdString());
-        if (j.find("import_unit") != j.end())
-            setImportUnit(j.value("import_unit", m_import_unit));
+        fifojson j          = json::parse(preferences.toStdString());
+        if (j.find("import_unit") != j.end()) setImportUnit(j.value("import_unit", m_import_unit));
         setDistanceUnit(j.value("distance", m_distance_unit));
         setVelocityUnit(j.value("velocity", m_velocity_unit));
         setAccelerationUnit(j.value("acceleration", m_acceleration_unit));
@@ -257,35 +264,28 @@ void PreferencesManager::importPreferences(QString filepath) {
         setLayerLag(j.value("layer_lag", m_layer_lag));
         setSegmentLag(j.value("segment_lag", m_segment_lag));
         m_project_shift_preference = j.value("shift", m_project_shift_preference);
-        m_file_shift_preference = j.value("file_shift", m_file_shift_preference);
-        m_align_preference = j.value("align", m_align_preference);
-        m_hide_travel_preference = j.value("hide_travel", m_hide_travel_preference);
-        m_hide_support_preference = j.value("hide_support", m_hide_support_preference);
-        m_is_maximized = j.value("is_window_maximized", m_is_maximized);
-        if (j.find("window_size") != j.end())
-            m_window_size = QSize(j["window_size"][0], j["window_size"][1]);
-        if (j.find("window_pos") != j.end())
-            m_window_pos = QPoint(j["window_pos"][0], j["window_pos"][1]);
+        m_file_shift_preference    = j.value("file_shift", m_file_shift_preference);
+        m_align_preference         = j.value("align", m_align_preference);
+        m_hide_travel_preference   = j.value("hide_travel", m_hide_travel_preference);
+        m_hide_support_preference  = j.value("hide_support", m_hide_support_preference);
+        m_is_maximized             = j.value("is_window_maximized", m_is_maximized);
+        if (j.find("window_size") != j.end()) m_window_size = QSize(j["window_size"][0], j["window_size"][1]);
+        if (j.find("window_pos") != j.end()) m_window_pos = QPoint(j["window_pos"][0], j["window_pos"][1]);
 
         if (j.find("hidden_settings") != j.end())
             m_hidden_settings = j.at("hidden_settings").get<std::unordered_map<std::string, std::list<std::string>>>();
 
         m_rotation_unit = j.value("rotation", m_rotation_unit);
 
-        if (j.find("invert_camera") != j.end())
-            setInvertCamera(j["invert_camera"]);
+        if (j.find("invert_camera") != j.end()) setInvertCamera(j["invert_camera"]);
 
-        if (j.contains("always_drop_parts"))
-            setShouldAlwaysDrop(j["always_drop_parts"]);
+        if (j.contains("always_drop_parts")) setShouldAlwaysDrop(j["always_drop_parts"]);
 
-        if (j.contains("use_implicit_transforms"))
-            setUseImplicitTransforms(j["use_implicit_transforms"]);
+        if (j.contains("use_implicit_transforms")) setUseImplicitTransforms(j["use_implicit_transforms"]);
 
-        if (j.contains("use_true_widths"))
-            setUseTrueWidthsPreference(j["use_true_widths"]);
+        if (j.contains("use_true_widths")) setUseTrueWidthsPreference(j["use_true_widths"]);
 
-        if (j.contains("gcode_preview_mode"))
-            setGCodePreviewModePreference(j["gcode_preview_mode"].get<int>());
+        if (j.contains("gcode_preview_mode")) setGCodePreviewModePreference(j["gcode_preview_mode"].get<int>());
 
         if (j.contains("gcode_preview_vertex_threshold"))
             setGCodePreviewVertexThresholdPreference(j["gcode_preview_vertex_threshold"].get<int>());
@@ -326,98 +326,154 @@ void PreferencesManager::exportPreferences(QString filepath) {
 fifojson PreferencesManager::json() {
     fifojson j;
 
-    j["import_unit"] = m_import_unit;
-    j["distance"] = m_distance_unit;
-    j["velocity"] = m_velocity_unit;
-    j["acceleration"] = m_acceleration_unit;
-    j["density"] = m_density_unit;
-    j["angle"] = m_angle_unit;
-    j["time"] = m_time_unit;
-    j["temperature"] = m_temperature_unit;
-    j["voltage"] = m_voltage_unit;
-    j["mass"] = m_mass_unit;
-    j["shift"] = m_project_shift_preference;
-    j["file_shift"] = m_file_shift_preference;
-    j["align"] = m_align_preference;
-    j["hide_travel"] = m_hide_travel_preference;
-    j["hide_support"] = m_hide_support_preference;
-    j["use_true_widths"] = m_use_true_widths_preference;
-    j["gcode_preview_mode"] = static_cast<int>(m_gcode_preview_mode_preference);
-    j["gcode_preview_vertex_threshold"] = m_gcode_preview_vertex_threshold_preference;
-    j["disabled_setting_visibility"] = static_cast<int>(m_disabled_setting_visibility_preference);
-    j["warn_unsaved_project_on_close"] = m_warn_unsaved_project_on_close_preference;
-    j["hidden_settings"] = m_hidden_settings;
-    j["rotation"] = m_rotation_unit;
-    j["invert_camera"] = m_invert_camera;
-    j["theme"] = m_themeName;
-    j["is_window_maximized"] = m_is_maximized;
-    j["window_size"] = {m_window_size.width(), m_window_size.height()};
-    j["window_pos"] = {m_window_pos.x(), m_window_pos.y()};
-    j["use_implicit_transforms"] = m_use_implicit_transforms;
-    j["always_drop_parts"] = m_always_drop_parts;
-    j["visualization_colors"] = getVisualizationHexColors();
+    j["import_unit"]                          = m_import_unit;
+    j["distance"]                             = m_distance_unit;
+    j["velocity"]                             = m_velocity_unit;
+    j["acceleration"]                         = m_acceleration_unit;
+    j["density"]                              = m_density_unit;
+    j["angle"]                                = m_angle_unit;
+    j["time"]                                 = m_time_unit;
+    j["temperature"]                          = m_temperature_unit;
+    j["voltage"]                              = m_voltage_unit;
+    j["mass"]                                 = m_mass_unit;
+    j["shift"]                                = m_project_shift_preference;
+    j["file_shift"]                           = m_file_shift_preference;
+    j["align"]                                = m_align_preference;
+    j["hide_travel"]                          = m_hide_travel_preference;
+    j["hide_support"]                         = m_hide_support_preference;
+    j["use_true_widths"]                      = m_use_true_widths_preference;
+    j["gcode_preview_mode"]                   = static_cast<int>(m_gcode_preview_mode_preference);
+    j["gcode_preview_vertex_threshold"]       = m_gcode_preview_vertex_threshold_preference;
+    j["disabled_setting_visibility"]          = static_cast<int>(m_disabled_setting_visibility_preference);
+    j["warn_unsaved_project_on_close"]        = m_warn_unsaved_project_on_close_preference;
+    j["hidden_settings"]                      = m_hidden_settings;
+    j["rotation"]                             = m_rotation_unit;
+    j["invert_camera"]                        = m_invert_camera;
+    j["theme"]                                = m_themeName;
+    j["is_window_maximized"]                  = m_is_maximized;
+    j["window_size"]                          = {m_window_size.width(), m_window_size.height()};
+    j["window_pos"]                           = {m_window_pos.x(), m_window_pos.y()};
+    j["use_implicit_transforms"]              = m_use_implicit_transforms;
+    j["always_drop_parts"]                    = m_always_drop_parts;
+    j["visualization_colors"]                 = getVisualizationHexColors();
     j[kVisualizationColorMigrationVersionKey] = m_visualization_color_migration_version;
-    j["layer_lag"] = m_layer_lag;
-    j["segment_lag"] = m_segment_lag;
+    j["layer_lag"]                            = m_layer_lag;
+    j["segment_lag"]                          = m_segment_lag;
 
     return j;
 }
 
-Distance PreferencesManager::getImportUnit() { return m_import_unit; }
+Distance PreferencesManager::getImportUnit() {
+    return m_import_unit;
+}
 
-Distance PreferencesManager::getDistanceUnit() { return m_distance_unit; }
+Distance PreferencesManager::getDistanceUnit() {
+    return m_distance_unit;
+}
 
-Velocity PreferencesManager::getVelocityUnit() { return m_velocity_unit; }
+Velocity PreferencesManager::getVelocityUnit() {
+    return m_velocity_unit;
+}
 
-Acceleration PreferencesManager::getAccelerationUnit() { return m_acceleration_unit; }
+Acceleration PreferencesManager::getAccelerationUnit() {
+    return m_acceleration_unit;
+}
 
-Density PreferencesManager::getDensityUnit() { return m_density_unit; }
+Density PreferencesManager::getDensityUnit() {
+    return m_density_unit;
+}
 
-Angle PreferencesManager::getAngleUnit() { return m_angle_unit; }
+Angle PreferencesManager::getAngleUnit() {
+    return m_angle_unit;
+}
 
-Theme PreferencesManager::getTheme() { return m_theme; }
+Theme PreferencesManager::getTheme() {
+    return m_theme;
+}
 
-Time PreferencesManager::getTimeUnit() { return m_time_unit; }
+Time PreferencesManager::getTimeUnit() {
+    return m_time_unit;
+}
 
-Temperature PreferencesManager::getTemperatureUnit() { return m_temperature_unit; }
+Temperature PreferencesManager::getTemperatureUnit() {
+    return m_temperature_unit;
+}
 
-Voltage PreferencesManager::getVoltageUnit() { return m_voltage_unit; }
+Voltage PreferencesManager::getVoltageUnit() {
+    return m_voltage_unit;
+}
 
-Mass PreferencesManager::getMassUnit() { return m_mass_unit; }
+Mass PreferencesManager::getMassUnit() {
+    return m_mass_unit;
+}
 
-QString PreferencesManager::getDistanceUnitText() { return m_distance_unit.toString(); }
+QString PreferencesManager::getDistanceUnitText() {
+    return m_distance_unit.toString();
+}
 
-QString PreferencesManager::getVelocityUnitText() { return m_velocity_unit.toString(); }
+QString PreferencesManager::getVelocityUnitText() {
+    return m_velocity_unit.toString();
+}
 
-QString PreferencesManager::getAccelerationUnitText() { return m_acceleration_unit.toString(); }
+QString PreferencesManager::getAccelerationUnitText() {
+    return m_acceleration_unit.toString();
+}
 
-QString PreferencesManager::getDensityUnitText() { return m_density_unit.toString(); }
+QString PreferencesManager::getDensityUnitText() {
+    return m_density_unit.toString();
+}
 
-QString PreferencesManager::getAngleUnitText() { return m_angle_unit.toString(); }
+QString PreferencesManager::getAngleUnitText() {
+    return m_angle_unit.toString();
+}
 
-QString PreferencesManager::getThemeText() { return toString(m_themeName); }
+QString PreferencesManager::getThemeText() {
+    return toString(m_themeName);
+}
 
-QString PreferencesManager::getTimeUnitText() { return m_time_unit.toString(); }
+QString PreferencesManager::getTimeUnitText() {
+    return m_time_unit.toString();
+}
 
-QString PreferencesManager::getTemperatureUnitText() { return m_temperature_unit.toString(); }
+QString PreferencesManager::getTemperatureUnitText() {
+    return m_temperature_unit.toString();
+}
 
-QString PreferencesManager::getVoltageUnitText() { return m_voltage_unit.toString(); }
+QString PreferencesManager::getVoltageUnitText() {
+    return m_voltage_unit.toString();
+}
 
-QString PreferencesManager::getMassUnitText() { return m_mass_unit.toString(); }
+QString PreferencesManager::getMassUnitText() {
+    return m_mass_unit.toString();
+}
 
-PreferenceChoice PreferencesManager::getProjectShiftPreference() { return m_project_shift_preference; }
+PreferenceChoice PreferencesManager::getProjectShiftPreference() {
+    return m_project_shift_preference;
+}
 
-PreferenceChoice PreferencesManager::getFileShiftPreference() { return m_file_shift_preference; }
+PreferenceChoice PreferencesManager::getFileShiftPreference() {
+    return m_file_shift_preference;
+}
 
-PreferenceChoice PreferencesManager::getAlignPreference() { return m_align_preference; }
+PreferenceChoice PreferencesManager::getAlignPreference() {
+    return m_align_preference;
+}
 
-bool PreferencesManager::getHideTravelPreference() { return m_hide_travel_preference; }
+bool PreferencesManager::getHideTravelPreference() {
+    return m_hide_travel_preference;
+}
 
-bool PreferencesManager::getHideSupportPreference() { return m_hide_support_preference; }
+bool PreferencesManager::getHideSupportPreference() {
+    return m_hide_support_preference;
+}
 
-bool PreferencesManager::getUseTrueWidthsPreference() { return m_use_true_widths_preference; }
+bool PreferencesManager::getUseTrueWidthsPreference() {
+    return m_use_true_widths_preference;
+}
 
-GCodePreviewMode PreferencesManager::getGCodePreviewModePreference() { return m_gcode_preview_mode_preference; }
+GCodePreviewMode PreferencesManager::getGCodePreviewModePreference() {
+    return m_gcode_preview_mode_preference;
+}
 
 int PreferencesManager::getGCodePreviewVertexThresholdPreference() {
     return m_gcode_preview_vertex_threshold_preference;
@@ -427,32 +483,52 @@ DisabledSettingVisibility PreferencesManager::getDisabledSettingVisibilityPrefer
     return m_disabled_setting_visibility_preference;
 }
 
-bool PreferencesManager::getWarnUnsavedProjectOnClosePreference() { return m_warn_unsaved_project_on_close_preference; }
+bool PreferencesManager::getWarnUnsavedProjectOnClosePreference() {
+    return m_warn_unsaved_project_on_close_preference;
+}
 
-bool PreferencesManager::getWindowMaximizedPreference() { return m_is_maximized; }
+bool PreferencesManager::getWindowMaximizedPreference() {
+    return m_is_maximized;
+}
 
-QSize PreferencesManager::getWindowSizePreference() { return m_window_size; }
+QSize PreferencesManager::getWindowSizePreference() {
+    return m_window_size;
+}
 
-QPoint PreferencesManager::getWindowPosPreference() { return m_window_pos; }
+QPoint PreferencesManager::getWindowPosPreference() {
+    return m_window_pos;
+}
 
-RotationUnit PreferencesManager::getRotationUnit() { return m_rotation_unit; }
+RotationUnit PreferencesManager::getRotationUnit() {
+    return m_rotation_unit;
+}
 
 QString PreferencesManager::getRotationUnitText() {
     if (m_rotation_unit == RotationUnit::kPitchRollYaw)
         return Constants::Units::kPitchRollYaw;
-    else // m_rotation_unit == RotationUnit::kXYZ
+    else  // m_rotation_unit == RotationUnit::kXYZ
         return Constants::Units::kXYZ;
 }
 
-bool PreferencesManager::invertCamera() { return m_invert_camera; }
+bool PreferencesManager::invertCamera() {
+    return m_invert_camera;
+}
 
-bool PreferencesManager::getUseImplicitTransforms() { return m_use_implicit_transforms; }
+bool PreferencesManager::getUseImplicitTransforms() {
+    return m_use_implicit_transforms;
+}
 
-bool PreferencesManager::getAlwaysDropParts() { return m_always_drop_parts; }
+bool PreferencesManager::getAlwaysDropParts() {
+    return m_always_drop_parts;
+}
 
-int PreferencesManager::getLayerLag() { return m_layer_lag; }
+int PreferencesManager::getLayerLag() {
+    return m_layer_lag;
+}
 
-int PreferencesManager::getSegmentLag() { return m_segment_lag; }
+int PreferencesManager::getSegmentLag() {
+    return m_segment_lag;
+}
 
 void PreferencesManager::setImportUnit(QString du) {
     try {
@@ -461,9 +537,9 @@ void PreferencesManager::setImportUnit(QString du) {
 }
 
 void PreferencesManager::setImportUnit(Distance du) {
-    Distance old = m_import_unit;
+    Distance old  = m_import_unit;
     m_import_unit = du;
-    m_dirty = true;
+    m_dirty       = true;
     emit importUnitChanged(m_import_unit, old);
     emit anyUnitChanged();
 }
@@ -476,9 +552,9 @@ void PreferencesManager::setDistanceUnit(QString du) {
 }
 
 void PreferencesManager::setDistanceUnit(Distance d) {
-    Distance old = m_distance_unit;
+    Distance old    = m_distance_unit;
     m_distance_unit = d;
-    m_dirty = true;
+    m_dirty         = true;
     emit distanceUnitChanged(m_distance_unit, old);
     emit anyUnitChanged();
 }
@@ -491,9 +567,9 @@ void PreferencesManager::setVelocityUnit(QString vu) {
 }
 
 void PreferencesManager::setVelocityUnit(Velocity v) {
-    Velocity old = m_velocity_unit;
+    Velocity old    = m_velocity_unit;
     m_velocity_unit = v;
-    m_dirty = true;
+    m_dirty         = true;
     emit velocityUnitChanged(m_velocity_unit, old);
     emit anyUnitChanged();
 }
@@ -506,9 +582,9 @@ void PreferencesManager::setAccelerationUnit(QString au) {
 }
 
 void PreferencesManager::setAccelerationUnit(Acceleration a) {
-    Acceleration old = m_acceleration_unit;
+    Acceleration old    = m_acceleration_unit;
     m_acceleration_unit = a;
-    m_dirty = true;
+    m_dirty             = true;
     emit accelerationUnitChanged(m_acceleration_unit, old);
     emit anyUnitChanged();
 }
@@ -521,9 +597,9 @@ void PreferencesManager::setDensityUnit(QString du) {
 }
 
 void PreferencesManager::setDensityUnit(Density d) {
-    Density old = m_density_unit;
+    Density old    = m_density_unit;
     m_density_unit = d;
-    m_dirty = true;
+    m_dirty        = true;
     emit densityUnitChanged(m_density_unit, old);
     emit anyUnitChanged();
 }
@@ -536,19 +612,19 @@ void PreferencesManager::setAngleUnit(QString au) {
 }
 
 void PreferencesManager::setAngleUnit(Angle a) {
-    Angle old = m_angle_unit;
+    Angle old    = m_angle_unit;
     m_angle_unit = a;
-    m_dirty = true;
+    m_dirty      = true;
     emit angleUnitChanged(m_angle_unit, old);
     emit anyUnitChanged();
 }
 
 void PreferencesManager::setTheme(QString theme) {
     ThemeName name = themeFromString(theme);
-    int themeNum = static_cast<int>(name);
+    int themeNum   = static_cast<int>(name);
     m_theme.chooseTheme(themeNum);
     m_themeName = name;
-    m_dirty = true;
+    m_dirty     = true;
     emit themeChanged();
 }
 
@@ -556,7 +632,7 @@ void PreferencesManager::setTheme(ThemeName theme) {
     int themeNum = static_cast<int>(theme);
     m_theme.chooseTheme(themeNum);
     m_themeName = theme;
-    m_dirty = true;
+    m_dirty     = true;
     emit themeChanged();
 }
 
@@ -568,9 +644,9 @@ void PreferencesManager::setTimeUnit(QString t) {
 }
 
 void PreferencesManager::setTimeUnit(Time t) {
-    Time old = m_time_unit;
+    Time old    = m_time_unit;
     m_time_unit = t;
-    m_dirty = true;
+    m_dirty     = true;
     emit timeUnitChanged(m_time_unit, old);
     emit anyUnitChanged();
 }
@@ -583,9 +659,9 @@ void PreferencesManager::setTemperatureUnit(QString t) {
 }
 
 void PreferencesManager::setTemperatureUnit(Temperature t) {
-    Temperature old = m_temperature_unit;
+    Temperature old    = m_temperature_unit;
     m_temperature_unit = t;
-    m_dirty = true;
+    m_dirty            = true;
     emit temperatureUnitChanged(m_temperature_unit, old);
     emit anyUnitChanged();
 }
@@ -598,9 +674,9 @@ void PreferencesManager::setVoltageUnit(QString v) {
 }
 
 void PreferencesManager::setVoltageUnit(Voltage v) {
-    Voltage old = m_voltage_unit;
+    Voltage old    = m_voltage_unit;
     m_voltage_unit = v;
-    m_dirty = true;
+    m_dirty        = true;
     emit voltageUnitChanged(m_voltage_unit, old);
     emit anyUnitChanged();
 }
@@ -613,41 +689,41 @@ void PreferencesManager::setMassUnit(QString m) {
 }
 
 void PreferencesManager::setMassUnit(Mass m) {
-    Mass old = m_mass_unit;
+    Mass old    = m_mass_unit;
     m_mass_unit = m;
-    m_dirty = true;
+    m_dirty     = true;
     emit massUnitChanged(m_mass_unit, old);
     emit anyUnitChanged();
 }
 
 void PreferencesManager::setProjectShiftPreference(PreferenceChoice shift) {
     m_project_shift_preference = shift;
-    m_dirty = true;
+    m_dirty                    = true;
 }
 
 void PreferencesManager::setFileShiftPreference(PreferenceChoice shift) {
     m_file_shift_preference = shift;
-    m_dirty = true;
+    m_dirty                 = true;
 }
 
 void PreferencesManager::setAlignPreference(PreferenceChoice align) {
     m_align_preference = align;
-    m_dirty = true;
+    m_dirty            = true;
 }
 
 void PreferencesManager::setHideTravelPreference(bool hide) {
     m_hide_travel_preference = hide;
-    m_dirty = true;
+    m_dirty                  = true;
 }
 
 void PreferencesManager::setHideSupportPreference(bool hide) {
     m_hide_support_preference = hide;
-    m_dirty = true;
+    m_dirty                   = true;
 }
 
 void PreferencesManager::setUseTrueWidthsPreference(bool use) {
     m_use_true_widths_preference = use;
-    m_dirty = true;
+    m_dirty                      = true;
 }
 
 void PreferencesManager::setGCodePreviewModePreference(GCodePreviewMode mode) {
@@ -671,7 +747,7 @@ void PreferencesManager::setGCodePreviewModePreference(int mode) {
 
 void PreferencesManager::setGCodePreviewVertexThresholdPreference(int threshold) {
     m_gcode_preview_vertex_threshold_preference = std::max(0, threshold);
-    m_dirty = true;
+    m_dirty                                     = true;
 }
 
 void PreferencesManager::setDisabledSettingVisibilityPreference(DisabledSettingVisibility visibility) {
@@ -695,7 +771,7 @@ void PreferencesManager::setDisabledSettingVisibilityPreference(int visibility) 
 
 void PreferencesManager::setWarnUnsavedProjectOnClosePreference(bool warn) {
     m_warn_unsaved_project_on_close_preference = warn;
-    m_dirty = true;
+    m_dirty                                    = true;
 }
 
 void PreferencesManager::setRotationUnit(QString unit) {
@@ -710,40 +786,49 @@ void PreferencesManager::setRotationUnit(QString unit) {
 
 void PreferencesManager::setInvertCamera(bool invert) {
     m_invert_camera = invert;
-    m_dirty = true;
+    m_dirty         = true;
 }
 
-void PreferencesManager::setUseImplicitTransforms(bool use) { m_use_implicit_transforms = use; }
+void PreferencesManager::setUseImplicitTransforms(bool use) {
+    m_use_implicit_transforms = use;
+}
 
-void PreferencesManager::setShouldAlwaysDrop(bool should) { m_always_drop_parts = should; }
+void PreferencesManager::setShouldAlwaysDrop(bool should) {
+    m_always_drop_parts = should;
+}
 
 void PreferencesManager::setWindowMaximizedPreference(bool isMaximized) {
     m_is_maximized = isMaximized;
-    m_dirty = true;
+    m_dirty        = true;
 }
 
 void PreferencesManager::setWindowSizePreference(QSize window_size) {
     m_window_size = window_size;
-    m_dirty = true;
+    m_dirty       = true;
 }
 
 void PreferencesManager::setWindowPosPreference(QPoint window_pos) {
     m_window_pos = window_pos;
-    m_dirty = true;
+    m_dirty      = true;
 }
 
-void PreferencesManager::setLayerLag(int lag) { m_layer_lag = lag; }
+void PreferencesManager::setLayerLag(int lag) {
+    m_layer_lag = lag;
+}
 
-void PreferencesManager::setSegmentLag(int lag) { m_segment_lag = lag; }
+void PreferencesManager::setSegmentLag(int lag) {
+    m_segment_lag = lag;
+}
 
-bool PreferencesManager::isDirty() { return m_dirty; }
+bool PreferencesManager::isDirty() {
+    return m_dirty;
+}
 
 QList<QString> PreferencesManager::getHiddenSettings(QString panel) {
     std::list<std::string> tempList(m_hidden_settings[panel.toStdString()]);
     QList<QString> result;
     result.reserve(tempList.size());
-    for (std::string str : tempList)
-        result.append(QString::fromStdString(str));
+    for (std::string str : tempList) result.append(QString::fromStdString(str));
 
     return result;
 }
@@ -763,4 +848,4 @@ bool PreferencesManager::isSettingHidden(QString panel, QString setting) {
     std::list<std::string> settingList = m_hidden_settings[panel.toStdString()];
     return std::find(settingList.begin(), settingList.end(), setting.toStdString()) != settingList.end();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -1,10 +1,10 @@
 
 #include "managers/session_manager.h"
 
-#include <cstdlib>
-
 #include <QCoreApplication>
 #include <QStandardPaths>
+#include <cstdlib>
+
 #include <qcontainerfwd.h>
 #include <qdir.h>
 #include <qfiledevice.h>
@@ -42,15 +42,15 @@
 
 namespace ORNL {
 namespace {
-bool supportsCylindricalSlicing(GcodeSyntax syntax) { return syntax == GcodeSyntax::kArcSpecialties; }
-} // namespace
+bool supportsCylindricalSlicing(GcodeSyntax syntax) {
+    return syntax == GcodeSyntax::kArcSpecialties;
+}
+}  // namespace
 
 QSharedPointer<SessionManager> SessionManager::m_singleton = QSharedPointer<SessionManager>();
 
 QSharedPointer<SessionManager> SessionManager::getInstance() {
-    if (m_singleton.isNull()) {
-        m_singleton.reset(new SessionManager());
-    }
+    if (m_singleton.isNull()) { m_singleton.reset(new SessionManager()); }
     return m_singleton;
 }
 
@@ -61,11 +61,9 @@ SessionManager::SessionManager() : m_file(QString()), m_sensor_files_generated(f
     QString httpAppLocationStr = QDir::temp().absolutePath() + "/http_config";
     QDir httpConfigPath(httpAppLocationStr);
     try {
-        if (!appPath.exists())
-            QDir().mkpath(appPathStr);
+        if (!appPath.exists()) QDir().mkpath(appPathStr);
 
-        if (!httpConfigPath.exists())
-            QDir().mkpath(httpAppLocationStr);
+        if (!httpConfigPath.exists()) QDir().mkpath(httpAppLocationStr);
     } catch (...) { qWarning() << "Check your path, cannot create directory:" + appPathStr; }
 
     defaultGcodeFile = appPath.filePath("gcode_output");
@@ -74,16 +72,12 @@ SessionManager::SessionManager() : m_file(QString()), m_sensor_files_generated(f
     // clear any temp STLs created from http import
     appPath.setNameFilters(QStringList() << "*.stl");
     appPath.setFilter(QDir::Files);
-    for (QString tempStls : appPath.entryList()) {
-        appPath.remove(tempStls);
-    }
+    for (QString tempStls : appPath.entryList()) { appPath.remove(tempStls); }
 }
 
 SessionManager::~SessionManager() {
     // Free the C allocated memory.
-    for (model_data file : m_models) {
-        free(file.model);
-    }
+    for (model_data file : m_models) { free(file.model); }
     saveHistory();
 }
 
@@ -93,8 +87,8 @@ void SessionManager::loadHistory() {
 
     if (file.exists()) {
         file.open(QIODevice::ReadOnly);
-        QString history = file.readAll();
-        fifojson j = json::parse(history.toStdString());
+        QString history         = file.readAll();
+        fifojson j              = json::parse(history.toStdString());
         QString defaultLocation = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
 
         m_most_recent_setting_history.insert(Constants::Settings::SettingTab::kPrinter,
@@ -106,12 +100,12 @@ void SessionManager::loadHistory() {
         m_most_recent_setting_history.insert(Constants::Settings::SettingTab::kExperimental,
                                              QString::fromStdString(j.value("experimental_setting", "LFAM_03in")));
 
-        m_most_recent_model_location = j.value("model_location", defaultLocation);
-        m_most_recent_project_location = j.value("project_location", defaultLocation);
-        m_most_recent_gcode_location = j.value("gcode_location", defaultLocation);
-        m_most_recent_setting_folder_location = j.value("setting_folder_location", defaultLocation);
+        m_most_recent_model_location                    = j.value("model_location", defaultLocation);
+        m_most_recent_project_location                  = j.value("project_location", defaultLocation);
+        m_most_recent_gcode_location                    = j.value("gcode_location", defaultLocation);
+        m_most_recent_setting_folder_location           = j.value("setting_folder_location", defaultLocation);
         m_most_recent_layer_bar_setting_folder_location = j.value("layer_bar_setting_folder_location", defaultLocation);
-        m_most_recent_http_config = j.value("http_config", QString());
+        m_most_recent_http_config                       = j.value("http_config", QString());
 
         file.close();
     }
@@ -134,16 +128,16 @@ void SessionManager::saveHistory() {
     if (m_dirty_history) {
         fifojson j;
 
-        j["printer_setting"] = m_most_recent_setting_history[Constants::Settings::SettingTab::kPrinter];
-        j["material_setting"] = m_most_recent_setting_history[Constants::Settings::SettingTab::kMaterial];
-        j["profile_setting"] = m_most_recent_setting_history[Constants::Settings::SettingTab::kProfile];
-        j["experimental_setting"] = m_most_recent_setting_history[Constants::Settings::SettingTab::kExperimental];
-        j["model_location"] = m_most_recent_model_location;
-        j["project_location"] = m_most_recent_project_location;
-        j["gcode_location"] = m_most_recent_gcode_location;
+        j["printer_setting"]         = m_most_recent_setting_history[Constants::Settings::SettingTab::kPrinter];
+        j["material_setting"]        = m_most_recent_setting_history[Constants::Settings::SettingTab::kMaterial];
+        j["profile_setting"]         = m_most_recent_setting_history[Constants::Settings::SettingTab::kProfile];
+        j["experimental_setting"]    = m_most_recent_setting_history[Constants::Settings::SettingTab::kExperimental];
+        j["model_location"]          = m_most_recent_model_location;
+        j["project_location"]        = m_most_recent_project_location;
+        j["gcode_location"]          = m_most_recent_gcode_location;
         j["setting_folder_location"] = m_most_recent_setting_folder_location;
         j["layer_bar_setting_folder_location"] = m_most_recent_layer_bar_setting_folder_location;
-        j["http_config"] = m_most_recent_http_config;
+        j["http_config"]                       = m_most_recent_http_config;
 
         // Causes segfault if QStandardPaths is referenced here?
         // QDir path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
@@ -156,7 +150,9 @@ void SessionManager::saveHistory() {
     }
 }
 
-QString SessionManager::sessionFile() { return m_file; }
+QString SessionManager::sessionFile() {
+    return m_file;
+}
 
 bool SessionManager::loadModel(QString filename, bool saveLocation, MeshType mt, bool synchRequired, QMatrix4x4 mtrx) {
     QFileInfo file_info(filename);
@@ -187,8 +183,7 @@ bool SessionManager::loadModel(QString filename, bool saveLocation, MeshType mt,
         loader->start();
     }
 
-    if (saveLocation)
-        setMostRecentModelLocation(file_info.absoluteFilePath());
+    if (saveLocation) setMostRecentModelLocation(file_info.absoluteFilePath());
 
     return true;
 }
@@ -197,9 +192,9 @@ void SessionManager::addPart(QSharedPointer<Part> new_part, bool notify) {
     m_load_mutex.lock();
 
     // Try to find a name for this part.
-    QString name = new_part->name();
+    QString name     = new_part->name();
     QString org_name = name;
-    uint count = 1;
+    uint count       = 1;
 
     while (m_parts.contains(name)) {
         name = org_name + "_" + QString::number(count);
@@ -209,8 +204,7 @@ void SessionManager::addPart(QSharedPointer<Part> new_part, bool notify) {
     new_part->setName(name);
     m_parts.insert(name, new_part);
 
-    if (notify)
-        emit partAdded(new_part);
+    if (notify) emit partAdded(new_part);
     m_load_mutex.unlock();
 }
 
@@ -220,23 +214,23 @@ void SessionManager::addPart(QSharedPointer<MeshBase> new_mesh, QString filename
 
     // Try to find a name for this part.
     QString file_name;
-    if (filename == "") // filename is blank because the part is being loaded via project import
+    if (filename == "")  // filename is blank because the part is being loaded via project import
     {
-        file_name = new_part->name();
+        file_name        = new_part->name();
         QString org_name = file_name;
-        uint count = 1;
+        uint count       = 1;
 
         while (m_parts.contains(file_name)) {
             file_name = org_name + "_" + QString::number(count);
             count++;
         }
     }
-    else // filename exists because the part is being loaded via UI button
+    else  // filename exists because the part is being loaded via UI button
     {
         // Find everything after the last /
         QStringList full_name_parts = filename.split("/");
-        file_name = full_name_parts.at(full_name_parts.size() - 1);
-        QString orig_file_name = file_name;
+        file_name                   = full_name_parts.at(full_name_parts.size() - 1);
+        QString orig_file_name      = file_name;
 
         // Add a number to duplicated file names
         uint count = 1;
@@ -244,10 +238,8 @@ void SessionManager::addPart(QSharedPointer<MeshBase> new_mesh, QString filename
             // Separate at the periods, then join everything before the last period
             QStringList orig_file_name_parts = orig_file_name.split(".");
             QString name;
-            for (int i = 0; i < orig_file_name_parts.size() - 1; i++) {
-                name += orig_file_name_parts[i] + ".";
-            }
-            name.chop(1); // Without this, the file name will always include an extra period
+            for (int i = 0; i < orig_file_name_parts.size() - 1; i++) { name += orig_file_name_parts[i] + "."; }
+            name.chop(1);  // Without this, the file name will always include an extra period
             // Add a number to signify a new instance of an existing file name
             file_name = name + "_" + QString::number(count);
             // Re-add the file extension
@@ -321,9 +313,9 @@ void SessionManager::replacePart(QSharedPointer<PartMetaItem> pm, QString filena
 
 void SessionManager::addCopiedPart(QSharedPointer<Part> new_part) {
     // Try to find a name for this part.
-    QString name = new_part->name();
+    QString name     = new_part->name();
     QString org_name = name;
-    uint count = 1;
+    uint count       = 1;
 
     while (m_parts.contains(name)) {
         name = org_name + "_" + QString::number(count);
@@ -336,20 +328,17 @@ void SessionManager::addCopiedPart(QSharedPointer<Part> new_part) {
 }
 
 bool SessionManager::removePart(QSharedPointer<Part> part) {
-    if (!m_parts.contains(part->name()))
-        return false;
+    if (!m_parts.contains(part->name())) return false;
 
     // Keep the part around for a second so we can emit a removed signal. That way, any object that wants to
     // perform some finals operations on the part can still do so.
     QSharedPointer<Part> old_part = m_parts[part->name()];
     m_parts.remove(old_part->name());
 
-    if (m_models.contains(part->rootMesh()->name()))
-        m_models.remove(part->rootMesh()->name());
+    if (m_models.contains(part->rootMesh()->name())) m_models.remove(part->rootMesh()->name());
 
     for (auto& model : part->subMeshes())
-        if (m_models.contains(model->name()))
-            m_models.remove(model->name());
+        if (m_models.contains(model->name())) m_models.remove(model->name());
 
     emit partRemoved(old_part);
 
@@ -357,8 +346,7 @@ bool SessionManager::removePart(QSharedPointer<Part> part) {
 }
 
 bool SessionManager::removePart(QString name) {
-    if (!m_parts.contains(name))
-        return false;
+    if (!m_parts.contains(name)) return false;
 
     // Keep the part around for a second so we can emit a removed signal. That way, any object that wants to
     // perform some finals operations on the part can still do so.
@@ -381,13 +369,13 @@ fifojson SessionManager::partsJson() const {
     for (QSharedPointer<Part> curr_part : m_parts) {
         fifojson part_json = fifojson::object();
 
-        part_json[Constants::Settings::Session::kFile] = curr_part->rootMesh()->path().split("/").back();
-        part_json[Constants::Settings::Session::kMeshType] = static_cast<int>(curr_part->rootMesh()->type());
-        part_json[Constants::Settings::Session::kGenType] = static_cast<int>(curr_part->rootMesh()->genType());
+        part_json[Constants::Settings::Session::kFile]         = curr_part->rootMesh()->path().split("/").back();
+        part_json[Constants::Settings::Session::kMeshType]     = static_cast<int>(curr_part->rootMesh()->type());
+        part_json[Constants::Settings::Session::kGenType]      = static_cast<int>(curr_part->rootMesh()->genType());
         part_json[Constants::Settings::Session::kOrgDims]["x"] = curr_part->rootMesh()->originalDimensions().x;
         part_json[Constants::Settings::Session::kOrgDims]["y"] = curr_part->rootMesh()->originalDimensions().y;
         part_json[Constants::Settings::Session::kOrgDims]["z"] = curr_part->rootMesh()->originalDimensions().z;
-        part_json[Constants::Settings::Session::kTransforms] = curr_part->rootMesh()->transformations();
+        part_json[Constants::Settings::Session::kTransforms]   = curr_part->rootMesh()->transformations();
 
         session_json[Constants::Settings::Session::kParts][curr_part->name().toStdString()] = part_json;
     }
@@ -397,16 +385,14 @@ fifojson SessionManager::partsJson() const {
 
 bool SessionManager::loadPartsJson(fifojson j) {
     int totalParts = 0;
-    for (auto it : j[Constants::Settings::Session::kParts].items()) {
-        ++totalParts;
-    }
+    for (auto it : j[Constants::Settings::Session::kParts].items()) { ++totalParts; }
 
     emit totalPartsInProject(totalParts);
 
     for (auto it : j[Constants::Settings::Session::kParts].items()) {
         // Get mesh information
-        QString name = QString::fromStdString(it.key());
-        MeshType mesh_type = it.value()[Constants::Settings::Session::kMeshType];
+        QString name               = QString::fromStdString(it.key());
+        MeshType mesh_type         = it.value()[Constants::Settings::Session::kMeshType];
         MeshGeneratorType gen_type = it.value()[Constants::Settings::Session::kGenType];
         Distance3D org_dims(it.value()[Constants::Settings::Session::kOrgDims]["x"],
                             it.value()[Constants::Settings::Session::kOrgDims]["y"],
@@ -428,11 +414,11 @@ bool SessionManager::loadPartsJson(fifojson j) {
         }
 
         switch (gen_type) {
-            case kNone: // Not generated, so load from file
+            case kNone:  // Not generated, so load from file
             {
                 QString filename = QString::fromStdString(it.value()[Constants::Settings::Session::kFile]);
 
-                if (m_models.contains(filename)) // Allready have this model data
+                if (m_models.contains(filename))  // Allready have this model data
                 {
                     auto data = m_models.value(filename);
                     auto meshes =
@@ -506,8 +492,7 @@ bool SessionManager::loadPartsJson(fifojson j) {
 
 bool SessionManager::isBuildMode() {
     for (auto part : m_parts) {
-        if (part->getMeshType() == MeshType::kBuild)
-            return true;
+        if (part->getMeshType() == MeshType::kBuild) return true;
     }
 
     return false;
@@ -515,7 +500,7 @@ bool SessionManager::isBuildMode() {
 
 bool SessionManager::doSlice() {
     const GcodeSyntax syntax = GSM->getGlobal()->setting<GcodeSyntax>(PRS::MachineSetup::kSyntax);
-    const SlicingMode type = static_cast<SlicingMode>(GSM->getGlobal()->setting<int>(PS::Slicing::kSlicingMode));
+    const SlicingMode type   = static_cast<SlicingMode>(GSM->getGlobal()->setting<int>(PS::Slicing::kSlicingMode));
     const CylindricalPathPattern path_pattern =
         static_cast<CylindricalPathPattern>(GSM->getGlobal()->setting<int>(PS::Slicing::kCylindricalPathPattern));
 
@@ -550,7 +535,6 @@ bool SessionManager::doSlice() {
 }
 
 bool SessionManager::sliceComplete() {
-
     Diagnostics::logLine(QString("SessionManager slice complete: %1").arg(tempGcodeFile));
     emit forwardSliceComplete(tempGcodeFile, true);
     return true;
@@ -560,18 +544,22 @@ void SessionManager::forwardDialogUpdate(StatusUpdateStepType type, int complete
     emit updateDialog(type, completedPercentage);
 }
 
-void SessionManager::cancelSlice() { m_ast->setCancel(); }
+void SessionManager::cancelSlice() {
+    m_ast->setCancel();
+}
 
-void SessionManager::setCopiedPart(QSharedPointer<Part> part) { m_copied_part = part; }
+void SessionManager::setCopiedPart(QSharedPointer<Part> part) {
+    m_copied_part = part;
+}
 
 void SessionManager::pastePart() {
     QSharedPointer<Part> new_copy = QSharedPointer<Part>(new Part(*m_copied_part));
     // reset transforms so that part matches it's original as loaded (graphical manipulations still apply)
     new_copy->setTransformation(QMatrix4x4());
 
-    QString name = new_copy->name();
+    QString name     = new_copy->name();
     QString org_name = name = name.left(name.lastIndexOf('_'));
-    uint count = 1;
+    uint count              = 1;
 
     // Try to find a name for this part.
     while (m_parts.contains(name)) {
@@ -587,9 +575,7 @@ void SessionManager::pastePart() {
 }
 
 qint64 SessionManager::getSliceTimeElapsed() {
-    if (m_ast.isNull()) {
-        return 0;
-    }
+    if (m_ast.isNull()) { return 0; }
 
     return m_ast->getTimeElapsed();
 }
@@ -609,12 +595,8 @@ bool SessionManager::changeSlicer(SlicingMode type) {
             m_ast.reset(new ImageSlicer(tempGcodeFile));
             break;
         case SlicingMode::kCylindrical:
-            if (path_pattern == CylindricalPathPattern::kHelical) {
-                m_ast.reset(new HelicalSlicer(tempGcodeFile));
-            }
-            else {
-                m_ast.reset(new RadialSlicer(tempGcodeFile));
-            }
+            if (path_pattern == CylindricalPathPattern::kHelical) { m_ast.reset(new HelicalSlicer(tempGcodeFile)); }
+            else { m_ast.reset(new RadialSlicer(tempGcodeFile)); }
             break;
         default:
             qWarning() << "Unknown slicing mode requested. Falling back to Planar slicer.";
@@ -623,13 +605,11 @@ bool SessionManager::changeSlicer(SlicingMode type) {
             break;
     }
 
-    m_slicing_mode = type;
+    m_slicing_mode             = type;
     m_cylindrical_path_pattern = type == SlicingMode::kCylindrical ? path_pattern : CylindricalPathPattern::kRadial;
 
     // Reset part steps
-    for (QSharedPointer<Part> part : m_parts) {
-        part->clearSteps();
-    }
+    for (QSharedPointer<Part> part : m_parts) { part->clearSteps(); }
 
     // Reconnect the signal to the AST.
     QObject::connect(this, &SessionManager::startSlice, m_ast.get(), &AbstractSlicingThread::doSlice);
@@ -651,8 +631,7 @@ SessionLoader* SessionManager::saveSession(QString path, bool shouldTrack, bool 
     loader->start();
     m_file = path;
 
-    if (shouldTrack)
-        setMostRecentProjectLocation(QFileInfo(path).absolutePath());
+    if (shouldTrack) setMostRecentProjectLocation(QFileInfo(path).absolutePath());
 
     return loader;
 }
@@ -660,8 +639,7 @@ SessionLoader* SessionManager::saveSession(QString path, bool shouldTrack, bool 
 SessionLoader* SessionManager::loadSession(bool shouldDelete, QString path, bool promptForSettingsUpdate) {
     // Clear out old data if necessary.
     if (shouldDelete) {
-        for (model_data file : m_models)
-            free(file.model);
+        for (model_data file : m_models) free(file.model);
 
         m_parts.clear();
         emit partsCleared();
@@ -677,12 +655,10 @@ SessionLoader* SessionManager::loadSession(bool shouldDelete, QString path, bool
     QString filename =
         QString::fromStdString(Constants::Settings::Session::Files::kGlobal) + " in project file: " + path + " ";
     fifojson settings = loader->getSettingsFromZip();
-    int result =
-        GSM->checkVersion(filename, settings,
-                          promptForSettingsUpdate ? SettingsVersionUpdateMode::kGuiPrompt
-                                                  : SettingsVersionUpdateMode::kAutoUpdate);
-    if (result == 1)
-        loader->updateSettingsJson(settings, promptForSettingsUpdate);
+    int result        = GSM->checkVersion(
+        filename, settings,
+        promptForSettingsUpdate ? SettingsVersionUpdateMode::kGuiPrompt : SettingsVersionUpdateMode::kAutoUpdate);
+    if (result == 1) loader->updateSettingsJson(settings, promptForSettingsUpdate);
 
     if (result >= 0) {
         connect(loader, &SessionLoader::finished, loader, &SessionLoader::deleteLater);
@@ -695,39 +671,49 @@ SessionLoader* SessionManager::loadSession(bool shouldDelete, QString path, bool
     return nullptr;
 }
 
-QHash<QString, QString> SessionManager::getMostRecentSettingHistory() { return m_most_recent_setting_history; }
+QHash<QString, QString> SessionManager::getMostRecentSettingHistory() {
+    return m_most_recent_setting_history;
+}
 
 void SessionManager::setMostRecentSettingHistory(QString key, QString name) {
     m_most_recent_setting_history[key] = name;
-    m_dirty_history = true;
+    m_dirty_history                    = true;
 }
 
-QString SessionManager::getMostRecentModelLocation() { return m_most_recent_model_location; }
+QString SessionManager::getMostRecentModelLocation() {
+    return m_most_recent_model_location;
+}
 
 void SessionManager::setMostRecentModelLocation(QString path) {
     m_most_recent_model_location = path;
-    m_dirty_history = true;
+    m_dirty_history              = true;
 }
 
-QString SessionManager::getMostRecentProjectLocation() { return m_most_recent_project_location; }
+QString SessionManager::getMostRecentProjectLocation() {
+    return m_most_recent_project_location;
+}
 
 void SessionManager::setMostRecentProjectLocation(QString path) {
     m_most_recent_project_location = path;
-    m_dirty_history = true;
+    m_dirty_history                = true;
 }
 
-QString SessionManager::getMostRecentGcodeLocation() { return m_most_recent_gcode_location; }
+QString SessionManager::getMostRecentGcodeLocation() {
+    return m_most_recent_gcode_location;
+}
 
 void SessionManager::setMostRecentGcodeLocation(QString path) {
     m_most_recent_gcode_location = path;
-    m_dirty_history = true;
+    m_dirty_history              = true;
 }
 
-QString SessionManager::getMostRecentSettingFolderLocation() { return m_most_recent_setting_folder_location; }
+QString SessionManager::getMostRecentSettingFolderLocation() {
+    return m_most_recent_setting_folder_location;
+}
 
 void SessionManager::setMostRecentSettingFolderLocation(QString path) {
     m_most_recent_setting_folder_location = path;
-    m_dirty_history = true;
+    m_dirty_history                       = true;
 }
 
 QString SessionManager::getMostRecentLayerBarSettingFolderLocation() {
@@ -736,13 +722,21 @@ QString SessionManager::getMostRecentLayerBarSettingFolderLocation() {
 
 void SessionManager::setMostRecentLayerBarSettingFolderLocation(QString path) {
     m_most_recent_layer_bar_setting_folder_location = path;
-    m_dirty_history = true;
+    m_dirty_history                                 = true;
 }
-bool SessionManager::sensorFilesGenerated() { return m_sensor_files_generated; }
+bool SessionManager::sensorFilesGenerated() {
+    return m_sensor_files_generated;
+}
 
-QString SessionManager::getMostRecentHTTPConfig() { return m_most_recent_http_config; }
+QString SessionManager::getMostRecentHTTPConfig() {
+    return m_most_recent_http_config;
+}
 
-void SessionManager::setMostRecentHTTPConfig(QString config) { m_most_recent_http_config = config; }
+void SessionManager::setMostRecentHTTPConfig(QString config) {
+    m_most_recent_http_config = config;
+}
 
-void SessionManager::setDefaultGcodeDir(QString dir) { defaultGcodeFile = dir + "\\gcode_output"; }
-} // namespace ORNL
+void SessionManager::setDefaultGcodeDir(QString dir) {
+    defaultGcodeFile = dir + "\\gcode_output";
+}
+}  // namespace ORNL

--- a/src/managers/settings/settings_manager.cpp
+++ b/src/managers/settings/settings_manager.cpp
@@ -1,14 +1,14 @@
 #include "managers/settings/settings_manager.h"
 
-#include <iostream>
-#include <string>
-
 #include <QCoreApplication>
 #include <QDirIterator>
 #include <QFile>
 #include <QMessageBox>
 #include <QRegularExpression>
 #include <QStandardPaths>
+#include <iostream>
+#include <string>
+
 #include <nlohmann/json.hpp>
 #include <qcontainerfwd.h>
 #include <qdir.h>
@@ -31,9 +31,7 @@ namespace ORNL {
 QSharedPointer<SettingsManager> SettingsManager::m_singleton = QSharedPointer<SettingsManager>();
 
 QSharedPointer<SettingsManager> SettingsManager::getInstance() {
-    if (m_singleton.isNull()) {
-        m_singleton.reset(new SettingsManager());
-    }
+    if (m_singleton.isNull()) { m_singleton.reset(new SettingsManager()); }
     return m_singleton;
 }
 
@@ -48,11 +46,9 @@ SettingsManager::SettingsManager() : m_global(new SettingsBase()), m_master(new 
     QFile setting_inputs_file(":/configs/setting_inputs.conf");
     if (setting_inputs_file.open(QIODevice::ReadOnly)) {
         QString input_data = setting_inputs_file.readAll();
-        m_setting_inputs = input_data.isEmpty() ? fifojson::object() : json::parse(input_data.toStdString());
+        m_setting_inputs   = input_data.isEmpty() ? fifojson::object() : json::parse(input_data.toStdString());
     }
-    else {
-        m_setting_inputs = fifojson::object();
-    }
+    else { m_setting_inputs = fifojson::object(); }
 
     for (auto& el : m_master->json().items()) {
         if (!m_allGlobals.contains(QString::fromStdString(el.value()[Constants::Settings::Master::kMajor]))) {
@@ -67,16 +63,20 @@ SettingsManager::SettingsManager() : m_global(new SettingsBase()), m_master(new 
 
     QFile versions(":/configs/versions.conf");
     versions.open(QIODevice::ReadOnly);
-    QString version_string = versions.readAll();
-    fifojson version_data = json::parse(version_string.toStdString());
+    QString version_string   = versions.readAll();
+    fifojson version_data    = json::parse(version_string.toStdString());
     m_current_master_version = version_data["master_version"];
-    m_yes_to_all_update = false;
-    m_current_template = "";
+    m_yes_to_all_update      = false;
+    m_current_template       = "";
 }
 
-QSharedPointer<SettingsBase> SettingsManager::getMaster() const { return m_master; }
+QSharedPointer<SettingsBase> SettingsManager::getMaster() const {
+    return m_master;
+}
 
-fifojson SettingsManager::getSettingInputs() const { return m_setting_inputs; }
+fifojson SettingsManager::getSettingInputs() const {
+    return m_setting_inputs;
+}
 
 fifojson SettingsManager::getSettingInput(const QString& setting_key) const {
     for (auto& input : m_setting_inputs.items()) {
@@ -91,9 +91,7 @@ fifojson SettingsManager::getSettingInput(const QString& setting_key) const {
 }
 
 bool SettingsManager::loadGlobalJson(QString path) {
-
-    if (path.isEmpty())
-        return false;
+    if (path.isEmpty()) return false;
     QFile conf_file(path);
 
     // Attempt to open the file.
@@ -142,40 +140,33 @@ bool SettingsManager::loadGlobalJson(QString path) {
 }
 
 bool SettingsManager::loadAllGlobals(QString path) {
-    if (path.isEmpty())
-        return false;
+    if (path.isEmpty()) return false;
 
     // resource profiles
     QDirIterator it(path, QDirIterator::Subdirectories);
     while (it.hasNext()) {
         QString nextFile = it.next();
         QFileInfo fileInfo(nextFile);
-        if (m_validSuffixes.contains(fileInfo.suffix())) {
-            loadGlobalJson(nextFile);
-        }
+        if (m_validSuffixes.contains(fileInfo.suffix())) { loadGlobalJson(nextFile); }
     }
     return true;
 }
 
 bool SettingsManager::loadLayerBarTemplate(QString path) {
-    if (path.isEmpty())
-        return false;
+    if (path.isEmpty()) return false;
 
     // resource profiles
     QDirIterator it(path, QDirIterator::Subdirectories);
     while (it.hasNext()) {
         QString nextFile = it.next();
         QFileInfo fileInfo(nextFile);
-        if (m_validLayerSuffixes.contains(fileInfo.suffix())) {
-            loadGlobalLayerBarTemplate(nextFile, false);
-        }
+        if (m_validLayerSuffixes.contains(fileInfo.suffix())) { loadGlobalLayerBarTemplate(nextFile, false); }
     }
     return true;
 }
 
 bool SettingsManager::loadGlobalLayerBarTemplate(QString path, bool newTemplateSaved) {
-    if (path.isEmpty())
-        return false;
+    if (path.isEmpty()) return false;
     QFile conf_file(path);
     QFileInfo fileInfo(conf_file);
     QVector<SettingsRange> new_range;
@@ -191,7 +182,7 @@ bool SettingsManager::loadGlobalLayerBarTemplate(QString path, bool newTemplateS
     conf_file.close();
     fifojson j_arr = json::parse(settings_data.toStdString());
     for (auto& item : j_arr.items()) {
-        fifojson j = item.value()["settings"];
+        fifojson j                      = item.value()["settings"];
         QSharedPointer<SettingsBase> sb = QSharedPointer<SettingsBase>::create();
         sb->populate(j);
         SettingsRange sr(item.value()["low"], item.value()["high"], "", sb);
@@ -199,46 +190,38 @@ bool SettingsManager::loadGlobalLayerBarTemplate(QString path, bool newTemplateS
     }
     m_all_layer_bar_templates[fileInfo.completeBaseName()] = new_range;
     // After new template added, emit signal that it has been saved so it is added to templates list.
-    if (newTemplateSaved) {
-        emit newLayerBarTemplateSaved();
-    }
+    if (newTemplateSaved) { emit newLayerBarTemplateSaved(); }
     return true;
 }
 
 void SettingsManager::constructActiveGlobal(QString settingTab, QString settingFile) {
     auto tab = m_allGlobals.find(settingTab);
-    if (tab == m_allGlobals.end())
-        return;
+    if (tab == m_allGlobals.end()) return;
 
     auto setting = tab.value().find(settingFile);
     if (setting == tab.value().end()) {
         setting = tab.value().find("LFAM_03in");
-        if (setting == tab.value().end() || setting.value().isNull())
-            return;
+        if (setting == tab.value().end() || setting.value().isNull()) return;
 
         CSM->setMostRecentSettingHistory(settingTab, "LFAM_03in");
     }
 
-    if (!setting.value().isNull())
-        m_global->populate(setting.value()->json());
+    if (!setting.value().isNull()) m_global->populate(setting.value()->json());
 }
 
 void SettingsManager::constructLayerBarTemplate(QString settingTab, QString settingFile) {
     auto tab = m_allGlobals.find(settingTab);
-    if (tab == m_allGlobals.end())
-        return;
+    if (tab == m_allGlobals.end()) return;
 
     auto setting = tab.value().find(settingFile);
     if (setting == tab.value().end()) {
         setting = tab.value().find("LFAM_03in");
-        if (setting == tab.value().end() || setting.value().isNull())
-            return;
+        if (setting == tab.value().end() || setting.value().isNull()) return;
 
         CSM->setMostRecentSettingHistory(settingTab, "LFAM_03in");
     }
 
-    if (!setting.value().isNull())
-        m_global->populate(setting.value()->json());
+    if (!setting.value().isNull()) m_global->populate(setting.value()->json());
 }
 
 void SettingsManager::constructActiveGlobal(QHash<QString, QString> settingTabAndFile) {
@@ -264,12 +247,12 @@ int SettingsManager::checkVersion(QString filename, fifojson& settings_data, boo
 
 int SettingsManager::checkVersion(QString filename, fifojson& settings_data, SettingsVersionUpdateMode update_mode) {
     fifojson header;
-    double version = 0;
-    auto item = settings_data.find(Constants::SettingFileStrings::kHeader);
+    double version    = 0;
+    auto item         = settings_data.find(Constants::SettingFileStrings::kHeader);
     bool header_found = item != settings_data.end() && !item.value().is_null();
 
     if (header_found) {
-        header = settings_data[Constants::SettingFileStrings::kHeader];
+        header     = settings_data[Constants::SettingFileStrings::kHeader];
         auto item2 = header.find(Constants::SettingFileStrings::kVersion);
         if (item2 != header.end() && !item2.value().is_null())
             version = header[Constants::SettingFileStrings::kVersion];
@@ -286,12 +269,12 @@ int SettingsManager::checkVersion(QString filename, fifojson& settings_data, Set
             if (!ret)
                 ret = QMessageBox::warning(
                     nullptr, QCoreApplication::applicationName(),
-                    filename + " is outdated. Do you want to update this template to the newest compatible version?  "
-                               "Failure to do so may result in program instability.",
+                    filename +
+                        " is outdated. Do you want to update this template to the newest compatible version?  "
+                        "Failure to do so may result in program instability.",
                     QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No);
 
-            if (ret == QMessageBox::YesToAll)
-                m_yes_to_all_update = true;
+            if (ret == QMessageBox::YesToAll) m_yes_to_all_update = true;
 
             if (ret == QMessageBox::Yes || m_yes_to_all_update) {
                 SettingsVersionControl::rollSettingsForward(version, settings_data);
@@ -301,8 +284,9 @@ int SettingsManager::checkVersion(QString filename, fifojson& settings_data, Set
                 return -1;
         }
         else {
-            qInfo() << filename + " is outdated. Failure to update may result in program instability. Do you want to "
-                                  "update this template to the newest compatible version? (Y/N)";
+            qInfo() << filename +
+                           " is outdated. Failure to update may result in program instability. Do you want to "
+                           "update this template to the newest compatible version? (Y/N)";
             std::string response;
             std::cin >> response;
             if (QString::fromStdString(response).toUpper() == "Y") {
@@ -341,7 +325,7 @@ void SettingsManager::consoleConstructActiveGlobal(QString path) {
 
 void SettingsManager::removeCurrentSettings(QString settingTab, QString settingFile) {
     fifojson j_array = fifojson::array({});
-    j_array = m_allGlobals[settingTab][settingFile]->json();
+    j_array          = m_allGlobals[settingTab][settingFile]->json();
     for (auto& array : j_array.items()) {
         for (auto& el : array.value().items()) {
             // reset current settings to default
@@ -353,16 +337,15 @@ void SettingsManager::removeCurrentSettings(QString settingTab, QString settingF
 fifojson SettingsManager::removeSuffixes(fifojson& j) {
     fifojson settings_array = fifojson::array({});
     fifojson current_index_settings;
-    int index = 0; // Last index denotes suffix
+    int index = 0;  // Last index denotes suffix
     for (auto& el : j[Constants::SettingFileStrings::kSettings].items()) {
         QString key_root = QString::fromStdString(el.key());
-        int last_index = key_root.lastIndexOf(QRegularExpression("_\\d+")); // index of suffix
+        int last_index   = key_root.lastIndexOf(QRegularExpression("_\\d+"));  // index of suffix
         if (last_index >= 0) {
-            key_root.chop(key_root.size() - last_index);                               // remove suffix
-            int key_suffix = key_root.right(key_root.size() - last_index - 1).toInt(); // get suffix
+            key_root.chop(key_root.size() - last_index);                                // remove suffix
+            int key_suffix = key_root.right(key_root.size() - last_index - 1).toInt();  // get suffix
             // If suffix matches index, add to json
-            if (key_suffix == index)
-                current_index_settings[key_root.toStdString()] = el.value();
+            if (key_suffix == index) current_index_settings[key_root.toStdString()] = el.value();
             // otherwise increment index and add current json to json array
             else {
                 index++;
@@ -374,16 +357,13 @@ fifojson SettingsManager::removeSuffixes(fifojson& j) {
                 current_index_settings[key_root.toStdString()] = el.value();
             }
         }
-        else {
-            current_index_settings[key_root.toStdString()] = el.value();
-        }
+        else { current_index_settings[key_root.toStdString()] = el.value(); }
     }
     settings_array.push_back(current_index_settings);
     return settings_array;
 }
 
 bool SettingsManager::loadGlobalJson(const fifojson& j) {
-
     // tabs must already exist by virtue of the settings manager having loaded already
     QStringList tabs {Constants::Settings::SettingTab::kPrinter, Constants::Settings::SettingTab::kMaterial,
                       Constants::Settings::SettingTab::kProfile, Constants::Settings::SettingTab::kExperimental};
@@ -393,11 +373,9 @@ bool SettingsManager::loadGlobalJson(const fifojson& j) {
     for (QString tab : tabs) {
         if (!m_allGlobals[tab].contains(name)) {
             QSharedPointer<SettingsBase> sb = QSharedPointer<SettingsBase>(new SettingsBase());
-            m_allGlobals[tab][name] = sb;
+            m_allGlobals[tab][name]         = sb;
         }
-        else {
-            m_allGlobals[tab][name]->reset();
-        }
+        else { m_allGlobals[tab][name]->reset(); }
     }
 
     // set all the globals that contain the last session values
@@ -422,8 +400,7 @@ bool SettingsManager::loadGlobalJson(const fifojson& j) {
 }
 
 bool SettingsManager::loadLayerSettings(QString path) {
-    if (path.isEmpty())
-        return false;
+    if (path.isEmpty()) return false;
     QFile conf_file(path);
 
     fifojson j_array = fifojson::array({});
@@ -439,7 +416,7 @@ bool SettingsManager::loadLayerSettings(QString path) {
     fifojson j_arr = json::parse(settings_data.toStdString());
     // Loop through json array to create settings ranges and add to settings range array.
     for (auto& item : j_arr.items()) {
-        fifojson j = item.value()["settings"];
+        fifojson j                      = item.value()["settings"];
         QSharedPointer<SettingsBase> sb = QSharedPointer<SettingsBase>::create();
         sb->populate(j);
         SettingsRange sr(item.value()["low"], item.value()["high"], "", sb);
@@ -449,16 +426,19 @@ bool SettingsManager::loadLayerSettings(QString path) {
 }
 
 bool SettingsManager::loadLayerSettingsFromTemplate(QVector<SettingsRange> layerBarTemplate) {
-    if (layerBarTemplate.size() == 0)
-        return false;
+    if (layerBarTemplate.size() == 0) return false;
     m_settings_ranges.clear();
     m_settings_ranges = layerBarTemplate;
     return true;
 }
 
-QVector<SettingsRange> SettingsManager::getLayerSettings() { return m_settings_ranges; }
+QVector<SettingsRange> SettingsManager::getLayerSettings() {
+    return m_settings_ranges;
+}
 
-QSharedPointer<SettingsBase> SettingsManager::getGlobal() const { return m_global; }
+QSharedPointer<SettingsBase> SettingsManager::getGlobal() const {
+    return m_global;
+}
 
 QMap<QString, QMap<QString, QSharedPointer<SettingsBase>>> SettingsManager::getAllGlobals() const {
     return m_allGlobals;
@@ -468,11 +448,17 @@ QMap<QString, QVector<SettingsRange>> SettingsManager::getAllLayerBarTemplates()
     return m_all_layer_bar_templates;
 }
 
-void SettingsManager::setCurrentTemplate(QString currentTemplate) { m_current_template = currentTemplate; }
+void SettingsManager::setCurrentTemplate(QString currentTemplate) {
+    m_current_template = currentTemplate;
+}
 
-QString SettingsManager::getCurrentTemplate() { return m_current_template; }
+QString SettingsManager::getCurrentTemplate() {
+    return m_current_template;
+}
 
-void SettingsManager::clearTemplate() { m_settings_ranges.clear(); }
+void SettingsManager::clearTemplate() {
+    m_settings_ranges.clear();
+}
 
 fifojson SettingsManager::globalJson() const {
     fifojson formattedJson = m_global->json();
@@ -480,11 +466,12 @@ fifojson SettingsManager::globalJson() const {
     return formattedJson;
 }
 
-void SettingsManager::clearGlobal() { m_global.reset(new SettingsBase()); }
+void SettingsManager::clearGlobal() {
+    m_global.reset(new SettingsBase());
+}
 
 void SettingsManager::saveTemplate(const QStringList& keys, QString path, QString name) {
-    if (path.isEmpty())
-        return;
+    if (path.isEmpty()) return;
     QFile conf_file(path);
 
     // Attempt to open the file.
@@ -496,7 +483,7 @@ void SettingsManager::saveTemplate(const QStringList& keys, QString path, QStrin
     // Collect the keys specified.
     fifojson tj = fifojson::object();
     for (QString key : keys) {
-        int index = 0;
+        int index  = 0;
         bool found = true;
         // save all suffixed versions of the key
         // assumes that suffixes are sequential, ie that if there is no _3, there is not _4, _5,...
@@ -509,18 +496,16 @@ void SettingsManager::saveTemplate(const QStringList& keys, QString path, QStrin
                     tj[key.toStdString()] = m_global->json()[0][key.toStdString()];
                 }
             }
-            else {
-                tj[key.toStdString()] = m_global->json()[0][key.toStdString()];
-            }
+            else { tj[key.toStdString()] = m_global->json()[0][key.toStdString()]; }
             ++index;
         }
     }
 
     SettingsVersionControl::formatSettings(m_current_master_version, tj);
-    fifojson whole_file;                  // json including header and settings
-    fifojson j_array = fifojson::array(); // array for settings template
-    j_array[0] = tj[Constants::SettingFileStrings::kSettings];
-    whole_file[Constants::SettingFileStrings::kHeader] = tj[Constants::SettingFileStrings::kHeader];
+    fifojson whole_file;                                                       // json including header and settings
+    fifojson j_array                                     = fifojson::array();  // array for settings template
+    j_array[0]                                           = tj[Constants::SettingFileStrings::kSettings];
+    whole_file[Constants::SettingFileStrings::kHeader]   = tj[Constants::SettingFileStrings::kHeader];
     whole_file[Constants::SettingFileStrings::kSettings] = j_array;
     if (!name.isEmpty())
         whole_file[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedBy] =
@@ -530,7 +515,11 @@ void SettingsManager::saveTemplate(const QStringList& keys, QString path, QStrin
     conf_file.close();
 }
 
-void SettingsManager::setConsoleSettings(QSharedPointer<SettingsBase> sb) { m_console_settings = sb; }
+void SettingsManager::setConsoleSettings(QSharedPointer<SettingsBase> sb) {
+    m_console_settings = sb;
+}
 
-QSharedPointer<SettingsBase> SettingsManager::getConsoleSettings() { return m_console_settings; }
-} // namespace ORNL
+QSharedPointer<SettingsBase> SettingsManager::getConsoleSettings() {
+    return m_console_settings;
+}
+}  // namespace ORNL

--- a/src/managers/settings/settings_version_control.cpp
+++ b/src/managers/settings/settings_version_control.cpp
@@ -1,134 +1,134 @@
 #include "managers/settings/settings_version_control.h"
 
+#include <QDateTime>
+#include <QRegularExpression>
 #include <array>
 #include <list>
 #include <string>
 #include <utility>
 
-#include <QDateTime>
-#include <QRegularExpression>
 #include <qhashfunctions.h>
 
 #include "utilities/constants.h"
 #include "utilities/qt_json_conversion.h"
 
 namespace {
-constexpr int kCincinnatiSyntax = 1;
-constexpr int kMarlinSyntax = 10;
-constexpr int kThermwoodSyntax = 16;
-constexpr int kRemovedGcodeSyntax = 28;
-constexpr int kRemovedRadialSyntax = 31;
-constexpr int kArcSpecialtiesSyntax = 31;
-constexpr int kLegacyArcSpecialtiesSyntax = 32;
-constexpr int kPlanarSlicingMode = 0;
-constexpr int kV4ImageSlicingMode = 1;
-constexpr int kLegacyRadialSlicingMode = 2;
-constexpr int kLegacyHelicalSlicingMode = 3;
-constexpr int kV8CylindricalSlicingMode = 2;
-constexpr int kV9CylindricalSlicingMode = 1;
-constexpr int kV9ImageSlicingMode = 2;
-constexpr int kRadialPathType = 0;
-constexpr int kHelicalPathType = 1;
-constexpr int kClipBoundaryHandling = 0;
-constexpr int kV3LegacySlicingMode2 = 2;
-constexpr int kV3ImageSlicingMode = 3;
-constexpr int kAllPerimeterBoundaries = 0;
+constexpr int kCincinnatiSyntax                = 1;
+constexpr int kMarlinSyntax                    = 10;
+constexpr int kThermwoodSyntax                 = 16;
+constexpr int kRemovedGcodeSyntax              = 28;
+constexpr int kRemovedRadialSyntax             = 31;
+constexpr int kArcSpecialtiesSyntax            = 31;
+constexpr int kLegacyArcSpecialtiesSyntax      = 32;
+constexpr int kPlanarSlicingMode               = 0;
+constexpr int kV4ImageSlicingMode              = 1;
+constexpr int kLegacyRadialSlicingMode         = 2;
+constexpr int kLegacyHelicalSlicingMode        = 3;
+constexpr int kV8CylindricalSlicingMode        = 2;
+constexpr int kV9CylindricalSlicingMode        = 1;
+constexpr int kV9ImageSlicingMode              = 2;
+constexpr int kRadialPathType                  = 0;
+constexpr int kHelicalPathType                 = 1;
+constexpr int kClipBoundaryHandling            = 0;
+constexpr int kV3LegacySlicingMode2            = 2;
+constexpr int kV3ImageSlicingMode              = 3;
+constexpr int kAllPerimeterBoundaries          = 0;
 const std::string kLegacyHelicalClippingMethod = "helical_clipping_method";
-const QString kLegacySlicingMode = "slicer_type";
-const QString kLegacySlicePlaneNormalX = "slicing_vector_x";
-const QString kLegacySlicePlaneNormalY = "slicing_vector_y";
-const QString kLegacySlicePlaneNormalZ = "slicing_vector_z";
-const QString kLegacyCylinderAxisSource = "radial_axis_mode";
-const QString kLegacyCylinderAxisX = "radial_axis_x";
-const QString kLegacyCylinderAxisY = "radial_axis_y";
-const QString kLegacyCylinderInnerRadius = "radial_initial_radius";
-const QString kLegacyCylindricalPathPattern = "cylindrical_path_type";
-const QString kLegacyRadialPathBoundaryPolicy = "radial_boundary_handling";
+const QString kLegacySlicingMode               = "slicer_type";
+const QString kLegacySlicePlaneNormalX         = "slicing_vector_x";
+const QString kLegacySlicePlaneNormalY         = "slicing_vector_y";
+const QString kLegacySlicePlaneNormalZ         = "slicing_vector_z";
+const QString kLegacyCylinderAxisSource        = "radial_axis_mode";
+const QString kLegacyCylinderAxisX             = "radial_axis_x";
+const QString kLegacyCylinderAxisY             = "radial_axis_y";
+const QString kLegacyCylinderInnerRadius       = "radial_initial_radius";
+const QString kLegacyCylindricalPathPattern    = "cylindrical_path_type";
+const QString kLegacyRadialPathBoundaryPolicy  = "radial_boundary_handling";
 const QString kLegacyHelicalPathBoundaryPolicy = "helical_boundary_handling";
-const QString kLegacyMaxHelicalPathLength = "helical_path_length";
-const QString kLegacyImagePixelSizeX = "image_resolution_x";
-const QString kLegacyImagePixelSizeY = "image_resolution_y";
+const QString kLegacyMaxHelicalPathLength      = "helical_path_length";
+const QString kLegacyImagePixelSizeX           = "image_resolution_x";
+const QString kLegacyImagePixelSizeY           = "image_resolution_y";
 
 constexpr std::array<int, 35> kSyntaxV2ToV3 = {
-    0,                 // Beam
-    1,                 // Cincinnati
-    2,                 // Common
-    3,                 // Dmg Dmu
-    kCincinnatiSyntax, // GKN removed
-    4,                 // Gudel
-    5,                 // Haas Inch
-    6,                 // Haas Metric
-    7,                 // Haas Metric No Comments
-    8,                 // Hurco
-    9,                 // Ingersoll
-    10,                // Marlin
-    11,                // JuggerBot
-    12,                // Mazak
-    13,                // MVP
-    14,                // RomiFanuc
-    kCincinnatiSyntax, // RPBF removed
-    15,                // Siemens
-    kThermwoodSyntax,  // SkyBaam removed; concrete templates now use Thermwood
-    16,                // Thermwood
-    17,                // Wolf
-    18,                // RepRap
-    19,                // Mach4
-    20,                // AeroBasic
-    21,                // Meld
-    22,                // ORNL
-    23,                // Okuma
-    24,                // Tormach
-    25,                // AML3D
-    26,                // KraussMaffei
-    27,                // Sandia
-    28,                // Removed syntax
-    29,                // Meltio
-    30,                // Adamantine
-    31                 // ORNL Metric
+    0,                  // Beam
+    1,                  // Cincinnati
+    2,                  // Common
+    3,                  // Dmg Dmu
+    kCincinnatiSyntax,  // GKN removed
+    4,                  // Gudel
+    5,                  // Haas Inch
+    6,                  // Haas Metric
+    7,                  // Haas Metric No Comments
+    8,                  // Hurco
+    9,                  // Ingersoll
+    10,                 // Marlin
+    11,                 // JuggerBot
+    12,                 // Mazak
+    13,                 // MVP
+    14,                 // RomiFanuc
+    kCincinnatiSyntax,  // RPBF removed
+    15,                 // Siemens
+    kThermwoodSyntax,   // SkyBaam removed; concrete templates now use Thermwood
+    16,                 // Thermwood
+    17,                 // Wolf
+    18,                 // RepRap
+    19,                 // Mach4
+    20,                 // AeroBasic
+    21,                 // Meld
+    22,                 // ORNL
+    23,                 // Okuma
+    24,                 // Tormach
+    25,                 // AML3D
+    26,                 // KraussMaffei
+    27,                 // Sandia
+    28,                 // Removed syntax
+    29,                 // Meltio
+    30,                 // Adamantine
+    31                  // ORNL Metric
 };
 
 constexpr std::array<int, 7> kSlicingModeV2ToV3 = {
-    0,                     // Polymer
-    1,                     // Legacy slicing mode 1
-    2,                     // Legacy slicing mode 2
-    kV3LegacySlicingMode2, // RPBF removed
-    kPlanarSlicingMode,    // Real Time Polymer removed
-    kV3LegacySlicingMode2, // Real Time RPBF removed
-    kV3ImageSlicingMode    // Image
+    0,                      // Polymer
+    1,                      // Legacy slicing mode 1
+    2,                      // Legacy slicing mode 2
+    kV3LegacySlicingMode2,  // RPBF removed
+    kPlanarSlicingMode,     // Real Time Polymer removed
+    kV3LegacySlicingMode2,  // Real Time RPBF removed
+    kV3ImageSlicingMode     // Image
 };
 
 constexpr std::array<int, 4> kSlicingModeV3ToV4 = {
-    kPlanarSlicingMode, // Polymer
-    kPlanarSlicingMode, // Legacy slicing mode 1 removed
-    kPlanarSlicingMode, // Legacy slicing mode 2 removed
-    kV4ImageSlicingMode // Image
+    kPlanarSlicingMode,  // Polymer
+    kPlanarSlicingMode,  // Legacy slicing mode 1 removed
+    kPlanarSlicingMode,  // Legacy slicing mode 2 removed
+    kV4ImageSlicingMode  // Image
 };
 
 constexpr std::array<int, 3> kSlicingModeV8ToV9 = {
-    kPlanarSlicingMode,       // Planar
-    kV9ImageSlicingMode,      // Image moved after Cylindrical
-    kV9CylindricalSlicingMode // Cylindrical moved before Image
+    kPlanarSlicingMode,        // Planar
+    kV9ImageSlicingMode,       // Image moved after Cylindrical
+    kV9CylindricalSlicingMode  // Cylindrical moved before Image
 };
 
 constexpr std::array<int, 7> kSkinPatternV4ToV5 = {
-    0, // Lines
-    1, // Grid
-    2, // Concentric
-    2, // Removed option; use Concentric
-    3, // Triangles
-    4, // Hexagons and Triangles
-    5  // Honeycomb
+    0,  // Lines
+    1,  // Grid
+    2,  // Concentric
+    2,  // Removed option; use Concentric
+    3,  // Triangles
+    4,  // Hexagons and Triangles
+    5   // Honeycomb
 };
 
 constexpr std::array<int, 8> kInfillPatternV4ToV5 = {
-    0, // Lines
-    1, // Grid
-    2, // Concentric
-    2, // Removed option; use Concentric
-    3, // Triangles
-    4, // Hexagons and Triangles
-    5, // Honeycomb
-    6  // Radial Hatch
+    0,  // Lines
+    1,  // Grid
+    2,  // Concentric
+    2,  // Removed option; use Concentric
+    3,  // Triangles
+    4,  // Hexagons and Triangles
+    5,  // Honeycomb
+    6   // Radial Hatch
 };
 
 constexpr std::array<const char*, 47> kRemovedV3Settings = {
@@ -157,12 +157,10 @@ constexpr std::array<const char*, 47> kRemovedV3Settings = {
 
 template <std::size_t N>
 void migrateIndexedSetting(fifojson& settings_group, const QString& setting_key, const std::array<int, N>& mapping) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
     auto setting = settings_group.find(setting_key.toStdString());
-    if (setting == settings_group.end() || !setting.value().is_number_integer())
-        return;
+    if (setting == settings_group.end() || !setting.value().is_number_integer()) return;
 
     int setting_value = setting.value().get<int>();
     if (setting_value >= 0 && static_cast<std::size_t>(setting_value) < mapping.size())
@@ -170,16 +168,13 @@ void migrateIndexedSetting(fifojson& settings_group, const QString& setting_key,
 }
 
 void removeV2Settings(fifojson& settings_group) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
-    for (const char* removed_setting : kRemovedV3Settings)
-        settings_group.erase(std::string(removed_setting));
+    for (const char* removed_setting : kRemovedV3Settings) settings_group.erase(std::string(removed_setting));
 }
 
 void addV3Settings(fifojson& settings_group) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
     const std::string perimeter_boundary_selection =
         ORNL::Constants::ProfileSettings::Perimeter::kBoundarySelection.toStdString();
@@ -188,13 +183,11 @@ void addV3Settings(fifojson& settings_group) {
 }
 
 void migrateRemovedGcodeSyntax(fifojson& settings_group) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
     const std::string syntax_key = ORNL::Constants::PrinterSettings::MachineSetup::kSyntax.toStdString();
-    auto setting = settings_group.find(syntax_key);
-    if (setting == settings_group.end() || !setting.value().is_number_integer())
-        return;
+    auto setting                 = settings_group.find(syntax_key);
+    if (setting == settings_group.end() || !setting.value().is_number_integer()) return;
 
     const int setting_value = setting.value().get<int>();
     if (setting_value == kRemovedGcodeSyntax)
@@ -204,13 +197,11 @@ void migrateRemovedGcodeSyntax(fifojson& settings_group) {
 }
 
 void migrateRemovedRadialSyntax(fifojson& settings_group) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
     const std::string syntax_key = ORNL::Constants::PrinterSettings::MachineSetup::kSyntax.toStdString();
-    auto setting = settings_group.find(syntax_key);
-    if (setting == settings_group.end() || !setting.value().is_number_integer())
-        return;
+    auto setting                 = settings_group.find(syntax_key);
+    if (setting == settings_group.end() || !setting.value().is_number_integer()) return;
 
     const int setting_value = setting.value().get<int>();
     if (setting_value == kRemovedRadialSyntax || setting_value == kLegacyArcSpecialtiesSyntax)
@@ -218,51 +209,46 @@ void migrateRemovedRadialSyntax(fifojson& settings_group) {
 }
 
 void renameSettingKey(fifojson& settings_group, const QString& old_key, const QString& new_key) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
     const std::string old_key_string = old_key.toStdString();
     const std::string new_key_string = new_key.toStdString();
-    auto old_setting = settings_group.find(old_key_string);
-    if (old_setting == settings_group.end())
-        return;
+    auto old_setting                 = settings_group.find(old_key_string);
+    if (old_setting == settings_group.end()) return;
 
     const bool should_insert_new_key = settings_group.find(new_key_string) == settings_group.end();
     fifojson old_value;
-    if (should_insert_new_key)
-        old_value = old_setting.value();
+    if (should_insert_new_key) old_value = old_setting.value();
     settings_group.erase(old_setting);
-    if (should_insert_new_key)
-        settings_group[new_key_string] = old_value;
+    if (should_insert_new_key) settings_group[new_key_string] = old_value;
 }
 
 void migrateCylindricalSlicingSettings(fifojson& settings_group) {
-    if (!settings_group.is_object())
-        return;
+    if (!settings_group.is_object()) return;
 
-    const std::string slicing_mode_key = kLegacySlicingMode.toStdString();
-    const std::string path_pattern_key = kLegacyCylindricalPathPattern.toStdString();
-    const std::string radial_boundary_key = kLegacyRadialPathBoundaryPolicy.toStdString();
+    const std::string slicing_mode_key     = kLegacySlicingMode.toStdString();
+    const std::string path_pattern_key     = kLegacyCylindricalPathPattern.toStdString();
+    const std::string radial_boundary_key  = kLegacyRadialPathBoundaryPolicy.toStdString();
     const std::string helical_boundary_key = kLegacyHelicalPathBoundaryPolicy.toStdString();
 
-    auto slicing_mode = settings_group.find(slicing_mode_key);
+    auto slicing_mode           = settings_group.find(slicing_mode_key);
     const bool has_slicing_mode = slicing_mode != settings_group.end() && slicing_mode.value().is_number_integer();
-    const int old_slicing_mode = has_slicing_mode ? slicing_mode.value().get<int>() : kPlanarSlicingMode;
+    const int old_slicing_mode  = has_slicing_mode ? slicing_mode.value().get<int>() : kPlanarSlicingMode;
 
     if (old_slicing_mode == kLegacyRadialSlicingMode) {
-        slicing_mode.value() = kV8CylindricalSlicingMode;
+        slicing_mode.value()             = kV8CylindricalSlicingMode;
         settings_group[path_pattern_key] = kRadialPathType;
     }
     else if (old_slicing_mode == kLegacyHelicalSlicingMode) {
-        slicing_mode.value() = kV8CylindricalSlicingMode;
+        slicing_mode.value()             = kV8CylindricalSlicingMode;
         settings_group[path_pattern_key] = kHelicalPathType;
 
-        int helical_boundary = kClipBoundaryHandling;
-        auto radial_boundary = settings_group.find(radial_boundary_key);
+        int helical_boundary             = kClipBoundaryHandling;
+        auto radial_boundary             = settings_group.find(radial_boundary_key);
         const bool old_boundary_was_clip = radial_boundary == settings_group.end() ||
                                            !radial_boundary.value().is_number_integer() ||
                                            radial_boundary.value().get<int>() == kClipBoundaryHandling;
-        auto legacy_helical_boundary = settings_group.find(kLegacyHelicalClippingMethod);
+        auto legacy_helical_boundary     = settings_group.find(kLegacyHelicalClippingMethod);
         if (old_boundary_was_clip && legacy_helical_boundary != settings_group.end() &&
             legacy_helical_boundary.value().is_number_integer()) {
             helical_boundary = legacy_helical_boundary.value().get<int>();
@@ -296,43 +282,34 @@ void migrateSlicingSettingKeys(fifojson& settings_group) {
     renameSettingKey(settings_group, kLegacyImagePixelSizeX, Slicing::kImagePixelSizeX);
     renameSettingKey(settings_group, kLegacyImagePixelSizeY, Slicing::kImagePixelSizeY);
 }
-} // namespace
+}  // namespace
 
 namespace ORNL {
 void SettingsVersionControl::rollSettingsForward(double& version, fifojson& settings) {
-    if (version < 1)
-        pre_1_0To1_0(version, settings);
-    if (version < 2) // all versions converted to Version 2.0
+    if (version < 1) pre_1_0To1_0(version, settings);
+    if (version < 2)  // all versions converted to Version 2.0
         pre_2_0To2_0(version, settings);
-    if (version < 3)
-        pre_3_0To3_0(version, settings);
-    if (version < 4)
-        pre_4_0To4_0(version, settings);
-    if (version < 5)
-        pre_5_0To5_0(version, settings);
-    if (version < 6)
-        pre_6_0To6_0(version, settings);
-    if (version < 7)
-        pre_7_0To7_0(version, settings);
-    if (version < 8)
-        pre_8_0To8_0(version, settings);
-    if (version < 9)
-        pre_9_0To9_0(version, settings);
-    if (version < 10)
-        pre_10_0To10_0(version, settings);
+    if (version < 3) pre_3_0To3_0(version, settings);
+    if (version < 4) pre_4_0To4_0(version, settings);
+    if (version < 5) pre_5_0To5_0(version, settings);
+    if (version < 6) pre_6_0To6_0(version, settings);
+    if (version < 7) pre_7_0To7_0(version, settings);
+    if (version < 8) pre_8_0To8_0(version, settings);
+    if (version < 9) pre_9_0To9_0(version, settings);
+    if (version < 10) pre_10_0To10_0(version, settings);
 }
 
 void SettingsVersionControl::formatSettings(double version, fifojson& settings) {
     QString dt = QDateTime::currentDateTime().toString();
     fifojson new_format;
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedBy] = "ORNLSlicer";
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedOn] = dt.toStdString();
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedBy]    = "ORNLSlicer";
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedOn]    = dt.toStdString();
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = version;
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLock] = "false";
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = version;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLock]         = "false";
 
     new_format[Constants::SettingFileStrings::kSettings] = settings;
-    settings = new_format;
+    settings                                             = new_format;
 }
 
 void SettingsVersionControl::migrateLegacySettingKeys(fifojson& settings_group) {
@@ -342,17 +319,16 @@ void SettingsVersionControl::migrateLegacySettingKeys(fifojson& settings_group) 
 void SettingsVersionControl::pre_1_0To1_0(double& version, fifojson& settings) {
     QString dt = QDateTime::currentDateTime().toString();
     fifojson new_format;
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedBy] = "";
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedOn] = dt.toStdString();
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedBy]    = "";
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kCreatedOn]    = dt.toStdString();
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 1.0;
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLock] = "false";
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 1.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLock]         = "false";
 
     new_format[Constants::SettingFileStrings::kSettings] = settings;
 
     std::list<std::string> keys;
-    for (auto& el : settings.items())
-        keys.push_back(el.key());
+    for (auto& el : settings.items()) keys.push_back(el.key());
 
     for (std::string key : keys) {
         // get iterator to old key; TODO: error handling if key is not present
@@ -367,23 +343,22 @@ void SettingsVersionControl::pre_1_0To1_0(double& version, fifojson& settings) {
 }
 
 void SettingsVersionControl::pre_2_0To2_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 2.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 2.0;
 
     fifojson settings_array = fifojson::array({});
     fifojson current_index_settings;
-    int index = 0; // Last index denotes suffix
+    int index = 0;  // Last index denotes suffix
     for (auto& el : new_format[Constants::SettingFileStrings::kSettings].items()) {
         QString key_root = QString::fromStdString(el.key());
-        int last_index = key_root.lastIndexOf(QRegularExpression("_\\d+")); // index of suffix
+        int last_index   = key_root.lastIndexOf(QRegularExpression("_\\d+"));  // index of suffix
         if (last_index >= 0) {
-            key_root.chop(key_root.size() - last_index);                               // remove suffix
-            int key_suffix = key_root.right(key_root.size() - last_index - 1).toInt(); // get suffix
+            key_root.chop(key_root.size() - last_index);                                // remove suffix
+            int key_suffix = key_root.right(key_root.size() - last_index - 1).toInt();  // get suffix
             // If suffix matches index, add to json
-            if (key_suffix == index)
-                current_index_settings[key_root.toStdString()] = el.value();
+            if (key_suffix == index) current_index_settings[key_root.toStdString()] = el.value();
             // otherwise increment index and add current json to json array
             else {
                 index++;
@@ -395,22 +370,20 @@ void SettingsVersionControl::pre_2_0To2_0(double& version, fifojson& settings) {
                 current_index_settings[key_root.toStdString()] = el.value();
             }
         }
-        else {
-            current_index_settings[key_root.toStdString()] = el.value();
-        }
+        else { current_index_settings[key_root.toStdString()] = el.value(); }
     }
     settings_array.push_back(current_index_settings);
 
     new_format[Constants::SettingFileStrings::kSettings] = settings_array;
-    version = 2.0;
-    settings = new_format;
+    version                                              = 2.0;
+    settings                                             = new_format;
 }
 
 void SettingsVersionControl::pre_3_0To3_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 3.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 3.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
@@ -422,15 +395,15 @@ void SettingsVersionControl::pre_3_0To3_0(double& version, fifojson& settings) {
         }
     }
 
-    version = 3.0;
+    version  = 3.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_4_0To4_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 4.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 4.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
@@ -439,15 +412,15 @@ void SettingsVersionControl::pre_4_0To4_0(double& version, fifojson& settings) {
         }
     }
 
-    version = 4.0;
+    version  = 4.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_5_0To5_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 5.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 5.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
@@ -457,63 +430,60 @@ void SettingsVersionControl::pre_5_0To5_0(double& version, fifojson& settings) {
         }
     }
 
-    version = 5.0;
+    version  = 5.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_6_0To6_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 6.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 6.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
-        for (auto& settings_group : settings_array.value())
-            migrateRemovedGcodeSyntax(settings_group);
+        for (auto& settings_group : settings_array.value()) migrateRemovedGcodeSyntax(settings_group);
     }
 
-    version = 6.0;
+    version  = 6.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_7_0To7_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 7.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 7.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
-        for (auto& settings_group : settings_array.value())
-            migrateRemovedRadialSyntax(settings_group);
+        for (auto& settings_group : settings_array.value()) migrateRemovedRadialSyntax(settings_group);
     }
 
-    version = 7.0;
+    version  = 7.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_8_0To8_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 8.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 8.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
-        for (auto& settings_group : settings_array.value())
-            migrateCylindricalSlicingSettings(settings_group);
+        for (auto& settings_group : settings_array.value()) migrateCylindricalSlicingSettings(settings_group);
     }
 
-    version = 8.0;
+    version  = 8.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_9_0To9_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 9.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 9.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
@@ -521,23 +491,22 @@ void SettingsVersionControl::pre_9_0To9_0(double& version, fifojson& settings) {
             migrateIndexedSetting(settings_group, kLegacySlicingMode, kSlicingModeV8ToV9);
     }
 
-    version = 9.0;
+    version  = 9.0;
     settings = new_format;
 }
 
 void SettingsVersionControl::pre_10_0To10_0(double& version, fifojson& settings) {
-    QString dt = QDateTime::currentDateTime().toString();
+    QString dt          = QDateTime::currentDateTime().toString();
     fifojson new_format = settings;
     new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kLastModified] = dt.toStdString();
-    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion] = 10.0;
+    new_format[Constants::SettingFileStrings::kHeader][Constants::SettingFileStrings::kVersion]      = 10.0;
 
     auto settings_array = new_format.find(Constants::SettingFileStrings::kSettings);
     if (settings_array != new_format.end() && settings_array.value().is_array()) {
-        for (auto& settings_group : settings_array.value())
-            migrateSlicingSettingKeys(settings_group);
+        for (auto& settings_group : settings_array.value()) migrateSlicingSettingKeys(settings_group);
     }
 
-    version = 10.0;
+    version  = 10.0;
     settings = new_format;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/optimizers/island_order_optimizer.cpp
+++ b/src/optimizers/island_order_optimizer.cpp
@@ -1,11 +1,11 @@
 
 #include "optimizers/island_order_optimizer.h"
 
+#include <QRandomGenerator>
 #include <algorithm>
 #include <cassert>
 #include <limits>
 
-#include <QRandomGenerator>
 #include <qcontainerfwd.h>
 #include <qhash.h>
 #include <qlist.h>
@@ -27,9 +27,11 @@ namespace ORNL {
 IslandBaseOrderOptimizer::IslandBaseOrderOptimizer(Point& current_positon,
                                                    QList<QSharedPointer<IslandBase>> island_list,
                                                    int last_island_visited, IslandOrderOptimization order_optimization)
-    : m_last_island_visited(last_island_visited), m_start(current_positon), m_order_optimization(order_optimization),
+    : m_last_island_visited(last_island_visited),
+      m_start(current_positon),
+      m_order_optimization(order_optimization),
       m_first_index(-1) {
-    m_island_list = island_list;
+    m_island_list        = island_list;
     m_was_first_selected = false;
 }
 
@@ -38,7 +40,7 @@ IslandBaseOrderOptimizer::IslandBaseOrderOptimizer(Point current_positon,
                                                    IslandOrderOptimization order_optimization)
     : m_start(current_positon), m_order_optimization(order_optimization) {
     m_part_island_list = part_island_list;
-    m_island_list = m_part_island_list.keys();
+    m_island_list      = m_part_island_list.keys();
 }
 
 void IslandBaseOrderOptimizer::setStartPoint(Point start_point) {
@@ -56,17 +58,19 @@ void IslandBaseOrderOptimizer::setOrderOptimization(IslandOrderOptimization orde
     m_tsp_result.clear();
 }
 
-int IslandBaseOrderOptimizer::getLastIslandBaseVisited() { return m_last_island_visited; }
+int IslandBaseOrderOptimizer::getLastIslandBaseVisited() {
+    return m_last_island_visited;
+}
 
-int IslandBaseOrderOptimizer::getFirstIndexSelected() { return m_first_index; }
+int IslandBaseOrderOptimizer::getFirstIndexSelected() {
+    return m_first_index;
+}
 
 int IslandBaseOrderOptimizer::computeNextIndex() {
-    if (m_island_list.isEmpty())
-        return -1;
+    if (m_island_list.isEmpty()) return -1;
 
     //! \note No need to optimize if we only have a single island
-    if (m_island_list.size() < 2)
-        return 0;
+    if (m_island_list.size() < 2) return 0;
 
     int index;
     switch (m_order_optimization) {
@@ -106,8 +110,7 @@ int IslandBaseOrderOptimizer::computeNextIndex() {
             break;
     }
 
-    if (index < 0 || index >= m_island_list.size())
-        return -1;
+    if (index < 0 || index >= m_island_list.size()) return -1;
 
     m_island_list.removeAt(index);
 
@@ -118,14 +121,12 @@ QList<QUuid> IslandBaseOrderOptimizer::computePartOrder() {
     QList<QUuid> result;
 
     while (m_part_island_list.size() > 0) {
-        if (m_island_list.isEmpty())
-            break;
+        if (m_island_list.isEmpty()) break;
 
         // make a copy of the island list to get reference to island from result of computeNext()
         QList<QSharedPointer<IslandBase>> islandSave = m_island_list;
-        int index = computeNextIndex();
-        if (index < 0 || index >= islandSave.size())
-            break;
+        int index                                    = computeNextIndex();
+        if (index < 0 || index >= islandSave.size()) break;
 
         QSharedPointer<IslandBase> next_island = islandSave[index];
 
@@ -157,7 +158,9 @@ QList<QUuid> IslandBaseOrderOptimizer::computePartOrder() {
     return result;
 }
 
-int IslandBaseOrderOptimizer::computeRandom() { return QRandomGenerator::global()->bounded(m_island_list.size()); }
+int IslandBaseOrderOptimizer::computeRandom() {
+    return QRandomGenerator::global()->bounded(m_island_list.size());
+}
 
 int IslandBaseOrderOptimizer::computeLeastRecentlyVisited() {
     if (m_last_island_visited == -1)
@@ -166,7 +169,7 @@ int IslandBaseOrderOptimizer::computeLeastRecentlyVisited() {
         m_last_island_visited = m_last_island_visited % m_island_list.size();
 
     if (!m_was_first_selected) {
-        m_first_index = m_last_island_visited;
+        m_first_index        = m_last_island_visited;
         m_was_first_selected = true;
     }
 
@@ -175,30 +178,28 @@ int IslandBaseOrderOptimizer::computeLeastRecentlyVisited() {
 
 int IslandBaseOrderOptimizer::extremumIslandBase(Point start_point, bool closest) {
     Distance start_point_distance = closest ? Distance(std::numeric_limits<float>::max()) : Distance(0);
-    int extremum_island_index = -1;
+    int extremum_island_index     = -1;
     for (int i = 0, end = m_island_list.size(); i < end; ++i) {
         QSharedPointer<IslandBase> isl = m_island_list[i];
-        if (isl.isNull() || isl->getGeometry().isEmpty())
-            continue;
+        if (isl.isNull() || isl->getGeometry().isEmpty()) continue;
 
         Polygon polygon = isl->getGeometry()[0];
-        if (polygon.isEmpty())
-            continue;
+        if (polygon.isEmpty()) continue;
 
         for (Point point : polygon) {
             Distance dis = point.distance(start_point);
             if (closest) {
                 if (dis < start_point_distance) {
-                    start_point_distance = dis;
+                    start_point_distance  = dis;
                     extremum_island_index = i;
-                    m_start = point;
+                    m_start               = point;
                 }
             }
             else {
                 if (dis > start_point_distance) {
-                    start_point_distance = dis;
+                    start_point_distance  = dis;
                     extremum_island_index = i;
-                    m_start = point;
+                    m_start               = point;
                 }
             }
         }
@@ -208,12 +209,8 @@ int IslandBaseOrderOptimizer::extremumIslandBase(Point start_point, bool closest
 
 int IslandBaseOrderOptimizer::computeExtremumDistance(bool shortest) {
     int first_island_index;
-    if (shortest) {
-        first_island_index = this->extremumIslandBase(m_start, true);
-    }
-    else {
-        first_island_index = this->extremumIslandBase(m_start, false);
-    }
+    if (shortest) { first_island_index = this->extremumIslandBase(m_start, true); }
+    else { first_island_index = this->extremumIslandBase(m_start, false); }
 
     // Only compute once. Use stored result otherwise
     if (m_tsp_result.empty()) {
@@ -222,11 +219,9 @@ int IslandBaseOrderOptimizer::computeExtremumDistance(bool shortest) {
         m_tsp_result = tsp.getOptimizedIslandBases();
     }
 
-    if (first_island_index < 0 || m_tsp_result.size() <= 0)
-        return -1;
+    if (first_island_index < 0 || m_tsp_result.size() <= 0) return -1;
 
     for (int i = 0, end = m_island_list.size(); i < end; ++i) {
-
         if (m_island_list[i] == m_tsp_result[0]) {
             m_tsp_result.removeFirst();
             return i;
@@ -237,9 +232,7 @@ int IslandBaseOrderOptimizer::computeExtremumDistance(bool shortest) {
 
 void IslandBaseOrderOptimizer::removeValue(QVector<int>& index_list, int value) {
     for (int i = 0, end = index_list.size(); i < end; ++i) {
-        if (index_list[i] == value) {
-            index_list.remove(i);
-        }
+        if (index_list[i] == value) { index_list.remove(i); }
     }
 }
 
@@ -258,13 +251,11 @@ int IslandBaseOrderOptimizer::computeNextFarthest() {
 int IslandBaseOrderOptimizer::computeApproximate() {
     QVector<Point> center_list;
     for (QSharedPointer<IslandBase>& island : m_island_list) {
-        if (island.isNull() || island.data()->getGeometry().isEmpty())
-            continue;
+        if (island.isNull() || island.data()->getGeometry().isEmpty()) continue;
 
         center_list += island.data()->getGeometry()[0].boundingRectCenter();
     }
-    if (center_list.size() != m_island_list.size())
-        return computeNextClosest();
+    if (center_list.size() != m_island_list.size()) return computeNextClosest();
 
     //! \note Find the minimal spanning tree, represented with an adjacency matrix
     QVector<QVector<int>> minimal_spanning_tree = minimalSpanningTree(center_list);
@@ -274,13 +265,9 @@ int IslandBaseOrderOptimizer::computeApproximate() {
     for (int i = 0, end = m_island_list.size(); i < end; ++i) {
         int degree = 0;
         for (int& value : minimal_spanning_tree[i]) {
-            if (value) {
-                ++degree;
-            }
+            if (value) { ++degree; }
         }
-        if (degree % 2 == 1) {
-            odd_degree_points_indice += i;
-        }
+        if (degree % 2 == 1) { odd_degree_points_indice += i; }
     }
 
     //! \note Find the minimal weight perfect matching for odd degree vertice
@@ -309,32 +296,26 @@ int IslandBaseOrderOptimizer::computeApproximate() {
 
 QVector<QVector<int>> IslandBaseOrderOptimizer::minimalSpanningTree(QVector<Point> vertice) {
     QVector<QVector<int>> minimal_spanning_tree(vertice.size());
-    for (QVector<int>& vertex : minimal_spanning_tree) {
-        vertex.fill(0, vertice.size());
-    }
+    for (QVector<int>& vertex : minimal_spanning_tree) { vertex.fill(0, vertice.size()); }
 
     //! \note Vector of all the edges, each edge is in format {length, {vertex_1, vertex_2}}
     QVector<QPair<Distance, QPair<int, int>>> edges;
     for (int i = 0, end = vertice.size(); i < end; ++i) {
-        for (int j = 0; j < i; ++j) {
-            edges += {vertice[i].distance(vertice[j]), {i, j}};
-        }
+        for (int j = 0; j < i; ++j) { edges += {vertice[i].distance(vertice[j]), {i, j}}; }
     }
     std::sort(edges.begin(), edges.end());
 
     //! \note Keep picking current shortest edge, if it forms a circle, drop it (Kruskal algorithm)
     QVector<QSet<int>> chosen_vertice;
     while (!(chosen_vertice.size() == 1 && chosen_vertice.first().size() == vertice.size())) {
-        int first_vertex_index = edges.first().second.first;
+        int first_vertex_index  = edges.first().second.first;
         int second_vertex_index = edges.first().second.second;
-        int set_num_first = findSet(chosen_vertice, first_vertex_index);
-        int set_num_second = findSet(chosen_vertice, second_vertex_index);
-        bool not_cycle = false;
+        int set_num_first       = findSet(chosen_vertice, first_vertex_index);
+        int set_num_second      = findSet(chosen_vertice, second_vertex_index);
+        bool not_cycle          = false;
         if (set_num_first != set_num_second) {
             not_cycle = true;
-            if (set_num_first == -1 && set_num_second != -1) {
-                chosen_vertice[set_num_second] += first_vertex_index;
-            }
+            if (set_num_first == -1 && set_num_second != -1) { chosen_vertice[set_num_second] += first_vertex_index; }
             else if (set_num_second == -1 && set_num_first != -1) {
                 chosen_vertice[set_num_first] += second_vertex_index;
             }
@@ -359,13 +340,13 @@ QVector<QVector<int>> IslandBaseOrderOptimizer::minimalSpanningTree(QVector<Poin
 
 int IslandBaseOrderOptimizer::findSet(QVector<QSet<int>> chosen_vertice, int vertex_index) {
     int set_num = -1;
-    bool found = false;
+    bool found  = false;
     if (!chosen_vertice.empty()) {
         for (int i = 0, end = chosen_vertice.size(); i < end && !found; ++i) {
             for (int vertex : chosen_vertice[i]) {
                 if (vertex == vertex_index) {
                     set_num = i;
-                    found = true;
+                    found   = true;
                     break;
                 }
             }
@@ -380,8 +361,8 @@ QVector<QPair<int, int>> IslandBaseOrderOptimizer::minimalMatching(QVector<int> 
     QVector<QPair<Distance, QPair<int, int>>> distance_ordered_edges;
     for (int i = 0, end = odd_degree_points_indice.size() - 1; i < end; ++i) {
         for (int j = i + 1, end = odd_degree_points_indice.size(); j < end; ++j) {
-            int index_0 = odd_degree_points_indice[i];
-            int index_1 = odd_degree_points_indice[j];
+            int index_0       = odd_degree_points_indice[i];
+            int index_1       = odd_degree_points_indice[j];
             Distance distance = center_list[index_0].distance(center_list[index_1]);
             distance_ordered_edges += {distance, {index_0, index_1}};
         }
@@ -401,9 +382,7 @@ QVector<QPair<int, int>> IslandBaseOrderOptimizer::minimalMatching(QVector<int> 
                 distance_ordered_edges[i].second.second == match_pair.second) {
                 distance_ordered_edges.remove(i);
             }
-            else {
-                ++i;
-            }
+            else { ++i; }
         }
     }
     return minimal_matching;
@@ -413,7 +392,7 @@ QVector<int> IslandBaseOrderOptimizer::shortcutEulerianTour(QVector<QVector<int>
     QVector<int> Eulerian_tour;
 
     int current_vertex_index = 0;
-    int graph_size = graph.size();
+    int graph_size           = graph.size();
 
     QVector<bool> visited;
     visited.fill(false, graph_size);
@@ -436,7 +415,7 @@ QVector<int> IslandBaseOrderOptimizer::shortcutEulerianTour(QVector<QVector<int>
             --graph[current_vertex_index][tmp_next];
             --graph[tmp_next][current_vertex_index];
             current_vertex_index = tmp_next;
-            found_next = true;
+            found_next           = true;
         }
         else {
             for (int i = 0; i < graph_size; ++i) {
@@ -452,7 +431,7 @@ QVector<int> IslandBaseOrderOptimizer::shortcutEulerianTour(QVector<QVector<int>
                     if (reachable_after_remove == reachable_before_remove) {
                         //! \note This is not a bridge, visit this edge
                         current_vertex_index = i;
-                        found_next = true;
+                        found_next           = true;
                         break;
                     }
                     else {
@@ -473,21 +452,17 @@ QVector<int> IslandBaseOrderOptimizer::shortcutEulerianTour(QVector<QVector<int>
             visited[Eulerian_tour[i]] = true;
             ++i;
         }
-        else {
-            Eulerian_tour.remove(i);
-        }
+        else { Eulerian_tour.remove(i); }
     }
 
     return Eulerian_tour;
 }
 
 int IslandBaseOrderOptimizer::DFSCount(int start_vertex, QVector<QVector<int>> graph, QVector<bool>& visited) {
-    int count = 1;
+    int count             = 1;
     visited[start_vertex] = true;
     for (int i = 0, end = graph.size(); i < end; ++i) {
-        if (graph[start_vertex][i] > 0 && !visited[i]) {
-            count += DFSCount(i, graph, visited);
-        }
+        if (graph[start_vertex][i] > 0 && !visited[i]) { count += DFSCount(i, graph, visited); }
     }
     return count;
 }
@@ -507,9 +482,7 @@ QSet<QSet<int>> IslandBaseOrderOptimizer::chooseSet(int size, int first_island_i
 void IslandBaseOrderOptimizer::recursiveChoose(int size, QSet<int> set, QSet<int> recurse_subset,
                                                QSet<QSet<int>>& subsets) {
     if (size <= set.size()) {
-        if (size == 0) {
-            subsets += recurse_subset;
-        }
+        if (size == 0) { subsets += recurse_subset; }
         else {
             QSet<int> this_set = set;
             for (int value : this_set) {
@@ -534,7 +507,7 @@ int IslandBaseOrderOptimizer::minDistanceLastPoint(QHash<QSet<int>, QMap<int, Di
                 m_island_list[last_point].data()->getGeometry()[0].boundingRectCenter().distance(
                     m_island_list[ending_point_index].data()->getGeometry()[0].boundingRectCenter());
             if (current_distance < shortestDistance) {
-                shortestDistance = current_distance;
+                shortestDistance        = current_distance;
                 min_distance_last_point = last_point;
             }
         }
@@ -543,4 +516,4 @@ int IslandBaseOrderOptimizer::minDistanceLastPoint(QHash<QSet<int>, QMap<int, Di
     return min_distance_last_point;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/optimizers/layer_order_optimizer.cpp
+++ b/src/optimizers/layer_order_optimizer.cpp
@@ -36,19 +36,17 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
                                     global_sb->setting<float>(PS::Slicing::kSlicePlaneNormalZ)};
         slicing_vector.normalize();
 
-        bool steps_left = true;
+        bool steps_left      = true;
         int num_global_steps = 0;
 
         // Make a map to track the step/layer number each part is currently on
         // Start each part at zero
         QMap<QUuid, int> current_layer;
-        for (auto& part : build_parts)
-            current_layer.insert(part->getId(), 0);
+        for (auto& part : build_parts) current_layer.insert(part->getId(), 0);
 
         while (steps_left) {
-
             // Check the current step of all the parts, find the minimum plane
-            QUuid part_with_min_plane = QUuid(); // null quuid initially
+            QUuid part_with_min_plane = QUuid();  // null quuid initially
             Plane min_plane;
             Distance min_dist;
 
@@ -57,14 +55,13 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
                 QUuid part_id = part->getId();
 
                 // Skip the part if all its layers have been assigned to a global layer
-                if (current_layer[part_id] >= part->countStepPairs())
-                    continue;
+                if (current_layer[part_id] >= part->countStepPairs()) continue;
 
                 // Get the current layer for this part
                 QSharedPointer<Step> current_step = part->getStepPair(current_layer[part_id]).printing_layer;
 
                 // calculate the distance from
-                Plane layer_plane = current_step->getSlicingPlane();
+                Plane layer_plane     = current_step->getSlicingPlane();
                 Distance layer_height = current_step->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
                 layer_plane.shiftAlongNormal(layer_height() / 2.0);
 
@@ -74,8 +71,8 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
                 // If this is the first plane in this loop, or its lower than the current min, set this layer as the min
                 if (part_with_min_plane.isNull() || layer_dist < min_dist) {
                     part_with_min_plane = part_id;
-                    min_plane = layer_plane;
-                    min_dist = layer_dist;
+                    min_plane           = layer_plane;
+                    min_dist            = layer_dist;
                 }
             }
 
@@ -86,8 +83,7 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
                 QUuid part_id = part->getId();
 
                 // skip the part if all its layers have been assigned to a global layer
-                if (current_layer[part_id] >= part->countStepPairs())
-                    continue;
+                if (current_layer[part_id] >= part->countStepPairs()) continue;
 
                 // get the current layer for this part
                 QSharedPointer<Step> current_step = part->getStepPair(current_layer[part_id]).printing_layer;
@@ -114,14 +110,13 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
             for (auto& part : build_parts)
                 steps_left = steps_left || (current_layer[part->getId()] < part->countStepPairs());
 
-        } // end while(steps left)
+        }  // end while(steps left)
     }
     else if (order_method == LayerOrdering::kByLayerNumber) {
         // look at all the parts to find the maximum number of steps
         // this will be the number of global layers
         int max_steps = 0;
-        for (auto part : build_parts)
-            max_steps = qMax(max_steps, part->countStepPairs());
+        for (auto part : build_parts) max_steps = qMax(max_steps, part->countStepPairs());
 
         global_layers.reserve(max_steps);
 
@@ -142,8 +137,7 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
     else if (order_method == LayerOrdering::kByPart) {
         // printing parts sequentially, so every part layer gets its own global layer
         int max_steps = 0;
-        for (auto part : build_parts)
-            max_steps += part->countStepPairs();
+        for (auto part : build_parts) max_steps += part->countStepPairs();
 
         global_layers.reserve(max_steps);
 
@@ -159,9 +153,9 @@ QList<QSharedPointer<GlobalLayer>> LayerOrderOptimizer::populateSteps(QSharedPoi
         }
     }
     else {
-        Q_ASSERT(false); // invalid order method
+        Q_ASSERT(false);  // invalid order method
     }
 
     return global_layers;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/optimizers/optimization_anchor.cpp
+++ b/src/optimizers/optimization_anchor.cpp
@@ -51,17 +51,12 @@ QVector3D seamAttractorVector(const QSharedPointer<SettingsBase>& sb, const Plan
     QVector3D direction;
     if (use_seam_attractor_vector) {
         direction = settingVector(sb, PS::Optimizations::kSeamAttractorVectorX,
-                                  PS::Optimizations::kSeamAttractorVectorY,
-                                  PS::Optimizations::kSeamAttractorVectorZ);
+                                  PS::Optimizations::kSeamAttractorVectorY, PS::Optimizations::kSeamAttractorVectorZ);
     }
 
-    if (direction.isNull()) {
-        direction = slicing_plane.normal();
-    }
+    if (direction.isNull()) { direction = slicing_plane.normal(); }
 
-    if (direction.isNull()) {
-        direction = QVector3D(0.0f, 0.0f, 1.0f);
-    }
+    if (direction.isNull()) { direction = QVector3D(0.0f, 0.0f, 1.0f); }
 
     direction.normalize();
     return direction;
@@ -69,21 +64,15 @@ QVector3D seamAttractorVector(const QSharedPointer<SettingsBase>& sb, const Plan
 
 Point projectAlongVector(const Point& anchor, const Plane& slicing_plane, QVector3D direction) {
     QVector3D normal = slicing_plane.normal();
-    if (normal.isNull()) {
-        return anchor;
-    }
+    if (normal.isNull()) { return anchor; }
 
     normal.normalize();
-    if (direction.isNull()) {
-        direction = normal;
-    }
-    else {
-        direction.normalize();
-    }
+    if (direction.isNull()) { direction = normal; }
+    else { direction.normalize(); }
 
     float denominator = QVector3D::dotProduct(direction, normal);
     if (std::fabs(denominator) <= kProjectionDenominatorEpsilon) {
-        direction = normal;
+        direction   = normal;
         denominator = 1.0f;
     }
 
@@ -94,24 +83,22 @@ Point projectAlongVector(const Point& anchor, const Plane& slicing_plane, QVecto
 
 Point flattenIntoOptimizationFrame(const Point& point, const Plane& slicing_plane, const Point& optimization_shift) {
     const QVector3D normal = slicing_plane.normal();
-    if (normal.isNull()) {
-        return point;
-    }
+    if (normal.isNull()) { return point; }
 
     const QQuaternion rotation = MathUtils::CreateQuaternion(normal, QVector3D(0, 0, 1));
-    const QVector3D shifted = (point - optimization_shift).toQVector3D();
+    const QVector3D shifted    = (point - optimization_shift).toQVector3D();
     return Point::fromQVector3D(rotation.rotatedVector(shifted)) + optimization_shift;
 }
 
 Point customOrderPoint(const QSharedPointer<SettingsBase>& sb, const Plane& slicing_plane,
                        const Point& optimization_shift, bool use_seam_attractor_vector, const QString& x_key,
                        const QString& y_key, const QString& z_key) {
-    return flattenIntoOptimizationFrame(projectAlongVector(settingPoint(sb, x_key, y_key, z_key), slicing_plane,
-                                                           seamAttractorVector(sb, slicing_plane,
-                                                                               use_seam_attractor_vector)),
-                                        slicing_plane, optimization_shift);
+    return flattenIntoOptimizationFrame(
+        projectAlongVector(settingPoint(sb, x_key, y_key, z_key), slicing_plane,
+                           seamAttractorVector(sb, slicing_plane, use_seam_attractor_vector)),
+        slicing_plane, optimization_shift);
 }
-} // namespace
+}  // namespace
 
 namespace OptimizationAnchor {
 Point customIslandOrderPoint(const QSharedPointer<SettingsBase>& sb, const Plane& slicing_plane,
@@ -134,5 +121,5 @@ Point customPointOrderPoint(const QSharedPointer<SettingsBase>& sb, const Plane&
                             PS::Optimizations::kCustomPointXLocation, PS::Optimizations::kCustomPointYLocation,
                             PS::Optimizations::kCustomPointZLocation);
 }
-} // namespace OptimizationAnchor
-} // namespace ORNL
+}  // namespace OptimizationAnchor
+}  // namespace ORNL

--- a/src/optimizers/path_order_optimizer.cpp
+++ b/src/optimizers/path_order_optimizer.cpp
@@ -1,10 +1,10 @@
 #include "optimizers/path_order_optimizer.h"
 
+#include <QRandomGenerator>
 #include <algorithm>
 #include <cmath>
 #include <limits>
 
-#include <QRandomGenerator>
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qsharedpointer.h>
@@ -27,23 +27,28 @@
 
 namespace ORNL {
 PathOrderOptimizer::PathOrderOptimizer(Point& start, uint layer_number, const QSharedPointer<SettingsBase>& sb)
-    : m_current_location(start), m_layer_number(layer_number), m_sb(sb), m_override_used(false),
+    : m_current_location(start),
+      m_layer_number(layer_number),
+      m_sb(sb),
+      m_override_used(false),
       m_point_override_used(false) {
     m_layer_num = layer_number;
 }
 
-Point& PathOrderOptimizer::getCurrentLocation() { return m_current_location; }
+Point& PathOrderOptimizer::getCurrentLocation() {
+    return m_current_location;
+}
 
-int PathOrderOptimizer::getCurrentPathCount() { return m_paths.size(); }
+int PathOrderOptimizer::getCurrentPathCount() {
+    return m_paths.size();
+}
 
 void PathOrderOptimizer::setPathsToEvaluate(QVector<Path> paths) {
     m_paths = paths;
-    for (Path& path : m_paths)
-        path.removeTravels();
+    for (Path& path : m_paths) path.removeTravels();
 
     for (int i = m_paths.size() - 1; i >= 0; --i) {
-        if (m_paths[i].size() == 0)
-            m_paths.removeAt(i);
+        if (m_paths[i].size() == 0) m_paths.removeAt(i);
     }
 
     if (m_paths.size() > 0 && !m_paths.front().getSegments().front().isNull())
@@ -52,12 +57,12 @@ void PathOrderOptimizer::setPathsToEvaluate(QVector<Path> paths) {
         m_current_region_type = RegionType::kUnknown;
 
     m_has_computed_heirarchy = false;
-    m_topo_level = 0;
+    m_topo_level             = 0;
     m_topo_order.clear();
 }
 
 void PathOrderOptimizer::setParameters(InfillPatterns infillPattern, PolygonList border_geometry) {
-    m_pattern = infillPattern;
+    m_pattern         = infillPattern;
     m_border_geometry = border_geometry;
 }
 
@@ -65,12 +70,12 @@ void PathOrderOptimizer::setParameters(PolygonList previousIslands) {}
 
 void PathOrderOptimizer::setStartOverride(Point pt) {
     m_override_location = pt;
-    m_override_used = true;
+    m_override_used     = true;
 }
 
 void PathOrderOptimizer::setStartPointOverride(Point pt) {
     m_point_override_location = pt;
-    m_point_override_used = true;
+    m_point_override_used     = true;
 }
 
 Path PathOrderOptimizer::linkNextPath(QVector<Path> paths) {
@@ -135,8 +140,7 @@ Path PathOrderOptimizer::linkNextInfillPath(QVector<Path>& paths) {
     else if (nextPath.back()->getSb()->setting<RegionType>(SS::kRegionType) == RegionType::kSkin)
         minDist = m_sb->setting<Distance>(PS::Skin::kMinPathLength);
 
-    if (nextPath.calculateLengthNoTravel() < minDist)
-        nextPath.clear();
+    if (nextPath.calculateLengthNoTravel() < minDist) nextPath.clear();
 
     // if there are no segments reset start location
     if (nextPath.size() > 0)
@@ -148,25 +152,22 @@ Path PathOrderOptimizer::linkNextInfillPath(QVector<Path>& paths) {
 }
 
 Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
-    if (m_paths.isEmpty())
-        return Path();
+    if (m_paths.isEmpty()) return Path();
 
     //! Gather settings for line segment links
-    Distance bead_width = m_paths.front().front()->getSb()->setting<Distance>(SS::kWidth);
-    Distance layer_height = m_paths.front().front()->getSb()->setting<Distance>(SS::kHeight);
-    Velocity speed = m_paths.front().front()->getSb()->setting<Velocity>(SS::kSpeed);
-    Acceleration acceleration = m_paths.front().front()->getSb()->setting<Acceleration>(SS::kAccel);
+    Distance bead_width            = m_paths.front().front()->getSb()->setting<Distance>(SS::kWidth);
+    Distance layer_height          = m_paths.front().front()->getSb()->setting<Distance>(SS::kHeight);
+    Velocity speed                 = m_paths.front().front()->getSb()->setting<Velocity>(SS::kSpeed);
+    Acceleration acceleration      = m_paths.front().front()->getSb()->setting<Acceleration>(SS::kAccel);
     AngularVelocity extruder_speed = m_paths.front().front()->getSb()->setting<AngularVelocity>(SS::kExtruderSpeed);
 
     Path new_path;
     QPair<int, bool> indexAndStart = closestOpenPath(m_paths);
-    int index = indexAndStart.first;
-    if (index < 0 || index >= m_paths.size())
-        return Path();
+    int index                      = indexAndStart.first;
+    if (index < 0 || index >= m_paths.size()) return Path();
 
     // if false, indicates index is closest if you start at the end point, so reverse
-    if (indexAndStart.second == false)
-        m_paths[index].reverseSegments();
+    if (indexAndStart.second == false) m_paths[index].reverseSegments();
 
     QVector<Path> empty_paths;
     PolygonList empty_polygon_list;
@@ -178,8 +179,7 @@ Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
     travel_segment->getSb()->setSetting(SS::kSpeed, velocity);
     new_path.append(travel_segment);
 
-    for (QSharedPointer<SegmentBase> seg : m_paths[index])
-        new_path.append(seg);
+    for (QSharedPointer<SegmentBase> seg : m_paths[index]) new_path.append(seg);
 
     m_current_location = new_path.back()->end();
     m_paths.remove(index);
@@ -189,16 +189,14 @@ Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
         for (int i = 0, end = m_paths.size(); i < end; ++i) {
             if (m_paths.size() > 0) {
                 indexAndStart = closestOpenPath(m_paths);
-                index = indexAndStart.first;
-                if (index < 0 || index >= m_paths.size())
-                    break;
+                index         = indexAndStart.first;
+                if (index < 0 || index >= m_paths.size()) break;
 
                 // if false, indicates index is closest if you start at the end point, so reverse
-                if (indexAndStart.second == false)
-                    m_paths[index].reverseSegments();
+                if (indexAndStart.second == false) m_paths[index].reverseSegments();
 
-                Point link_start = m_current_location;
-                Point link_end = m_paths[index].front()->start();
+                Point link_start       = m_current_location;
+                Point link_end         = m_paths[index].front()->start();
                 Distance link_distance = link_start.distance(link_end);
 
                 // If link intersects the border geometry, always travel. If link intersects the infill/skin paths,
@@ -224,8 +222,7 @@ Path PathOrderOptimizer::linkNextInfillLines(QVector<Path>& paths) {
 
                     new_path.append(line_segment);
 
-                    for (QSharedPointer<SegmentBase> seg : m_paths[index])
-                        new_path.append(seg);
+                    for (QSharedPointer<SegmentBase> seg : m_paths[index]) new_path.append(seg);
 
                     m_current_location = new_path.back()->end();
                     m_paths.remove(index);
@@ -244,8 +241,7 @@ Path PathOrderOptimizer::linkNextInfillConcentric() {
 
     //! \note Future work: travels aren't always needed between concentric paths, only needed when link distance is
     //! longer than \note travel distance or when link/travel segment crosses paths or border geometry
-    if (m_paths.size() > 0)
-        new_path = linkTo();
+    if (m_paths.size() > 0) new_path = linkTo();
 
     return new_path;
 }
@@ -254,10 +250,9 @@ Path PathOrderOptimizer::linkNextSkeletonPath() {
     Path new_path;
     if (!m_paths.isEmpty()) {
         QPair<int, bool> location = closestOpenPath(m_paths);
-        int index = location.first;
-        bool start = location.second;
-        if (index < 0 || index >= m_paths.size())
-            return new_path;
+        int index                 = location.first;
+        bool start                = location.second;
+        if (index < 0 || index >= m_paths.size()) return new_path;
 
         new_path.setCCW(m_paths[index].getCCW());
 
@@ -268,10 +263,9 @@ Path PathOrderOptimizer::linkNextSkeletonPath() {
             travel_segment->getSb()->setSetting(SS::kSpeed, velocity);
             new_path.append(travel_segment);
 
-            for (QSharedPointer<SegmentBase> seg : m_paths[index])
-                new_path.append(seg);
+            for (QSharedPointer<SegmentBase> seg : m_paths[index]) new_path.append(seg);
         }
-        else // End
+        else  // End
         {
             QSharedPointer<TravelSegment> travel_segment =
                 QSharedPointer<TravelSegment>::create(m_current_location, m_paths[index].back()->end());
@@ -295,15 +289,12 @@ Path PathOrderOptimizer::linkNextSkeletonPath() {
 
 Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
     Path new_path;
-    if (m_paths.isEmpty()) {
-        return new_path;
-    }
+    if (m_paths.isEmpty()) { return new_path; }
 
     QPair<int, bool> location = radialOpenPath(center);
-    int index = location.first;
-    bool start = location.second;
-    if (index < 0 || index >= m_paths.size())
-        return new_path;
+    int index                 = location.first;
+    bool start                = location.second;
+    if (index < 0 || index >= m_paths.size()) return new_path;
 
     new_path.setCCW(m_paths[index].getCCW());
 
@@ -314,9 +305,7 @@ Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
     new_path.append(travel_segment);
 
     if (start) {
-        for (QSharedPointer<SegmentBase> seg : m_paths[index]) {
-            new_path.append(seg);
-        }
+        for (QSharedPointer<SegmentBase> seg : m_paths[index]) { new_path.append(seg); }
     }
     else {
         QList<QSharedPointer<SegmentBase>> segments = m_paths[index].getSegments();
@@ -334,8 +323,7 @@ Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
 }
 
 QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
-    if (m_paths.isEmpty())
-        return QPair<int, bool>(-1, true);
+    if (m_paths.isEmpty()) return QPair<int, bool>(-1, true);
 
     PathOrderOptimization path_order =
         static_cast<PathOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPathOrder));
@@ -348,7 +336,7 @@ QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
             for (int i = 0, end = m_paths.size(); i < end; ++i) {
                 const double distance = nearestOpenEndpointDistance(query_point, m_paths[i])();
                 if (distance > farthest) {
-                    farthest = distance;
+                    farthest       = distance;
                     selected_index = i;
                 }
             }
@@ -360,26 +348,22 @@ QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
         case PathOrderOptimization::kOutsideIn:
         case PathOrderOptimization::kInsideOut: {
             const double query_radius = std::hypot(query_point.x() - center.x(), query_point.y() - center.y());
-            const bool reverse_sweep = path_order == PathOrderOptimization::kInsideOut;
-            double best_sweep = std::numeric_limits<double>::max();
+            const bool reverse_sweep  = path_order == PathOrderOptimization::kInsideOut;
+            double best_sweep         = std::numeric_limits<double>::max();
 
             for (int i = 0, end = m_paths.size(); i < end; ++i) {
                 const double path_angle = radialArcMidpointAngle(m_paths[i], center);
-                double sweep = path_angle;
+                double sweep            = path_angle;
                 if (query_radius > std::numeric_limits<double>::epsilon()) {
                     const double query_angle = std::atan2(query_point.y() - center.y(), query_point.x() - center.x());
-                    sweep = reverse_sweep ? positiveAngularDelta(query_angle - path_angle)
-                                          : positiveAngularDelta(path_angle - query_angle);
+                    sweep                    = reverse_sweep ? positiveAngularDelta(query_angle - path_angle)
+                                                             : positiveAngularDelta(path_angle - query_angle);
                 }
-                else if (reverse_sweep) {
-                    sweep = positiveAngularDelta(-path_angle);
-                }
-                else {
-                    sweep = positiveAngularDelta(path_angle);
-                }
+                else if (reverse_sweep) { sweep = positiveAngularDelta(-path_angle); }
+                else { sweep = positiveAngularDelta(path_angle); }
 
                 if (sweep < best_sweep) {
-                    best_sweep = sweep;
+                    best_sweep     = sweep;
                     selected_index = i;
                 }
             }
@@ -392,7 +376,7 @@ QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
             for (int i = 0, end = m_paths.size(); i < end; ++i) {
                 const double distance = nearestOpenEndpointDistance(query_point, m_paths[i])();
                 if (distance < closest) {
-                    closest = distance;
+                    closest        = distance;
                     selected_index = i;
                 }
             }
@@ -412,9 +396,7 @@ QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
 }
 
 Point PathOrderOptimizer::radialPathQueryPoint(PathOrderOptimization optimization) const {
-    if (m_override_used) {
-        return m_override_location;
-    }
+    if (m_override_used) { return m_override_location; }
 
     if (optimization == PathOrderOptimization::kCustomPoint) {
         return Point(m_sb->setting<double>(PS::Optimizations::kCustomPathXLocation),
@@ -426,9 +408,7 @@ Point PathOrderOptimizer::radialPathQueryPoint(PathOrderOptimization optimizatio
 
 Point PathOrderOptimizer::radialPointQueryPoint(PointOrderOptimization optimization) const {
     if (usesCustomPointLocation(optimization)) {
-        if (m_point_override_used) {
-            return m_point_override_location;
-        }
+        if (m_point_override_used) { return m_point_override_location; }
 
         return Point(m_sb->setting<double>(PS::Optimizations::kCustomPointXLocation),
                      m_sb->setting<double>(PS::Optimizations::kCustomPointYLocation), m_current_location.z());
@@ -445,26 +425,18 @@ double PathOrderOptimizer::radialArcMidpointAngle(const Path& path, const Point&
     const double start_angle =
         std::atan2(path.front()->start().y() - center.y(), path.front()->start().x() - center.x());
     const double end_angle = std::atan2(path.back()->end().y() - center.y(), path.back()->end().x() - center.x());
-    const double pi = std::acos(-1.0);
-    double delta = end_angle - start_angle;
-    while (delta > pi) {
-        delta -= 2.0 * pi;
-    }
-    while (delta < -pi) {
-        delta += 2.0 * pi;
-    }
+    const double pi        = std::acos(-1.0);
+    double delta           = end_angle - start_angle;
+    while (delta > pi) { delta -= 2.0 * pi; }
+    while (delta < -pi) { delta += 2.0 * pi; }
 
     return start_angle + delta / 2.0;
 }
 
 double PathOrderOptimizer::positiveAngularDelta(double delta) const {
     const double two_pi = 2.0 * std::acos(-1.0);
-    while (delta < 0.0) {
-        delta += two_pi;
-    }
-    while (delta >= two_pi) {
-        delta -= two_pi;
-    }
+    while (delta < 0.0) { delta += two_pi; }
+    while (delta >= two_pi) { delta -= two_pi; }
 
     return delta;
 }
@@ -482,25 +454,22 @@ bool PathOrderOptimizer::linkIntersects(Point link_start, Point link_end, QVecto
     //! Check for possible intersections with border geometry
     for (Polygon poly : border_geometry) {
         for (int i = 0, end = poly.size() - 1; i < end; ++i)
-            if (MathUtils::intersect(link_start, link_end, poly[i], poly[i + 1]))
-                return true;
+            if (MathUtils::intersect(link_start, link_end, poly[i], poly[i + 1])) return true;
 
         //! Check last line of polygon
-        if (MathUtils::intersect(link_start, link_end, poly.last(), poly.first()))
-            return true;
+        if (MathUtils::intersect(link_start, link_end, poly.last(), poly.first())) return true;
     }
 
     return false;
 }
 
 QPair<int, bool> PathOrderOptimizer::closestOpenPath(QVector<Path> paths) {
-    if (paths.isEmpty())
-        return QPair<int, bool>(-1, true);
+    if (paths.isEmpty()) return QPair<int, bool>(-1, true);
 
     Distance shortest = Distance(std::numeric_limits<float>::max());
 
-    int index = 0;
-    bool start = true;
+    int index       = 0;
+    bool start      = true;
     bool found_path = false;
 
     Point queryPoint;
@@ -510,25 +479,23 @@ QPair<int, bool> PathOrderOptimizer::closestOpenPath(QVector<Path> paths) {
         queryPoint = m_current_location;
 
     for (int i = 0, end = paths.size(); i < end; ++i) {
-        if (paths[i].size() == 0)
-            continue;
+        if (paths[i].size() == 0) continue;
 
         if (queryPoint.distance(paths[i].front()->start()) < shortest) {
-            shortest = queryPoint.distance(paths[i].front()->start());
-            index = i;
-            start = true;
+            shortest   = queryPoint.distance(paths[i].front()->start());
+            index      = i;
+            start      = true;
             found_path = true;
         }
 
         if (queryPoint.distance(paths[i].back()->end()) < shortest) {
-            shortest = queryPoint.distance(paths[i].back()->end());
-            index = i;
-            start = false;
+            shortest   = queryPoint.distance(paths[i].back()->end());
+            index      = i;
+            start      = false;
             found_path = true;
         }
     }
-    if (!found_path)
-        return QPair<int, bool>(-1, true);
+    if (!found_path) return QPair<int, bool>(-1, true);
 
     return QPair<int, bool>(index, start);
 }
@@ -540,15 +507,12 @@ void PathOrderOptimizer::addTravel(int index, Path& path) {
     travel_segment->getSb()->setSetting(SS::kSpeed, velocity);
 
     m_current_location = path[index]->start();
-    for (int i = 0; i < index; ++i) {
-        path.move(0, path.size() - 1);
-    }
+    for (int i = 0; i < index; ++i) { path.move(0, path.size() - 1); }
     path.prepend(travel_segment);
 }
 
 Path PathOrderOptimizer::linkTo() {
-    if (m_paths.isEmpty())
-        return Path();
+    if (m_paths.isEmpty()) return Path();
 
     int pathIndex;
     PathOrderOptimization orderOptimization =
@@ -573,13 +537,11 @@ Path PathOrderOptimizer::linkTo() {
             pathIndex = findShortestOrLongestDistance();
             break;
     }
-    if (pathIndex < 0 || pathIndex >= m_paths.size())
-        return Path();
+    if (pathIndex < 0 || pathIndex >= m_paths.size()) return Path();
 
     Path nextPath = m_paths[pathIndex];
     m_paths.removeAt(pathIndex);
-    if (nextPath.size() == 0)
-        return Path();
+    if (nextPath.size() == 0) return Path();
 
     Point queryPoint;
     PointOrderOptimization pointOrderOptimization =
@@ -591,8 +553,7 @@ Path PathOrderOptimizer::linkTo() {
         queryPoint = m_current_location;
 
     Polyline line;
-    for (QSharedPointer<SegmentBase> seg : nextPath)
-        line.append(seg->start());
+    for (QSharedPointer<SegmentBase> seg : nextPath) line.append(seg->start());
 
     int pointIndex =
         PointOrderOptimizer::linkToPoint(queryPoint, line, m_layer_num, pointOrderOptimization,
@@ -610,8 +571,7 @@ Path PathOrderOptimizer::linkTo() {
 }
 
 int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
-    if (m_paths.isEmpty())
-        return -1;
+    if (m_paths.isEmpty()) return -1;
 
     Point queryPoint;
     if (m_override_used)
@@ -625,14 +585,13 @@ int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
         for (int j = 0, end2 = m_paths[i].size(); j < end2; ++j) {
             QSharedPointer<SegmentBase> seg = m_paths[i][j];
-            if (seg.isNull())
-                continue;
+            if (seg.isNull()) continue;
 
             Distance closestSegment = MathUtils::distanceFromLineSegSqrd(queryPoint, seg->start(), seg->end());
             if (pathIndex < 0 || (shortest && closestSegment < selected_distance) ||
                 (!shortest && closestSegment > selected_distance)) {
                 selected_distance = closestSegment;
-                pathIndex = i;
+                pathIndex         = i;
             }
         }
     }
@@ -641,38 +600,32 @@ int PathOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
 }
 
 int PathOrderOptimizer::linkToRandom() {
-    if (m_paths.isEmpty())
-        return -1;
+    if (m_paths.isEmpty()) return -1;
 
     return QRandomGenerator::global()->bounded(m_paths.size());
 }
 
 int PathOrderOptimizer::findInteriorExterior(bool ExtToInt) {
-    if (m_paths.isEmpty())
-        return -1;
+    if (m_paths.isEmpty()) return -1;
 
     if (!m_has_computed_heirarchy && m_paths.size() > 0) {
         QSharedPointer<TopologicalNode> root = computeTopologicalHeirarchy();
         // inOrderTraversal(root);
         levelOrder(root);
-        if (!ExtToInt)
-            std::reverse(m_topo_order.begin(), m_topo_order.end());
+        if (!ExtToInt) std::reverse(m_topo_order.begin(), m_topo_order.end());
 
         m_has_computed_heirarchy = true;
     }
 
-    if (m_topo_order.isEmpty() || m_topo_order.first().isEmpty())
-        return findShortestOrLongestDistance();
+    if (m_topo_order.isEmpty() || m_topo_order.first().isEmpty()) return findShortestOrLongestDistance();
 
     int result = m_topo_order.first().first();
     m_topo_order.first().pop_front();
-    if (m_topo_order.first().size() == 0)
-        m_topo_order.pop_front();
+    if (m_topo_order.first().size() == 0) m_topo_order.pop_front();
 
     for (QVector<int>& level : m_topo_order)
         for (int& element : level)
-            if (element > result)
-                --element;
+            if (element > result) --element;
 
     return result;
 }
@@ -682,27 +635,22 @@ QSharedPointer<PathOrderOptimizer::TopologicalNode> PathOrderOptimizer::computeT
     all_nodes.reserve(m_paths.size());
 
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
-        if (m_paths[i].size() == 0)
-            continue;
+        if (m_paths[i].size() == 0) continue;
 
         Polygon poly;
         poly.reserve(m_paths[i].size());
-        for (QSharedPointer<SegmentBase> seg : m_paths[i].getSegments())
-            poly.push_back(Point(seg->start()));
+        for (QSharedPointer<SegmentBase> seg : m_paths[i].getSegments()) poly.push_back(Point(seg->start()));
 
-        if (!poly.isEmpty())
-            all_nodes.push_back(QSharedPointer<TopologicalNode>::create(TopologicalNode(i, poly)));
+        if (!poly.isEmpty()) all_nodes.push_back(QSharedPointer<TopologicalNode>::create(TopologicalNode(i, poly)));
     }
-    if (all_nodes.isEmpty())
-        return QSharedPointer<TopologicalNode>();
+    if (all_nodes.isEmpty()) return QSharedPointer<TopologicalNode>();
 
     // assume first path is outer contour
     QSharedPointer<TopologicalNode> root;
     root = all_nodes[0];
     all_nodes.removeFirst();
 
-    for (QSharedPointer<TopologicalNode> node : all_nodes)
-        insert(root, node);
+    for (QSharedPointer<TopologicalNode> node : all_nodes) insert(root, node);
 
     return root;
 }
@@ -733,8 +681,7 @@ void PathOrderOptimizer::insert(QSharedPointer<TopologicalNode> root, QSharedPoi
 }
 
 void PathOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
-    if (root.isNull())
-        return;
+    if (root.isNull()) return;
 
     if (m_topo_order.size() == m_topo_level)
         m_topo_order.push_back({root->m_path_index});
@@ -743,16 +690,14 @@ void PathOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
 
     ++m_topo_level;
 
-    for (QSharedPointer<TopologicalNode> n : root->m_children)
-        levelOrder(n);
+    for (QSharedPointer<TopologicalNode> n : root->m_children) levelOrder(n);
 
     --m_topo_level;
 }
 
 Path PathOrderOptimizer::linkSpiralPath2D(bool last_spiral) {
     int pathIndex = findShortestOrLongestDistance();
-    if (pathIndex < 0 || pathIndex >= m_paths.size())
-        return Path();
+    if (pathIndex < 0 || pathIndex >= m_paths.size()) return Path();
 
     Path newPath = m_paths[pathIndex];
     m_paths.removeAt(pathIndex);
@@ -763,15 +708,13 @@ Path PathOrderOptimizer::linkSpiralPath2D(bool last_spiral) {
     temp_sb->setSetting<Distance>(PS::Optimizations::kMinDistanceThreshold, Distance());
 
     Polyline line;
-    for (QSharedPointer<SegmentBase> seg : newPath)
-        line.append(seg->start());
+    for (QSharedPointer<SegmentBase> seg : newPath) line.append(seg->start());
 
     int pointIndex = PointOrderOptimizer::linkToPoint(m_current_location, line, m_layer_num,
                                                       PointOrderOptimization::kNextClosest, false, 0, 0, false, 0)
                          .rotation_index;
 
-    for (int i = 0; i < pointIndex; ++i)
-        newPath.move(0, newPath.size() - 1);
+    for (int i = 0; i < pointIndex; ++i) newPath.move(0, newPath.size() - 1);
 
     Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
 
@@ -786,8 +729,8 @@ Path PathOrderOptimizer::linkSpiralPath2D(bool last_spiral) {
 
     for (int end = newPath.size(); start < end; ++start) {
         QSharedPointer<SegmentBase> seg = newPath[start];
-        Point startPt = seg->start();
-        Point endPt = seg->end();
+        Point startPt                   = seg->start();
+        Point endPt                     = seg->end();
 
         currentLength += startPt.distance(m_current_location);
         startPt.z(startPt.z() + ((currentLength / pathLength) * layer_height)());
@@ -806,4 +749,4 @@ Path PathOrderOptimizer::linkSpiralPath2D(bool last_spiral) {
     return newPath;
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/optimizers/point_order_optimizer.cpp
+++ b/src/optimizers/point_order_optimizer.cpp
@@ -1,12 +1,12 @@
 #include "optimizers/point_order_optimizer.h"
 
+#include <QRandomGenerator>
 #include <algorithm>
 #include <cfloat>
 #include <cmath>
 #include <limits>
 #include <optional>
 
-#include <QRandomGenerator>
 #include <qcontainerfwd.h>
 #include <qtypes.h>
 
@@ -28,25 +28,22 @@ std::optional<Point> pointAtPlanarDistance(const Point& start, const Point& end,
                                            Distance distance) {
     const double dx = static_cast<double>(end.x() - start.x());
     const double dy = static_cast<double>(end.y() - start.y());
-    const double a = (dx * dx) + (dy * dy);
-    if (a <= kDistanceTolerance)
-        return std::nullopt;
+    const double a  = (dx * dx) + (dy * dy);
+    if (a <= kDistanceTolerance) return std::nullopt;
 
-    const double fx = static_cast<double>(start.x() - reference.x());
-    const double fy = static_cast<double>(start.y() - reference.y());
-    const double b = 2.0 * ((fx * dx) + (fy * dy));
-    const double c = (fx * fx) + (fy * fy) - (distance() * distance());
+    const double fx           = static_cast<double>(start.x() - reference.x());
+    const double fy           = static_cast<double>(start.y() - reference.y());
+    const double b            = 2.0 * ((fx * dx) + (fy * dy));
+    const double c            = (fx * fx) + (fy * fy) - (distance() * distance());
     const double discriminant = (b * b) - (4.0 * a * c);
-    if (discriminant < -kDistanceTolerance)
-        return std::nullopt;
+    if (discriminant < -kDistanceTolerance) return std::nullopt;
 
-    const double root = std::sqrt(std::max(0.0, discriminant));
+    const double root    = std::sqrt(std::max(0.0, discriminant));
     double candidates[2] = {(-b - root) / (2.0 * a), (-b + root) / (2.0 * a)};
     std::sort(candidates, candidates + 2);
 
     for (double t : candidates) {
-        if (t < -kDistanceTolerance || t > 1.0 + kDistanceTolerance)
-            continue;
+        if (t < -kDistanceTolerance || t > 1.0 + kDistanceTolerance) continue;
 
         t = std::clamp(t, 0.0, 1.0);
         return Point(start.x() + (dx * t), start.y() + (dy * t), start.z() + ((end.z() - start.z()) * t));
@@ -54,14 +51,13 @@ std::optional<Point> pointAtPlanarDistance(const Point& start, const Point& end,
 
     return std::nullopt;
 }
-} // namespace
+}  // namespace
 
-PointOrderOptimizer::PointOrderSelection
-PointOrderOptimizer::linkToPoint(const Point& current_location, const Polyline& polyline, uint layer_number,
-                                 PointOrderOptimization pointOptimization, bool min_dist_enabled,
-                                 Distance min_dist_threshold, Distance consecutive_dist_threshold,
-                                 bool local_randomness_enable, Distance randomness_radius,
-                                 bool allow_segment_breaking, const std::optional<Point>& consecutive_reference) {
+PointOrderOptimizer::PointOrderSelection PointOrderOptimizer::linkToPoint(
+    const Point& current_location, const Polyline& polyline, uint layer_number,
+    PointOrderOptimization pointOptimization, bool min_dist_enabled, Distance min_dist_threshold,
+    Distance consecutive_dist_threshold, bool local_randomness_enable, Distance randomness_radius,
+    bool allow_segment_breaking, const std::optional<Point>& consecutive_reference) {
     PointOrderSelection result;
 
     bool use_segment_breaking = allow_segment_breaking && polyline.size() > 1 && !min_dist_enabled &&
@@ -102,10 +98,9 @@ PointOrderOptimizer::linkToPoint(const Point& current_location, const Polyline& 
     }
 
     if (local_randomness_enable && !polyline.isEmpty()) {
-        const Point random_origin = result.insert_split_point ? result.split_point : polyline[result.rotation_index];
+        const Point random_origin  = result.insert_split_point ? result.split_point : polyline[result.rotation_index];
         const int randomized_index = computePerturbation(polyline, random_origin, randomness_radius);
-        if (randomized_index >= 0)
-            result = selectionFromIndex(randomized_index);
+        if (randomized_index >= 0) result = selectionFromIndex(randomized_index);
     }
 
     return result;
@@ -131,8 +126,7 @@ bool PointOrderOptimizer::findSkeletonPointOrder(const Point& current_location, 
                 return false;
             break;
         case PointOrderOptimization::kRandom:
-            if (QRandomGenerator::global()->generate() % 2)
-                result = true;
+            if (QRandomGenerator::global()->generate() % 2) result = true;
             break;
         case PointOrderOptimization::kCustomPoint:
             if (findClosestEnd(polyline, current_location, min_dist_enabled, min_dist_threshold) == 0)
@@ -152,30 +146,27 @@ int PointOrderOptimizer::findShortestOrLongestDistance(const Polyline& polyline,
                                                        bool minThresholdEnable, Distance minThreshold, bool shortest) {
     int pointIndex = -1;
     Distance closest;
-    if (shortest)
-        closest = Distance(DBL_MAX);
-    if (minThresholdEnable)
-        closest = Distance(minThreshold);
+    if (shortest) closest = Distance(DBL_MAX);
+    if (minThresholdEnable) closest = Distance(minThreshold);
 
     for (int i = 0, end = polyline.size(); i < end; ++i) {
         Distance dist = polyline[i].distance(startPoint);
         if (shortest) {
             if (dist < closest) {
-                closest = dist;
+                closest    = dist;
                 pointIndex = i;
             }
         }
         else {
             if (dist > closest) {
-                closest = dist;
+                closest    = dist;
                 pointIndex = i;
             }
         }
     }
 
     // if no candidates found it's because nothing met threshold, so find farthest point
-    if (pointIndex == -1)
-        pointIndex = findShortestOrLongestDistance(polyline, startPoint, false, Distance(0), false);
+    if (pointIndex == -1) pointIndex = findShortestOrLongestDistance(polyline, startPoint, false, Distance(0), false);
 
     return pointIndex;
 }
@@ -183,8 +174,7 @@ int PointOrderOptimizer::findShortestOrLongestDistance(const Polyline& polyline,
 PointOrderOptimizer::PointOrderSelection PointOrderOptimizer::findClosestPointOnClosedLoop(const Polyline& polyline,
                                                                                            const Point& queryPoint) {
     PointOrderSelection result;
-    if (polyline.isEmpty())
-        return result;
+    if (polyline.isEmpty()) return result;
 
     double closest_distance = std::numeric_limits<double>::max();
 
@@ -196,17 +186,13 @@ PointOrderOptimizer::PointOrderSelection PointOrderOptimizer::findClosestPointOn
         if (distance < closest_distance) {
             closest_distance = distance;
 
-            if (closest_point == polyline[i]) {
-                result = selectionFromIndex(i);
-            }
-            else if (closest_point == polyline[next_index]) {
-                result = selectionFromIndex(next_index);
-            }
+            if (closest_point == polyline[i]) { result = selectionFromIndex(i); }
+            else if (closest_point == polyline[next_index]) { result = selectionFromIndex(next_index); }
             else {
-                result.rotation_index = next_index;
+                result.rotation_index     = next_index;
                 result.insert_split_point = true;
-                result.split_point = closest_point;
-                result.insertion_index = next_index;
+                result.split_point        = closest_point;
+                result.insertion_index    = next_index;
             }
         }
     }
@@ -245,14 +231,11 @@ int PointOrderOptimizer::linkToRandom(const Polyline& polyline) {
     return QRandomGenerator::global()->bounded(polyline.size());
 }
 
-PointOrderOptimizer::PointOrderSelection
-PointOrderOptimizer::linkToConsecutive(const Polyline& polyline, uint layer_number, Distance minDist,
-                                       const std::optional<Point>& previous_start) {
-    if (polyline.isEmpty())
-        return PointOrderSelection();
+PointOrderOptimizer::PointOrderSelection PointOrderOptimizer::linkToConsecutive(
+    const Polyline& polyline, uint layer_number, Distance minDist, const std::optional<Point>& previous_start) {
+    if (polyline.isEmpty()) return PointOrderSelection();
 
-    if (polyline.size() == 1)
-        return selectionFromIndex(0);
+    if (polyline.size() == 1) return selectionFromIndex(0);
 
     if (!previous_start.has_value() || minDist <= 0)
         return selectionFromIndex(linkToConsecutiveByIndex(polyline, layer_number, minDist));
@@ -263,45 +246,44 @@ PointOrderOptimizer::linkToConsecutive(const Polyline& polyline, uint layer_numb
     Point segment_start;
     int segment_end_index;
     if (nearest_selection.insert_split_point) {
-        segment_start = nearest_selection.split_point;
+        segment_start     = nearest_selection.split_point;
         segment_end_index = nearest_selection.insertion_index;
     }
     else {
         const int start_index = nearest_selection.rotation_index % polyline.size();
-        segment_start = polyline[start_index];
-        segment_end_index = (start_index + 1) % polyline.size();
+        segment_start         = polyline[start_index];
+        segment_end_index     = (start_index + 1) % polyline.size();
     }
 
-    if (planarDistance(segment_start, reference) >= minDist)
-        return nearest_selection;
+    if (planarDistance(segment_start, reference) >= minDist) return nearest_selection;
 
     Distance farthest_distance = Distance(-1.0);
-    int farthest_index = 0;
+    int farthest_index         = 0;
 
     for (int segment_count = 0; segment_count < polyline.size(); ++segment_count) {
-        const Point& segment_end = polyline[segment_end_index];
+        const Point& segment_end    = polyline[segment_end_index];
         const Distance end_distance = planarDistance(segment_end, reference);
 
         if (end_distance > farthest_distance) {
             farthest_distance = end_distance;
-            farthest_index = segment_end_index;
+            farthest_index    = segment_end_index;
         }
 
         if (end_distance >= minDist) {
             std::optional<Point> split_point = pointAtPlanarDistance(segment_start, segment_end, reference, minDist);
             if (split_point.has_value() && *split_point != segment_start && *split_point != segment_end) {
                 PointOrderSelection selection;
-                selection.rotation_index = segment_end_index;
+                selection.rotation_index     = segment_end_index;
                 selection.insert_split_point = true;
-                selection.split_point = *split_point;
-                selection.insertion_index = segment_end_index;
+                selection.split_point        = *split_point;
+                selection.insertion_index    = segment_end_index;
                 return selection;
             }
 
             return selectionFromIndex(segment_end_index);
         }
 
-        segment_start = segment_end;
+        segment_start     = segment_end;
         segment_end_index = (segment_end_index + 1) % polyline.size();
     }
 
@@ -309,12 +291,10 @@ PointOrderOptimizer::linkToConsecutive(const Polyline& polyline, uint layer_numb
 }
 
 int PointOrderOptimizer::linkToConsecutiveByIndex(const Polyline& polyline, uint layer_number, Distance minDist) {
-    if (polyline.isEmpty())
-        return 0;
+    if (polyline.isEmpty()) return 0;
 
     int startIndex = (static_cast<int>(layer_number) - 2) % polyline.size();
-    if (startIndex < 0)
-        startIndex += polyline.size();
+    if (startIndex < 0) startIndex += polyline.size();
 
     int previousIndex = startIndex;
 
@@ -324,9 +304,7 @@ int PointOrderOptimizer::linkToConsecutiveByIndex(const Polyline& polyline, uint
         dist += polyline[previousIndex].distance(polyline[startIndex]);
 
         // looped through whole polyline
-        if (startIndex == previousIndex) {
-            break;
-        }
+        if (startIndex == previousIndex) { break; }
 
     } while (dist < minDist);
 
@@ -337,14 +315,12 @@ int PointOrderOptimizer::computePerturbation(const Polyline& polyline, const Poi
     QVector<int> candidates;
 
     for (int i = 0; i < polyline.size(); ++i) {
-        if (polyline[i].distance(current_start) < radius)
-            candidates.push_back(i);
+        if (polyline[i].distance(current_start) < radius) candidates.push_back(i);
     }
 
-    if (candidates.isEmpty())
-        return -1;
+    if (candidates.isEmpty()) return -1;
 
     return candidates[QRandomGenerator::global()->bounded(candidates.size())];
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/optimizers/polyline_order_optimizer.cpp
+++ b/src/optimizers/polyline_order_optimizer.cpp
@@ -1,9 +1,9 @@
 #include "optimizers/polyline_order_optimizer.h"
 
+#include <QRandomGenerator>
 #include <algorithm>
 #include <tuple>
 
-#include <QRandomGenerator>
 #include <qcontainerfwd.h>
 #include <qsharedpointer.h>
 #include <qtypes.h>
@@ -19,27 +19,28 @@
 namespace ORNL {
 namespace {
 const Distance kLinkOverlapContainmentTolerance = 1 * micron;
-} // namespace
+}  // namespace
 
 PolylineOrderOptimizer::PolylineOrderOptimizer(Point& start, uint layer_number)
     : m_current_location(start), m_layer_number(layer_number), m_override_used(false) {
     m_layer_num = layer_number;
 }
 
-int PolylineOrderOptimizer::getCurrentPolylineCount() { return m_polylines.size(); }
+int PolylineOrderOptimizer::getCurrentPolylineCount() {
+    return m_polylines.size();
+}
 
 void PolylineOrderOptimizer::setGeometryToEvaluate(QVector<Polyline> polylines, RegionType type,
                                                    PathOrderOptimization optimization) {
     m_polylines = polylines;
     for (int i = m_polylines.size() - 1; i >= 0; --i) {
-        if (m_polylines[i].size() < 2)
-            m_polylines.removeAt(i);
+        if (m_polylines[i].size() < 2) m_polylines.removeAt(i);
     }
 
-    m_current_region_type = type;
-    m_optimization = optimization;
+    m_current_region_type    = type;
+    m_optimization           = optimization;
     m_has_computed_heirarchy = false;
-    m_topo_level = 0;
+    m_topo_level             = 0;
     m_topo_order.clear();
     m_open_path_selection_count = 0;
 }
@@ -48,13 +49,13 @@ void PolylineOrderOptimizer::setInfillParameters(InfillPatterns infillPattern, P
                                                  Distance minInfillPathDistance, Distance minTravelDistance,
                                                  bool enable_partitioned_linking, bool avoid_link_overlap,
                                                  Distance link_core_width, PolygonList link_overlap_geometry) {
-    m_pattern = infillPattern;
-    m_border_geometry = border_geometry;
-    m_min_distance = minInfillPathDistance;
-    m_min_travel_distance = minTravelDistance;
+    m_pattern                    = infillPattern;
+    m_border_geometry            = border_geometry;
+    m_min_distance               = minInfillPathDistance;
+    m_min_travel_distance        = minTravelDistance;
     m_enable_partitioned_linking = enable_partitioned_linking && m_pattern == InfillPatterns::kLines;
-    m_avoid_link_overlap = avoid_link_overlap;
-    m_link_core_width = link_core_width;
+    m_avoid_link_overlap         = avoid_link_overlap;
+    m_link_core_width            = link_core_width;
     // Links generated from offset geometry can legally touch the allowed boundary; relax by one internal unit so
     // Clipper slivers from exact boundary contact do not turn safe links into travels.
     m_link_overlap_geometry = m_avoid_link_overlap && !link_overlap_geometry.isEmpty()
@@ -66,13 +67,13 @@ void PolylineOrderOptimizer::setPointParameters(PointOrderOptimization pointOpti
                                                 Distance minDistanceThreshold, Distance consecutiveThreshold,
                                                 bool randomnessEnable, Distance randomnessRadius,
                                                 bool enableSegmentBreaking) {
-    m_point_optimization = pointOptimization;
+    m_point_optimization        = pointOptimization;
     m_min_point_distance_enable = minDistanceEnable;
-    m_min_point_distance = minDistanceThreshold;
-    m_consecutive_threshold = consecutiveThreshold;
-    m_randomness_enable = randomnessEnable;
-    m_randomness_radius = randomnessRadius;
-    m_segment_breaking_enable = enableSegmentBreaking;
+    m_min_point_distance        = minDistanceThreshold;
+    m_consecutive_threshold     = consecutiveThreshold;
+    m_randomness_enable         = randomnessEnable;
+    m_randomness_radius         = randomnessRadius;
+    m_segment_breaking_enable   = enableSegmentBreaking;
 }
 
 void PolylineOrderOptimizer::setConsecutiveReferencePoint(const std::optional<Point>& point) {
@@ -81,10 +82,12 @@ void PolylineOrderOptimizer::setConsecutiveReferencePoint(const std::optional<Po
 
 void PolylineOrderOptimizer::setStartOverride(Point pt) {
     m_override_location = pt;
-    m_override_used = true;
+    m_override_used     = true;
 }
 
-void PolylineOrderOptimizer::setStartPointOverride(Point pt) { m_point_override_location = pt; }
+void PolylineOrderOptimizer::setStartPointOverride(Point pt) {
+    m_point_override_location = pt;
+}
 
 Polyline PolylineOrderOptimizer::linkNextPolyline(QVector<Polyline> polylines) {
     if (m_polylines.size() > 0) {
@@ -136,8 +139,7 @@ Polyline PolylineOrderOptimizer::linkNextInfillPolyline(QVector<Polyline>& polyl
             break;
     }
 
-    if (nextPolyline.length() < m_min_distance)
-        nextPolyline.clear();
+    if (nextPolyline.length() < m_min_distance) nextPolyline.clear();
 
     return nextPolyline;
 }
@@ -164,13 +166,10 @@ Polyline PolylineOrderOptimizer::linkNextInfillLines(QVector<Polyline>& polyline
                 closestOpenPolyline({m_polylines.front(), m_polylines.back()}, temp_current_location);
             index = (endpoint_index == 0) ? 0 : (m_polylines.size() - 1);
         }
-        if (index < 0 || index >= m_polylines.size())
-            return new_polyline;
+        if (index < 0 || index >= m_polylines.size()) return new_polyline;
 
         // if false, indicates index is closest if you start at the end point, so reverse
-        if (start == false) {
-            m_polylines[index] = m_polylines[index].reverse();
-        }
+        if (start == false) { m_polylines[index] = m_polylines[index].reverse(); }
 
         new_polyline += m_polylines[index];
         temp_current_location = new_polyline.back();
@@ -182,16 +181,13 @@ Polyline PolylineOrderOptimizer::linkNextInfillLines(QVector<Polyline>& polyline
         for (int i = 0, end = m_polylines.size(); i < end; ++i) {
             if (m_polylines.size() > 0) {
                 const auto& [index, start] = closestOpenPolyline(m_polylines, temp_current_location);
-                if (index < 0 || index >= m_polylines.size())
-                    break;
+                if (index < 0 || index >= m_polylines.size()) break;
 
                 // if false, indicates index is closest if you start at the end point, so reverse
-                if (start == false) {
-                    m_polylines[index] = m_polylines[index].reverse();
-                }
+                if (start == false) { m_polylines[index] = m_polylines[index].reverse(); }
 
-                Point link_start = temp_current_location;
-                Point link_end = m_polylines[index].front();
+                Point link_start       = temp_current_location;
+                Point link_end         = m_polylines[index].front();
                 Distance link_distance = link_start.distance(link_end);
 
                 // Link must not intersect border geometry, remaining polylines, previously created/optimized polylines,
@@ -224,14 +220,11 @@ Polyline PolylineOrderOptimizer::linkNextInfillLines(QVector<Polyline>& polyline
         }
         else {
             Distance front_distance = m_point_override_location.distance(new_polyline.front());
-            Distance back_distance = m_point_override_location.distance(new_polyline.back());
+            Distance back_distance  = m_point_override_location.distance(new_polyline.back());
             if (m_point_optimization == PointOrderOptimization::kCustomFarthestPoint) {
-                if (front_distance < back_distance)
-                    new_polyline = new_polyline.reverse();
+                if (front_distance < back_distance) new_polyline = new_polyline.reverse();
             }
-            else if (front_distance > back_distance) {
-                new_polyline = new_polyline.reverse();
-            }
+            else if (front_distance > back_distance) { new_polyline = new_polyline.reverse(); }
         }
     }
 
@@ -243,8 +236,7 @@ Polyline PolylineOrderOptimizer::linkNextInfillConcentric() {
 
     //! \note Future work: travels aren't always needed between concentric Polylines, only needed when link distance is
     //! longer than \note travel distance or when link/travel segment crosses Polylines or border geometry
-    if (m_polylines.size() > 0)
-        new_polyline = linkTo();
+    if (m_polylines.size() > 0) new_polyline = linkTo();
 
     return new_polyline;
 }
@@ -253,13 +245,10 @@ Polyline PolylineOrderOptimizer::linkNextSkeletonPolyline() {
     Polyline new_polyline;
     if (!m_polylines.isEmpty()) {
         const auto& [index, start] = closestOpenPolyline(m_polylines, m_current_location);
-        if (index < 0 || index >= m_polylines.size())
-            return new_polyline;
+        if (index < 0 || index >= m_polylines.size()) return new_polyline;
 
         new_polyline = m_polylines[index];
-        if (!start) {
-            new_polyline = new_polyline.reverse();
-        }
+        if (!start) { new_polyline = new_polyline.reverse(); }
         m_polylines.remove(index);
     }
 
@@ -269,19 +258,17 @@ Polyline PolylineOrderOptimizer::linkNextSkeletonPolyline() {
     else
         queryPoint = m_current_location;
 
-    if (new_polyline.isEmpty())
-        return new_polyline;
+    if (new_polyline.isEmpty()) return new_polyline;
 
     // If polyline is closed loop, apply point optimization strategies for a closed-loop path not a skeleton
     if (new_polyline.front() == new_polyline.back()) {
         // Remove last element because it is a duplicate of the first. It will be re-added after re-ordering the vector.
         new_polyline.removeLast();
 
-        auto pointSelection =
-            PointOrderOptimizer::linkToPoint(queryPoint, new_polyline, m_layer_num, m_point_optimization,
-                                             m_min_point_distance_enable, m_min_point_distance, m_consecutive_threshold,
-                                             m_randomness_enable, m_randomness_radius, m_segment_breaking_enable,
-                                             m_consecutive_reference_point);
+        auto pointSelection = PointOrderOptimizer::linkToPoint(
+            queryPoint, new_polyline, m_layer_num, m_point_optimization, m_min_point_distance_enable,
+            m_min_point_distance, m_consecutive_threshold, m_randomness_enable, m_randomness_radius,
+            m_segment_breaking_enable, m_consecutive_reference_point);
 
         applyPointOrderSelection(new_polyline, pointSelection);
 
@@ -303,12 +290,10 @@ bool PolylineOrderOptimizer::linkIntersects(Point link_start, Point link_end, QV
     for (Polyline polyline : infill_geometry) {
         for (int i = 0, end = polyline.size() - 1; i < end; ++i) {
             Point startPt = polyline[i];
-            Point endPt = polyline[(i + 1) % polyline.size()];
+            Point endPt   = polyline[(i + 1) % polyline.size()];
 
             if (link_start != startPt && link_start != endPt && link_end != startPt && link_end != endPt) {
-                if (MathUtils::intersect(link_start, link_end, startPt, endPt)) {
-                    return true;
-                }
+                if (MathUtils::intersect(link_start, link_end, startPt, endPt)) { return true; }
             }
         }
     }
@@ -316,15 +301,11 @@ bool PolylineOrderOptimizer::linkIntersects(Point link_start, Point link_end, QV
     //! Check for possible intersections with border geometry
     for (Polygon poly : border_geometry) {
         for (int i = 0, end = poly.size() - 1; i < end; ++i) {
-            if (MathUtils::intersect(link_start, link_end, poly[i], poly[i + 1])) {
-                return true;
-            }
+            if (MathUtils::intersect(link_start, link_end, poly[i], poly[i + 1])) { return true; }
         }
 
         //! Check last line of polygon
-        if (MathUtils::intersect(link_start, link_end, poly.last(), poly.first())) {
-            return true;
-        }
+        if (MathUtils::intersect(link_start, link_end, poly.last(), poly.first())) { return true; }
     }
 
     return false;
@@ -348,43 +329,39 @@ QPair<int, bool> PolylineOrderOptimizer::closestOpenPolyline(QVector<Polyline> p
 
 QPair<int, bool> PolylineOrderOptimizer::extremumOpenPolyline(QVector<Polyline> polylines, Point currentLocation,
                                                               bool closest) {
-    if (polylines.isEmpty())
-        return QPair<int, bool>(-1, true);
+    if (polylines.isEmpty()) return QPair<int, bool>(-1, true);
 
     Distance selected_distance;
 
-    int index = 0;
-    bool start = true;
+    int index           = 0;
+    bool start          = true;
     bool found_polyline = false;
 
     Point queryPoint = currentLocation;
 
     for (int i = 0, end = polylines.size(); i < end; ++i) {
-        if (polylines[i].isEmpty())
-            continue;
+        if (polylines[i].isEmpty()) continue;
 
         const Distance front_distance = queryPoint.distance(polylines[i].front());
-        const Distance back_distance = queryPoint.distance(polylines[i].back());
-        const Distance path_distance = std::min(front_distance, back_distance);
+        const Distance back_distance  = queryPoint.distance(polylines[i].back());
+        const Distance path_distance  = std::min(front_distance, back_distance);
 
         if (!found_polyline || (closest && path_distance < selected_distance) ||
             (!closest && path_distance > selected_distance)) {
             selected_distance = path_distance;
-            index = i;
-            start = front_distance <= back_distance;
-            found_polyline = true;
+            index             = i;
+            start             = front_distance <= back_distance;
+            found_polyline    = true;
         }
     }
     return QPair<int, bool>(index, start);
 }
 
 QPair<int, bool> PolylineOrderOptimizer::orderedOpenPolyline(QVector<Polyline> polylines, Point currentLocation) {
-    if (polylines.isEmpty())
-        return QPair<int, bool>(-1, true);
+    if (polylines.isEmpty()) return QPair<int, bool>(-1, true);
 
     Point query_point = currentLocation;
-    if (m_optimization == PathOrderOptimization::kCustomPoint && m_override_used)
-        query_point = m_override_location;
+    if (m_optimization == PathOrderOptimization::kCustomPoint && m_override_used) query_point = m_override_location;
 
     switch (m_optimization) {
         case PathOrderOptimization::kNextFarthest:
@@ -394,12 +371,12 @@ QPair<int, bool> PolylineOrderOptimizer::orderedOpenPolyline(QVector<Polyline> p
                                     QRandomGenerator::global()->bounded(2) == 0);
         case PathOrderOptimization::kOutsideIn: {
             if (m_open_path_selection_count == 0) {
-                const auto exterior = closestOpenPolyline({polylines.front(), polylines.back()}, query_point);
+                const auto exterior     = closestOpenPolyline({polylines.front(), polylines.back()}, query_point);
                 m_outside_in_from_front = exterior.first == 0;
             }
 
             const bool select_front = (m_open_path_selection_count % 2 == 0) == m_outside_in_from_front;
-            const int index = select_front ? 0 : polylines.size() - 1;
+            const int index         = select_front ? 0 : polylines.size() - 1;
             ++m_open_path_selection_count;
 
             bool start =
@@ -421,34 +398,25 @@ QPair<int, bool> PolylineOrderOptimizer::orderedOpenPolyline(QVector<Polyline> p
 
 void PolylineOrderOptimizer::applyPointOrderSelection(Polyline& polyline,
                                                       const PointOrderOptimizer::PointOrderSelection& selection) const {
-    if (polyline.isEmpty())
-        return;
+    if (polyline.isEmpty()) return;
 
     int rotation_index = selection.rotation_index;
 
     if (selection.insert_split_point) {
         int insertion_index = selection.insertion_index;
-        int previous_index = (insertion_index == 0) ? polyline.size() - 1 : insertion_index - 1;
-        int next_index = insertion_index % polyline.size();
+        int previous_index  = (insertion_index == 0) ? polyline.size() - 1 : insertion_index - 1;
+        int next_index      = insertion_index % polyline.size();
 
-        if (selection.split_point == polyline[previous_index]) {
-            rotation_index = previous_index;
-        }
-        else if (selection.split_point == polyline[next_index]) {
-            rotation_index = next_index;
-        }
-        else {
-            polyline.insert(insertion_index, selection.split_point);
-        }
+        if (selection.split_point == polyline[previous_index]) { rotation_index = previous_index; }
+        else if (selection.split_point == polyline[next_index]) { rotation_index = next_index; }
+        else { polyline.insert(insertion_index, selection.split_point); }
     }
 
-    for (int i = 0; i < rotation_index; ++i)
-        polyline.move(0, polyline.size() - 1);
+    for (int i = 0; i < rotation_index; ++i) polyline.move(0, polyline.size() - 1);
 }
 
 Polyline PolylineOrderOptimizer::linkTo() {
-    if (m_polylines.isEmpty())
-        return Polyline();
+    if (m_polylines.isEmpty()) return Polyline();
 
     int polylineIndex;
     switch (m_optimization) {
@@ -471,13 +439,11 @@ Polyline PolylineOrderOptimizer::linkTo() {
             polylineIndex = findShortestOrLongestDistance();
             break;
     }
-    if (polylineIndex < 0 || polylineIndex >= m_polylines.size())
-        return Polyline();
+    if (polylineIndex < 0 || polylineIndex >= m_polylines.size()) return Polyline();
 
     Polyline nextPolyline = m_polylines[polylineIndex];
     m_polylines.removeAt(polylineIndex);
-    if (nextPolyline.size() < 2)
-        return Polyline();
+    if (nextPolyline.size() < 2) return Polyline();
 
     Point queryPoint;
     if (usesCustomPointLocation(m_point_optimization))
@@ -496,8 +462,7 @@ Polyline PolylineOrderOptimizer::linkTo() {
 }
 
 int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
-    if (m_polylines.isEmpty())
-        return -1;
+    if (m_polylines.isEmpty()) return -1;
 
     Point queryPoint;
     if (m_optimization == PathOrderOptimization::kCustomPoint && m_override_used)
@@ -509,8 +474,7 @@ int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
     Distance selected_distance;
 
     for (int i = 0, end = m_polylines.size(); i < end; ++i) {
-        if (m_polylines[i].size() < 2)
-            continue;
+        if (m_polylines[i].size() < 2) continue;
 
         for (int j = 0, end2 = m_polylines[i].size(); j < end2; ++j) {
             int next_index = (j + 1) % m_polylines[i].size();
@@ -519,7 +483,7 @@ int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
             if (polylineIndex < 0 || (shortest && closestSegment < selected_distance) ||
                 (!shortest && closestSegment > selected_distance)) {
                 selected_distance = closestSegment;
-                polylineIndex = i;
+                polylineIndex     = i;
             }
         }
     }
@@ -528,15 +492,13 @@ int PolylineOrderOptimizer::findShortestOrLongestDistance(bool shortest) {
 }
 
 int PolylineOrderOptimizer::linkToRandom() {
-    if (m_polylines.isEmpty())
-        return -1;
+    if (m_polylines.isEmpty()) return -1;
 
     return QRandomGenerator::global()->bounded(m_polylines.size());
 }
 
 int PolylineOrderOptimizer::findInteriorExterior(bool ExtToInt) {
-    if (m_polylines.isEmpty())
-        return -1;
+    if (m_polylines.isEmpty()) return -1;
 
     if (!m_has_computed_heirarchy && m_polylines.size() > 0) {
         QSharedPointer<TopologicalNode> root = computeTopologicalHeirarchy();
@@ -544,26 +506,21 @@ int PolylineOrderOptimizer::findInteriorExterior(bool ExtToInt) {
         levelOrder(root);
         if (!ExtToInt) {
             std::reverse(m_topo_order.begin(), m_topo_order.end());
-            for (QVector<int>& level : m_topo_order) {
-                std::reverse(level.begin(), level.end());
-            }
+            for (QVector<int>& level : m_topo_order) { std::reverse(level.begin(), level.end()); }
         }
 
         m_has_computed_heirarchy = true;
     }
 
-    if (m_topo_order.isEmpty() || m_topo_order.first().isEmpty())
-        return findShortestOrLongestDistance();
+    if (m_topo_order.isEmpty() || m_topo_order.first().isEmpty()) return findShortestOrLongestDistance();
 
     int result = m_topo_order.first().first();
     m_topo_order.first().pop_front();
-    if (m_topo_order.first().size() == 0)
-        m_topo_order.pop_front();
+    if (m_topo_order.first().size() == 0) m_topo_order.pop_front();
 
     for (QVector<int>& level : m_topo_order)
         for (int& element : level)
-            if (element > result)
-                --element;
+            if (element > result) --element;
 
     return result;
 }
@@ -573,21 +530,18 @@ QSharedPointer<PolylineOrderOptimizer::TopologicalNode> PolylineOrderOptimizer::
     all_nodes.reserve(m_polylines.size());
 
     for (int i = 0, end = m_polylines.size(); i < end; ++i) {
-        if (m_polylines[i].size() < 2)
-            continue;
+        if (m_polylines[i].size() < 2) continue;
 
         all_nodes.push_back(QSharedPointer<TopologicalNode>::create(TopologicalNode(i, m_polylines[i])));
     }
-    if (all_nodes.isEmpty())
-        return QSharedPointer<TopologicalNode>();
+    if (all_nodes.isEmpty()) return QSharedPointer<TopologicalNode>();
 
     // assume first Polyline is outer contour
     QSharedPointer<TopologicalNode> root;
     root = all_nodes[0];
     all_nodes.removeFirst();
 
-    for (QSharedPointer<TopologicalNode> node : all_nodes)
-        insert(root, node);
+    for (QSharedPointer<TopologicalNode> node : all_nodes) insert(root, node);
 
     return root;
 }
@@ -618,8 +572,7 @@ void PolylineOrderOptimizer::insert(QSharedPointer<TopologicalNode> root, QShare
 }
 
 void PolylineOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
-    if (root.isNull())
-        return;
+    if (root.isNull()) return;
 
     if (m_topo_order.size() == m_topo_level)
         m_topo_order.push_back({root->m_Polyline_index});
@@ -628,8 +581,7 @@ void PolylineOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
 
     ++m_topo_level;
 
-    for (QSharedPointer<TopologicalNode> n : root->m_children)
-        levelOrder(n);
+    for (QSharedPointer<TopologicalNode> n : root->m_children) levelOrder(n);
 
     --m_topo_level;
 }
@@ -637,8 +589,7 @@ void PolylineOrderOptimizer::levelOrder(QSharedPointer<TopologicalNode> root) {
 Polyline PolylineOrderOptimizer::linkSpiralPolyline2D(bool last_spiral, Distance layerHeight,
                                                       PointOrderOptimization pointOrder) {
     int polylineIndex = findShortestOrLongestDistance();
-    if (polylineIndex < 0 || polylineIndex >= m_polylines.size())
-        return Polyline();
+    if (polylineIndex < 0 || polylineIndex >= m_polylines.size()) return Polyline();
 
     Polyline newPolyline = m_polylines[polylineIndex];
     m_polylines.removeAt(polylineIndex);
@@ -650,14 +601,14 @@ Polyline PolylineOrderOptimizer::linkSpiralPolyline2D(bool last_spiral, Distance
     if (m_layer_num == 0) {
         if (usesCustomPointLocation(pointOrder)) {
             Point startOverride = m_point_override_location;
-            pointSelection = PointOrderOptimizer::linkToPoint(startOverride, newPolyline, m_layer_num, pointOrder,
-                                                              false, 0, 0, false, 0, m_segment_breaking_enable,
-                                                              m_consecutive_reference_point);
+            pointSelection =
+                PointOrderOptimizer::linkToPoint(startOverride, newPolyline, m_layer_num, pointOrder, false, 0, 0,
+                                                 false, 0, m_segment_breaking_enable, m_consecutive_reference_point);
         }
         else {
-            pointSelection = PointOrderOptimizer::linkToPoint(m_current_location, newPolyline, m_layer_num, pointOrder,
-                                                              false, 0, 0, false, 0, m_segment_breaking_enable,
-                                                              m_consecutive_reference_point);
+            pointSelection =
+                PointOrderOptimizer::linkToPoint(m_current_location, newPolyline, m_layer_num, pointOrder, false, 0, 0,
+                                                 false, 0, m_segment_breaking_enable, m_consecutive_reference_point);
         }
     }
 
@@ -679,4 +630,4 @@ Polyline PolylineOrderOptimizer::linkSpiralPolyline2D(bool last_spiral, Distance
     }
     return newPolyline;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/part/part.cpp
+++ b/src/part/part.cpp
@@ -28,55 +28,53 @@
 
 namespace ORNL {
 Part::Part() {
-    m_sb = QSharedPointer<SettingsBase>::create();
+    m_sb   = QSharedPointer<SettingsBase>::create();
     m_uuid = QUuid::createUuid();
 }
 
 Part::Part(const QSharedPointer<Part>& p) {
     // Copy root and sub meshes
     auto closed_mesh = dynamic_cast<ClosedMesh*>(p->m_root_mesh.get());
-    if (closed_mesh != nullptr) {
-        m_root_mesh = QSharedPointer<ClosedMesh>::create(*closed_mesh);
-    }
-    else {
-        m_root_mesh = QSharedPointer<OpenMesh>::create(*dynamic_cast<OpenMesh*>(p->m_root_mesh.get()));
-    }
+    if (closed_mesh != nullptr) { m_root_mesh = QSharedPointer<ClosedMesh>::create(*closed_mesh); }
+    else { m_root_mesh = QSharedPointer<OpenMesh>::create(*dynamic_cast<OpenMesh*>(p->m_root_mesh.get())); }
 
     for (QSharedPointer<MeshBase> sub : p->m_sub_meshes) {
         auto closed_sub_mesh = dynamic_cast<ClosedMesh*>(sub.get());
         if (closed_sub_mesh != nullptr) {
             m_sub_meshes.push_back(QSharedPointer<ClosedMesh>::create(*closed_sub_mesh));
         }
-        else {
-            m_sub_meshes.push_back(QSharedPointer<OpenMesh>::create(*dynamic_cast<OpenMesh*>(sub.get())));
-        }
+        else { m_sub_meshes.push_back(QSharedPointer<OpenMesh>::create(*dynamic_cast<OpenMesh*>(sub.get()))); }
     }
 
-    m_name = p->m_name;
+    m_name      = p->m_name;
     m_file_name = p->m_file_name;
 
     m_sb = QSharedPointer<SettingsBase>::create(*p->getSb());
 
-    m_template_applied = false;
+    m_template_applied      = false;
     m_current_part_template = "";
 
     m_uuid = QUuid::createUuid();
 }
 
 Part::Part(QSharedPointer<MeshBase> root_mesh, QString file_name, MeshType mt) {
-    m_file_name = file_name;
-    m_mesh_type = mt;
-    m_name = root_mesh->name();
-    m_root_mesh = root_mesh;
-    m_sb = QSharedPointer<SettingsBase>::create();
+    m_file_name        = file_name;
+    m_mesh_type        = mt;
+    m_name             = root_mesh->name();
+    m_root_mesh        = root_mesh;
+    m_sb               = QSharedPointer<SettingsBase>::create();
     m_template_applied = false;
 
     m_uuid = QUuid::createUuid();
 }
 
-QSharedPointer<SettingsBase> Part::getSb() const { return m_sb; }
+QSharedPointer<SettingsBase> Part::getSb() const {
+    return m_sb;
+}
 
-QMap<uint, QSharedPointer<SettingsRange>> Part::getSettingsRanges() { return m_ranges; }
+QMap<uint, QSharedPointer<SettingsRange>> Part::getSettingsRanges() {
+    return m_ranges;
+}
 
 void Part::createSettingsRange(int low, int high, QString group_name) {
     int min = qMin(low, high);
@@ -93,24 +91,24 @@ void Part::createSettingsRange(int low, int high, QString group_name) {
     }
     QSharedPointer<SettingsRange> new_range;
     if (sb != nullptr)
-        new_range = QSharedPointer<SettingsRange>::create(min, max, group_name, sb); // use found sb
+        new_range = QSharedPointer<SettingsRange>::create(min, max, group_name, sb);  // use found sb
     else
         new_range = QSharedPointer<SettingsRange>::create(
-            min, max, group_name, QSharedPointer<SettingsBase>::create(*m_sb)); // make new sb as a copy of the part's
+            min, max, group_name, QSharedPointer<SettingsBase>::create(*m_sb));  // make new sb as a copy of the part's
 
     m_ranges[MathUtils::cantorPair(min, max)] = new_range;
     m_range_from_template[MathUtils::cantorPair(min, max)] =
-        false; // not from template. Set corresponding index to false.
+        false;  // not from template. Set corresponding index to false.
 }
 
 void Part::createSettingsRange(int low, int high, QSharedPointer<SettingsBase> sb, QString group_name) {
-    int min = qMin(low, high);
-    int max = qMax(low, high);
-    QSharedPointer<SettingsRange> new_range = QSharedPointer<SettingsRange>::create(min, max, group_name, sb);
+    int min                                   = qMin(low, high);
+    int max                                   = qMax(low, high);
+    QSharedPointer<SettingsRange> new_range   = QSharedPointer<SettingsRange>::create(min, max, group_name, sb);
     m_ranges[MathUtils::cantorPair(min, max)] = new_range;
-    m_range_from_template[MathUtils::cantorPair(min, max)] = true; // from template
-    m_current_part_template = GSM->getCurrentTemplate();
-    m_template_applied = true;
+    m_range_from_template[MathUtils::cantorPair(min, max)] = true;  // from template
+    m_current_part_template                                = GSM->getCurrentTemplate();
+    m_template_applied                                     = true;
 }
 
 QSharedPointer<SettingsRange> Part::getSettingsRange(int low, int high) {
@@ -119,21 +117,29 @@ QSharedPointer<SettingsRange> Part::getSettingsRange(int low, int high) {
     return m_ranges.value(MathUtils::cantorPair(min, max));
 }
 
-bool Part::getTemplateApplied() { return m_template_applied; }
+bool Part::getTemplateApplied() {
+    return m_template_applied;
+}
 
-void Part::setCurrentPartTemplate(QString current_template) { m_current_part_template = current_template; }
+void Part::setCurrentPartTemplate(QString current_template) {
+    m_current_part_template = current_template;
+}
 
-QString Part::getCurrentPartTemplate() { return m_current_part_template; }
+QString Part::getCurrentPartTemplate() {
+    return m_current_part_template;
+}
 
-QMap<uint, bool> Part::getRangesFromTemplate() { return m_range_from_template; }
+QMap<uint, bool> Part::getRangesFromTemplate() {
+    return m_range_from_template;
+}
 
 bool Part::currentPartTemplateEqualToSetTemplate(QString set_template) {
     return m_current_part_template == set_template;
 }
 
 void Part::removeSettingsRange(int low, int high) {
-    int min = qMin(low, high);
-    int max = qMax(low, high);
+    int min        = qMin(low, high);
+    int max        = qMax(low, high);
     const uint key = MathUtils::cantorPair(min, max);
     m_ranges.remove(key);
     m_range_from_template.remove(key);
@@ -149,9 +155,9 @@ json Part::SettingsRangesToJson() {
 
     for (auto& range : m_ranges) {
         json range_json;
-        range_json[Constants::Settings::Session::Range::kLow] = range->low();
-        range_json[Constants::Settings::Session::Range::kHigh] = range->high();
-        range_json[Constants::Settings::Session::Range::kName] = range->groupName();
+        range_json[Constants::Settings::Session::Range::kLow]      = range->low();
+        range_json[Constants::Settings::Session::Range::kHigh]     = range->high();
+        range_json[Constants::Settings::Session::Range::kName]     = range->groupName();
         range_json[Constants::Settings::Session::Range::kSettings] = range->getSb()->json();
         output.push_back(range_json);
     }
@@ -163,10 +169,10 @@ void Part::loadRangesFromJson(json input) {
     m_ranges.clear();
     m_range_from_template.clear();
     for (auto& range_json : input) {
-        int low = range_json[Constants::Settings::Session::Range::kLow];
-        int high = range_json[Constants::Settings::Session::Range::kHigh];
+        int low       = range_json[Constants::Settings::Session::Range::kLow];
+        int high      = range_json[Constants::Settings::Session::Range::kHigh];
         QString group = range_json[Constants::Settings::Session::Range::kName];
-        auto sb = QSharedPointer<SettingsBase>::create();
+        auto sb       = QSharedPointer<SettingsBase>::create();
         sb->json(range_json[Constants::Settings::Session::Range::kSettings]);
         createSettingsRange(low, high, sb, group);
     }
@@ -175,67 +181,72 @@ void Part::loadRangesFromJson(json input) {
 void Part::splitSettingsRange(int low, int high) {
     // create new single ranges for endpoints with copies of setttings
     // then delete the range
-    int min = qMin(low, high);
-    int max = qMax(low, high);
+    int min                         = qMin(low, high);
+    int max                         = qMax(low, high);
     QSharedPointer<SettingsBase> sb = m_ranges[MathUtils::cantorPair(min, max)]->getSb();
 
     QSharedPointer<SettingsRange> new_range_low = QSharedPointer<SettingsRange>::create(min, min, "", sb);
-    m_ranges[MathUtils::cantorPair(min, min)] = new_range_low;
+    m_ranges[MathUtils::cantorPair(min, min)]   = new_range_low;
 
     QSharedPointer<SettingsRange> new_range_high = QSharedPointer<SettingsRange>::create(max, max, "", sb);
-    m_ranges[MathUtils::cantorPair(max, max)] = new_range_high;
+    m_ranges[MathUtils::cantorPair(max, max)]    = new_range_high;
 
     removeSettingsRange(min, max);
 }
 
 void Part::updateSettingsRangeLimits(int old_low, int old_high, int new_low, int new_high) {
     // get the old one, to use its sb and group name
-    int old_min = qMin(old_low, old_high);
-    int old_max = qMax(old_low, old_high);
-    const uint old_key = MathUtils::cantorPair(old_min, old_max);
+    int old_min                       = qMin(old_low, old_high);
+    int old_max                       = qMax(old_low, old_high);
+    const uint old_key                = MathUtils::cantorPair(old_min, old_max);
     QSharedPointer<SettingsRange> old = getSettingsRange(old_min, old_max);
-    if (old.isNull())
-        return;
+    if (old.isNull()) return;
 
     // make a new range at the new location
     int min = qMin(new_low, new_high);
     int max = qMax(new_low, new_high);
-    if (old_min == min && old_max == max)
-        return;
+    if (old_min == min && old_max == max) return;
 
-    const bool was_from_template = m_range_from_template.value(old_key, false);
+    const bool was_from_template    = m_range_from_template.value(old_key, false);
     QSharedPointer<SettingsBase> sb = old->getSb();
-    QString group_name = old->groupName();
+    QString group_name              = old->groupName();
     removeSettingsRange(old_min, old_max);
-    const uint new_key = MathUtils::cantorPair(min, max);
-    m_ranges[new_key] = QSharedPointer<SettingsRange>::create(min, max, group_name, sb);
+    const uint new_key             = MathUtils::cantorPair(min, max);
+    m_ranges[new_key]              = QSharedPointer<SettingsRange>::create(min, max, group_name, sb);
     m_range_from_template[new_key] = was_from_template;
 }
 
-void Part::setRootMesh(QSharedPointer<MeshBase> mesh) { m_root_mesh = mesh; }
+void Part::setRootMesh(QSharedPointer<MeshBase> mesh) {
+    m_root_mesh = mesh;
+}
 
 void Part::setRootMesh(const QVector<MeshVertex>& vertices, const QVector<MeshFace>& faces) {
     m_root_mesh = QSharedPointer<ClosedMesh>(new ClosedMesh(vertices, faces));
 }
 
-QSharedPointer<MeshBase> Part::rootMesh() { return m_root_mesh; }
+QSharedPointer<MeshBase> Part::rootMesh() {
+    return m_root_mesh;
+}
 
-QVector<QSharedPointer<MeshBase>> Part::subMeshes() { return m_sub_meshes; }
+QVector<QSharedPointer<MeshBase>> Part::subMeshes() {
+    return m_sub_meshes;
+}
 
-void Part::appendSubMesh(QSharedPointer<MeshBase> mesh) { m_sub_meshes.push_back(mesh); }
+void Part::appendSubMesh(QSharedPointer<MeshBase> mesh) {
+    m_sub_meshes.push_back(mesh);
+}
 
-void Part::clearSubMeshes() { m_sub_meshes.clear(); }
+void Part::clearSubMeshes() {
+    m_sub_meshes.clear();
+}
 
 void Part::scaleSubMeshes() {
-    for (auto mesh : m_sub_meshes) {
-        mesh->scaleUniform(this->m_root_mesh->dimensions());
-    }
+    for (auto mesh : m_sub_meshes) { mesh->scaleUniform(this->m_root_mesh->dimensions()); }
 }
 
 bool Part::containsSubMesh(QString name) {
     for (QSharedPointer<MeshBase> mesh : m_sub_meshes) {
-        if (name == mesh->name())
-            return true;
+        if (name == mesh->name()) return true;
     }
 
     return false;
@@ -253,16 +264,12 @@ void Part::setTransformation(const QMatrix4x4& mtrx) {
     if (!qFuzzyCompare(mtrx, m_root_mesh->transformation())) {
         m_root_mesh->setTransformation(mtrx);
 
-        for (auto mesh : m_sub_meshes) {
-            mesh->setTransformation(mtrx);
-        }
+        for (auto mesh : m_sub_meshes) { mesh->setTransformation(mtrx); }
         this->setStepsDirty();
 
         // If this was a settings mesh then all other parts are now also dirty
         if (m_root_mesh->type() == kSettings) {
-            for (const auto& part : CSM->parts()) {
-                part->setStepsDirty();
-            }
+            for (const auto& part : CSM->parts()) { part->setStepsDirty(); }
         }
     }
 }
@@ -277,13 +284,16 @@ void Part::orphanChild(QSharedPointer<Part> p) {
     p->m_parent.reset();
 }
 
-QList<QSharedPointer<Part>> Part::children() { return m_children; }
+QList<QSharedPointer<Part>> Part::children() {
+    return m_children;
+}
 
-QSharedPointer<Part> Part::parent() { return m_parent; }
+QSharedPointer<Part> Part::parent() {
+    return m_parent;
+}
 
 void Part::prependStep(QSharedPointer<Step> step) {
-    if (step == nullptr)
-        return;
+    if (step == nullptr) return;
 
     StepPair new_group;
     switch (step->getType()) {
@@ -295,15 +305,14 @@ void Part::prependStep(QSharedPointer<Step> step) {
             new_group.scan_layer = qSharedPointerDynamicCast<ScanLayer>(step);
             break;
         case StepType::kAll:
-            Q_ASSERT(false); // a step shouldn't have type of 'All'
+            Q_ASSERT(false);  // a step shouldn't have type of 'All'
             break;
     }
     m_step_pairs.push_front(new_group);
 }
 
 void Part::appendStep(QSharedPointer<Step> step) {
-    if (step == nullptr)
-        return;
+    if (step == nullptr) return;
 
     StepPair new_group;
     switch (step->getType()) {
@@ -315,26 +324,30 @@ void Part::appendStep(QSharedPointer<Step> step) {
             new_group.scan_layer = qSharedPointerDynamicCast<ScanLayer>(step);
             break;
         case StepType::kAll:
-            Q_ASSERT(false); // a step shouldn't have type of 'All'
+            Q_ASSERT(false);  // a step shouldn't have type of 'All'
             break;
     }
     m_step_pairs.push_back(new_group);
 }
 
-void Part::clearSteps() { m_step_pairs.clear(); }
+void Part::clearSteps() {
+    m_step_pairs.clear();
+}
 
 void Part::addScanLayerToStep(int step_index, QSharedPointer<ScanLayer> scan_layer) {
     Q_ASSERT(step_index < m_step_pairs.size());
     m_step_pairs[step_index].scan_layer = scan_layer;
 }
 
-int Part::countStepPairs() { return m_step_pairs.size(); }
+int Part::countStepPairs() {
+    return m_step_pairs.size();
+}
 
 QSharedPointer<Step> Part::step(int index, StepType type) {
     // this function could return a nullptr if the type isn't on this specified step
     Q_ASSERT(index < m_step_pairs.size());
     QSharedPointer<Step> result = nullptr;
-    StepPair step_group = m_step_pairs[index];
+    StepPair step_group         = m_step_pairs[index];
     switch (type) {
         case StepType::kLayer:
             if (step_group.printing_layer != nullptr && step_group.printing_layer->getType() == StepType::kLayer)
@@ -347,7 +360,7 @@ QSharedPointer<Step> Part::step(int index, StepType type) {
         case StepType::kScan:
             result = step_group.scan_layer;
             break;
-        case StepType::kAll: // this function should not be called with this step type
+        case StepType::kAll:  // this function should not be called with this step type
             Q_ASSERT(false);
             break;
     }
@@ -356,7 +369,7 @@ QSharedPointer<Step> Part::step(int index, StepType type) {
 
 bool Part::stepGroupContains(int index, StepType type) {
     Q_ASSERT(index < m_step_pairs.size());
-    bool result = false;
+    bool result         = false;
     StepPair step_group = m_step_pairs[index];
     switch (type) {
         case StepType::kLayer:
@@ -368,11 +381,10 @@ bool Part::stepGroupContains(int index, StepType type) {
                 result = true;
             break;
         case StepType::kScan:
-            if (step_group.scan_layer != nullptr)
-                result = true;
+            if (step_group.scan_layer != nullptr) result = true;
             break;
         case StepType::kAll:
-            Q_ASSERT(false); // function shouldn't be called with type 'All'
+            Q_ASSERT(false);  // function shouldn't be called with type 'All'
             break;
     }
     return result;
@@ -393,20 +405,18 @@ void Part::removeStepFromGroup(int index, StepType type) {
         case StepType::kScan:
             step_group.scan_layer = nullptr;
             break;
-        case StepType::kAll: // shouldn't call this function with type 'All'
-            Q_ASSERT(false); // removeStep(index) should be called instead
+        case StepType::kAll:  // shouldn't call this function with type 'All'
+            Q_ASSERT(false);  // removeStep(index) should be called instead
             break;
     }
 
-    if (step_group.printing_layer == nullptr && step_group.scan_layer == nullptr)
-        m_step_pairs.removeAt(index);
+    if (step_group.printing_layer == nullptr && step_group.scan_layer == nullptr) m_step_pairs.removeAt(index);
 }
 
 void Part::replaceStep(int index, QSharedPointer<Step> step) {
     Q_ASSERT(index < m_step_pairs.size());
 
-    if (step == nullptr)
-        return;
+    if (step == nullptr) return;
 
     StepPair new_group;
     switch (step->getType()) {
@@ -418,7 +428,7 @@ void Part::replaceStep(int index, QSharedPointer<Step> step) {
             new_group.scan_layer = qSharedPointerDynamicCast<ScanLayer>(step);
             break;
         case StepType::kAll:
-            Q_ASSERT(false); // a step shouldn't have type of 'All'
+            Q_ASSERT(false);  // a step shouldn't have type of 'All'
             break;
     }
     m_step_pairs[index] = new_group;
@@ -454,13 +464,9 @@ QList<QSharedPointer<Step>> Part::steps(StepType type) {
     switch (type) {
         case StepType::kAll:
             for (StepPair step_grp : m_step_pairs) {
-                if (step_grp.printing_layer != nullptr) {
-                    result.push_back(step_grp.printing_layer);
-                }
+                if (step_grp.printing_layer != nullptr) { result.push_back(step_grp.printing_layer); }
 
-                if (step_grp.scan_layer != nullptr) {
-                    result.push_back(step_grp.scan_layer);
-                }
+                if (step_grp.scan_layer != nullptr) { result.push_back(step_grp.scan_layer); }
             }
             break;
         case StepType::kLayer:
@@ -479,9 +485,7 @@ QList<QSharedPointer<Step>> Part::steps(StepType type) {
             break;
         case StepType::kScan:
             for (StepPair step_grp : m_step_pairs) {
-                if (step_grp.scan_layer != nullptr) {
-                    result.push_back(step_grp.scan_layer);
-                }
+                if (step_grp.scan_layer != nullptr) { result.push_back(step_grp.scan_layer); }
             }
             break;
     }
@@ -490,8 +494,7 @@ QList<QSharedPointer<Step>> Part::steps(StepType type) {
 }
 
 void Part::clearStepsFromIndex(int index) {
-    while (m_step_pairs.size() > index)
-        m_step_pairs.removeAt(index);
+    while (m_step_pairs.size() > index) m_step_pairs.removeAt(index);
 }
 
 void Part::removeStepAtIndex(int index) {
@@ -501,12 +504,8 @@ void Part::removeStepAtIndex(int index) {
 
 void Part::setStepsDirty() {
     for (StepPair step_grp : m_step_pairs) {
-        if (step_grp.printing_layer != nullptr) {
-            step_grp.printing_layer->setDirtyBit(true);
-        }
-        if (step_grp.scan_layer != nullptr) {
-            step_grp.scan_layer->setDirtyBit(true);
-        }
+        if (step_grp.printing_layer != nullptr) { step_grp.printing_layer->setDirtyBit(true); }
+        if (step_grp.scan_layer != nullptr) { step_grp.scan_layer->setDirtyBit(true); }
     }
 }
 
@@ -521,6 +520,8 @@ bool Part::isPartDirty() {
     return false;
 }
 
-QUuid Part::getId() { return m_uuid; }
+QUuid Part::getId() {
+    return m_uuid;
+}
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/slicing/buffered_slicer.cpp
+++ b/src/slicing/buffered_slicer.cpp
@@ -30,14 +30,14 @@ BufferedSlicer::BufferedSlicer(const QSharedPointer<MeshBase>& mesh, const QShar
                                QVector<QSharedPointer<Part>> settings_parts,
                                QMap<uint, QSharedPointer<SettingsRange>> ranges, int previous_buffer, int future_buffer,
                                bool use_cgal_cross_section, bool include_build_plate_gap) {
-    m_mesh = mesh;
-    m_settings = settings;
-    m_settings_parts = settings_parts;
-    m_settings_ranges = ranges;
+    m_mesh                   = mesh;
+    m_settings               = settings;
+    m_settings_parts         = settings_parts;
+    m_settings_ranges        = ranges;
     m_use_cgal_cross_section = use_cgal_cross_section;
 
     m_previous_buffer_size = previous_buffer;
-    m_future_buffer_size = future_buffer;
+    m_future_buffer_size   = future_buffer;
 
     std::tie(m_slicing_plane, m_mesh_min, m_mesh_max) = SlicingUtilities::GetDefaultSlicingAxis(m_settings, m_mesh);
 
@@ -53,15 +53,13 @@ BufferedSlicer::BufferedSlicer(const QSharedPointer<MeshBase>& mesh, const QShar
     }
 
     // Fill previous slots will nullptr to start
-    for (int i = 0; i < previous_buffer; ++i)
-        m_buffered_slices.enqueue(nullptr);
+    for (int i = 0; i < previous_buffer; ++i) m_buffered_slices.enqueue(nullptr);
 
     // Take first slice
     m_buffered_slices.enqueue(processSingleSlice());
 
     // Process future slice up to buffer size
-    for (int i = 0; i < future_buffer; ++i)
-        m_buffered_slices.enqueue(processSingleSlice());
+    for (int i = 0; i < future_buffer; ++i) m_buffered_slices.enqueue(processSingleSlice());
 }
 
 QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processNextSlice() {
@@ -83,8 +81,7 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::peekNextSlice() {
 
 QQueue<QSharedPointer<BufferedSlicer::SliceMeta>> BufferedSlicer::getPreviousSlices() {
     QQueue<QSharedPointer<BufferedSlicer::SliceMeta>> previous_slices;
-    for (int i = m_previous_buffer_size - 1; i >= 0; --i)
-        previous_slices.enqueue(m_buffered_slices[i]);
+    for (int i = m_previous_buffer_size - 1; i >= 0; --i) previous_slices.enqueue(m_buffered_slices[i]);
 
     return previous_slices;
 }
@@ -97,7 +94,9 @@ QQueue<QSharedPointer<BufferedSlicer::SliceMeta>> BufferedSlicer::getFutureSlice
     return future_slices;
 }
 
-int BufferedSlicer::getSliceCount() { return m_slice_count - m_future_buffer_size; }
+int BufferedSlicer::getSliceCount() {
+    return m_slice_count - m_future_buffer_size;
+}
 
 QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
     QSharedPointer<SliceMeta> slice_meta = nullptr;
@@ -106,13 +105,13 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
     if (m_slicing_plane.evaluatePoint(m_mesh_max) > 0) {
         // Create new layer settings
         QSharedPointer<SettingsBase> layer_specific_settings =
-            QSharedPointer<SettingsBase>::create(*m_settings); // Copy part settings
+            QSharedPointer<SettingsBase>::create(*m_settings);  // Copy part settings
 
         // Apply settings ranges if available
         for (const QSharedPointer<SettingsRange>& range : m_settings_ranges) {
             if (range->includesIndex(m_slice_count) && !range->getSb()->json().is_null()) {
                 QSharedPointer<SettingsBase> range_sb = range->getSb();
-                layer_specific_settings->populate(range_sb); // Apply range settings overrides
+                layer_specific_settings->populate(range_sb);  // Apply range settings overrides
             }
         }
         layer_specific_settings->makeLocalAdjustments(m_slice_count);
@@ -122,23 +121,20 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
         m_last_layer_height = layer_specific_settings->setting<Distance>(PS::Layer::kLayerHeight);
 
         // If the slicing plane is beyond the max_point of the part, stop
-        if (m_slicing_plane.evaluatePoint(m_mesh_max) < 0)
-            return nullptr;
+        if (m_slicing_plane.evaluatePoint(m_mesh_max) < 0) return nullptr;
 
-        Point shift_amount = Point(0, 0, 0); // cross sectioning will add data (primary mesh)
+        Point shift_amount = Point(0, 0, 0);  // cross sectioning will add data (primary mesh)
         QVector3D average_normal;
 
         PolygonList geometry;
         QVector<Polyline> opt_polylines;
 
         if (m_use_cgal_cross_section) {
-            auto result = m_mesh->intersect(m_slicing_plane);
+            auto result   = m_mesh->intersect(m_slicing_plane);
             opt_polylines = result.first;
 
             // Extract polygons
-            for (auto polygon : result.second) {
-                geometry += polygon;
-            }
+            for (auto polygon : result.second) { geometry += polygon; }
 
             shift_amount = CrossSection::findSlicingPlaneMidPoint(m_mesh, m_slicing_plane);
         }
@@ -170,7 +166,7 @@ QSharedPointer<BufferedSlicer::SliceMeta> BufferedSlicer::processSingleSlice() {
 
 void BufferedSlicer::computeSettingsPolygons(QVector<SettingsPolygon>& settings_polygons, const Point& base_shift) {
     for (const auto& settings_part : m_settings_parts) {
-        Point part_shift = base_shift; // preserve base shift
+        Point part_shift = base_shift;  // preserve base shift
         QVector3D tmp_vec;
         PolygonList geometry = CrossSection::doCrossSection(settings_part->rootMesh(), m_slicing_plane, part_shift,
                                                             tmp_vec, settings_part->getSb(), true);
@@ -178,18 +174,14 @@ void BufferedSlicer::computeSettingsPolygons(QVector<SettingsPolygon>& settings_
         if (part_shift != base_shift) {
             Point delta = base_shift - part_shift;
             for (Polygon& poly : geometry) {
-                for (Point& p : poly) {
-                    p = p + delta;
-                }
+                for (Point& p : poly) { p = p + delta; }
             }
         }
         QVector<Polygon> geom_vec;
         geom_vec.reserve(geometry.size());
-        for (const Polygon& poly : geometry) {
-            geom_vec.push_back(poly);
-        }
+        for (const Polygon& poly : geometry) { geom_vec.push_back(poly); }
         auto sb = settings_part->getSb();
         settings_polygons.push_back(SettingsPolygon(geom_vec, sb));
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/slicing/layer_additions.cpp
+++ b/src/slicing/layer_additions.cpp
@@ -36,15 +36,13 @@ QSharedPointer<Layer> LayerAdditions::createRaft(QSharedPointer<Layer> layer) {
     // Extract island geometry from existing layer
     PolygonList source_geometry = layer->getGeometry();
     if (source_geometry.isEmpty()) {
-        for (const QSharedPointer<IslandBase>& island : layer->getIslands())
-            source_geometry |= island->getGeometry();
+        for (const QSharedPointer<IslandBase>& island : layer->getIslands()) source_geometry |= island->getGeometry();
     }
     QVector<PolygonList> island_outlines = source_geometry.splitIntoParts();
 
     // Offset by raft offset
     PolygonList new_outlines;
-    for (PolygonList poly : island_outlines)
-        new_outlines |= poly.offset(raft_offset);
+    for (PolygonList poly : island_outlines) new_outlines |= poly.offset(raft_offset);
 
     // Extract new islands based on the offsetting
     QVector<PolygonList> new_islands = new_outlines.splitIntoParts();
@@ -71,7 +69,7 @@ QSharedPointer<Layer> LayerAdditions::createRaft(QSharedPointer<Layer> layer) {
 }
 
 void LayerAdditions::addBrim(QSharedPointer<Layer> layer) {
-    QList<QSharedPointer<IslandBase>> raftIslands = layer->getIslands(IslandType::kRaft);
+    QList<QSharedPointer<IslandBase>> raftIslands    = layer->getIslands(IslandType::kRaft);
     QList<QSharedPointer<IslandBase>> polymerIslands = layer->getIslands(IslandType::kPolymer);
     QList<QSharedPointer<IslandBase>> supportIslands = layer->getIslands(IslandType::kSupport);
     QSharedPointer<SettingsBase> currentLocalSettings;
@@ -86,18 +84,16 @@ void LayerAdditions::addBrim(QSharedPointer<Layer> layer) {
 
     PolygonList geometry = layer->getGeometry();
     if (geometry.isEmpty()) {
-        for (const auto& island : supportIslands)
-            geometry |= island->getGeometry();
+        for (const auto& island : supportIslands) geometry |= island->getGeometry();
     }
 
     Distance brimWidth = currentLocalSettings->setting<Distance>(MS::PlatformAdhesion::kBrimWidth);
     Distance beadWidth = currentLocalSettings->setting<Distance>(MS::PlatformAdhesion::kBrimBeadWidth);
-    if (beadWidth <= 0)
-        return;
+    if (beadWidth <= 0) return;
     int m_rings = qCeil(brimWidth() / beadWidth());
 
     // set the offset as the location of the outer most loop, which is where the brim printing starts
-    Distance brim_offset = (m_rings - 0.5) * beadWidth;
+    Distance brim_offset                = (m_rings - 0.5) * beadWidth;
     QVector<PolygonList> islandOutlines = geometry.splitIntoParts();
     PolygonList newOutlines;
     for (PolygonList poly : islandOutlines) {
@@ -120,7 +116,7 @@ void LayerAdditions::addSkirt(QSharedPointer<Layer> layer) {
     float minX = std::numeric_limits<float>::max(), maxX = std::numeric_limits<float>::lowest(),
           minY = std::numeric_limits<float>::max(), maxY = std::numeric_limits<float>::lowest();
 
-    QList<QSharedPointer<IslandBase>> raftIslands = layer->getIslands(IslandType::kRaft);
+    QList<QSharedPointer<IslandBase>> raftIslands    = layer->getIslands(IslandType::kRaft);
     QList<QSharedPointer<IslandBase>> polymerIslands = layer->getIslands(IslandType::kPolymer);
     QList<QSharedPointer<IslandBase>> supportIslands = layer->getIslands(IslandType::kSupport);
     QSharedPointer<SettingsBase> currentLocalSettings;
@@ -134,14 +130,13 @@ void LayerAdditions::addSkirt(QSharedPointer<Layer> layer) {
         return;
 
     QList<QSharedPointer<IslandBase>> islands = layer->getIslands();
-    if (islands.isEmpty())
-        return;
+    if (islands.isEmpty()) return;
     for (QSharedPointer<IslandBase>& isl : islands) {
         PolygonList poly = isl->getGeometry();
-        minX = qMin(minX, poly.min().x());
-        maxX = qMax(maxX, poly.max().x());
-        minY = qMin(minY, poly.min().y());
-        maxY = qMax(maxY, poly.max().y());
+        minX             = qMin(minX, poly.min().x());
+        maxX             = qMax(maxX, poly.max().x());
+        minY             = qMin(minY, poly.min().y());
+        maxY             = qMax(maxY, poly.max().y());
     }
 
     QVector<Point> points;
@@ -162,16 +157,15 @@ void LayerAdditions::addThermalScan(QSharedPointer<Layer> layer) {
     PolygonList current_layer_islands;
 
     // Gather current layer island geometries
-    for (QSharedPointer<IslandBase> island : layer->getIslands())
-        current_layer_islands += island->getGeometry();
+    for (QSharedPointer<IslandBase> island : layer->getIslands()) current_layer_islands += island->getGeometry();
 
     // Determine thermal_scan_island geometry
     QRect boundary = current_layer_islands.boundingRect();
-    Polygon poly = Polygon({boundary.bottomLeft(), boundary.topLeft(), boundary.topRight(), boundary.bottomRight()});
+    Polygon poly   = Polygon({boundary.bottomLeft(), boundary.topLeft(), boundary.topRight(), boundary.bottomRight()});
     PolygonList island;
     island += poly;
 
-    QList<QSharedPointer<IslandBase>> raftIslands = layer->getIslands(IslandType::kRaft);
+    QList<QSharedPointer<IslandBase>> raftIslands    = layer->getIslands(IslandType::kRaft);
     QList<QSharedPointer<IslandBase>> polymerIslands = layer->getIslands(IslandType::kPolymer);
     QSharedPointer<SettingsBase> currentLocalSettings;
     if (raftIslands.size() > 0)
@@ -201,11 +195,9 @@ void LayerAdditions::addLaserScan(QSharedPointer<Part> part, int layer_index, do
         // Determine laser_scan_island geometry
         PolygonList scan_geometry = build_layer->getGeometry();
         if (scan_geometry.isEmpty()) {
-            for (const auto& island : build_layer->getIslands())
-                scan_geometry |= island->getGeometry();
+            for (const auto& island : build_layer->getIslands()) scan_geometry |= island->getGeometry();
         }
-        if (scan_geometry.isEmpty())
-            return;
+        if (scan_geometry.isEmpty()) return;
 
         QRect boundary = scan_geometry.boundingRect();
         Polygon poly =
@@ -213,16 +205,14 @@ void LayerAdditions::addLaserScan(QSharedPointer<Part> part, int layer_index, do
         PolygonList island;
         island += poly;
 
-        if (layer_index == 0)
-            sb->setSetting(PS::Layer::kLayerHeight, 0.0);
+        if (layer_index == 0) sb->setSetting(PS::Layer::kLayerHeight, 0.0);
 
         QVector<QSharedPointer<IslandBase>> newIslands;
         newIslands.push_back(QSharedPointer<LaserScanIsland>::create(island, sb, QVector<SettingsPolygon>()));
 
         Point shift = build_layer->getShift();
         shift.z(running_total);
-        if (layer_index == 0)
-            shift.z(0.0);
+        if (layer_index == 0) shift.z(0.0);
 
         scan_layer->setOrientation(build_layer->getSlicingPlane(), shift);
         scan_layer->updateIslands(IslandType::kLaserScan, newIslands);
@@ -231,4 +221,4 @@ void LayerAdditions::addLaserScan(QSharedPointer<Part> part, int layer_index, do
     }
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/slicing/preprocessor.cpp
+++ b/src/slicing/preprocessor.cpp
@@ -23,7 +23,7 @@ Preprocessor::Preprocessor(bool use_cgal_cross_section, bool include_build_plate
         SlicingUtilities::GetPartsByType(CSM->parts(), MeshType::kSettings),
     };
 
-    m_use_cgal_cross_section = use_cgal_cross_section;
+    m_use_cgal_cross_section  = use_cgal_cross_section;
     m_include_build_plate_gap = include_build_plate_gap;
 }
 
@@ -31,24 +31,22 @@ void Preprocessor::processAll() {
     QSharedPointer<SettingsBase> global_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
 
     if (m_initial_processing != nullptr)
-        if (m_initial_processing(m_parts, global_sb))
-            return; // halt slicing
+        if (m_initial_processing(m_parts, global_sb)) return;  // halt slicing
 
     int total_num_parts = m_parts.build_parts.size();
-    int parts_done = 0;
+    int parts_done      = 0;
     for (const QSharedPointer<Part>& part : m_parts.build_parts) {
         // Setup settings
-        auto part_sb = QSharedPointer<SettingsBase>::create(*global_sb); // Copy global
-        part_sb->populate(part->getSb());                                // Fill with part overrides
+        auto part_sb = QSharedPointer<SettingsBase>::create(*global_sb);  // Copy global
+        part_sb->populate(part->getSb());                                 // Fill with part overrides
 
         ActivePartMeta part_meta(part, part_sb);
 
         if (m_part_processing != nullptr)
-            if (m_part_processing(part, part_sb))
-                return; // halt slicing
+            if (m_part_processing(part, part_sb)) return;  // halt slicing
 
         part_meta.steps_processed = part->countStepPairs();
-        part_meta.part_start = SlicingUtilities::GetPartStart(part, part_meta.steps_processed);
+        part_meta.part_start      = SlicingUtilities::GetPartStart(part, part_meta.steps_processed);
 
         for (const QSharedPointer<MeshBase>& original_mesh : part->meshes()) {
             QSharedPointer<MeshBase> mesh;
@@ -60,26 +58,23 @@ void Preprocessor::processAll() {
                 mesh = QSharedPointer<OpenMesh>::create(OpenMesh(*dynamic_cast<OpenMesh*>(original_mesh.get())));
 
             if (m_mesh_processing != nullptr)
-                if (m_mesh_processing(mesh, part_sb))
-                    return; // halt slicing
+                if (m_mesh_processing(mesh, part_sb)) return;  // halt slicing
 
             part_meta.steps_processed = part->countStepPairs();
-            part_meta.part_start = SlicingUtilities::GetPartStart(part, part_meta.steps_processed);
+            part_meta.part_start      = SlicingUtilities::GetPartStart(part, part_meta.steps_processed);
 
             BufferedSlicer slicer(mesh, part_sb, m_parts.settings_parts, part->getSettingsRanges(), 0, 0,
                                   m_use_cgal_cross_section, m_include_build_plate_gap);
             QSharedPointer<BufferedSlicer::SliceMeta> next_layer_meta = nullptr;
-            int last_step_count = 0;
+            int last_step_count                                       = 0;
             do {
                 next_layer_meta = slicer.processNextSlice();
 
-                if (next_layer_meta == nullptr)
-                    break;
+                if (next_layer_meta == nullptr) break;
 
                 // Build steps using slicing info
                 if (m_step_builder != nullptr)
-                    if (m_step_builder(next_layer_meta, part_meta))
-                        return; // halt slicing
+                    if (m_step_builder(next_layer_meta, part_meta)) return;  // halt slicing
 
                 last_step_count = next_layer_meta->number;
             } while (next_layer_meta != nullptr);
@@ -87,35 +82,46 @@ void Preprocessor::processAll() {
             part_meta.last_step_count = last_step_count;
 
             if (m_cross_section_processing != nullptr)
-                if (m_cross_section_processing(part_meta))
-                    return; // halt slicing
+                if (m_cross_section_processing(part_meta)) return;  // halt slicing
         }
 
         ++parts_done;
-        if (m_status_update != nullptr)
-            m_status_update((double)parts_done / (double)total_num_parts * 100);
+        if (m_status_update != nullptr) m_status_update((double)parts_done / (double)total_num_parts * 100);
     }
 
     if (m_final_processing != nullptr)
-        if (m_final_processing(m_parts, global_sb))
-            return; // halt slicing
+        if (m_final_processing(m_parts, global_sb)) return;  // halt slicing
 }
 
-void Preprocessor::addInitialProcessing(Processing processing) { m_initial_processing = processing; }
+void Preprocessor::addInitialProcessing(Processing processing) {
+    m_initial_processing = processing;
+}
 
-void Preprocessor::addFinalProcessing(Processing processing) { m_final_processing = processing; }
+void Preprocessor::addFinalProcessing(Processing processing) {
+    m_final_processing = processing;
+}
 
-void Preprocessor::addPartProcessing(PartProcessing processing) { m_part_processing = processing; }
+void Preprocessor::addPartProcessing(PartProcessing processing) {
+    m_part_processing = processing;
+}
 
-void Preprocessor::addMeshProcessing(MeshProcessing processing) { m_mesh_processing = processing; }
+void Preprocessor::addMeshProcessing(MeshProcessing processing) {
+    m_mesh_processing = processing;
+}
 
 void Preprocessor::addCrossSectionProcessing(CrossSectionProcessing processing) {
     m_cross_section_processing = processing;
 }
 
-void Preprocessor::addStepBuilder(StepBuilder builder) { m_step_builder = builder; }
+void Preprocessor::addStepBuilder(StepBuilder builder) {
+    m_step_builder = builder;
+}
 
-void Preprocessor::addStatusUpdate(StatusUpdate update) { m_status_update = update; }
+void Preprocessor::addStatusUpdate(StatusUpdate update) {
+    m_status_update = update;
+}
 
-Preprocessor::Parts Preprocessor::getParts() { return m_parts; }
-} // namespace ORNL
+Preprocessor::Parts Preprocessor::getParts() {
+    return m_parts;
+}
+}  // namespace ORNL

--- a/src/slicing/slicing_utilities.cpp
+++ b/src/slicing/slicing_utilities.cpp
@@ -54,32 +54,26 @@ double radialDistance(const Point& point, const Point& center) {
 double counterClockwiseSweep(const Point& start, const Point& end, const Point& center) {
     const double start_x = start.x() - center.x();
     const double start_y = start.y() - center.y();
-    const double end_x = end.x() - center.x();
-    const double end_y = end.y() - center.y();
+    const double end_x   = end.x() - center.x();
+    const double end_y   = end.y() - center.y();
 
     double sweep = std::atan2((start_x * end_y) - (start_y * end_x), (start_x * end_x) + (start_y * end_y));
-    if (sweep < 0.0) {
-        sweep += 2.0 * M_PI;
-    }
+    if (sweep < 0.0) { sweep += 2.0 * M_PI; }
     return sweep;
 }
 
 //! \brief Returns the sweep from start to end in the selected angular direction.
 double directedSweep(const Point& start, const Point& end, const Point& center, bool counterclockwise) {
     const double ccw_sweep = counterClockwiseSweep(start, end, center);
-    if (counterclockwise || ccw_sweep <= kArcSweepTolerance) {
-        return ccw_sweep;
-    }
+    if (counterclockwise || ccw_sweep <= kArcSweepTolerance) { return ccw_sweep; }
     return (2.0 * M_PI) - ccw_sweep;
 }
-} // namespace
+}  // namespace
 
 QVector<Point> SlicingUtilities::GetCylindricalArcPoints(const Polyline& polyline, const Point& center, Distance radius,
                                                          int arcs_per_revolution, bool counterclockwise) {
     QVector<Point> arc_points;
-    if (polyline.size() < 2 || radius <= 0 || arcs_per_revolution <= 0) {
-        return arc_points;
-    }
+    if (polyline.size() < 2 || radius <= 0 || arcs_per_revolution <= 0) { return arc_points; }
     arcs_per_revolution = clampArcsPerRevolution(arcs_per_revolution);
 
     QVector<double> cumulative_sweeps;
@@ -92,34 +86,30 @@ QVector<Point> SlicingUtilities::GetCylindricalArcPoints(const Polyline& polylin
         cumulative_sweeps.push_back(total_sweep);
     }
 
-    if (total_sweep <= kArcSweepTolerance) {
-        return arc_points;
-    }
+    if (total_sweep <= kArcSweepTolerance) { return arc_points; }
 
     // Retain clipping intersections exactly. Intermediate arc boundaries are
     // projected to the analytic cylinder below.
     arc_points.push_back(polyline.first());
 
     const double arc_sweep = (2.0 * M_PI) / static_cast<double>(arcs_per_revolution);
-    int source_segment = 1;
+    int source_segment     = 1;
     for (double target_sweep = arc_sweep; target_sweep < total_sweep - kArcSweepTolerance; target_sweep += arc_sweep) {
         while (source_segment < cumulative_sweeps.size() - 1 && cumulative_sweeps[source_segment] < target_sweep) {
             ++source_segment;
         }
 
         const double segment_start_sweep = cumulative_sweeps[source_segment - 1];
-        const double segment_sweep = cumulative_sweeps[source_segment] - segment_start_sweep;
-        if (segment_sweep <= std::numeric_limits<double>::epsilon()) {
-            continue;
-        }
+        const double segment_sweep       = cumulative_sweeps[source_segment] - segment_start_sweep;
+        if (segment_sweep <= std::numeric_limits<double>::epsilon()) { continue; }
 
-        const double fraction = std::clamp((target_sweep - segment_start_sweep) / segment_sweep, 0.0, 1.0);
+        const double fraction     = std::clamp((target_sweep - segment_start_sweep) / segment_sweep, 0.0, 1.0);
         const Point& source_start = polyline[source_segment - 1];
-        const Point& source_end = polyline[source_segment];
-        const double start_angle = std::atan2(source_start.y() - center.y(), source_start.x() - center.x());
-        const double direction = counterclockwise ? 1.0 : -1.0;
-        const double angle = start_angle + direction * segment_sweep * fraction;
-        const double z = source_start.z() + ((source_end.z() - source_start.z()) * fraction);
+        const Point& source_end   = polyline[source_segment];
+        const double start_angle  = std::atan2(source_start.y() - center.y(), source_start.x() - center.x());
+        const double direction    = counterclockwise ? 1.0 : -1.0;
+        const double angle        = start_angle + direction * segment_sweep * fraction;
+        const double z            = source_start.z() + ((source_end.z() - source_start.z()) * fraction);
 
         arc_points.push_back(
             Point(center.x() + (radius() * std::cos(angle)), center.y() + (radius() * std::sin(angle)), z));
@@ -132,32 +122,28 @@ QVector<Point> SlicingUtilities::GetCylindricalArcPoints(const Polyline& polylin
 bool SlicingUtilities::IsCylindricalArcSegment(const Point& start, const Point& end, const Point& center,
                                                Distance radius, int arcs_per_revolution, bool counterclockwise) {
     const double expected_radius = radius();
-    if (expected_radius <= std::numeric_limits<double>::epsilon() || arcs_per_revolution <= 0) {
-        return false;
-    }
+    if (expected_radius <= std::numeric_limits<double>::epsilon() || arcs_per_revolution <= 0) { return false; }
     arcs_per_revolution = clampArcsPerRevolution(arcs_per_revolution);
 
-    const double tolerance = std::max(kArcGeometryTolerance(), expected_radius * kArcGeometryRelativeTolerance);
+    const double tolerance         = std::max(kArcGeometryTolerance(), expected_radius * kArcGeometryRelativeTolerance);
     const double angular_tolerance = std::max(kMinArcAngularSpan, tolerance / expected_radius);
-    const double planar_chord = std::hypot(end.x() - start.x(), end.y() - start.y());
+    const double planar_chord      = std::hypot(end.x() - start.x(), end.y() - start.y());
     if (planar_chord <= tolerance) {
         return arcs_per_revolution == 1 && std::abs(radialDistance(start, center) - expected_radius) <= tolerance &&
                std::abs(radialDistance(end, center) - expected_radius) <= tolerance;
     }
 
-    const double sweep = directedSweep(start, end, center, counterclockwise);
+    const double sweep     = directedSweep(start, end, center, counterclockwise);
     const double max_sweep = (2.0 * M_PI) / static_cast<double>(arcs_per_revolution);
-    if (sweep <= angular_tolerance || sweep > max_sweep + angular_tolerance) {
-        return false;
-    }
+    if (sweep <= angular_tolerance || sweep > max_sweep + angular_tolerance) { return false; }
 
     const Point arc_center = GetCylindricalArcCenter(start, end, center);
     return radialDistance(arc_center, center) <= tolerance;
 }
 
 Point SlicingUtilities::GetCylindricalArcCenter(const Point& start, const Point& end, const Point& center) {
-    const double chord_x = end.x() - start.x();
-    const double chord_y = end.y() - start.y();
+    const double chord_x              = end.x() - start.x();
+    const double chord_y              = end.y() - start.y();
     const double chord_length_squared = (chord_x * chord_x) + (chord_y * chord_y);
     if (chord_length_squared <= std::numeric_limits<double>::epsilon()) {
         return Point(center.x(), center.y(), start.z());
@@ -175,8 +161,7 @@ QVector<QSharedPointer<MeshBase>> SlicingUtilities::GetMeshesByType(QMap<QString
                                                                     MeshType mt) {
     QVector<QSharedPointer<MeshBase>> meshes;
     for (QSharedPointer<Part> part : parts) {
-        if (part->rootMesh()->type() == mt)
-            meshes.push_back(part->rootMesh());
+        if (part->rootMesh()->type() == mt) meshes.push_back(part->rootMesh());
     }
     return meshes;
 }
@@ -184,8 +169,7 @@ QVector<QSharedPointer<MeshBase>> SlicingUtilities::GetMeshesByType(QMap<QString
 QVector<QSharedPointer<Part>> SlicingUtilities::GetPartsByType(QMap<QString, QSharedPointer<Part>> parts, MeshType mt) {
     QVector<QSharedPointer<Part>> found_parts;
     for (QSharedPointer<Part> part : parts) {
-        if (part->rootMesh()->type() == mt)
-            found_parts.push_back(part);
+        if (part->rootMesh()->type() == mt) found_parts.push_back(part);
     }
     return found_parts;
 }
@@ -193,9 +177,8 @@ QVector<QSharedPointer<Part>> SlicingUtilities::GetPartsByType(QMap<QString, QSh
 void SlicingUtilities::ClipMesh(QSharedPointer<MeshBase> mesh, QVector<QSharedPointer<MeshBase>> clippers) {
     for (QSharedPointer<MeshBase> clipper : clippers) {
         auto closed_clipper = dynamic_cast<ClosedMesh*>(clipper.get());
-        auto closed_mesh = dynamic_cast<ClosedMesh*>(mesh.get());
-        if (closed_clipper != nullptr && closed_mesh != nullptr)
-            closed_mesh->difference(*closed_clipper);
+        auto closed_mesh    = dynamic_cast<ClosedMesh*>(mesh.get());
+        if (closed_clipper != nullptr && closed_mesh != nullptr) closed_mesh->difference(*closed_clipper);
     }
 }
 
@@ -210,8 +193,7 @@ void SlicingUtilities::UnionMesh(QSharedPointer<ClosedMesh> mesh, QSharedPointer
 int SlicingUtilities::GetPartStart(QSharedPointer<Part> part, int current_steps) {
     int part_start = 0;
     if (part->countStepPairs() > 0) {
-        while (part_start < current_steps && !part->stepGroupContains(part_start, StepType::kLayer))
-            ++part_start;
+        while (part_start < current_steps && !part->stepGroupContains(part_start, StepType::kLayer)) ++part_start;
     }
     return part_start;
 }
@@ -252,16 +234,14 @@ bool SlicingUtilities::doPartsOverlap(QVector<QSharedPointer<Part>> parts, Plane
             CrossSection::doCrossSection(part->rootMesh(), slicing_plane, tmp_point, tmp_vec, part->getSb());
 
         // Since settings meshes are always rectangular prisms there is only a single island
-        if (!geometry.isEmpty()) {
-            polygons.push_back(geometry.first());
-        }
+        if (!geometry.isEmpty()) { polygons.push_back(geometry.first()); }
     }
 
     // Polygon in Polygon test
     bool overlap = false;
     for (int i = 0, end = polygons.size(); i < end; ++i) {
         for (int j = i + 1; j < end; ++j) {
-            Polygon first = polygons[i];
+            Polygon first  = polygons[i];
             Polygon second = polygons[j];
 
             if (first.overlaps(second)) {
@@ -273,4 +253,4 @@ bool SlicingUtilities::doPartsOverlap(QVector<QSharedPointer<Part>> parts, Plane
 
     return overlap;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/global_layer.cpp
+++ b/src/step/global_layer.cpp
@@ -31,7 +31,7 @@ namespace ORNL {
 
 GlobalLayer::GlobalLayer(int layer_number) {
     // make a new empty list for the step groups
-    m_step_pairs = QMap<QUuid, QSharedPointer<Part::StepPair>>();
+    m_step_pairs   = QMap<QUuid, QSharedPointer<Part::StepPair>>();
     m_layer_number = layer_number;
 }
 
@@ -39,8 +39,7 @@ void GlobalLayer::unorient() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
-        if (step_pair.isNull() || step_pair->printing_layer.isNull())
-            continue;
+        if (step_pair.isNull() || step_pair->printing_layer.isNull()) continue;
 
         step_pair->printing_layer->unorient();
     }
@@ -50,8 +49,7 @@ void GlobalLayer::reorient() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
-        if (step_pair.isNull() || step_pair->printing_layer.isNull())
-            continue;
+        if (step_pair.isNull() || step_pair->printing_layer.isNull()) continue;
 
         step_pair->printing_layer->reorient();
     }
@@ -62,8 +60,8 @@ void GlobalLayer::calculateModifiers(QSharedPointer<SettingsBase> global_sb, Poi
         QSharedPointer<IslandBase> firstIsland = m_island_order.front();
         if (!firstIsland.isNull() && !firstIsland->getRegions().isEmpty()) {
             // Retrieve relevant settings
-            bool perimeter_enabled = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnable);
-            bool perimeter_lead_in_enabled = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnableLeadIn);
+            bool perimeter_enabled                  = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnable);
+            bool perimeter_lead_in_enabled          = firstIsland->getSb()->setting<bool>(PS::Perimeter::kEnableLeadIn);
             bool perimeter_lead_in_first_layer_only = global_sb->setting<bool>(PS::Perimeter::kLeadInFirstLayerOnly);
 
             if (perimeter_enabled && perimeter_lead_in_enabled &&
@@ -86,18 +84,18 @@ void GlobalLayer::calculateModifiers(QSharedPointer<SettingsBase> global_sb, Poi
         if (!lastIsland.isNull() && !lastIsland->getRegions().isEmpty()) {
             Q_ASSERT(lastIsland->getType() == IslandType::kPolymer);
             QList<QSharedPointer<RegionBase>> regions = lastIsland->getRegions();
-            QSharedPointer<RegionBase> lastRegion = regions.back();
+            QSharedPointer<RegionBase> lastRegion     = regions.back();
             if (!lastRegion.isNull() && !lastRegion->getPaths().isEmpty() && lastRegion->getPaths().back().size() > 0) {
                 Path& finalPath = lastRegion->getPaths().back();
 
                 if (finalPath.back()->getSb()->setting<PathModifiers>(SS::kPathModifiers) !=
                     PathModifiers::kSpiralLift) {
-                    PathModifierGenerator::GenerateSpiralLift(
-                        finalPath, global_sb->setting<Distance>(MS::SpiralLift::kLiftRadius),
-                        global_sb->setting<Distance>(MS::SpiralLift::kLiftHeight),
-                        global_sb->setting<int>(MS::SpiralLift::kLiftPoints),
-                        global_sb->setting<Velocity>(MS::SpiralLift::kLiftSpeed),
-                        global_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
+                    PathModifierGenerator::GenerateSpiralLift(finalPath,
+                                                              global_sb->setting<Distance>(MS::SpiralLift::kLiftRadius),
+                                                              global_sb->setting<Distance>(MS::SpiralLift::kLiftHeight),
+                                                              global_sb->setting<int>(MS::SpiralLift::kLiftPoints),
+                                                              global_sb->setting<Velocity>(MS::SpiralLift::kLiftSpeed),
+                                                              global_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
 
                     // move current location to the end of the spiral lift
                     current_location = finalPath.back()->end();
@@ -107,8 +105,7 @@ void GlobalLayer::calculateModifiers(QSharedPointer<SettingsBase> global_sb, Poi
     }
 
     for (QSharedPointer<IslandBase> island : m_island_order) {
-        if (!island.isNull())
-            island->fitCircularArcs(global_sb);
+        if (!island.isNull()) island->fitCircularArcs(global_sb);
     }
 }
 
@@ -117,12 +114,10 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
     // this function "connects" paths by inserting travels between disconnected pathing. Also orders parts & islands.
 
     for (auto i = m_step_pairs.constBegin(); i != m_step_pairs.constEnd(); ++i) {
-        if (i.value().isNull())
-            continue;
+        if (i.value().isNull()) continue;
 
         QSharedPointer<Layer> printing_layer = i.value()->printing_layer;
-        if (printing_layer.isNull())
-            continue;
+        if (printing_layer.isNull()) continue;
 
         for (QSharedPointer<IslandBase> island : printing_layer->getIslands()) {
             if (!island.isNull())
@@ -144,15 +139,13 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         // 1.1.1) Get a list of all the islands and the parts they belong to
         QHash<QSharedPointer<IslandBase>, QUuid> islands_for_all_parts;
         for (auto i = m_step_pairs.constBegin(); i != m_step_pairs.constEnd(); ++i) {
-            QUuid part_id = i.key();
+            QUuid part_id                            = i.key();
             QSharedPointer<Part::StepPair> step_pair = i.value();
-            if (step_pair.isNull() || step_pair->printing_layer.isNull())
-                continue;
+            if (step_pair.isNull() || step_pair->printing_layer.isNull()) continue;
 
             auto part_islands = step_pair->printing_layer->getIslands().toVector();
             for (auto island : part_islands) {
-                if (!island.isNull() && !island->getGeometry().isEmpty())
-                    islands_for_all_parts.insert(island, part_id);
+                if (!island.isNull() && !island->getGeometry().isEmpty()) islands_for_all_parts.insert(island, part_id);
             }
         }
 
@@ -169,7 +162,7 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         }
 
         // 1.1.3) Make the IOO and get the order results
-        IslandBaseOrderOptimizer part_oo(start_point, islands_for_all_parts, islandOrderMethod); // mode 2
+        IslandBaseOrderOptimizer part_oo(start_point, islands_for_all_parts, islandOrderMethod);  // mode 2
         m_part_order = part_oo.computePartOrder();
 
         // 1.2) Connect the scans in determined order
@@ -194,19 +187,18 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
     m_island_order.clear();
     QMultiMap<int, QSharedPointer<IslandBase>> islands_for_layer;
     for (auto island : getIslands()) {
-        if (island.isNull() || island->getGeometry().isEmpty())
-            continue;
+        if (island.isNull() || island->getGeometry().isEmpty()) continue;
 
         islands_for_layer.insert(static_cast<int>(island->getType()), island);
     }
 
     // make an optimizer to do the ordering
     IslandBaseOrderOptimizer island_optimizer(start, islands_for_layer.values(), start_index,
-                                              islandOrderMethod); // mode 1 - ordering islands
+                                              islandOrderMethod);  // mode 1 - ordering islands
 
     // Do seam adjustment if necessary
     if (islandOrderMethod == IslandOrderOptimization::kCustomPoint) {
-        Point start_override = start;
+        Point start_override       = start;
         const auto first_step_pair = m_step_pairs.constBegin();
         if (first_step_pair != m_step_pairs.constEnd() && !first_step_pair.value().isNull() &&
             !first_step_pair.value()->printing_layer.isNull()) {
@@ -249,8 +241,7 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
         }
 
         if (print_support_first) {
-            if (!support_islands.isEmpty())
-                ordered_islands_to_process.push_back(support_islands);
+            if (!support_islands.isEmpty()) ordered_islands_to_process.push_back(support_islands);
 
             if (islands_for_layer.values(static_cast<int>(IslandType::kPolymer)).size() > 0)
                 ordered_islands_to_process.push_back(islands_for_layer.values(static_cast<int>(IslandType::kPolymer)));
@@ -259,8 +250,7 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
             if (islands_for_layer.values(static_cast<int>(IslandType::kPolymer)).size() > 0)
                 ordered_islands_to_process.push_back(islands_for_layer.values(static_cast<int>(IslandType::kPolymer)));
 
-            if (!support_islands.isEmpty())
-                ordered_islands_to_process.push_back(support_islands);
+            if (!support_islands.isEmpty()) ordered_islands_to_process.push_back(support_islands);
         }
     }
 
@@ -333,13 +323,11 @@ void GlobalLayer::connectPaths(QSharedPointer<SettingsBase> global_sb, Point& st
     if (islandOrderMethod == IslandOrderOptimization::kLeastRecentlyVisited)
         start_index = island_optimizer.getFirstIndexSelected();
 
-    for (QSharedPointer<IslandBase> island : islands_for_layer)
-        island->markRegionStartSegment();
+    for (QSharedPointer<IslandBase> island : islands_for_layer) island->markRegionStartSegment();
 }
 
-QList<QMap<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>>
-GlobalLayer::createSequence(QList<QSharedPointer<IslandBase>> parent,
-                            QList<QList<QSharedPointer<IslandBase>>> children) {
+QList<QMap<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>> GlobalLayer::createSequence(
+    QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children) {
     QList<QMap<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>> result;
     int children_size = children.size();
     result.reserve(children_size);
@@ -351,15 +339,13 @@ GlobalLayer::createSequence(QList<QSharedPointer<IslandBase>> parent,
 
     QList<QSharedPointer<IslandBase>> valid_parent;
     for (const QSharedPointer<IslandBase>& brim : parent) {
-        if (hasSequenceGeometry(brim))
-            valid_parent.append(brim);
+        if (hasSequenceGeometry(brim)) valid_parent.append(brim);
     }
 
     if (valid_parent.size() == 0) {
         for (int i = 0; i < children_size; ++i) {
             QList<QSharedPointer<IslandBase>> islandSet = children[i];
-            for (QSharedPointer<IslandBase> isl : islandSet)
-                result[i].insert(isl, QList<QSharedPointer<IslandBase>>());
+            for (QSharedPointer<IslandBase> isl : islandSet) result[i].insert(isl, QList<QSharedPointer<IslandBase>>());
         }
     }
     else {
@@ -367,8 +353,7 @@ GlobalLayer::createSequence(QList<QSharedPointer<IslandBase>> parent,
             for (int i = 0; i < children_size; ++i) {
                 QList<QSharedPointer<IslandBase>> islandSet = children[i];
                 for (QSharedPointer<IslandBase> isl : islandSet) {
-                    if (!hasSequenceGeometry(isl))
-                        continue;
+                    if (!hasSequenceGeometry(isl)) continue;
 
                     if (brim->getGeometry().first().inside(isl->getGeometry().first().first())) {
                         result[i][brim].append(isl);
@@ -384,11 +369,9 @@ bool GlobalLayer::containsScanLayers() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
-        if (step_pair.isNull())
-            continue;
+        if (step_pair.isNull()) continue;
 
-        if (step_pair->scan_layer != nullptr)
-            return true;
+        if (step_pair->scan_layer != nullptr) return true;
     }
     return false;
 }
@@ -398,8 +381,7 @@ QVector<QSharedPointer<IslandBase>> GlobalLayer::getIslands() {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
-        if (step_pair.isNull() || step_pair->printing_layer.isNull())
-            continue;
+        if (step_pair.isNull() || step_pair->printing_layer.isNull()) continue;
 
         auto part_islands = step_pair->printing_layer->getIslands().toVector();
         layer_islands.append(part_islands);
@@ -424,8 +406,7 @@ QString GlobalLayer::writeGCode(QSharedPointer<WriterBase> writer) {
         if (containsScanLayers()) {
             for (auto part : m_part_order) {
                 QSharedPointer<ScanLayer> scan_layer = m_step_pairs[part]->scan_layer;
-                if (scan_layer != nullptr)
-                    gcode += scan_layer->writeGCode(writer);
+                if (scan_layer != nullptr) gcode += scan_layer->writeGCode(writer);
             }
             gcode += writer->writeAfterAllScans();
         }
@@ -435,9 +416,7 @@ QString GlobalLayer::writeGCode(QSharedPointer<WriterBase> writer) {
             gcode += writer->writeAfterIsland();
         }
     }
-    else {
-        gcode += writer->writeEmptyStep();
-    }
+    else { gcode += writer->writeEmptyStep(); }
 
     return gcode;
 }
@@ -446,11 +425,9 @@ void GlobalLayer::setDirtyBit(bool dirty) {
     QMap<QUuid, QSharedPointer<Part::StepPair>>::ConstIterator itr;
     for (itr = m_step_pairs.constBegin(); itr != m_step_pairs.constEnd(); ++itr) {
         auto step_pair = itr.value();
-        if (step_pair->printing_layer != nullptr)
-            step_pair->printing_layer->setDirtyBit(dirty);
+        if (step_pair->printing_layer != nullptr) step_pair->printing_layer->setDirtyBit(dirty);
 
-        if (step_pair->scan_layer != nullptr)
-            step_pair->scan_layer->setDirtyBit(dirty);
+        if (step_pair->scan_layer != nullptr) step_pair->scan_layer->setDirtyBit(dirty);
     }
 }
 
@@ -466,8 +443,7 @@ double GlobalLayer::getMinZ() {
         auto step_pair = itr.value();
         if (step_pair->printing_layer != nullptr) {
             double step_min = step_pair->printing_layer->getMinZ();
-            if (step_min < min)
-                min = step_min;
+            if (step_min < min) min = step_min;
         }
     }
     return min;
@@ -479,4 +455,4 @@ Distance GlobalLayer::getLayerHeight() {
     Q_ASSERT(first_layer != nullptr);
     return first_layer->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/helical_layer.cpp
+++ b/src/step/layer/helical_layer.cpp
@@ -27,9 +27,7 @@ const QString kRadialCenterY = "radial_center_y";
 //! @brief Returns the first printable helical segment in a path, or nullptr when the path only contains travels.
 QSharedPointer<SegmentBase> firstPrintSegment(const Path& path) {
     for (const QSharedPointer<SegmentBase>& segment : path) {
-        if (dynamic_cast<TravelSegment*>(segment.data()) == nullptr) {
-            return segment;
-        }
+        if (dynamic_cast<TravelSegment*>(segment.data()) == nullptr) { return segment; }
     }
 
     return nullptr;
@@ -38,9 +36,7 @@ QSharedPointer<SegmentBase> firstPrintSegment(const Path& path) {
 //! @brief Returns segment settings from the first printable segment in a path.
 QSharedPointer<SettingsBase> firstPrintSettings(const Path& path, const QSharedPointer<SettingsBase>& fallback) {
     QSharedPointer<SegmentBase> print_segment = firstPrintSegment(path);
-    if (print_segment != nullptr) {
-        return print_segment->getSb();
-    }
+    if (print_segment != nullptr) { return print_segment->getSb(); }
 
     return fallback;
 }
@@ -57,37 +53,27 @@ void restoreHelicalPathSettings(Path& path, const QSharedPointer<SettingsBase>& 
             travel_settings->setSetting(SS::kRegionType, RegionType::kPerimeter);
             segment->setSb(travel_settings);
         }
-        else {
-            segment->getSb()->setSetting(SS::kRegionType, RegionType::kPerimeter);
-        }
+        else { segment->getSb()->setSetting(SS::kRegionType, RegionType::kPerimeter); }
     }
 }
-} // namespace
+}  // namespace
 
 HelicalLayer::HelicalLayer(uint layer_nr, const QSharedPointer<SettingsBase>& sb) : Layer(layer_nr, sb) {}
 
 void HelicalLayer::addPath(const Path& path) {
-    if (path.size() > 0) {
-        m_paths.push_back(path);
-    }
+    if (path.size() > 0) { m_paths.push_back(path); }
 }
 
 QString HelicalLayer::writeGCode(QSharedPointer<WriterBase> writer) {
-    if (m_paths.isEmpty()) {
-        return writer->writeEmptyStep();
-    }
+    if (m_paths.isEmpty()) { return writer->writeEmptyStep(); }
 
     QString gcode;
     gcode += writer->writeBeforeRegion(RegionType::kPerimeter, m_paths.size());
     for (Path& path : m_paths) {
-        if (path.size() == 0) {
-            continue;
-        }
+        if (path.size() == 0) { continue; }
 
         gcode += writer->writeBeforePath(RegionType::kPerimeter);
-        for (const QSharedPointer<SegmentBase>& segment : path) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (const QSharedPointer<SegmentBase>& segment : path) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kPerimeter);
     }
     gcode += writer->writeAfterRegion(RegionType::kPerimeter);
@@ -104,9 +90,7 @@ void HelicalLayer::calculateModifiers(Point& currentLocation) {
     print_paths.reserve(m_paths.size());
     for (Path path : m_paths) {
         path.removeTravels();
-        if (firstPrintSegment(path) != nullptr) {
-            print_paths.push_back(path);
-        }
+        if (firstPrintSegment(path) != nullptr) { print_paths.push_back(path); }
     }
 
     if (print_paths.isEmpty()) {
@@ -130,9 +114,7 @@ void HelicalLayer::calculateModifiers(Point& currentLocation) {
 }
 
 Point HelicalLayer::getStartLocation() const {
-    if (m_paths.isEmpty() || m_paths.first().size() == 0) {
-        return Point(0, 0, 0);
-    }
+    if (m_paths.isEmpty() || m_paths.first().size() == 0) { return Point(0, 0, 0); }
 
     return m_paths.first().front()->start();
 }
@@ -140,21 +122,19 @@ Point HelicalLayer::getStartLocation() const {
 float HelicalLayer::getMinZ() {
     float min_z = std::numeric_limits<float>::max();
     for (const Path& path : m_paths) {
-        for (const QSharedPointer<SegmentBase>& segment : path) {
-            min_z = std::min(min_z, segment->getMinZ());
-        }
+        for (const QSharedPointer<SegmentBase>& segment : path) { min_z = std::min(min_z, segment->getMinZ()); }
     }
 
     return min_z == std::numeric_limits<float>::max() ? 0.0f : min_z;
 }
 
 Point HelicalLayer::getEndLocation() {
-    if (m_paths.isEmpty() || m_paths.last().size() == 0) {
-        return Point(0, 0, 0);
-    }
+    if (m_paths.isEmpty() || m_paths.last().size() == 0) { return Point(0, 0, 0); }
 
     return m_paths.last().back()->end();
 }
 
-bool HelicalLayer::hasPaths() const { return !m_paths.isEmpty(); }
-} // namespace ORNL
+bool HelicalLayer::hasPaths() const {
+    return !m_paths.isEmpty();
+}
+}  // namespace ORNL

--- a/src/step/layer/island/brim_island.cpp
+++ b/src/step/layer/island/brim_island.cpp
@@ -29,4 +29,4 @@ void BrimIsland::optimize(int layerNumber, Point& currentLocation,
         r->optimize(layerNumber, currentLocation, unused);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/island_base.cpp
+++ b/src/step/layer/island/island_base.cpp
@@ -55,24 +55,26 @@ QString IslandBase::writeGCode(QSharedPointer<WriterBase> writer) {
     QString ret;
 
     for (auto r : m_regions) {
-        if (r->getPaths().size() > 0)
-            ret += r->writeGCode(writer);
+        if (r->getPaths().size() > 0) ret += r->writeGCode(writer);
     }
 
     return ret;
 }
 
-void IslandBase::addRegion(QSharedPointer<RegionBase> region) { m_regions.push_back(region); }
+void IslandBase::addRegion(QSharedPointer<RegionBase> region) {
+    m_regions.push_back(region);
+}
 
-const QList<QSharedPointer<RegionBase>> IslandBase::getRegions() const { return m_regions; }
+const QList<QSharedPointer<RegionBase>> IslandBase::getRegions() const {
+    return m_regions;
+}
 
 QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
     switch (type) {
         case RegionType::kPerimeter:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Perimeter> perimeter = r.dynamicCast<Perimeter>();
-                if (perimeter.isNull())
-                    continue;
+                if (perimeter.isNull()) continue;
 
                 return std::move(perimeter);
             }
@@ -80,8 +82,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kInset:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Inset> inset = r.dynamicCast<Inset>();
-                if (inset.isNull())
-                    continue;
+                if (inset.isNull()) continue;
 
                 return std::move(inset);
             }
@@ -89,8 +90,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kSkin:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Skin> skin = r.dynamicCast<Skin>();
-                if (skin.isNull())
-                    continue;
+                if (skin.isNull()) continue;
 
                 return std::move(skin);
             }
@@ -98,8 +98,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kInfill:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Infill> infill = r.dynamicCast<Infill>();
-                if (infill.isNull())
-                    continue;
+                if (infill.isNull()) continue;
 
                 return std::move(infill);
             }
@@ -107,8 +106,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kSkeleton:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Skeleton> skeleton = r.dynamicCast<Skeleton>();
-                if (skeleton.isNull())
-                    continue;
+                if (skeleton.isNull()) continue;
 
                 return std::move(skeleton);
             }
@@ -116,8 +114,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kBrim:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Brim> brim = r.dynamicCast<Brim>();
-                if (brim.isNull())
-                    continue;
+                if (brim.isNull()) continue;
 
                 return std::move(brim);
             }
@@ -125,8 +122,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kSkirt:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Skirt> skirt = r.dynamicCast<Skirt>();
-                if (skirt.isNull())
-                    continue;
+                if (skirt.isNull()) continue;
 
                 return std::move(skirt);
             }
@@ -134,8 +130,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kRaft:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Raft> raft = r.dynamicCast<Raft>();
-                if (raft.isNull())
-                    continue;
+                if (raft.isNull()) continue;
 
                 return std::move(raft);
             }
@@ -143,8 +138,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kSupport:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<Support> support = r.dynamicCast<Support>();
-                if (support.isNull())
-                    continue;
+                if (support.isNull()) continue;
 
                 return std::move(support);
             }
@@ -152,8 +146,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kLaserScan:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<LaserScan> laserscan = r.dynamicCast<LaserScan>();
-                if (laserscan.isNull())
-                    continue;
+                if (laserscan.isNull()) continue;
 
                 return std::move(laserscan);
             }
@@ -161,8 +154,7 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
         case RegionType::kThermalScan:
             for (QSharedPointer<RegionBase> r : m_regions) {
                 QSharedPointer<ThermalScan> thermalscan = r.dynamicCast<ThermalScan>();
-                if (thermalscan.isNull())
-                    continue;
+                if (thermalscan.isNull()) continue;
 
                 return std::move(thermalscan);
             }
@@ -176,7 +168,9 @@ QSharedPointer<RegionBase> IslandBase::getRegion(RegionType type) {
     return nullptr;
 }
 
-const PolygonList& IslandBase::getGeometry() const { return m_geometry; }
+const PolygonList& IslandBase::getGeometry() const {
+    return m_geometry;
+}
 
 void IslandBase::compute(uint layer_num) {
     PolygonList pl = m_geometry;
@@ -188,30 +182,28 @@ void IslandBase::compute(uint layer_num) {
     }
 }
 
-QSharedPointer<SettingsBase> IslandBase::getSb() const { return m_sb; }
+QSharedPointer<SettingsBase> IslandBase::getSb() const {
+    return m_sb;
+}
 
 void IslandBase::setSb(const QSharedPointer<SettingsBase>& sb) {
     m_sb = sb;
 
     // For each region in the stages, populate their sb's with the island's.
-    for (auto r : m_regions) {
-        r->setSb(m_sb);
-    }
+    for (auto r : m_regions) { r->setSb(m_sb); }
 }
 
 void IslandBase::setOptimizationFrame(const Plane& slicing_plane, const Point& optimization_shift) {
-    for (auto r : m_regions) {
-        r->setOptimizationFrame(slicing_plane, optimization_shift);
-    }
+    for (auto r : m_regions) { r->setOptimizationFrame(slicing_plane, optimization_shift); }
 }
 
-IslandType IslandBase::getType() { return m_island_type; }
+IslandType IslandBase::getType() {
+    return m_island_type;
+}
 
 void IslandBase::transform(QQuaternion rotation, Point shift) {
     // rotate and then shift every region in this island
-    for (QSharedPointer<RegionBase> region : m_regions) {
-        region->transform(rotation, shift);
-    }
+    for (QSharedPointer<RegionBase> region : m_regions) { region->transform(rotation, shift); }
 }
 
 float IslandBase::getMinZ() {
@@ -219,8 +211,7 @@ float IslandBase::getMinZ() {
     float island_min = std::numeric_limits<float>::max();
     for (QSharedPointer<RegionBase> region : m_regions) {
         float region_min = region->getMinZ();
-        if (region_min < island_min)
-            island_min = region_min;
+        if (region_min < island_min) island_min = region_min;
     }
     return island_min;
 }
@@ -238,7 +229,9 @@ bool IslandBase::getAnyValidPaths() {
     return ret;
 }
 
-QVector<SettingsPolygon> IslandBase::getSettingsPolygons() { return m_settings_polygons; }
+QVector<SettingsPolygon> IslandBase::getSettingsPolygons() {
+    return m_settings_polygons;
+}
 
 void IslandBase::prepareRegionForOptimization(const QSharedPointer<RegionBase>& region, int layerNumber,
                                               QVector<QSharedPointer<RegionBase>>& previousRegions) {
@@ -246,15 +239,12 @@ void IslandBase::prepareRegionForOptimization(const QSharedPointer<RegionBase>& 
 
     for (int i = previousRegions.size() - 1; i >= 0; --i) {
         const QSharedPointer<RegionBase>& previous_region = previousRegions[i];
-        if (previous_region->getRegionType() != region->getRegionType())
-            continue;
+        if (previous_region->getRegionType() != region->getRegionType()) continue;
 
-        if (previous_region->getOptimizedLayerNumber() >= layerNumber)
-            continue;
+        if (previous_region->getOptimizedLayerNumber() >= layerNumber) continue;
 
         previous_start = previous_region->getFirstPrintingStartPoint();
-        if (previous_start.has_value())
-            break;
+        if (previous_start.has_value()) break;
     }
 
     region->setOptimizedLayerNumber(layerNumber);
@@ -263,16 +253,14 @@ void IslandBase::prepareRegionForOptimization(const QSharedPointer<RegionBase>& 
 
 void IslandBase::calculateMultiMaterialTransitions(QVector<QSharedPointer<RegionBase>>& previousRegions) {
     if (previousRegions.size() > 1) {
-        QSharedPointer<RegionBase> lastRegion = previousRegions.last();
+        QSharedPointer<RegionBase> lastRegion       = previousRegions.last();
         QSharedPointer<RegionBase> preceedingRegion = previousRegions[previousRegions.size() - 2];
         if (lastRegion->getMaterialNumber() != preceedingRegion->getMaterialNumber()) {
             Distance transition_distance;
             if (m_sb->setting<int>(MS::MultiMaterial::kEnableSecondDistance) && lastRegion->getMaterialNumber() == 2) {
                 transition_distance = m_sb->setting<Distance>(MS::MultiMaterial::kSecondDistance);
             }
-            else {
-                transition_distance = m_sb->setting<Distance>(MS::MultiMaterial::kTransitionDistance);
-            }
+            else { transition_distance = m_sb->setting<Distance>(MS::MultiMaterial::kTransitionDistance); }
 
             int i = previousRegions.size() - 2;
             while (i >= 0 && transition_distance > 0) {
@@ -285,8 +273,7 @@ void IslandBase::calculateMultiMaterialTransitions(QVector<QSharedPointer<Region
 }
 
 void IslandBase::fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb) {
-    for (QSharedPointer<RegionBase> region : m_regions)
-        region->fitCircularArcs(global_sb);
+    for (QSharedPointer<RegionBase> region : m_regions) region->fitCircularArcs(global_sb);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/laser_scan_island.cpp
+++ b/src/step/layer/island/laser_scan_island.cpp
@@ -30,4 +30,4 @@ void LaserScanIsland::optimize(int layerNumber, Point& currentLocation,
         r->optimize(layerNumber, currentLocation, unused);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/polymer_island.cpp
+++ b/src/step/layer/island/polymer_island.cpp
@@ -27,15 +27,14 @@ PolymerIsland::PolymerIsland(const PolygonList& geometry, const QSharedPointer<S
                              const QVector<SettingsPolygon>& settings_polygons, const PolygonList& uncut_geometry)
     : IslandBase(geometry, sb, settings_polygons) {
     bool enable_perimeter = this->getSb()->setting<bool>(PS::Perimeter::kEnable);
-    bool enable_inset = this->getSb()->setting<bool>(PS::Inset::kEnable);
-    bool enable_skin = this->getSb()->setting<bool>(PS::Skin::kEnable);
-    bool enable_infill = this->getSb()->setting<bool>(PS::Infill::kEnable);
-    bool enable_skeleton = this->getSb()->setting<bool>(PS::Skeleton::kEnable);
+    bool enable_inset     = this->getSb()->setting<bool>(PS::Inset::kEnable);
+    bool enable_skin      = this->getSb()->setting<bool>(PS::Skin::kEnable);
+    bool enable_infill    = this->getSb()->setting<bool>(PS::Infill::kEnable);
+    bool enable_skeleton  = this->getSb()->setting<bool>(PS::Skeleton::kEnable);
 
     QList<QString> order = this->getSb()->setting<QList<QString>>(PS::Ordering::kRegionOrder);
     QList<RegionType> regionOrder;
-    for (QString str : order)
-        regionOrder.push_back(fromString(str.toUpper()));
+    for (QString str : order) regionOrder.push_back(fromString(str.toUpper()));
 
     for (int i = regionOrder.size() - 1; i >= 0; --i) {
         if ((regionOrder[i] == RegionType::kPerimeter && !enable_perimeter) ||
@@ -80,8 +79,7 @@ void PolymerIsland::optimize(int layerNumber, Point& currentLocation,
 
         r->optimize(layerNumber, currentLocation, shouldNextPathBeCCW);
 
-        if (r->getPaths().size() > 0)
-            previousRegions.push_back(r);
+        if (r->getPaths().size() > 0) previousRegions.push_back(r);
 
         if (m_sb->setting<bool>(MS::MultiMaterial::kEnable) &&
             m_sb->setting<Distance>(MS::MultiMaterial::kTransitionDistance) > 0) {
@@ -94,4 +92,4 @@ void PolymerIsland::reorderRegions() {
     std::sort(m_regions.begin(), m_regions.end(),
               [](auto const& a, auto const& b) { return a->getIndex() < b->getIndex(); });
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/raft_island.cpp
+++ b/src/step/layer/island/raft_island.cpp
@@ -29,4 +29,4 @@ void RaftIsland::optimize(int layerNumber, Point& currentLocation,
         r->optimize(layerNumber, currentLocation, unused);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/skirt_island.cpp
+++ b/src/step/layer/island/skirt_island.cpp
@@ -28,8 +28,7 @@ void SkirtIsland::optimize(int layerNumber, Point& currentLocation,
         prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
 
-        if (r->getPaths().size() > 0)
-            previousRegions.push_back(r);
+        if (r->getPaths().size() > 0) previousRegions.push_back(r);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/support_island.cpp
+++ b/src/step/layer/island/support_island.cpp
@@ -31,12 +31,11 @@ void SupportIsland::optimize(int layerNumber, Point& currentLocation,
         prepareRegionForOptimization(r, layerNumber, previousRegions);
         r->optimize(layerNumber, currentLocation, unused);
 
-        if (r->getPaths().size() > 0)
-            previousRegions.push_back(r);
+        if (r->getPaths().size() > 0) previousRegions.push_back(r);
 
         if (m_sb->setting<bool>(MS::MultiMaterial::kEnable) &&
             m_sb->setting<Distance>(MS::MultiMaterial::kTransitionDistance) > 0)
             calculateMultiMaterialTransitions(previousRegions);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/island/thermal_scan_island.cpp
+++ b/src/step/layer/island/thermal_scan_island.cpp
@@ -30,4 +30,4 @@ void ThermalScanIsland::optimize(int layerNumber, Point& currentLocation,
         r->optimize(layerNumber, currentLocation, unused);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/layer.cpp
+++ b/src/step/layer/layer.cpp
@@ -48,40 +48,36 @@ bool isBelowBuildPlate(const Point& point, const MeshTypes::Plane_3& build_plate
 }
 
 bool lineIntersectsBuildPlate(const Point& start, const Point& end, const MeshTypes::Plane_3& build_plate) {
-    if (isBelowBuildPlate(start, build_plate) || isBelowBuildPlate(end, build_plate)) {
-        return true;
-    }
+    if (isBelowBuildPlate(start, build_plate) || isBelowBuildPlate(end, build_plate)) { return true; }
 
     return false;
 }
 
 bool arcIntersectsBuildPlate(const ArcSegment& arc, const Point& start, const Point& end,
                              const MeshTypes::Plane_3& build_plate) {
-    const Point center = arc.center();
-    const double start_radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    const double end_radius = std::hypot(end.x() - center.x(), end.y() - center.y());
+    const Point center                = arc.center();
+    const double start_radius         = std::hypot(start.x() - center.x(), start.y() - center.y());
+    const double end_radius           = std::hypot(end.x() - center.x(), end.y() - center.y());
     constexpr double kRadiusTolerance = 1.0e-4;
     if (start_radius <= kRadiusTolerance || std::abs(start_radius - end_radius) > kRadiusTolerance) {
         return lineIntersectsBuildPlate(start, end, build_plate);
     }
 
     constexpr double kMaxSampleAngle = M_PI / 36.0;
-    const double arc_angle = std::abs(arc.angle()());
-    const int sample_count = std::max(1, static_cast<int>(std::ceil(arc_angle / kMaxSampleAngle)));
-    const double start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
-    const double signed_angle = arc.counterclockwise() ? arc_angle : -arc_angle;
+    const double arc_angle           = std::abs(arc.angle()());
+    const int sample_count           = std::max(1, static_cast<int>(std::ceil(arc_angle / kMaxSampleAngle)));
+    const double start_angle         = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const double signed_angle        = arc.counterclockwise() ? arc_angle : -arc_angle;
 
     Point previous = start;
     for (int sample = 1; sample <= sample_count; ++sample) {
         const double fraction = static_cast<double>(sample) / sample_count;
-        const double angle = start_angle + (signed_angle * fraction);
+        const double angle    = start_angle + (signed_angle * fraction);
         const Point current(center.x() + (start_radius * std::cos(angle)),
                             center.y() + (start_radius * std::sin(angle)),
                             start.z() + ((end.z() - start.z()) * fraction));
 
-        if (lineIntersectsBuildPlate(previous, current, build_plate)) {
-            return true;
-        }
+        if (lineIntersectsBuildPlate(previous, current, build_plate)) { return true; }
         previous = current;
     }
 
@@ -91,9 +87,7 @@ bool arcIntersectsBuildPlate(const ArcSegment& arc, const Point& start, const Po
 bool clearanceMoveIntersectsBuildPlate(const QSharedPointer<SegmentBase>& segment, const Point& start, const Point& end,
                                        const MeshTypes::Plane_3& build_plate) {
     const QSharedPointer<ArcSegment> arc = segment.dynamicCast<ArcSegment>();
-    if (!arc.isNull()) {
-        return arcIntersectsBuildPlate(*arc, start, end, build_plate);
-    }
+    if (!arc.isNull()) { return arcIntersectsBuildPlate(*arc, start, end, build_plate); }
 
     return lineIntersectsBuildPlate(start, end, build_plate);
 }
@@ -101,7 +95,7 @@ bool clearanceMoveIntersectsBuildPlate(const QSharedPointer<SegmentBase>& segmen
 Point redirectTipWipeEnd(const Point& start, const QVector3D& original_move, const QVector3D& slicing_normal) {
     // Mirror the move's in-plane component while preserving its lift along the slicing normal.
     const QVector3D normal_component = slicing_normal * QVector3D::dotProduct(original_move, slicing_normal);
-    const QVector3D redirected_move = (2.0f * normal_component) - original_move;
+    const QVector3D redirected_move  = (2.0f * normal_component) - original_move;
 
     return start + Point::fromQVector3D(redirected_move);
 }
@@ -121,7 +115,7 @@ QSharedPointer<SegmentBase> rewriteRedirectedSegment(const QSharedPointer<Segmen
     redirected_segment->setEnd(end);
     return redirected_segment;
 }
-} // namespace
+}  // namespace
 
 Layer::Layer(uint layer_nr, const QSharedPointer<SettingsBase>& sb)
     : Step(sb), m_layer_nr(layer_nr), m_minimum_z_shift(0) {
@@ -145,23 +139,21 @@ QString Layer::writeGCode(QSharedPointer<WriterBase> writer) {
             writer->writeAfterIsland();
         }
     }
-    else {
-        gcode += writer->writeEmptyStep();
-    }
+    else { gcode += writer->writeEmptyStep(); }
 
     return gcode;
 }
 
-uint Layer::getLayerNumber() const { return m_layer_nr; }
+uint Layer::getLayerNumber() const {
+    return m_layer_nr;
+}
 
 void Layer::compute() {
     for (QSharedPointer<IslandBase> island : m_islands) {
         island->compute(m_layer_nr);
 
         QSharedPointer<PolymerIsland> polyIsland = island.dynamicCast<PolymerIsland>();
-        if (polyIsland != nullptr) {
-            polyIsland->reorderRegions();
-        }
+        if (polyIsland != nullptr) { polyIsland->reorderRegions(); }
     }
 }
 
@@ -169,8 +161,7 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
     m_island_order.clear();
 
     for (QSharedPointer<IslandBase> island : m_islands) {
-        if (!island.isNull())
-            island->setOptimizationFrame(m_slicing_plane, m_shift_amount);
+        if (!island.isNull()) island->setOptimizationFrame(m_slicing_plane, m_shift_amount);
     }
 
     // Optimize the layer.
@@ -178,7 +169,7 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
         static_cast<IslandOrderOptimization>(this->getSb()->setting<int>(PS::Optimizations::kIslandOrder));
 
     // start index = index of last visited island
-    IslandBaseOrderOptimizer ioo(start, m_islands.values(), start_index, islandOrderOptimization); // mode 1
+    IslandBaseOrderOptimizer ioo(start, m_islands.values(), start_index, islandOrderOptimization);  // mode 1
 
     // seam adjustment
     if (islandOrderOptimization == IslandOrderOptimization::kCustomPoint) {
@@ -299,13 +290,11 @@ void Layer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<
         start_index = ioo.getFirstIndexSelected();
     }
 
-    for (QSharedPointer<IslandBase> island : m_islands) {
-        island->markRegionStartSegment();
-    }
+    for (QSharedPointer<IslandBase> island : m_islands) { island->markRegionStartSegment(); }
 }
 
-QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>>
-Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children) {
+QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>> Layer::createSequence(
+    QList<QSharedPointer<IslandBase>> parent, QList<QList<QSharedPointer<IslandBase>>> children) {
     QList<QHash<QSharedPointer<IslandBase>, QList<QSharedPointer<IslandBase>>>> result;
     int children_size = children.size();
     result.reserve(children_size);
@@ -319,8 +308,7 @@ Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSha
 
     QList<QSharedPointer<IslandBase>> validParent;
     for (const QSharedPointer<IslandBase>& brim : parent) {
-        if (hasSequenceGeometry(brim))
-            validParent.append(brim);
+        if (hasSequenceGeometry(brim)) validParent.append(brim);
     }
 
     if (validParent.size() == 0) {
@@ -337,8 +325,7 @@ Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSha
             for (int i = 0; i < children_size; ++i) {
                 QList<QSharedPointer<IslandBase>> islandSet = children[i];
                 for (QSharedPointer<IslandBase> isl : islandSet) {
-                    if (!hasSequenceGeometry(isl))
-                        continue;
+                    if (!hasSequenceGeometry(isl)) continue;
 
                     if (brim->getGeometry().first().inside(isl->getGeometry().first().first())) {
                         result[i][brim].append(isl);
@@ -353,10 +340,10 @@ Layer::createSequence(QList<QSharedPointer<IslandBase>> parent, QList<QList<QSha
 void Layer::calculateModifiers(Point& currentLocation) {
     // check for spiral lift for end of layer
     if (this->getSb()->setting<bool>(MS::SpiralLift::kLayerEnable)) {
-        QSharedPointer<IslandBase> lastIsland = m_islands.value(static_cast<int>(IslandType::kPolymer)); // back();
+        QSharedPointer<IslandBase> lastIsland     = m_islands.value(static_cast<int>(IslandType::kPolymer));  // back();
         QList<QSharedPointer<RegionBase>> regions = lastIsland->getRegions();
-        QSharedPointer<RegionBase> lastRegion = regions.back();
-        Path finalPath = lastRegion->getPaths().back();
+        QSharedPointer<RegionBase> lastRegion     = regions.back();
+        Path finalPath                            = lastRegion->getPaths().back();
 
         if (finalPath.back()->getSb()->setting<PathModifiers>(SS::kPathModifiers) != PathModifiers::kSpiralLift) {
             PathModifierGenerator::GenerateSpiralLift(finalPath,
@@ -371,17 +358,14 @@ void Layer::calculateModifiers(Point& currentLocation) {
         }
     }
 
-    for (QSharedPointer<IslandBase> island : getIslands())
-        island->fitCircularArcs(this->getSb());
+    for (QSharedPointer<IslandBase> island : getIslands()) island->fitCircularArcs(this->getSb());
 }
 
 void Layer::setSb(const QSharedPointer<SettingsBase>& sb) {
     this->Step::setSb(sb);
 
     // For every island, set the the settings base.
-    for (auto isl : m_islands) {
-        isl->setSb(this->getSb());
-    }
+    for (auto isl : m_islands) { isl->setSb(this->getSb()); }
 }
 
 void Layer::flagIfDirtySettingsPolygons(const QVector<SettingsPolygon>& new_settings_polys) {
@@ -403,9 +387,7 @@ void Layer::flagIfDirtySettingsPolygons(const QVector<SettingsPolygon>& new_sett
         }
     }
 
-    if (any_non_matching) {
-        this->setDirtyBit(true);
-    }
+    if (any_non_matching) { this->setDirtyBit(true); }
 }
 
 Point Layer::getEndLocation() {
@@ -418,9 +400,7 @@ Point Layer::getEndLocation() {
             for (int path_index = paths.size() - 1; path_index >= 0; --path_index) {
                 auto path = paths[path_index];
 
-                if (path.size() > 0) {
-                    return path.back()->end();
-                }
+                if (path.size() > 0) { return path.back()->end(); }
             }
         }
     }
@@ -445,38 +425,30 @@ Point Layer::getOrientationShift() const {
 void Layer::applyMinimumZShift() {
     m_minimum_z_shift = 0;
 
-    if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize))
-        return;
+    if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize)) return;
 
-    const QVector3D normal = m_slicing_plane.normal().normalized();
+    const QVector3D normal             = m_slicing_plane.normal().normalized();
     constexpr float kMinimumZComponent = 1.0e-6f;
-    const float z_component = std::abs(normal.z());
-    if (z_component < kMinimumZComponent)
-        return;
+    const float z_component            = std::abs(normal.z());
+    if (z_component < kMinimumZComponent) return;
 
     const float current_min_z_value = getMinimumPrintZ();
-    if (current_min_z_value == std::numeric_limits<float>::max())
-        return;
+    if (current_min_z_value == std::numeric_limits<float>::max()) return;
 
-    const Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    const Distance current_min_z = current_min_z_value;
+    const Distance layer_height    = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    const Distance current_min_z   = current_min_z_value;
     const Distance minimum_print_z = current_min_z + (layer_height / (2.0 * z_component));
 
     m_minimum_z_shift = minimum_print_z - current_min_z;
     const Point shift(0.0f, 0.0f, m_minimum_z_shift());
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(QQuaternion(), shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(QQuaternion(), shift); }
 }
 
 void Layer::removeMinimumZShift() {
-    if (m_minimum_z_shift == 0)
-        return;
+    if (m_minimum_z_shift == 0) return;
 
     const Point shift(0.0f, 0.0f, -m_minimum_z_shift());
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(QQuaternion(), shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(QQuaternion(), shift); }
     m_minimum_z_shift = 0;
 }
 
@@ -489,8 +461,7 @@ float Layer::getMinimumPrintZ() {
                 for (const QSharedPointer<SegmentBase>& segment : path.getSegments()) {
                     if (segment->isPrintingSegment()) {
                         const float segment_min_z = segment->getMinZ();
-                        if (segment_min_z < minimum_print_z)
-                            minimum_print_z = segment_min_z;
+                        if (segment_min_z < minimum_print_z) minimum_print_z = segment_min_z;
                     }
                 }
             }
@@ -516,9 +487,7 @@ void Layer::unorient() {
         Point origin_shift = Point(.0, .0, .0) - m_shift_amount;
         origin_shift.z(.0);
 
-        for (QSharedPointer<IslandBase> island : getIslands()) {
-            island->transform(QQuaternion(), origin_shift * -1);
-        }
+        for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(QQuaternion(), origin_shift * -1); }
     }
 }
 
@@ -527,18 +496,14 @@ void Layer::reorient() {
     Point origin_shift = Point(.0, .0, .0) - m_shift_amount;
     origin_shift.z(.0);
 
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(QQuaternion(), origin_shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(QQuaternion(), origin_shift); }
 
     const Point orientation_shift = getOrientationShift();
 
     // Rotate and then shift every island in the layer
     QQuaternion rotation = MathUtils::CreateQuaternion(QVector3D(0, 0, 1), m_slicing_plane.normal());
 
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(rotation, orientation_shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(rotation, orientation_shift); }
 
     applyMinimumZShift();
     redirectClearanceMoves();
@@ -546,9 +511,7 @@ void Layer::reorient() {
 
 void Layer::redirectClearanceMoves() {
     QVector3D slicing_normal = m_slicing_plane.normal().normalized();
-    if (slicing_normal.isNull()) {
-        return;
-    }
+    if (slicing_normal.isNull()) { return; }
 
     const MeshTypes::Plane_3 build_plate(MeshTypes::Point_3(0.0, 0.0, 0.0), MeshTypes::Vector_3(0.0, 0.0, 1.0));
 
@@ -563,24 +526,24 @@ void Layer::redirectClearanceMoves() {
                         continue;
                     }
 
-                    Point original_position = index > 0 ? segments[index - 1]->end() : segments[index]->start();
+                    Point original_position   = index > 0 ? segments[index - 1]->end() : segments[index]->start();
                     Point redirected_position = original_position;
-                    bool has_redirected = false;
+                    bool has_redirected       = false;
 
                     // Reconstruct the emitted moves from successive endpoints. Multi-segment wipes and spiral lifts
                     // can store starts on the source contour, but the machine moves from the preceding endpoint.
                     while (index < segments.size() &&
                            isClearanceModifier(segments[index]->getSb()->setting<PathModifiers>(SS::kPathModifiers))) {
                         const QSharedPointer<SegmentBase>& segment = segments[index];
-                        const Point original_end = segment->end();
-                        const QVector3D original_move = (original_end - original_position).toQVector3D();
+                        const Point original_end                   = segment->end();
+                        const QVector3D original_move              = (original_end - original_position).toQVector3D();
                         Point candidate_end =
                             has_redirected ? redirected_position + Point::fromQVector3D(original_move) : original_end;
                         bool should_rewrite_segment = has_redirected;
 
                         if (clearanceMoveIntersectsBuildPlate(segment, redirected_position, candidate_end,
                                                               build_plate)) {
-                            candidate_end = redirectTipWipeEnd(redirected_position, original_move, slicing_normal);
+                            candidate_end  = redirectTipWipeEnd(redirected_position, original_move, slicing_normal);
                             has_redirected = true;
                             should_rewrite_segment = true;
                         }
@@ -589,7 +552,7 @@ void Layer::redirectClearanceMoves() {
                             segments[index] = rewriteRedirectedSegment(segment, redirected_position, candidate_end);
                         }
 
-                        original_position = original_end;
+                        original_position   = original_end;
                         redirected_position = candidate_end;
                         ++index;
                     }
@@ -600,9 +563,7 @@ void Layer::redirectClearanceMoves() {
 }
 
 void Layer::compensateForRafts() {
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(QQuaternion(), m_raft_shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(QQuaternion(), m_raft_shift); }
 }
 
 float Layer::getMinZ() {
@@ -610,9 +571,7 @@ float Layer::getMinZ() {
 
     for (QSharedPointer<IslandBase> island : m_islands) {
         float island_min = island->getMinZ();
-        if (island_min < min_z) {
-            min_z = island_min;
-        }
+        if (island_min < min_z) { min_z = island_min; }
     }
 
     return min_z;
@@ -626,5 +585,7 @@ void Layer::setSettingsPolygons(QVector<SettingsPolygon>& settings_polygons) {
     m_settings_polygons = settings_polygons;
 }
 
-QVector<SettingsPolygon> Layer::getSettingsPolygons() { return m_settings_polygons; }
-} // namespace ORNL
+QVector<SettingsPolygon> Layer::getSettingsPolygons() {
+    return m_settings_polygons;
+}
+}  // namespace ORNL

--- a/src/step/layer/radial_layer.cpp
+++ b/src/step/layer/radial_layer.cpp
@@ -34,9 +34,7 @@ struct CirclePathGroup {
 //! @brief Returns the first printable radial segment in a path, or nullptr when the path only contains travels.
 QSharedPointer<SegmentBase> firstPrintSegment(const Path& path) {
     for (const QSharedPointer<SegmentBase>& segment : path) {
-        if (dynamic_cast<TravelSegment*>(segment.data()) == nullptr) {
-            return segment;
-        }
+        if (dynamic_cast<TravelSegment*>(segment.data()) == nullptr) { return segment; }
     }
 
     return nullptr;
@@ -45,9 +43,7 @@ QSharedPointer<SegmentBase> firstPrintSegment(const Path& path) {
 //! @brief Returns segment settings from the first printable segment in a path.
 QSharedPointer<SettingsBase> firstPrintSettings(const Path& path, const QSharedPointer<SettingsBase>& fallback) {
     QSharedPointer<SegmentBase> print_segment = firstPrintSegment(path);
-    if (print_segment != nullptr) {
-        return print_segment->getSb();
-    }
+    if (print_segment != nullptr) { return print_segment->getSb(); }
 
     return fallback;
 }
@@ -89,37 +85,27 @@ void restoreRadialPathSettings(Path& path, const QSharedPointer<SettingsBase>& l
             travel_settings->setSetting(SS::kRegionType, RegionType::kPerimeter);
             segment->setSb(travel_settings);
         }
-        else {
-            segment->getSb()->setSetting(SS::kRegionType, RegionType::kPerimeter);
-        }
+        else { segment->getSb()->setSetting(SS::kRegionType, RegionType::kPerimeter); }
     }
 }
-} // namespace
+}  // namespace
 
 RadialLayer::RadialLayer(uint layer_nr, const QSharedPointer<SettingsBase>& sb) : Layer(layer_nr, sb) {}
 
 void RadialLayer::addPath(const Path& path) {
-    if (path.size() > 0) {
-        m_paths.push_back(path);
-    }
+    if (path.size() > 0) { m_paths.push_back(path); }
 }
 
 QString RadialLayer::writeGCode(QSharedPointer<WriterBase> writer) {
-    if (m_paths.isEmpty()) {
-        return writer->writeEmptyStep();
-    }
+    if (m_paths.isEmpty()) { return writer->writeEmptyStep(); }
 
     QString gcode;
     gcode += writer->writeBeforeRegion(RegionType::kPerimeter, m_paths.size());
     for (Path& path : m_paths) {
-        if (path.size() == 0) {
-            continue;
-        }
+        if (path.size() == 0) { continue; }
 
         gcode += writer->writeBeforePath(RegionType::kPerimeter);
-        for (const QSharedPointer<SegmentBase>& segment : path) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (const QSharedPointer<SegmentBase>& segment : path) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kPerimeter);
     }
     gcode += writer->writeAfterRegion(RegionType::kPerimeter);
@@ -135,9 +121,7 @@ void RadialLayer::calculateModifiers(Point& currentLocation) {
     QVector<CirclePathGroup> circle_groups;
     for (Path path : m_paths) {
         path.removeTravels();
-        if (firstPrintSegment(path) != nullptr) {
-            addToCircleGroup(circle_groups, path);
-        }
+        if (firstPrintSegment(path) != nullptr) { addToCircleGroup(circle_groups, path); }
     }
 
     if (circle_groups.isEmpty()) {
@@ -165,9 +149,7 @@ void RadialLayer::calculateModifiers(Point& currentLocation) {
 }
 
 Point RadialLayer::getStartLocation() const {
-    if (m_paths.isEmpty() || m_paths.first().size() == 0) {
-        return Point(0, 0, 0);
-    }
+    if (m_paths.isEmpty() || m_paths.first().size() == 0) { return Point(0, 0, 0); }
 
     return m_paths.first().front()->start();
 }
@@ -175,21 +157,19 @@ Point RadialLayer::getStartLocation() const {
 float RadialLayer::getMinZ() {
     float min_z = std::numeric_limits<float>::max();
     for (const Path& path : m_paths) {
-        for (const QSharedPointer<SegmentBase>& segment : path) {
-            min_z = std::min(min_z, segment->getMinZ());
-        }
+        for (const QSharedPointer<SegmentBase>& segment : path) { min_z = std::min(min_z, segment->getMinZ()); }
     }
 
     return min_z == std::numeric_limits<float>::max() ? 0.0f : min_z;
 }
 
 Point RadialLayer::getEndLocation() {
-    if (m_paths.isEmpty() || m_paths.last().size() == 0) {
-        return Point(0, 0, 0);
-    }
+    if (m_paths.isEmpty() || m_paths.last().size() == 0) { return Point(0, 0, 0); }
 
     return m_paths.last().back()->end();
 }
 
-bool RadialLayer::hasPaths() const { return !m_paths.isEmpty(); }
-} // namespace ORNL
+bool RadialLayer::hasPaths() const {
+    return !m_paths.isEmpty();
+}
+}  // namespace ORNL

--- a/src/step/layer/regions/brim.cpp
+++ b/src/step/layer/regions/brim.cpp
@@ -35,9 +35,7 @@ QString Brim::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kBrim);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kBrim);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kBrim);
     }
     gcode += writer->writeAfterRegion(RegionType::kBrim);
@@ -51,19 +49,16 @@ void Brim::compute(uint layer_num) {
 
     Distance brimWidth = m_sb->setting<Distance>(MS::PlatformAdhesion::kBrimWidth);
     Distance beadWidth = m_sb->setting<Distance>(MS::PlatformAdhesion::kBrimBeadWidth);
-    int m_rings = qCeil(brimWidth() / beadWidth());
+    int m_rings        = qCeil(brimWidth() / beadWidth());
 
     // m_geometry is set to the outer most loop, which is printed first
     // printing inwards if there are more than 1 loops
     for (int ring_nr = 0; ring_nr < m_rings; ring_nr++) {
         Distance addOffset = beadWidth;
-        if (ring_nr == 0)
-            addOffset = 0;
+        if (ring_nr == 0) addOffset = 0;
         PolygonList path_line = m_geometry.offset(-addOffset);
 
-        if (!path_line.size()) {
-            break;
-        }
+        if (!path_line.size()) { break; }
         m_geometry = path_line;
 
         for (Polygon poly : path_line) {
@@ -109,7 +104,7 @@ void Brim::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
 
     while (poo.getCurrentPolylineCount() > 0) {
         Polyline result = poo.linkNextPolyline();
-        Path newPath = createPath(result);
+        Path newPath    = createPath(result);
 
         if (newPath.size() > 0) {
             calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -128,16 +123,16 @@ void Brim::calculateModifiers(Path& path, bool supportsG3) {
 Path Brim::createPath(Polyline line) {
     Path new_path;
 
-    Distance default_width = m_sb->setting<Distance>(MS::PlatformAdhesion::kBrimBeadWidth);
-    Distance default_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    Velocity default_speed = m_sb->setting<Velocity>(PS::Layer::kSpeed);
-    Acceleration default_acceleration = m_sb->setting<Acceleration>(PRS::Acceleration::kDefault);
+    Distance default_width                 = m_sb->setting<Distance>(MS::PlatformAdhesion::kBrimBeadWidth);
+    Distance default_height                = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    Velocity default_speed                 = m_sb->setting<Velocity>(PS::Layer::kSpeed);
+    Acceleration default_acceleration      = m_sb->setting<Acceleration>(PRS::Acceleration::kDefault);
     AngularVelocity default_extruder_speed = m_sb->setting<AngularVelocity>(PS::Layer::kExtruderSpeed);
-    int material_number = m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum);
+    int material_number                    = m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum);
 
     for (int i = 0, end_cond = line.size(); i < end_cond; ++i) {
         Point start = line[i];
-        Point end = line[(i + 1) % end_cond];
+        Point end   = line[(i + 1) % end_cond];
 
         bool is_settings_region = false;
 
@@ -150,12 +145,9 @@ Path Brim::createPath(Polyline line) {
                 start.setSettings(updatedBase);
                 is_settings_region = true;
             }
-            else {
-                start.setSettings(m_sb);
-            }
+            else { start.setSettings(m_sb); }
 
-            if (settings_poly.inside(end))
-                end.setSettings(updatedBase);
+            if (settings_poly.inside(end)) end.setSettings(updatedBase);
 
             // Find if/ where this line intersects with a settings polygon
             QVector<Point> poly_intersect = settings_poly.clipLine(start, end);
@@ -170,8 +162,7 @@ Path Brim::createPath(Polyline line) {
 
             for (Point& point : intersections) {
                 // If no settings change, skip this point
-                if (point.getSettings()->json() == m_sb->json())
-                    continue;
+                if (point.getSettings()->json() == m_sb->json()) continue;
 
                 QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(start, point);
 
@@ -200,7 +191,7 @@ Path Brim::createPath(Polyline line) {
 
                 new_path.append(segment);
                 is_settings_region = !is_settings_region;
-                start = point;
+                start              = point;
             }
         }
 
@@ -230,11 +221,7 @@ Path Brim::createPath(Polyline line) {
         new_path.append(segment);
     }
 
-    if (new_path.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) {
-        return new_path;
-    }
-    else {
-        return Path();
-    }
+    if (new_path.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) { return new_path; }
+    else { return Path(); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/infill.cpp
+++ b/src/step/layer/regions/infill.cpp
@@ -33,9 +33,7 @@ QString Infill::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kInfill);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kInfill);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kInfill);
     }
     gcode += writer->writeAfterRegion(RegionType::kInfill);
@@ -49,7 +47,7 @@ void Infill::compute(uint layer_num) {
 
     // Keep around the overlapped geometry for later connections/travels.
     const Distance overlap = m_sb->setting<Distance>(PS::Infill::kOverlap);
-    m_geometry_copy = m_geometry.offset(overlap);
+    m_geometry_copy        = m_geometry.offset(overlap);
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kInfillNum));
 
@@ -86,8 +84,8 @@ void Infill::compute(uint layer_num) {
 
 void Infill::fillGeometry(PolygonList geometry, const QSharedPointer<SettingsBase>& sb) {
     InfillPatterns default_infill_pattern = static_cast<InfillPatterns>(sb->setting<int>(PS::Infill::kPattern));
-    Distance default_line_spacing = sb->setting<Distance>(PS::Infill::kLineSpacing);
-    Distance default_bead_width = sb->setting<Distance>(PS::Infill::kBeadWidth);
+    Distance default_line_spacing         = sb->setting<Distance>(PS::Infill::kLineSpacing);
+    Distance default_bead_width           = sb->setting<Distance>(PS::Infill::kBeadWidth);
 
     // kAngle in the setting has already been updated for each layer
     Angle default_angle = sb->setting<Angle>(PS::Infill::kAngle);
@@ -103,7 +101,7 @@ void Infill::fillGeometry(PolygonList geometry, const QSharedPointer<SettingsBas
     }
 
     if (!sb->setting<bool>(PS::Infill::kManualLineSpacing)) {
-        double density = sb->setting<double>(PS::Infill::kDensity) / 100.0;
+        double density       = sb->setting<double>(PS::Infill::kDensity) / 100.0;
         default_line_spacing = default_bead_width / density;
     }
 
@@ -164,8 +162,8 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
 
         poo.setStartPointOverride(startOverride);
     }
-    const Distance bead_width = getSb()->setting<Distance>(PS::Infill::kBeadWidth);
-    const Distance overlap = getSb()->setting<Distance>(PS::Infill::kOverlap);
+    const Distance bead_width      = getSb()->setting<Distance>(PS::Infill::kBeadWidth);
+    const Distance overlap         = getSb()->setting<Distance>(PS::Infill::kOverlap);
     const Distance link_core_width = bead_width - 2 * overlap;
     poo.setInfillParameters(static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern)), m_geometry_copy,
                             getSb()->setting<Distance>(PS::Infill::kMinPathLength),
@@ -206,19 +204,17 @@ void Infill::optimize(int layerNumber, Point& current_location, bool& shouldNext
 
 Path Infill::createPath(Polyline line) {
     const InfillPatterns pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Infill::kPattern));
-    const bool is_closed_path = pattern == InfillPatterns::kConcentric;
+    const bool is_closed_path    = pattern == InfillPatterns::kConcentric;
 
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Infill::kMinSegmentLength), is_closed_path);
-    if (line.size() < (is_closed_path ? 3 : 2)) {
-        return Path();
-    }
+    if (line.size() < (is_closed_path ? 3 : 2)) { return Path(); }
 
-    Distance width = m_sb->setting<Distance>(PS::Infill::kBeadWidth);
-    Distance height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    Velocity speed = m_sb->setting<Velocity>(PS::Infill::kSpeed);
-    Acceleration acceleration = m_sb->setting<Acceleration>(PRS::Acceleration::kInfill);
+    Distance width                 = m_sb->setting<Distance>(PS::Infill::kBeadWidth);
+    Distance height                = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    Velocity speed                 = m_sb->setting<Velocity>(PS::Infill::kSpeed);
+    Acceleration acceleration      = m_sb->setting<Acceleration>(PRS::Acceleration::kInfill);
     AngularVelocity extruder_speed = m_sb->setting<AngularVelocity>(PS::Infill::kExtruderSpeed);
-    int material_number = m_sb->setting<int>(MS::MultiMaterial::kInfillNum);
+    int material_number            = m_sb->setting<int>(MS::MultiMaterial::kInfillNum);
 
     Path newPath;
     for (int j = 0, polyEnd = line.size() - 1; j < polyEnd; ++j) {
@@ -357,4 +353,4 @@ bool Infill::settingsSame(QSharedPointer<SettingsBase> a, QSharedPointer<Setting
            qFuzzyCompare(a->setting<Angle>(PS::Infill::kAngle)(), b->setting<Angle>(PS::Infill::kAngle)()) &&
            a->setting<bool>(PS::Infill::kEnable) == b->setting<bool>(PS::Infill::kEnable);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -32,9 +32,7 @@ namespace ORNL {
 namespace {
 Polyline toOpenPolyline(Polygon poly) {
     Polyline line = poly.toPolyline();
-    if (!line.isEmpty()) {
-        line.pop_back();
-    }
+    if (!line.isEmpty()) { line.pop_back(); }
     return line;
 }
 
@@ -76,29 +74,23 @@ QVector<Polygon> validPathLines(const PolygonList& path_lines, Distance min_path
 
 Distance totalPathLineLength(const QVector<Polygon>& path_lines) {
     Distance total_length;
-    for (const Polygon& poly : path_lines) {
-        total_length += SpiralPath::closedPolylineLength(toOpenPolyline(poly));
-    }
+    for (const Polygon& poly : path_lines) { total_length += SpiralPath::closedPolylineLength(toOpenPolyline(poly)); }
     return total_length;
 }
 
 PolygonList pathLineFootprint(const Polygon& path_line, Distance bead_width, const PolygonList& clipping_geometry) {
     PolygonList outer_offset = path_line.offset(bead_width / 2);
     PolygonList inner_offset = path_line.offset(-bead_width / 2);
-    PolygonList footprint = outer_offset ^ inner_offset;
+    PolygonList footprint    = outer_offset ^ inner_offset;
 
     return footprint & clipping_geometry;
 }
 
 bool subtractPathLineFootprints(PolygonList& geometry, const QVector<Polygon>& path_lines, Distance bead_width) {
     PolygonList path_line_footprint;
-    for (const Polygon& poly : path_lines) {
-        path_line_footprint += pathLineFootprint(poly, bead_width, geometry);
-    }
+    for (const Polygon& poly : path_lines) { path_line_footprint += pathLineFootprint(poly, bead_width, geometry); }
 
-    if (path_line_footprint.isEmpty()) {
-        return false;
-    }
+    if (path_line_footprint.isEmpty()) { return false; }
 
     geometry -= path_line_footprint;
     return true;
@@ -106,42 +98,38 @@ bool subtractPathLineFootprints(PolygonList& geometry, const QVector<Polygon>& p
 
 PolygonList insetPathLines(const PolygonList& geometry, Distance bead_width, Distance overlap) {
     PolygonList path_line = geometry.offset(-bead_width / 2);
-    if (overlap > 0) {
-        path_line = path_line.offset(overlap);
-    }
+    if (overlap > 0) { path_line = path_line.offset(overlap); }
 
     return path_line;
 }
 
-double netAreaAbs(PolygonList geometry) { return std::fabs(geometry.netArea()()); }
+double netAreaAbs(PolygonList geometry) {
+    return std::fabs(geometry.netArea()());
+}
 
 double negligibleAreaTolerance(double reference_area, Distance nominal_width) {
     return std::max(reference_area * 1.0e-6, nominal_width() * nominal_width() * 1.0e-4);
 }
 
-bool hasInternalBoundaries(const PolygonList& geometry) { return !geometry.internalPolygonBoundaries().isEmpty(); }
+bool hasInternalBoundaries(const PolygonList& geometry) {
+    return !geometry.internalPolygonBoundaries().isEmpty();
+}
 
 Distance clampedAdaptiveWidth(Distance requested_width, Distance nominal_width, Distance min_width,
                               Distance max_width) {
     double requested = requested_width();
-    if (!std::isfinite(requested) || requested <= 0) {
-        requested = nominal_width();
-    }
+    if (!std::isfinite(requested) || requested <= 0) { requested = nominal_width(); }
 
     double lower = std::max(0.0, min_width());
     double upper = max_width() > 0 ? max_width() : std::numeric_limits<double>::max();
-    if (upper < lower) {
-        upper = lower;
-    }
+    if (upper < lower) { upper = lower; }
 
     return Distance(std::clamp(requested, lower, upper));
 }
 
 bool geometryClearedByFootprints(PolygonList geometry, const QVector<Polygon>& path_lines, Distance bead_width,
                                  double reference_area, Distance nominal_width) {
-    if (!subtractPathLineFootprints(geometry, path_lines, bead_width)) {
-        return false;
-    }
+    if (!subtractPathLineFootprints(geometry, path_lines, bead_width)) { return false; }
 
     return geometry.isEmpty() || netAreaAbs(geometry) <= negligibleAreaTolerance(reference_area, nominal_width);
 }
@@ -149,9 +137,7 @@ bool geometryClearedByFootprints(PolygonList geometry, const QVector<Polygon>& p
 bool shellWidthCoversGeometry(PolygonList geometry, const QVector<Polygon>& path_lines, Distance bead_width,
                               Distance nominal_width) {
     const Distance path_length = totalPathLineLength(path_lines);
-    if (path_length <= 0) {
-        return false;
-    }
+    if (path_length <= 0) { return false; }
 
     const Distance full_area_width = Distance(netAreaAbs(geometry) / path_length());
     return std::fabs(full_area_width() - bead_width()) <= std::max(nominal_width() * 1.0e-4, 1.0e-6);
@@ -161,9 +147,7 @@ std::optional<Distance> fullCoverageAdaptiveWidth(PolygonList geometry, Distance
                                                   Distance min_path_length, Distance min_segment_length,
                                                   Distance min_width, Distance max_width) {
     const double initial_area = netAreaAbs(geometry);
-    if (initial_area <= 0) {
-        return std::nullopt;
-    }
+    if (initial_area <= 0) { return std::nullopt; }
     const bool shell_geometry = hasInternalBoundaries(geometry);
 
     Distance candidate_width = nominal_width;
@@ -172,9 +156,7 @@ std::optional<Distance> fullCoverageAdaptiveWidth(PolygonList geometry, Distance
         candidate_path_lines =
             validPathLines(insetPathLines(geometry, candidate_width, overlap), min_path_length, min_segment_length);
         const Distance candidate_length = totalPathLineLength(candidate_path_lines);
-        if (candidate_length <= 0) {
-            return std::nullopt;
-        }
+        if (candidate_length <= 0) { return std::nullopt; }
 
         const Distance next_width =
             clampedAdaptiveWidth(Distance(initial_area / candidate_length()), nominal_width, min_width, max_width);
@@ -188,9 +170,7 @@ std::optional<Distance> fullCoverageAdaptiveWidth(PolygonList geometry, Distance
 
     candidate_path_lines =
         validPathLines(insetPathLines(geometry, candidate_width, overlap), min_path_length, min_segment_length);
-    if (candidate_path_lines.isEmpty()) {
-        return std::nullopt;
-    }
+    if (candidate_path_lines.isEmpty()) { return std::nullopt; }
 
     if (geometryClearedByFootprints(geometry, candidate_path_lines, candidate_width, initial_area, nominal_width)) {
         return candidate_width;
@@ -217,24 +197,18 @@ Distance adaptiveContourWidthForGeometry(PolygonList geometry, Distance nominal_
     for (int i = 0; i < remaining_count && !preview_geometry.isEmpty(); ++i) {
         QVector<Polygon> preview_path_lines = validPathLines(insetPathLines(preview_geometry, nominal_width, overlap),
                                                              min_path_length, min_segment_length);
-        if (preview_path_lines.isEmpty()) {
-            break;
-        }
+        if (preview_path_lines.isEmpty()) { break; }
 
         preview_length += totalPathLineLength(preview_path_lines);
-        if (!subtractPathLineFootprints(preview_geometry, preview_path_lines, nominal_width)) {
-            break;
-        }
+        if (!subtractPathLineFootprints(preview_geometry, preview_path_lines, nominal_width)) { break; }
     }
 
-    if (preview_length <= 0) {
-        return nominal_width;
-    }
+    if (preview_length <= 0) { return nominal_width; }
 
     const bool more_nominal_paths_fit =
         !validPathLines(insetPathLines(preview_geometry, nominal_width, overlap), min_path_length, min_segment_length)
              .isEmpty();
-    const double initial_area = netAreaAbs(geometry);
+    const double initial_area           = netAreaAbs(geometry);
     const double preview_remaining_area = netAreaAbs(preview_geometry);
     const double target_area =
         more_nominal_paths_fit ? std::max(0.0, initial_area - preview_remaining_area) : initial_area;
@@ -251,11 +225,9 @@ QVector<Distance> plannedAdaptiveContourWidths(PolygonList geometry, Distance no
         const Distance path_width =
             adaptiveContourWidthForGeometry(geometry, nominal_width, remaining_count - i, overlap, min_path_length,
                                             min_segment_length, min_width, max_width);
-        PolygonList path_lines = insetPathLines(geometry, path_width, overlap);
+        PolygonList path_lines            = insetPathLines(geometry, path_width, overlap);
         QVector<Polygon> valid_path_lines = validPathLines(path_lines, min_path_length, min_segment_length);
-        if (valid_path_lines.isEmpty()) {
-            break;
-        }
+        if (valid_path_lines.isEmpty()) { break; }
 
         widths.push_back(path_width);
 
@@ -263,12 +235,8 @@ QVector<Distance> plannedAdaptiveContourWidths(PolygonList geometry, Distance no
             hasInternalBoundaries(geometry) &&
             shellWidthCoversGeometry(geometry, valid_path_lines, path_width, nominal_width);
 
-        if (!subtractPathLineFootprints(geometry, valid_path_lines, path_width)) {
-            break;
-        }
-        if (clear_shell_geometry) {
-            geometry.clear();
-        }
+        if (!subtractPathLineFootprints(geometry, valid_path_lines, path_width)) { break; }
+        if (clear_shell_geometry) { geometry.clear(); }
     }
 
     return widths;
@@ -279,17 +247,15 @@ Distance adaptiveContourWidth(PolygonList geometry, Distance nominal_width, int 
                               Distance max_width) {
     QVector<Distance> widths = plannedAdaptiveContourWidths(geometry, nominal_width, remaining_count, overlap,
                                                             min_path_length, min_segment_length, min_width, max_width);
-    if (widths.isEmpty()) {
-        return nominal_width;
-    }
+    if (widths.isEmpty()) { return nominal_width; }
 
     return *std::max_element(widths.begin(), widths.end(),
                              [](const Distance& lhs, const Distance& rhs) { return lhs() < rhs(); });
 }
 
 double distanceXYToSegment(const Point& point, const Point& start, const Point& end) {
-    const double dx = end.x() - start.x();
-    const double dy = end.y() - start.y();
+    const double dx     = end.x() - start.x();
+    const double dy     = end.y() - start.y();
     const double len_sq = dx * dx + dy * dy;
     if (len_sq <= std::numeric_limits<double>::epsilon()) {
         return std::hypot(point.x() - start.x(), point.y() - start.y());
@@ -302,20 +268,16 @@ double distanceXYToSegment(const Point& point, const Point& start, const Point& 
 }
 
 bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double tolerance) {
-    if (line.size() < 2) {
-        return false;
-    }
+    if (line.size() < 2) { return false; }
 
     for (int i = 0; i < line.size(); ++i) {
-        if (distanceXYToSegment(point, line[i], line[(i + 1) % line.size()]) <= tolerance) {
-            return true;
-        }
+        if (distanceXYToSegment(point, line[i], line[(i + 1) % line.size()]) <= tolerance) { return true; }
     }
 
     return false;
 }
 
-} // namespace
+}  // namespace
 
 Inset::Inset(const QSharedPointer<SettingsBase>& sb, const int index, const QVector<SettingsPolygon>& settings_polygons)
     : RegionBase(sb, index, settings_polygons, PolygonList(), RegionType::kInset) {
@@ -327,9 +289,7 @@ QString Inset::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kInset);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kInset);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kInset);
     }
     gcode += writer->writeAfterRegion(RegionType::kInset);
@@ -344,17 +304,15 @@ void Inset::compute(uint layer_num) {
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kInsetNum));
 
     Distance beadWidth = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
-    int rings = m_sb->setting<int>(PS::Inset::kCount);
+    int rings          = m_sb->setting<int>(PS::Inset::kCount);
 
-    Distance overlap = m_sb->setting<Distance>(PS::Inset::kOverlap);
-    const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+    Distance overlap                  = m_sb->setting<Distance>(PS::Inset::kOverlap);
+    const Distance min_path_length    = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
     const Distance min_segment_length = m_sb->setting<Distance>(PS::Inset::kMinSegmentLength);
 
-    int ring_nr = 0;
+    int ring_nr           = 0;
     PolygonList path_line = m_geometry.offset(-beadWidth / 2);
-    if (overlap > 0) {
-        path_line = path_line.offset(overlap);
-    }
+    if (overlap > 0) { path_line = path_line.offset(overlap); }
 
     if (m_sb->setting<bool>(PS::Inset::kAdaptive)) {
         const Distance min_adaptive_width = m_sb->setting<Distance>(PS::Inset::kAdaptiveMinWidth);
@@ -372,9 +330,7 @@ void Inset::compute(uint layer_num) {
                 appendValidPathLines(path_line, m_computed_geometry, m_computed_widths, min_path_length, path_width,
                                      min_segment_length, skipped_path_line);
 
-            if (valid_path_lines.isEmpty()) {
-                break;
-            }
+            if (valid_path_lines.isEmpty()) { break; }
 
             ring_nr++;
 
@@ -382,12 +338,8 @@ void Inset::compute(uint layer_num) {
                 hasInternalBoundaries(m_geometry) &&
                 shellWidthCoversGeometry(m_geometry, valid_path_lines, path_width, beadWidth);
 
-            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, path_width)) {
-                break;
-            }
-            if (clear_shell_geometry) {
-                m_geometry.clear();
-            }
+            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, path_width)) { break; }
+            if (clear_shell_geometry) { m_geometry.clear(); }
         }
         return;
     }
@@ -398,22 +350,18 @@ void Inset::compute(uint layer_num) {
             appendValidPathLines(path_line, m_computed_geometry, m_computed_widths, min_path_length, beadWidth,
                                  min_segment_length, skipped_path_line);
 
-        if (valid_path_lines.isEmpty()) {
-            break;
-        }
+        if (valid_path_lines.isEmpty()) { break; }
 
         ring_nr++;
 
         if (skipped_path_line) {
-            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, beadWidth)) {
-                break;
-            }
+            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, beadWidth)) { break; }
 
             path_line = m_geometry.offset(-beadWidth / 2);
         }
         else {
             m_geometry = path_line.offset(-beadWidth / 2., -beadWidth / 2.);
-            path_line = path_line.offset(-beadWidth, -beadWidth / 2.);
+            path_line  = path_line.offset(-beadWidth, -beadWidth / 2.);
         }
     }
 }
@@ -453,27 +401,19 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
     if (static_cast<PrintDirection>(m_sb->setting<int>(PS::Ordering::kInsetReverseDirection)) !=
         PrintDirection::kReverse_off) {
-        for (Polyline& line : m_computed_geometry) {
-            line = line.reverse();
-        }
+        for (Polyline& line : m_computed_geometry) { line = line.reverse(); }
     }
 
     auto appendSpiralPaths = [&](const QVector<Polyline>& spiral_groups, bool ccw, Distance min_path_length) {
         for (const Polyline& spiral_group : spiral_groups) {
-            if (spiral_group.size() < 3) {
-                continue;
-            }
+            if (spiral_group.size() < 3) { continue; }
 
             Path newPath = createPath(spiral_group);
             newPath.setCCW(ccw);
 
-            if (newPath.size() > 0) {
-                newPath.getSegments().removeLast();
-            }
+            if (newPath.size() > 0) { newPath.getSegments().removeLast(); }
 
-            if (newPath.calculateLength() < min_path_length) {
-                continue;
-            }
+            if (newPath.calculateLength() < min_path_length) { continue; }
 
             if (newPath.size() > 0) {
                 calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
@@ -495,7 +435,7 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
             QVector<Polyline> ordered_insets;
             const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
-            const Distance bead_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
+            const Distance bead_width      = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
 
             while (spiral_poo.getCurrentPolylineCount() > 0) {
                 if (!ordered_insets.isEmpty()) {
@@ -504,17 +444,13 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
                 Polyline result = spiral_poo.linkNextPolyline();
 
-                if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
-                    continue;
-                }
+                if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) { continue; }
 
                 spiral_query_location = SpiralPath::transitionStartPoint(result, bead_width);
                 ordered_insets.push_back(result);
             }
 
-            if (ordered_insets.isEmpty()) {
-                return;
-            }
+            if (ordered_insets.isEmpty()) { return; }
 
             if (ordered_insets.size() == 1) {
                 Polyline result = ordered_insets.first();
@@ -522,9 +458,7 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
                 Path newPath = createPath(result);
                 newPath.setCCW(result.orientation());
 
-                if (newPath.calculateLength() < min_path_length) {
-                    return;
-                }
+                if (newPath.calculateLength() < min_path_length) { return; }
 
                 if (newPath.size() > 0) {
                     calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -551,8 +485,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
         QVector<Polyline> ordered_insets;
         QVector<Distance> ordered_inset_widths;
-        bool has_spiral_orientation = false;
-        bool spiral_orientation = false;
+        bool has_spiral_orientation    = false;
+        bool spiral_orientation        = false;
         const Distance min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
 
         while (spiral_poo.getCurrentPolylineCount() > 0) {
@@ -562,12 +496,10 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
             Polyline result = spiral_poo.linkNextPolyline();
 
-            if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
-                continue;
-            }
+            if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) { continue; }
 
             if (!has_spiral_orientation) {
-                spiral_orientation = result.orientation();
+                spiral_orientation     = result.orientation();
                 has_spiral_orientation = true;
             }
             else if (result.orientation() != spiral_orientation) {
@@ -581,9 +513,7 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             spiral_query_location = SpiralPath::transitionStartPoint(result, result_width);
         }
 
-        if (ordered_insets.isEmpty()) {
-            return;
-        }
+        if (ordered_insets.isEmpty()) { return; }
 
         if (ordered_insets.size() == 1) {
             PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
@@ -591,16 +521,12 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             first_loop_poo.setGeometryToEvaluate({ordered_insets.first()}, RegionType::kInset,
                                                  PathOrderOptimization::kNextClosest);
             Polyline result = first_loop_poo.linkNextPolyline();
-            if (result.size() < 3) {
-                result = ordered_insets.first();
-            }
+            if (result.size() < 3) { result = ordered_insets.first(); }
 
             Path newPath = createPath(result);
             newPath.setCCW(result.orientation());
 
-            if (newPath.calculateLength() < min_path_length) {
-                return;
-            }
+            if (newPath.calculateLength() < min_path_length) { return; }
 
             if (newPath.size() > 0) {
                 calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -627,18 +553,14 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         Polyline result = poo.linkNextPolyline();
 
         // Exit early if no inset path can be made
-        if (result.size() < 3) {
-            continue;
-        }
+        if (result.size() < 3) { continue; }
 
         // Create path from polyline
         Path newPath = createPath(result);
         newPath.setCCW(result.orientation());
 
         // Exit early if inset path is too short
-        if (newPath.calculateLength() < m_sb->setting<Distance>(PS::Inset::kMinPathLength)) {
-            continue;
-        }
+        if (newPath.calculateLength() < m_sb->setting<Distance>(PS::Inset::kMinPathLength)) { continue; }
 
         if (newPath.size() > 0) {
             calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -652,17 +574,15 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
 Path Inset::createPath(Polyline line) {
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Inset::kMinSegmentLength), true);
-    if (line.size() < 3) {
-        return Path();
-    }
+    if (line.size() < 3) { return Path(); }
 
     // ---------- No Settings Regions ----------
     if (m_settings_polygons.isEmpty()) {
         Path path;
 
         for (size_t i = 0; i < line.size(); ++i) {
-            const Point& start = line[i];
-            const Point& end = line[(i + 1) % line.size()];
+            const Point& start        = line[i];
+            const Point& end          = line[(i + 1) % line.size()];
             const Distance bead_width = beadWidthForSegment(start, end, m_sb);
 
             LSegmentPtr segment = LSegmentPtr::create(start, end);
@@ -676,9 +596,13 @@ Path Inset::createPath(Polyline line) {
     return createPathWithLocalizedSettings(line);
 }
 
-QVector<Polyline> Inset::getComputedGeometry() { return m_computed_geometry; }
+QVector<Polyline> Inset::getComputedGeometry() {
+    return m_computed_geometry;
+}
 
-void Inset::calculateModifiers(Path& path, bool supportsG3) { calculateModifiers(path, supportsG3, false); }
+void Inset::calculateModifiers(Path& path, bool supportsG3) {
+    calculateModifiers(path, supportsG3, false);
+}
 
 void Inset::calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe) {
     PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
@@ -768,13 +692,11 @@ Path Inset::createPathWithLocalizedSettings(const Polyline& line) {
     // Iterate through each segment of the polyline
     for (size_t i = 0; i < line.size(); ++i) {
         const Point& start = line[i];
-        const Point& end = line[(i + 1) % line.size()];
+        const Point& end   = line[(i + 1) % line.size()];
 
         // Clip the segment against the settings polygons
         QVector<Point> cuts;
-        for (const SettingsPolygon& polygon : m_settings_polygons) {
-            cuts += polygon.clipLine(start, end);
-        }
+        for (const SettingsPolygon& polygon : m_settings_polygons) { cuts += polygon.clipLine(start, end); }
 
         // Sort cuts based on their distance from the start point
         std::sort(cuts.begin(), cuts.end(),
@@ -801,7 +723,7 @@ Path Inset::createPathWithLocalizedSettings(const Polyline& line) {
                 }
             }
 
-            LSegmentPtr segment = LSegmentPtr::create(p0, p1);
+            LSegmentPtr segment       = LSegmentPtr::create(p0, p1);
             const Distance bead_width = beadWidthForSegment(p0, p1, parent_sb);
             populateSegmentSettings(segment->getSb(), parent_sb, bead_width, isAdaptedWidth(bead_width, parent_sb));
             path.append(segment);
@@ -820,8 +742,8 @@ void Inset::populateSegmentSettings(QSharedPointer<SettingsBase> segment_sb,
     if (adapted && bead_width > 0) {
         const Distance ref_width = parent_sb->setting<Distance>(PS::Inset::kBeadWidth);
         const Velocity ref_speed = parent_sb->setting<Velocity>(PS::Inset::kSpeed);
-        const double min_speed = ref_speed() * 0.01;
-        speed = Velocity(std::max((ref_speed() * ref_width()) / bead_width(), min_speed));
+        const double min_speed   = ref_speed() * 0.01;
+        speed                    = Velocity(std::max((ref_speed() * ref_width()) / bead_width(), min_speed));
     }
 
     segment_sb->setSetting(SS::kWidth, bead_width);
@@ -837,26 +759,20 @@ void Inset::populateSegmentSettings(QSharedPointer<SettingsBase> segment_sb,
 Distance Inset::beadWidthForSegment(const Point& start, const Point& end,
                                     const QSharedPointer<SettingsBase>& parent_sb) const {
     const Distance fallback_width = parent_sb->setting<Distance>(PS::Inset::kBeadWidth);
-    if (!parent_sb->setting<bool>(PS::Inset::kAdaptive)) {
-        return fallback_width;
-    }
+    if (!parent_sb->setting<bool>(PS::Inset::kAdaptive)) { return fallback_width; }
 
     Point midpoint = (start + end) * 0.5;
     const Distance tolerance(std::max(fallback_width() * 1.0e-3, 1.0e-6));
     for (int i = 0; i < m_computed_geometry.size() && i < m_computed_widths.size(); ++i) {
-        if (pointOnClosedPolylineXY(midpoint, m_computed_geometry[i], tolerance())) {
-            return m_computed_widths[i];
-        }
+        if (pointOnClosedPolylineXY(midpoint, m_computed_geometry[i], tolerance())) { return m_computed_widths[i]; }
     }
     if (!m_computed_widths.isEmpty()) {
         const Distance first_width = m_computed_widths.first();
-        const bool uniform_width = std::all_of(m_computed_widths.begin(), m_computed_widths.end(),
-                                               [first_width, tolerance](const Distance& width) {
+        const bool uniform_width   = std::all_of(m_computed_widths.begin(), m_computed_widths.end(),
+                                                 [first_width, tolerance](const Distance& width) {
                                                    return std::fabs(width() - first_width()) <= tolerance();
-                                               });
-        if (uniform_width) {
-            return first_width;
-        }
+                                                 });
+        if (uniform_width) { return first_width; }
     }
 
     return fallback_width;
@@ -866,4 +782,4 @@ bool Inset::isAdaptedWidth(const Distance& width, const QSharedPointer<SettingsB
     const Distance nominal_width = parent_sb->setting<Distance>(PS::Inset::kBeadWidth);
     return std::fabs(width() - nominal_width()) > std::max(nominal_width() * 1.0e-3, 1.0e-6);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/laser_scan.cpp
+++ b/src/step/layer/regions/laser_scan.cpp
@@ -27,9 +27,7 @@ QString LaserScan::writeGCode(QSharedPointer<WriterBase> writer) {
     QString gcode;
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kLaserScan);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
     }
     return gcode;
 }
@@ -37,8 +35,8 @@ QString LaserScan::writeGCode(QSharedPointer<WriterBase> writer) {
 void LaserScan::compute(uint layer_num) {
     m_paths.clear();
 
-    Distance x_offset = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerXOffset);
-    Distance y_offset = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerYOffset);
+    Distance x_offset   = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerXOffset);
+    Distance y_offset   = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerYOffset);
     Distance scan_width = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerWidth);
 
     Distance buffer_distance = 0;
@@ -50,7 +48,7 @@ void LaserScan::compute(uint layer_num) {
     // Determine which axis the laser scanner will travel
     if (static_cast<Axis>(m_sb->setting<int>(PS::LaserScanner::kLaserScannerAxis)) == Axis::kX) {
         // Determine number of scan lines
-        float y_distance = m_geometry.max().y() - m_geometry.min().y();
+        float y_distance         = m_geometry.max().y() - m_geometry.min().y();
         int number_of_scan_lines = qCeil(y_distance / scan_width());
 
         // Determine starting point of first scan line
@@ -78,10 +76,10 @@ void LaserScan::compute(uint layer_num) {
             scan_lines += scan_line.reverse();
         }
     }
-    else // Scanner Axis = Y
+    else  // Scanner Axis = Y
     {
         // Determine number of scan lines
-        float x_distance = m_geometry.max().x() - m_geometry.min().x();
+        float x_distance         = m_geometry.max().x() - m_geometry.min().x();
         int number_of_scan_lines = qCeil(x_distance / scan_width());
 
         // Determine starting point of first scan line
@@ -113,8 +111,7 @@ void LaserScan::compute(uint layer_num) {
     m_computed_geometry = scan_lines;
 
     Path finalPath;
-    for (Polyline line : m_computed_geometry)
-        finalPath.append(createPath(line));
+    for (Polyline line : m_computed_geometry) finalPath.append(createPath(line));
 
     m_paths.append(finalPath);
 }
@@ -144,4 +141,4 @@ Path LaserScan::createPath(Polyline line) {
 
     return newPath;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -32,9 +32,7 @@ namespace ORNL {
 namespace {
 Polyline toOpenPolyline(Polygon poly) {
     Polyline line = poly.toPolyline();
-    if (!line.isEmpty()) {
-        line.pop_back();
-    }
+    if (!line.isEmpty()) { line.pop_back(); }
     return line;
 }
 
@@ -76,29 +74,23 @@ QVector<Polygon> validPathLines(const PolygonList& path_lines, Distance min_path
 
 Distance totalPathLineLength(const QVector<Polygon>& path_lines) {
     Distance total_length;
-    for (const Polygon& poly : path_lines) {
-        total_length += SpiralPath::closedPolylineLength(toOpenPolyline(poly));
-    }
+    for (const Polygon& poly : path_lines) { total_length += SpiralPath::closedPolylineLength(toOpenPolyline(poly)); }
     return total_length;
 }
 
 PolygonList pathLineFootprint(const Polygon& path_line, Distance bead_width, const PolygonList& clipping_geometry) {
     PolygonList outer_offset = path_line.offset(bead_width / 2);
     PolygonList inner_offset = path_line.offset(-bead_width / 2);
-    PolygonList footprint = outer_offset ^ inner_offset;
+    PolygonList footprint    = outer_offset ^ inner_offset;
 
     return footprint & clipping_geometry;
 }
 
 bool subtractPathLineFootprints(PolygonList& geometry, const QVector<Polygon>& path_lines, Distance bead_width) {
     PolygonList path_line_footprint;
-    for (const Polygon& poly : path_lines) {
-        path_line_footprint += pathLineFootprint(poly, bead_width, geometry);
-    }
+    for (const Polygon& poly : path_lines) { path_line_footprint += pathLineFootprint(poly, bead_width, geometry); }
 
-    if (path_line_footprint.isEmpty()) {
-        return false;
-    }
+    if (path_line_footprint.isEmpty()) { return false; }
 
     geometry -= path_line_footprint;
     return true;
@@ -112,8 +104,8 @@ PolygonList selectedBoundaryOffsetGeometry(const PolygonList& external_boundarie
     }
 
     PolygonList offset_external_geometry = external_boundaries.offset(-offset_distance);
-    PolygonList offset_geometry = offset_external_geometry - internal_boundaries;
-    offset_geometry.lost_geometry = offset_external_geometry.lost_geometry;
+    PolygonList offset_geometry          = offset_external_geometry - internal_boundaries;
+    offset_geometry.lost_geometry        = offset_external_geometry.lost_geometry;
     return offset_geometry;
 }
 
@@ -128,43 +120,39 @@ PolygonList selectedBoundaryPathLines(const PolygonList& external_boundaries, co
 
 PolygonList selectedBoundaryPathLines(const PolygonList& geometry, PerimeterBoundarySelection selection,
                                       Distance bead_width) {
-    if (selection == PerimeterBoundarySelection::kAll) {
-        return geometry.offset(-bead_width / 2);
-    }
+    if (selection == PerimeterBoundarySelection::kAll) { return geometry.offset(-bead_width / 2); }
 
     return selectedBoundaryPathLines(geometry.externalPolygonBoundaries(), geometry.internalPolygonBoundaries(),
                                      selection, bead_width / 2);
 }
 
-double netAreaAbs(PolygonList geometry) { return std::fabs(geometry.netArea()()); }
+double netAreaAbs(PolygonList geometry) {
+    return std::fabs(geometry.netArea()());
+}
 
 double negligibleAreaTolerance(double reference_area, Distance nominal_width) {
     return std::max(reference_area * 1.0e-6, nominal_width() * nominal_width() * 1.0e-4);
 }
 
-bool hasInternalBoundaries(const PolygonList& geometry) { return !geometry.internalPolygonBoundaries().isEmpty(); }
+bool hasInternalBoundaries(const PolygonList& geometry) {
+    return !geometry.internalPolygonBoundaries().isEmpty();
+}
 
 Distance clampedAdaptiveWidth(Distance requested_width, Distance nominal_width, Distance min_width,
                               Distance max_width) {
     double requested = requested_width();
-    if (!std::isfinite(requested) || requested <= 0) {
-        requested = nominal_width();
-    }
+    if (!std::isfinite(requested) || requested <= 0) { requested = nominal_width(); }
 
     double lower = std::max(0.0, min_width());
     double upper = max_width() > 0 ? max_width() : std::numeric_limits<double>::max();
-    if (upper < lower) {
-        upper = lower;
-    }
+    if (upper < lower) { upper = lower; }
 
     return Distance(std::clamp(requested, lower, upper));
 }
 
 bool geometryClearedByFootprints(PolygonList geometry, const QVector<Polygon>& path_lines, Distance bead_width,
                                  double reference_area, Distance nominal_width) {
-    if (!subtractPathLineFootprints(geometry, path_lines, bead_width)) {
-        return false;
-    }
+    if (!subtractPathLineFootprints(geometry, path_lines, bead_width)) { return false; }
 
     return geometry.isEmpty() || netAreaAbs(geometry) <= negligibleAreaTolerance(reference_area, nominal_width);
 }
@@ -172,9 +160,7 @@ bool geometryClearedByFootprints(PolygonList geometry, const QVector<Polygon>& p
 bool shellWidthCoversGeometry(PolygonList geometry, const QVector<Polygon>& path_lines, Distance bead_width,
                               Distance nominal_width) {
     const Distance path_length = totalPathLineLength(path_lines);
-    if (path_length <= 0) {
-        return false;
-    }
+    if (path_length <= 0) { return false; }
 
     const Distance full_area_width = Distance(netAreaAbs(geometry) / path_length());
     return std::fabs(full_area_width() - bead_width()) <= std::max(nominal_width() * 1.0e-4, 1.0e-6);
@@ -185,9 +171,7 @@ std::optional<Distance> fullCoverageAdaptiveWidth(PolygonList geometry, Distance
                                                   PerimeterBoundarySelection selection, Distance min_width,
                                                   Distance max_width) {
     const double initial_area = netAreaAbs(geometry);
-    if (initial_area <= 0) {
-        return std::nullopt;
-    }
+    if (initial_area <= 0) { return std::nullopt; }
     const bool shell_geometry = selection == PerimeterBoundarySelection::kAll && hasInternalBoundaries(geometry);
 
     Distance candidate_width = nominal_width;
@@ -196,9 +180,7 @@ std::optional<Distance> fullCoverageAdaptiveWidth(PolygonList geometry, Distance
         candidate_path_lines = validPathLines(selectedBoundaryPathLines(geometry, selection, candidate_width),
                                               min_path_length, min_segment_length);
         const Distance candidate_length = totalPathLineLength(candidate_path_lines);
-        if (candidate_length <= 0) {
-            return std::nullopt;
-        }
+        if (candidate_length <= 0) { return std::nullopt; }
 
         const Distance next_width =
             clampedAdaptiveWidth(Distance(initial_area / candidate_length()), nominal_width, min_width, max_width);
@@ -212,9 +194,7 @@ std::optional<Distance> fullCoverageAdaptiveWidth(PolygonList geometry, Distance
 
     candidate_path_lines = validPathLines(selectedBoundaryPathLines(geometry, selection, candidate_width),
                                           min_path_length, min_segment_length);
-    if (candidate_path_lines.isEmpty()) {
-        return std::nullopt;
-    }
+    if (candidate_path_lines.isEmpty()) { return std::nullopt; }
 
     if (geometryClearedByFootprints(geometry, candidate_path_lines, candidate_width, initial_area, nominal_width)) {
         return candidate_width;
@@ -241,25 +221,19 @@ Distance adaptiveContourWidthForGeometry(PolygonList geometry, Distance nominal_
     for (int i = 0; i < remaining_count && !preview_geometry.isEmpty(); ++i) {
         QVector<Polygon> preview_path_lines = validPathLines(
             selectedBoundaryPathLines(preview_geometry, selection, nominal_width), min_path_length, min_segment_length);
-        if (preview_path_lines.isEmpty()) {
-            break;
-        }
+        if (preview_path_lines.isEmpty()) { break; }
 
         preview_length += totalPathLineLength(preview_path_lines);
-        if (!subtractPathLineFootprints(preview_geometry, preview_path_lines, nominal_width)) {
-            break;
-        }
+        if (!subtractPathLineFootprints(preview_geometry, preview_path_lines, nominal_width)) { break; }
     }
 
-    if (preview_length <= 0) {
-        return nominal_width;
-    }
+    if (preview_length <= 0) { return nominal_width; }
 
     const bool more_nominal_paths_fit =
         !validPathLines(selectedBoundaryPathLines(preview_geometry, selection, nominal_width), min_path_length,
                         min_segment_length)
              .isEmpty();
-    const double initial_area = netAreaAbs(geometry);
+    const double initial_area           = netAreaAbs(geometry);
     const double preview_remaining_area = netAreaAbs(preview_geometry);
     const double target_area =
         more_nominal_paths_fit ? std::max(0.0, initial_area - preview_remaining_area) : initial_area;
@@ -277,11 +251,9 @@ QVector<Distance> plannedAdaptiveContourWidths(PolygonList geometry, Distance no
         const Distance path_width =
             adaptiveContourWidthForGeometry(geometry, nominal_width, remaining_count - i, min_path_length,
                                             min_segment_length, selection, min_width, max_width);
-        PolygonList path_lines = selectedBoundaryPathLines(geometry, selection, path_width);
+        PolygonList path_lines            = selectedBoundaryPathLines(geometry, selection, path_width);
         QVector<Polygon> valid_path_lines = validPathLines(path_lines, min_path_length, min_segment_length);
-        if (valid_path_lines.isEmpty()) {
-            break;
-        }
+        if (valid_path_lines.isEmpty()) { break; }
 
         widths.push_back(path_width);
 
@@ -289,12 +261,8 @@ QVector<Distance> plannedAdaptiveContourWidths(PolygonList geometry, Distance no
             selection == PerimeterBoundarySelection::kAll && hasInternalBoundaries(geometry) &&
             shellWidthCoversGeometry(geometry, valid_path_lines, path_width, nominal_width);
 
-        if (!subtractPathLineFootprints(geometry, valid_path_lines, path_width)) {
-            break;
-        }
-        if (clear_shell_geometry) {
-            geometry.clear();
-        }
+        if (!subtractPathLineFootprints(geometry, valid_path_lines, path_width)) { break; }
+        if (clear_shell_geometry) { geometry.clear(); }
     }
 
     return widths;
@@ -305,17 +273,15 @@ Distance adaptiveContourWidth(PolygonList geometry, Distance nominal_width, int 
                               PerimeterBoundarySelection selection, Distance min_width, Distance max_width) {
     QVector<Distance> widths = plannedAdaptiveContourWidths(geometry, nominal_width, remaining_count, min_path_length,
                                                             min_segment_length, selection, min_width, max_width);
-    if (widths.isEmpty()) {
-        return nominal_width;
-    }
+    if (widths.isEmpty()) { return nominal_width; }
 
     return *std::max_element(widths.begin(), widths.end(),
                              [](const Distance& lhs, const Distance& rhs) { return lhs() < rhs(); });
 }
 
 double distanceXYToSegment(const Point& point, const Point& start, const Point& end) {
-    const double dx = end.x() - start.x();
-    const double dy = end.y() - start.y();
+    const double dx     = end.x() - start.x();
+    const double dy     = end.y() - start.y();
     const double len_sq = dx * dx + dy * dy;
     if (len_sq <= std::numeric_limits<double>::epsilon()) {
         return std::hypot(point.x() - start.x(), point.y() - start.y());
@@ -328,20 +294,16 @@ double distanceXYToSegment(const Point& point, const Point& start, const Point& 
 }
 
 bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double tolerance) {
-    if (line.size() < 2) {
-        return false;
-    }
+    if (line.size() < 2) { return false; }
 
     for (int i = 0; i < line.size(); ++i) {
-        if (distanceXYToSegment(point, line[i], line[(i + 1) % line.size()]) <= tolerance) {
-            return true;
-        }
+        if (distanceXYToSegment(point, line[i], line[(i + 1) % line.size()]) <= tolerance) { return true; }
     }
 
     return false;
 }
 
-} // namespace
+}  // namespace
 
 Perimeter::Perimeter(const QSharedPointer<SettingsBase>& sb, const int index,
                      const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry)
@@ -352,9 +314,7 @@ QString Perimeter::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kPerimeter);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kPerimeter);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kPerimeter);
     }
     gcode += writer->writeAfterRegion(RegionType::kPerimeter);
@@ -367,9 +327,9 @@ void Perimeter::compute(uint layer_num) {
     m_computed_widths.clear();
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum));
-    Distance beadWidth = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
-    int perimeter_count = m_sb->setting<int>(PS::Perimeter::kCount);
-    const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
+    Distance beadWidth                = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
+    int perimeter_count               = m_sb->setting<int>(PS::Perimeter::kCount);
+    const Distance min_path_length    = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
     const Distance min_segment_length = m_sb->setting<Distance>(PS::Perimeter::kMinSegmentLength);
     const PerimeterBoundarySelection boundary_selection =
         static_cast<PerimeterBoundarySelection>(m_sb->setting<int>(PS::Perimeter::kBoundarySelection));
@@ -392,26 +352,20 @@ void Perimeter::compute(uint layer_num) {
                 appendValidPathLines(path_lines, m_computed_geometry, m_computed_widths, min_path_length, path_width,
                                      min_segment_length, skipped_path_line);
 
-            if (valid_path_lines.isEmpty()) {
-                break;
-            }
+            if (valid_path_lines.isEmpty()) { break; }
 
             const bool clear_shell_geometry =
                 boundary_selection == PerimeterBoundarySelection::kAll && hasInternalBoundaries(m_geometry) &&
                 shellWidthCoversGeometry(m_geometry, valid_path_lines, path_width, beadWidth);
 
-            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, path_width)) {
-                break;
-            }
-            if (clear_shell_geometry) {
-                m_geometry.clear();
-            }
+            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, path_width)) { break; }
+            if (clear_shell_geometry) { m_geometry.clear(); }
         }
         return;
     }
 
     if (boundary_selection == PerimeterBoundarySelection::kAll) {
-        PolygonList path_lines = m_geometry.offset(-beadWidth / 2);
+        PolygonList path_lines         = m_geometry.offset(-beadWidth / 2);
         bool use_footprint_subtraction = false;
 
         for (int perimeter_number = 0; !path_lines.isEmpty() && perimeter_number < perimeter_count;
@@ -421,15 +375,11 @@ void Perimeter::compute(uint layer_num) {
                 appendValidPathLines(path_lines, m_computed_geometry, m_computed_widths, min_path_length, beadWidth,
                                      min_segment_length, skipped_path_line);
 
-            if (valid_path_lines.isEmpty()) {
-                break;
-            }
+            if (valid_path_lines.isEmpty()) { break; }
 
             if (skipped_path_line || use_footprint_subtraction) {
                 use_footprint_subtraction = true;
-                if (!subtractPathLineFootprints(m_geometry, valid_path_lines, beadWidth)) {
-                    break;
-                }
+                if (!subtractPathLineFootprints(m_geometry, valid_path_lines, beadWidth)) { break; }
                 path_lines = selectedBoundaryPathLines(m_geometry, boundary_selection, beadWidth);
             }
             else {
@@ -445,7 +395,7 @@ void Perimeter::compute(uint layer_num) {
     // would no longer clip the offset.
     const PolygonList external_boundaries = original_geometry.externalPolygonBoundaries();
     const PolygonList internal_boundaries = original_geometry.internalPolygonBoundaries();
-    bool use_footprint_subtraction = false;
+    bool use_footprint_subtraction        = false;
     PolygonList path_lines;
 
     for (int perimeter_number = 0; perimeter_number < perimeter_count; ++perimeter_number) {
@@ -458,24 +408,18 @@ void Perimeter::compute(uint layer_num) {
                 selectedBoundaryPathLines(external_boundaries, internal_boundaries, boundary_selection, path_offset);
         }
 
-        if (path_lines.isEmpty()) {
-            break;
-        }
+        if (path_lines.isEmpty()) { break; }
 
         bool skipped_path_line = false;
         QVector<Polygon> valid_path_lines =
             appendValidPathLines(path_lines, m_computed_geometry, m_computed_widths, min_path_length, beadWidth,
                                  min_segment_length, skipped_path_line);
 
-        if (valid_path_lines.isEmpty()) {
-            break;
-        }
+        if (valid_path_lines.isEmpty()) { break; }
 
         if (skipped_path_line || use_footprint_subtraction) {
             use_footprint_subtraction = true;
-            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, beadWidth)) {
-                break;
-            }
+            if (!subtractPathLineFootprints(m_geometry, valid_path_lines, beadWidth)) { break; }
         }
         else {
             const Distance remaining_offset = beadWidth * (perimeter_number + 1);
@@ -522,31 +466,24 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
     if (m_sb->setting<bool>(PS::SpecialModes::kEnableSpiralize)) {
         if (m_computed_geometry.size() > 0) {
-            poo.setGeometryToEvaluate(
-                m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
+            poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
 
             Polyline result = poo.linkSpiralPolyline2D(m_was_last_region_spiral,
                                                        m_sb->setting<Distance>(PS::Layer::Layer::kLayerHeight),
                                                        pointOrderOptimization);
 
             // Exit early if no perimeter path can be made
-            if (result.size() < 3) {
-                return;
-            }
+            if (result.size() < 3) { return; }
 
             // Create path from polyline
             Path newPath = createPath(result);
-            if (newPath.size() == 0) {
-                return;
-            }
+            if (newPath.size() == 0) { return; }
 
-            newPath.setCCW(result.orientation()); // Set orientation of path
-            newPath.getSegments().removeLast();   // Remove last segment of path to enable spiral path linking
+            newPath.setCCW(result.orientation());  // Set orientation of path
+            newPath.getSegments().removeLast();    // Remove last segment of path to enable spiral path linking
 
             // Exit early if perimeter path is too short
-            if (newPath.calculateLength() < m_sb->setting<Distance>(PS::Perimeter::kMinPathLength)) {
-                return;
-            }
+            if (newPath.calculateLength() < m_sb->setting<Distance>(PS::Perimeter::kMinPathLength)) { return; }
 
             if (!m_was_last_region_spiral) {
                 PathModifierGenerator::GenerateTravel(newPath, current_location,
@@ -561,26 +498,18 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
     else {
         if (static_cast<PrintDirection>(m_sb->setting<int>(PS::Ordering::kPerimeterReverseDirection)) !=
             PrintDirection::kReverse_off)
-            for (Polyline& line : m_computed_geometry) {
-                line = line.reverse();
-            }
+            for (Polyline& line : m_computed_geometry) { line = line.reverse(); }
 
         auto appendSpiralPaths = [&](const QVector<Polyline>& spiral_groups, bool ccw, Distance min_path_length) {
             for (const Polyline& spiral_group : spiral_groups) {
-                if (spiral_group.size() < 3) {
-                    continue;
-                }
+                if (spiral_group.size() < 3) { continue; }
 
                 Path newPath = createPath(spiral_group);
                 newPath.setCCW(ccw);
 
-                if (newPath.size() > 0) {
-                    newPath.getSegments().removeLast();
-                }
+                if (newPath.size() > 0) { newPath.getSegments().removeLast(); }
 
-                if (newPath.calculateLength() < min_path_length) {
-                    continue;
-                }
+                if (newPath.calculateLength() < min_path_length) { continue; }
 
                 if (newPath.size() > 0) {
                     calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
@@ -602,7 +531,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
                 QVector<Polyline> ordered_perimeters;
                 const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
-                const Distance bead_width = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
+                const Distance bead_width      = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
 
                 while (spiral_poo.getCurrentPolylineCount() > 0) {
                     if (!ordered_perimeters.isEmpty()) {
@@ -612,17 +541,13 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
                     Polyline result = spiral_poo.linkNextPolyline();
 
-                    if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
-                        continue;
-                    }
+                    if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) { continue; }
 
                     spiral_query_location = SpiralPath::transitionStartPoint(result, bead_width);
                     ordered_perimeters.push_back(result);
                 }
 
-                if (ordered_perimeters.isEmpty()) {
-                    return;
-                }
+                if (ordered_perimeters.isEmpty()) { return; }
 
                 if (ordered_perimeters.size() == 1) {
                     Polyline result = ordered_perimeters.first();
@@ -630,9 +555,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                     Path newPath = createPath(result);
                     newPath.setCCW(result.orientation());
 
-                    if (newPath.calculateLength() < min_path_length) {
-                        return;
-                    }
+                    if (newPath.calculateLength() < min_path_length) { return; }
 
                     if (newPath.size() > 0) {
                         calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -659,8 +582,8 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
             QVector<Polyline> ordered_perimeters;
             QVector<Distance> ordered_perimeter_widths;
-            bool has_spiral_orientation = false;
-            bool spiral_orientation = false;
+            bool has_spiral_orientation    = false;
+            bool spiral_orientation        = false;
             const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
 
             while (spiral_poo.getCurrentPolylineCount() > 0) {
@@ -670,12 +593,10 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
                 Polyline result = spiral_poo.linkNextPolyline();
 
-                if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) {
-                    continue;
-                }
+                if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) { continue; }
 
                 if (!has_spiral_orientation) {
-                    spiral_orientation = result.orientation();
+                    spiral_orientation     = result.orientation();
                     has_spiral_orientation = true;
                 }
                 else if (result.orientation() != spiral_orientation) {
@@ -689,9 +610,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 spiral_query_location = SpiralPath::transitionStartPoint(result, result_width);
             }
 
-            if (ordered_perimeters.isEmpty()) {
-                return;
-            }
+            if (ordered_perimeters.isEmpty()) { return; }
 
             if (ordered_perimeters.size() == 1) {
                 PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
@@ -699,16 +618,12 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 first_loop_poo.setGeometryToEvaluate({ordered_perimeters.first()}, RegionType::kPerimeter,
                                                      PathOrderOptimization::kNextClosest);
                 Polyline result = first_loop_poo.linkNextPolyline();
-                if (result.size() < 3) {
-                    result = ordered_perimeters.first();
-                }
+                if (result.size() < 3) { result = ordered_perimeters.first(); }
 
                 Path newPath = createPath(result);
                 newPath.setCCW(result.orientation());
 
-                if (newPath.calculateLength() < min_path_length) {
-                    return;
-                }
+                if (newPath.calculateLength() < min_path_length) { return; }
 
                 if (newPath.size() > 0) {
                     calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -730,25 +645,20 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             return;
         }
 
-        poo.setGeometryToEvaluate(
-            m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
+        poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
 
         while (poo.getCurrentPolylineCount() > 0) {
             Polyline result = poo.linkNextPolyline();
 
             // Exit early if no perimeter path can be made
-            if (result.size() < 3) {
-                continue;
-            }
+            if (result.size() < 3) { continue; }
 
             // Create path from polyline
             Path newPath = createPath(result);
             newPath.setCCW(result.orientation());
 
             // Exit early if perimeter path is too short
-            if (newPath.calculateLength() < m_sb->setting<Distance>(PS::Perimeter::kMinPathLength)) {
-                continue;
-            }
+            if (newPath.calculateLength() < m_sb->setting<Distance>(PS::Perimeter::kMinPathLength)) { continue; }
 
             if (newPath.size() > 0) {
                 calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -765,17 +675,15 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
 Path Perimeter::createPath(Polyline line) {
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Perimeter::kMinSegmentLength), true);
-    if (line.size() < 3) {
-        return Path();
-    }
+    if (line.size() < 3) { return Path(); }
 
     // ---------- No Settings Regions ----------
     if (m_settings_polygons.isEmpty()) {
         Path path;
 
         for (size_t i = 0; i < line.size(); ++i) {
-            const Point& start = line[i];
-            const Point& end = line[(i + 1) % line.size()];
+            const Point& start        = line[i];
+            const Point& end          = line[(i + 1) % line.size()];
             const Distance bead_width = beadWidthForSegment(start, end, m_sb);
 
             LSegmentPtr segment = LSegmentPtr::create(start, end);
@@ -789,9 +697,13 @@ Path Perimeter::createPath(Polyline line) {
     return createPathWithLocalizedSettings(line);
 }
 
-QVector<Polyline> Perimeter::getComputedGeometry() { return m_computed_geometry; }
+QVector<Polyline> Perimeter::getComputedGeometry() {
+    return m_computed_geometry;
+}
 
-void Perimeter::calculateModifiers(Path& path, bool supportsG3) { calculateModifiers(path, supportsG3, false); }
+void Perimeter::calculateModifiers(Path& path, bool supportsG3) {
+    calculateModifiers(path, supportsG3, false);
+}
 
 void Perimeter::calculateModifiers(Path& path, bool supportsG3, bool open_loop_tip_wipe) {
     PathModifierGenerator::GenerateSharpCornerExtension(path, m_sb);
@@ -888,13 +800,11 @@ Path Perimeter::createPathWithLocalizedSettings(const Polyline& line) {
     // Iterate through each segment of the polyline
     for (size_t i = 0; i < line.size(); ++i) {
         const Point& start = line[i];
-        const Point& end = line[(i + 1) % line.size()];
+        const Point& end   = line[(i + 1) % line.size()];
 
         // Clip the segment against the settings polygons
         QVector<Point> cuts;
-        for (const SettingsPolygon& polygon : m_settings_polygons) {
-            cuts += polygon.clipLine(start, end);
-        }
+        for (const SettingsPolygon& polygon : m_settings_polygons) { cuts += polygon.clipLine(start, end); }
 
         // Sort cuts based on their distance from the start point
         std::sort(cuts.begin(), cuts.end(),
@@ -921,7 +831,7 @@ Path Perimeter::createPathWithLocalizedSettings(const Polyline& line) {
                 }
             }
 
-            LSegmentPtr segment = LSegmentPtr::create(p0, p1);
+            LSegmentPtr segment       = LSegmentPtr::create(p0, p1);
             const Distance bead_width = beadWidthForSegment(p0, p1, parent_sb);
             populateSegmentSettings(segment->getSb(), parent_sb, bead_width, isAdaptedWidth(bead_width, parent_sb));
             path.append(segment);
@@ -940,8 +850,8 @@ void Perimeter::populateSegmentSettings(QSharedPointer<SettingsBase> segment_sb,
     if (adapted && bead_width > 0) {
         const Distance ref_width = parent_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
         const Velocity ref_speed = parent_sb->setting<Velocity>(PS::Perimeter::kSpeed);
-        const double min_speed = ref_speed() * 0.01;
-        speed = Velocity(std::max((ref_speed() * ref_width()) / bead_width(), min_speed));
+        const double min_speed   = ref_speed() * 0.01;
+        speed                    = Velocity(std::max((ref_speed() * ref_width()) / bead_width(), min_speed));
     }
 
     segment_sb->setSetting(SS::kWidth, bead_width);
@@ -957,26 +867,20 @@ void Perimeter::populateSegmentSettings(QSharedPointer<SettingsBase> segment_sb,
 Distance Perimeter::beadWidthForSegment(const Point& start, const Point& end,
                                         const QSharedPointer<SettingsBase>& parent_sb) const {
     const Distance fallback_width = parent_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
-    if (!parent_sb->setting<bool>(PS::Perimeter::kAdaptive)) {
-        return fallback_width;
-    }
+    if (!parent_sb->setting<bool>(PS::Perimeter::kAdaptive)) { return fallback_width; }
 
     Point midpoint = (start + end) * 0.5;
     const Distance tolerance(std::max(fallback_width() * 1.0e-3, 1.0e-6));
     for (int i = 0; i < m_computed_geometry.size() && i < m_computed_widths.size(); ++i) {
-        if (pointOnClosedPolylineXY(midpoint, m_computed_geometry[i], tolerance())) {
-            return m_computed_widths[i];
-        }
+        if (pointOnClosedPolylineXY(midpoint, m_computed_geometry[i], tolerance())) { return m_computed_widths[i]; }
     }
     if (!m_computed_widths.isEmpty()) {
         const Distance first_width = m_computed_widths.first();
-        const bool uniform_width = std::all_of(m_computed_widths.begin(), m_computed_widths.end(),
-                                               [first_width, tolerance](const Distance& width) {
+        const bool uniform_width   = std::all_of(m_computed_widths.begin(), m_computed_widths.end(),
+                                                 [first_width, tolerance](const Distance& width) {
                                                    return std::fabs(width() - first_width()) <= tolerance();
-                                               });
-        if (uniform_width) {
-            return first_width;
-        }
+                                                 });
+        if (uniform_width) { return first_width; }
     }
 
     return fallback_width;
@@ -986,4 +890,4 @@ bool Perimeter::isAdaptedWidth(const Distance& width, const QSharedPointer<Setti
     const Distance nominal_width = parent_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
     return std::fabs(width() - nominal_width()) > std::max(nominal_width() * 1.0e-3, 1.0e-6);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/raft.cpp
+++ b/src/step/layer/regions/raft.cpp
@@ -31,9 +31,7 @@ QString Raft::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kRaft);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kRaft);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kRaft);
     }
     gcode += writer->writeAfterRegion(RegionType::kRaft);
@@ -107,12 +105,12 @@ void Raft::calculateModifiers(Path& path, bool supportsG3) {
 
 Path Raft::createPath(Polyline line) {
     // Populate the paths.
-    Distance default_width = this->getSb()->setting<Distance>(MS::PlatformAdhesion::kRaftBeadWidth);
-    Distance default_height = this->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
-    Velocity default_speed = m_sb->setting<Velocity>(PS::Layer::kSpeed);
-    Acceleration default_acceleration = m_sb->setting<Acceleration>(PRS::Acceleration::kDefault);
+    Distance default_width                 = this->getSb()->setting<Distance>(MS::PlatformAdhesion::kRaftBeadWidth);
+    Distance default_height                = this->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
+    Velocity default_speed                 = m_sb->setting<Velocity>(PS::Layer::kSpeed);
+    Acceleration default_acceleration      = m_sb->setting<Acceleration>(PRS::Acceleration::kDefault);
     AngularVelocity default_extruder_speed = m_sb->setting<AngularVelocity>(PS::Layer::kExtruderSpeed);
-    int material_number = m_sb->setting<int>(MS::MultiMaterial::kInfillNum);
+    int material_number                    = m_sb->setting<int>(MS::MultiMaterial::kInfillNum);
 
     Path newPath;
     for (int i = 0, end = line.size() - 1; i < end; ++i) {
@@ -130,11 +128,7 @@ Path Raft::createPath(Polyline line) {
         newPath.append(segment);
     }
 
-    if (newPath.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) {
-        return newPath;
-    }
-    else {
-        return Path();
-    }
+    if (newPath.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) { return newPath; }
+    else { return Path(); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/region_base.cpp
+++ b/src/step/layer/regions/region_base.cpp
@@ -39,14 +39,11 @@ bool selectedSyntaxSupportsArcFitting(const QSharedPointer<SettingsBase>& global
 }
 
 bool planarArcFittingAllowed(const QSharedPointer<SettingsBase>& global_sb) {
-    if (global_sb == nullptr)
-        return false;
+    if (global_sb == nullptr) return false;
 
-    if (!global_sb->setting<bool>(PRS::MachineSetup::kSupportG3))
-        return false;
+    if (!global_sb->setting<bool>(PRS::MachineSetup::kSupportG3)) return false;
 
-    if (!selectedSyntaxSupportsArcFitting(global_sb))
-        return false;
+    if (!selectedSyntaxSupportsArcFitting(global_sb)) return false;
 
     if (static_cast<SlicingMode>(global_sb->setting<int>(PS::Slicing::kSlicingMode)) != SlicingMode::kPlanar)
         return false;
@@ -59,19 +56,21 @@ bool planarArcFittingAllowed(const QSharedPointer<SettingsBase>& global_sb) {
 
 Point flattenIntoOptimizationFrame(const Point& point, const Plane& slicing_plane, const Point& optimization_shift) {
     const QVector3D normal = slicing_plane.normal();
-    if (normal.isNull())
-        return point;
+    if (normal.isNull()) return point;
 
     const QQuaternion rotation = MathUtils::CreateQuaternion(normal, QVector3D(0, 0, 1));
-    const QVector3D shifted = (point - optimization_shift).toQVector3D();
+    const QVector3D shifted    = (point - optimization_shift).toQVector3D();
     return Point::fromQVector3D(rotation.rotatedVector(shifted)) + optimization_shift;
 }
-} // namespace
+}  // namespace
 
 RegionBase::RegionBase(const QSharedPointer<SettingsBase>& sb, const int index,
                        const QVector<SettingsPolygon>& settings_polygons, PolygonList uncut_geometry,
                        RegionType region_type)
-    : m_sb(sb), m_settings_polygons(settings_polygons), m_index(index), m_region_type(region_type),
+    : m_sb(sb),
+      m_settings_polygons(settings_polygons),
+      m_index(index),
+      m_region_type(region_type),
       m_uncut_geometry(uncut_geometry) {
     // NOP
 }
@@ -82,13 +81,14 @@ RegionBase::RegionBase(const QSharedPointer<SettingsBase>& sb, const QVector<Set
     // NOP
 }
 
-QVector<Path>& RegionBase::getPaths() { return m_paths; }
+QVector<Path>& RegionBase::getPaths() {
+    return m_paths;
+}
 
 std::optional<Point> RegionBase::getFirstPrintingStartPoint() {
     for (Path& path : m_paths) {
         for (const QSharedPointer<SegmentBase>& segment : path.getSegments()) {
-            if (segment->isPrintingSegment())
-                return segment->start();
+            if (segment->isPrintingSegment()) return segment->start();
         }
     }
 
@@ -97,23 +97,31 @@ std::optional<Point> RegionBase::getFirstPrintingStartPoint() {
 
 void RegionBase::setPreviousLayerStartPoint(const std::optional<Point>& point) {
     if (point.has_value())
-        m_previous_layer_start_point = flattenIntoOptimizationFrame(*point, m_optimization_slicing_plane,
-                                                                    m_optimization_shift);
+        m_previous_layer_start_point =
+            flattenIntoOptimizationFrame(*point, m_optimization_slicing_plane, m_optimization_shift);
     else
         m_previous_layer_start_point = std::nullopt;
 }
 
-std::optional<Point> RegionBase::getPreviousLayerStartPoint() const { return m_previous_layer_start_point; }
+std::optional<Point> RegionBase::getPreviousLayerStartPoint() const {
+    return m_previous_layer_start_point;
+}
 
-void RegionBase::appendPath(const Path& path) { m_paths.append(path); }
+void RegionBase::appendPath(const Path& path) {
+    m_paths.append(path);
+}
 
-QSharedPointer<SettingsBase> RegionBase::getSb() const { return m_sb; }
+QSharedPointer<SettingsBase> RegionBase::getSb() const {
+    return m_sb;
+}
 
-void RegionBase::setSb(const QSharedPointer<SettingsBase>& sb) { m_sb = sb; }
+void RegionBase::setSb(const QSharedPointer<SettingsBase>& sb) {
+    m_sb = sb;
+}
 
 void RegionBase::setOptimizationFrame(const Plane& slicing_plane, const Point& optimization_shift) {
     m_optimization_slicing_plane = slicing_plane;
-    m_optimization_shift = optimization_shift;
+    m_optimization_shift         = optimization_shift;
 }
 
 Point RegionBase::customPathOrderPoint() const {
@@ -145,9 +153,7 @@ Point RegionBase::customPointOrderPoint() const {
 
 void RegionBase::transform(QQuaternion rotation, Point shift) {
     // rotate and the shift every path in this region
-    for (Path path : m_paths) {
-        path.transform(rotation, shift);
-    }
+    for (Path path : m_paths) { path.transform(rotation, shift); }
 }
 
 float RegionBase::getMinZ() {
@@ -155,29 +161,46 @@ float RegionBase::getMinZ() {
     float region_min = std::numeric_limits<float>::max();
     for (Path path : m_paths) {
         float path_min = path.getMinZ();
-        if (path_min < region_min)
-            region_min = path_min;
+        if (path_min < region_min) region_min = path_min;
     }
     return region_min;
 }
 
-PolygonList RegionBase::getGeometry() const { return m_geometry; }
+PolygonList RegionBase::getGeometry() const {
+    return m_geometry;
+}
 
-void RegionBase::setGeometry(const PolygonList& geometry) { m_geometry = geometry; }
+void RegionBase::setGeometry(const PolygonList& geometry) {
+    m_geometry = geometry;
+}
 
-void RegionBase::reversePaths() { std::reverse(m_paths.begin(), m_paths.end()); }
+void RegionBase::reversePaths() {
+    std::reverse(m_paths.begin(), m_paths.end());
+}
 
-int RegionBase::getIndex() { return m_index; }
+int RegionBase::getIndex() {
+    return m_index;
+}
 
-RegionType RegionBase::getRegionType() const { return m_region_type; }
+RegionType RegionBase::getRegionType() const {
+    return m_region_type;
+}
 
-void RegionBase::setOptimizedLayerNumber(int layer_number) { m_optimized_layer_number = layer_number; }
+void RegionBase::setOptimizedLayerNumber(int layer_number) {
+    m_optimized_layer_number = layer_number;
+}
 
-int RegionBase::getOptimizedLayerNumber() const { return m_optimized_layer_number; }
+int RegionBase::getOptimizedLayerNumber() const {
+    return m_optimized_layer_number;
+}
 
-int RegionBase::getMaterialNumber() { return m_material_number; }
+int RegionBase::getMaterialNumber() {
+    return m_material_number;
+}
 
-void RegionBase::setMaterialNumber(int material_number) { m_material_number = material_number; }
+void RegionBase::setMaterialNumber(int material_number) {
+    m_material_number = material_number;
+}
 
 void RegionBase::calculateMultiMaterialTransition(Distance& transition_distance, int next_material_number) {
     // Step backwards through the paths, evaluating each segment
@@ -196,10 +219,10 @@ void RegionBase::calculateMultiMaterialTransition(Distance& transition_distance,
                 Distance next_segment_distance = current_segments[j]->end().distance(current_segments[j]->start());
                 if (next_segment_distance > transition_distance) {
                     float percentage = ((next_segment_distance - transition_distance) / next_segment_distance)();
-                    Point end = Point((1.0 - percentage) * current_segments[j]->start().x() +
-                                          percentage * current_segments[j]->end().x(),
-                                      (1.0 - percentage) * current_segments[j]->start().y() +
-                                          percentage * current_segments[j]->end().y());
+                    Point end        = Point((1.0 - percentage) * current_segments[j]->start().x() +
+                                                 percentage * current_segments[j]->end().x(),
+                                             (1.0 - percentage) * current_segments[j]->start().y() +
+                                                 percentage * current_segments[j]->end().y());
 
                     Point old_end = current_segments[j]->end();
                     current_segments[j]->setEnd(end);
@@ -223,26 +246,22 @@ void RegionBase::calculateMultiMaterialTransition(Distance& transition_distance,
                     m_paths[i].insert(j + 1, segment);
                 }
                 // Segment is shorter than transition distance, update its material number and continue
-                else {
-                    current_segments[j]->getSb()->setSetting(SS::kMaterialNumber, next_material_number);
-                }
+                else { current_segments[j]->getSb()->setSetting(SS::kMaterialNumber, next_material_number); }
                 transition_distance -= next_segment_distance;
             }
-            if (transition_distance <= 0)
-                break;
+            if (transition_distance <= 0) break;
         }
-        if (transition_distance <= 0)
-            break;
+        if (transition_distance <= 0) break;
     }
 }
 
 void RegionBase::fitCircularArcs(const QSharedPointer<SettingsBase>& global_sb) {
-    if (!planarArcFittingAllowed(global_sb))
-        return;
+    if (!planarArcFittingAllowed(global_sb)) return;
 
-    for (Path& path : m_paths)
-        path.fitCircularArcs(m_sb);
+    for (Path& path : m_paths) path.fitCircularArcs(m_sb);
 }
 
-void RegionBase::setLastSpiral(bool spiral) { m_was_last_region_spiral = spiral; }
-} // namespace ORNL
+void RegionBase::setLastSpiral(bool spiral) {
+    m_was_last_region_spiral = spiral;
+}
+}  // namespace ORNL

--- a/src/step/layer/regions/skeleton.cpp
+++ b/src/step/layer/regions/skeleton.cpp
@@ -35,11 +35,13 @@
 #include "utilities/enums.h"
 #include "utilities/mathutils.h"
 
-template <> struct boost::polygon::geometry_concept<ORNL::Point> {
+template <>
+struct boost::polygon::geometry_concept<ORNL::Point> {
     typedef point_concept type;
 };
 
-template <> struct boost::polygon::point_traits<ORNL::Point> {
+template <>
+struct boost::polygon::point_traits<ORNL::Point> {
     using coordinate_type = int;
 
     static coordinate_type get(const ORNL::Point& point, orientation_2d orient) {
@@ -47,13 +49,15 @@ template <> struct boost::polygon::point_traits<ORNL::Point> {
     }
 };
 
-template <> struct boost::polygon::geometry_concept<ORNL::Polyline> {
+template <>
+struct boost::polygon::geometry_concept<ORNL::Polyline> {
     typedef segment_concept type;
 };
 
-template <> struct boost::polygon::segment_traits<ORNL::Polyline> {
+template <>
+struct boost::polygon::segment_traits<ORNL::Polyline> {
     using coordinate_type = int;
-    using point_type = ORNL::Point;
+    using point_type      = ORNL::Point;
 
     static point_type get(const ORNL::Polyline& segment, direction_1d dir) {
         return dir.to_int() ? segment.first() : segment.last();
@@ -70,9 +74,7 @@ QString Skeleton::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kSkeleton);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kSkeleton);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kSkeleton);
     }
     gcode += writer->writeAfterRegion(RegionType::kSkeleton);
@@ -113,13 +115,9 @@ void Skeleton::compute(uint layer_num) {
             //! Uncomment to inspect Skeleton structure. See instructions in header file.
             // inspectSkeleton(layer_num);
         }
-        else {
-            qDebug() << "\t\tNo permitted skeletons generated from geometry on layer " << m_layer_num;
-        }
+        else { qDebug() << "\t\tNo permitted skeletons generated from geometry on layer " << m_layer_num; }
     }
-    else {
-        qDebug() << "\t\tNo geometry for skeletons to compute";
-    }
+    else { qDebug() << "\t\tNo geometry for skeletons to compute"; }
 }
 
 void Skeleton::computeSegmentVoronoi() {
@@ -171,10 +169,10 @@ void Skeleton::computeSegmentVoronoi() {
                                 // If adaptive bead width is enabled, include all skeleton segments.
                                 // Otherwise, filter skeleton segments whose minimum distance to the border geometry is
                                 // less than half the bead width.
-                                if (m_sb->setting<bool>(PS::Skeleton::kSkeletonAdapt)) { // Adaptive bead width
+                                if (m_sb->setting<bool>(PS::Skeleton::kSkeletonAdapt)) {  // Adaptive bead width
                                     m_skeleton_geometry += m_geometry & Polyline({start, end});
                                 }
-                                else if (!filter(source1, source2, start, end)) { // Static bead width
+                                else if (!filter(source1, source2, start, end)) {  // Static bead width
                                     m_skeleton_geometry += m_geometry & Polyline({start, end});
                                 }
                             }
@@ -188,24 +186,20 @@ void Skeleton::computeSegmentVoronoi() {
 
     //! Remove any skeleton segments that may overlap with border geometry
     //! Extremely rare and may be unnecessary with input geometry cleaning
-    QVector<Polyline>::iterator segment_iter = m_skeleton_geometry.begin(),
+    QVector<Polyline>::iterator segment_iter     = m_skeleton_geometry.begin(),
                                 segment_iter_end = m_skeleton_geometry.end();
     while (segment_iter != segment_iter_end) {
         if (bounding_edges.contains(*segment_iter) || bounding_edges.contains(segment_iter->reverse())) {
             segment_iter = m_skeleton_geometry.erase(segment_iter);
         }
-        else {
-            ++segment_iter;
-        }
+        else { ++segment_iter; }
     }
 }
 
 void Skeleton::computePointVoronoi() {
     //! Gather input geometry
     QVector<Point> points;
-    for (Polygon& poly : m_geometry) {
-        points += poly;
-    }
+    for (Polygon& poly : m_geometry) { points += poly; }
 
     //! Construct Voronoi Diagram
     boost::polygon::voronoi_diagram<double> vd;
@@ -227,7 +221,7 @@ void Skeleton::computePointVoronoi() {
                         m_skeleton_geometry += m_geometry & Polyline({start, end});
                     }
                 }
-                else { //! Infinite edge case
+                else {  //! Infinite edge case
                     auto v0 = edge->vertex0();
 
                     //! Ensures skeleton segments are only generated once since voronoi diagram implements twin edges
@@ -253,9 +247,7 @@ void Skeleton::computePointVoronoi() {
 void Skeleton::incorporateLostGeometry() {
     //! Integrate lost geometry with m_geometry, ensuring they share no common geometry
     for (Polygon& poly : m_geometry.lost_geometry) {
-        if ((m_geometry & poly).isEmpty()) {
-            m_geometry += poly;
-        }
+        if ((m_geometry & poly).isEmpty()) { m_geometry += poly; }
     }
 }
 
@@ -273,19 +265,13 @@ void Skeleton::simplifyInputGeometry() {
                     break;
                 }
             }
-            if (!valid)
-                break;
+            if (!valid) break;
         }
-        if (!valid)
-            break;
+        if (!valid) break;
     }
 
-    if (valid) {
-        m_geometry = m_geometry.cleanPolygons(cleaning_dist);
-    }
-    else {
-        qDebug() << "Layer " << m_layer_num << " Skeleton input geometry cleaning distance too large.";
-    }
+    if (valid) { m_geometry = m_geometry.cleanPolygons(cleaning_dist); }
+    else { qDebug() << "Layer " << m_layer_num << " Skeleton input geometry cleaning distance too large."; }
 
     //! Chamfer long axis corner of triangles
     for (Polygon& poly : m_geometry) {
@@ -326,17 +312,13 @@ void Skeleton::simplifyInputGeometry() {
             if (MathUtils::internalAngle(poly[i - 1], poly[i], poly[i + 1]) < threshold) {
                 new_geometry.append(MathUtils::chamferCorner(poly[i - 1], poly[i], poly[i + 1], 10));
             }
-            else {
-                new_geometry.append(poly[i]);
-            }
+            else { new_geometry.append(poly[i]); }
         }
 
         if (MathUtils::internalAngle(geometry.last(), geometry[0], geometry[1]) < threshold) {
             new_geometry.append(MathUtils::chamferCorner(geometry.last(), geometry[0], geometry[1], 10));
         }
-        else {
-            new_geometry.append(geometry.first());
-        }
+        else { new_geometry.append(geometry.first()); }
 
         geometry = new_geometry;
     }
@@ -345,9 +327,7 @@ void Skeleton::simplifyInputGeometry() {
 void Skeleton::simplifyOutputGeometry() {
     const Distance& cleaning_distance = m_sb->setting<Distance>(PS::Skeleton::kSkeletonOutputCleaningDistance);
 
-    for (Polyline& poly_line : m_computed_geometry) {
-        poly_line = poly_line.simplify(cleaning_distance);
-    }
+    for (Polyline& poly_line : m_computed_geometry) { poly_line = poly_line.simplify(cleaning_distance); }
 }
 
 void Skeleton::generateSkeletonGraph() {
@@ -356,18 +336,14 @@ void Skeleton::generateSkeletonGraph() {
 
     for (Polyline& edge : m_skeleton_geometry) {
         SkeletonVertex v0;
-        if (vertices.contains(edge.first())) {
-            v0 = vertices[edge.first()];
-        }
+        if (vertices.contains(edge.first())) { v0 = vertices[edge.first()]; }
         else {
             v0 = add_vertex(edge.first(), m_skeleton_graph);
             vertices.insert(edge.first(), v0);
         }
 
         SkeletonVertex v1;
-        if (vertices.contains(edge.last())) {
-            v1 = vertices[edge.last()];
-        }
+        if (vertices.contains(edge.last())) { v1 = vertices[edge.last()]; }
         else {
             v1 = add_vertex(edge.last(), m_skeleton_graph);
             vertices.insert(edge.last(), v1);
@@ -415,18 +391,17 @@ void Skeleton::cleanSkeletonGraph(Distance cleaning_distance) {
                 remove_edge(*e1, m_skeleton_graph);
                 remove_vertex(*v_root, m_skeleton_graph);
 
-                vertex_mod_map[v0] = true;
-                vertex_mod_map[v1] = true;
+                vertex_mod_map[v0]   = true;
+                vertex_mod_map[v1]   = true;
                 std::tie(vi, vi_end) = vertices(m_skeleton_graph);
             }
-            else {
-                vertex_mod_map[*v_root] = true;
-            }
+            else { vertex_mod_map[*v_root] = true; }
         }
     }
 }
 
-template <typename TVertex, typename TEdge, typename TGraph> struct dfs_visitor : public boost::dfs_visitor<> {
+template <typename TVertex, typename TEdge, typename TGraph>
+struct dfs_visitor : public boost::dfs_visitor<> {
     dfs_visitor(QVector<SkeletonEdge>& longest_path_) : longest_path(longest_path_) {}
 
     using VertexColorMap = std::map<SkeletonVertex, boost::default_color_type>;
@@ -441,9 +416,7 @@ template <typename TVertex, typename TEdge, typename TGraph> struct dfs_visitor 
         predecessor_map[target] = predecessor_map[source];
         predecessor_map[target].push(source);
 
-        if (typeid(g) == typeid(SkeletonSubgraph) && boost::degree(target, g) == 1) {
-            getSimplePath(target, g);
-        }
+        if (typeid(g) == typeid(SkeletonSubgraph) && boost::degree(target, g) == 1) { getSimplePath(target, g); }
     }
 
     void back_edge(const TEdge& e, const TGraph& g) {
@@ -461,7 +434,7 @@ template <typename TVertex, typename TEdge, typename TGraph> struct dfs_visitor 
         QVector<SkeletonEdge> cycle;
         Distance cycle_length = 0;
         while (predecessor_map[v].top() != v) {
-            target = predecessor_map[v].pop();
+            target  = predecessor_map[v].pop();
             TEdge e = edge(source, target, g).first;
             cycle += e;
             cycle_length += g[e].length();
@@ -473,7 +446,7 @@ template <typename TVertex, typename TEdge, typename TGraph> struct dfs_visitor 
         cycle_length += g[e].length();
 
         if (cycle_length > longest_path_length) {
-            longest_path = cycle;
+            longest_path        = cycle;
             longest_path_length = cycle_length;
         }
     }
@@ -484,7 +457,7 @@ template <typename TVertex, typename TEdge, typename TGraph> struct dfs_visitor 
         QVector<SkeletonEdge> simple_path;
         Distance length = 0;
         while (!predecessor_map[v].isEmpty()) {
-            target = predecessor_map[v].pop();
+            target  = predecessor_map[v].pop();
             TEdge e = edge(source, target, g).first;
             length += g[e].length();
             simple_path += e;
@@ -492,12 +465,12 @@ template <typename TVertex, typename TEdge, typename TGraph> struct dfs_visitor 
         }
 
         if (length > longest_path_length) {
-            longest_path = simple_path;
+            longest_path        = simple_path;
             longest_path_length = length;
         }
     }
 
-  private:
+   private:
     QMap<SkeletonVertex, QStack<SkeletonVertex>> predecessor_map;
     QVector<SkeletonEdge>& longest_path;
     Distance longest_path_length = 0;
@@ -511,17 +484,13 @@ void Skeleton::extractCycles() {
         boost::undirected_dfs(m_skeleton_graph, vis, make_assoc_property_map(vis.vertex_coloring),
                               make_assoc_property_map(vis.edge_coloring));
 
-        if (!longest_cycle.isEmpty()) {
-            extractPath(longest_cycle);
-        }
+        if (!longest_cycle.isEmpty()) { extractPath(longest_cycle); }
         else {
-            break; // All cycles have been removed
+            break;  // All cycles have been removed
         }
 
         // Check if cycle removal empties graph
-        if (boost::num_edges(m_skeleton_graph) == 0 || boost::num_vertices(m_skeleton_graph) == 0) {
-            break;
-        }
+        if (boost::num_edges(m_skeleton_graph) == 0 || boost::num_vertices(m_skeleton_graph) == 0) { break; }
     }
 }
 
@@ -532,9 +501,7 @@ void Skeleton::extractSimplePaths() {
         std::map<SkeletonVertex, int> vertex_index_map;
         boost::associative_property_map<std::map<SkeletonVertex, int>> index_map(vertex_index_map);
         auto [v, v_end] = boost::vertices(m_skeleton_graph);
-        for (int i = 0; v != v_end; ++v, ++i) {
-            boost::put(index_map, *v, i);
-        }
+        for (int i = 0; v != v_end; ++v, ++i) { boost::put(index_map, *v, i); }
 
         //! Create SubGraph Map
         std::map<SkeletonVertex, int> vertex_subgraph_map;
@@ -548,7 +515,7 @@ void Skeleton::extractSimplePaths() {
 
         //! Find open edge to start dfs from
         SkeletonSubgraph::vertex_iterator vi, vi_end;
-        boost::tie(vi, vi_end) = vertices(subgraph);
+        boost::tie(vi, vi_end)                    = vertices(subgraph);
         SkeletonSubgraph::vertex_descriptor start = *vi;
         while (vi != vi_end) {
             if (boost::degree(*vi, subgraph) == 1) {
@@ -566,15 +533,12 @@ void Skeleton::extractSimplePaths() {
         boost::undirected_dfs(subgraph, vis, make_assoc_property_map(vis.vertex_coloring),
                               make_assoc_property_map(vis.edge_coloring), start);
 
-        if (!longest_simple_path.isEmpty()) {
-            extractPath(longest_simple_path);
-        }
+        if (!longest_simple_path.isEmpty()) { extractPath(longest_simple_path); }
     }
 }
 
 void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
-    if (path_.isEmpty())
-        return;
+    if (path_.isEmpty()) return;
 
     struct EdgeEndpoints {
         SkeletonVertex source;
@@ -589,11 +553,10 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     auto trackEdge = [&sameUndirectedEdge](QVector<EdgeEndpoints>& edges, SkeletonVertex source,
                                            SkeletonVertex target) {
         EdgeEndpoints endpoints {source, target};
-        const auto duplicate = std::any_of(edges.cbegin(), edges.cend(), [&sameUndirectedEdge, &endpoints](const auto& edge) {
-            return sameUndirectedEdge(edge, endpoints);
-        });
-        if (!duplicate)
-            edges.push_back(endpoints);
+        const auto duplicate = std::any_of(
+            edges.cbegin(), edges.cend(),
+            [&sameUndirectedEdge, &endpoints](const auto& edge) { return sameUndirectedEdge(edge, endpoints); });
+        if (!duplicate) edges.push_back(endpoints);
     };
 
     Polyline path;
@@ -601,11 +564,10 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     QVector<SkeletonVertex> touched_vertices;
 
     auto trackVertex = [&touched_vertices](SkeletonVertex vertex) {
-        if (!touched_vertices.contains(vertex))
-            touched_vertices.push_back(vertex);
+        if (!touched_vertices.contains(vertex)) touched_vertices.push_back(vertex);
     };
 
-    SkeletonEdge e = path_.takeFirst();
+    SkeletonEdge e        = path_.takeFirst();
     SkeletonVertex source = boost::source(e, m_skeleton_graph);
     SkeletonVertex target = boost::target(e, m_skeleton_graph);
     path << m_skeleton_graph[source] << m_skeleton_graph[target];
@@ -626,13 +588,11 @@ void Skeleton::extractPath(QVector<SkeletonEdge> path_) {
     // by a stale descriptor a second time corrupts Boost's list-backed edge container.
     for (const EdgeEndpoints& edge : edges_to_remove) {
         auto [edge_descriptor, found] = boost::edge(edge.source, edge.target, m_skeleton_graph);
-        if (found)
-            boost::remove_edge(edge_descriptor, m_skeleton_graph);
+        if (found) boost::remove_edge(edge_descriptor, m_skeleton_graph);
     }
 
     for (SkeletonVertex vertex : touched_vertices) {
-        if (boost::degree(vertex, m_skeleton_graph) == 0)
-            boost::remove_vertex(vertex, m_skeleton_graph);
+        if (boost::degree(vertex, m_skeleton_graph) == 0) boost::remove_vertex(vertex, m_skeleton_graph);
     }
 
     m_computed_geometry.append(path);
@@ -693,17 +653,17 @@ LSegmentList Skeleton::createSegments(const Point& start, const Point& end,
     }
 
     // ---------- Adaptive bead width ----------
-    const Distance ref_width = parent_sb->setting<Distance>(PS::Skeleton::kBeadWidth);
-    const Velocity ref_speed = parent_sb->setting<Velocity>(PS::Skeleton::kSpeed);
-    const double speed_factor = ref_speed() * ref_width(); // Inverse-proportional speed factor
-    const double min_speed = ref_speed() * 0.01;           // 1% of reference speed
+    const Distance ref_width  = parent_sb->setting<Distance>(PS::Skeleton::kBeadWidth);
+    const Velocity ref_speed  = parent_sb->setting<Velocity>(PS::Skeleton::kSpeed);
+    const double speed_factor = ref_speed() * ref_width();  // Inverse-proportional speed factor
+    const double min_speed    = ref_speed() * 0.01;         // 1% of reference speed
 
     // Discretize the input segment
     const Distance step = parent_sb->setting<Distance>(PS::Skeleton::kSkeletonAdaptStepSize);
-    const int steps = std::max(1, int(std::ceil(start.distance(end)() / step())));
-    const double dx = (end.x() - start.x()) / steps;
-    const double dy = (end.y() - start.y()) / steps;
-    const double tol = ref_width() * 0.01; // Consolidation tolerance = 1% of reference bead width
+    const int steps     = std::max(1, int(std::ceil(start.distance(end)() / step())));
+    const double dx     = (end.x() - start.x()) / steps;
+    const double dy     = (end.y() - start.y()) / steps;
+    const double tol    = ref_width() * 0.01;  // Consolidation tolerance = 1% of reference bead width
 
     QVector<Point> pts;
     pts.reserve(steps + 1);
@@ -719,9 +679,9 @@ LSegmentList Skeleton::createSegments(const Point& start, const Point& end,
             radius = std::min(radius, MathUtils::nearestPointOnSegment(edge.first(), edge.last(), p).second);
         }
         pts.push_back(p);
-        bw.push_back(radius * 2.0); // Bead width = 2 * radius
+        bw.push_back(radius * 2.0);  // Bead width = 2 * radius
     }
-    pts.back() = end; // Exact end-point
+    pts.back() = end;  // Exact end-point
 
     // Helper lambda to create a subsegment with adapted settings
     auto createSubsegment = [&](size_t start_idx, size_t end_idx) {
@@ -740,7 +700,7 @@ LSegmentList Skeleton::createSegments(const Point& start, const Point& end,
     size_t start_idx = 0;
     for (size_t end_idx = 1; end_idx <= steps; ++end_idx) {
         const bool boundary = std::fabs(bw[end_idx]() - bw[start_idx]()) > tol;
-        const bool last = (end_idx == steps);
+        const bool last     = (end_idx == steps);
         if (boundary || last) {
             segments.append(createSubsegment(start_idx, end_idx));
             start_idx = end_idx;
@@ -752,18 +712,14 @@ LSegmentList Skeleton::createSegments(const Point& start, const Point& end,
 
 Path Skeleton::createPath(Polyline line) {
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Skeleton::kMinSegmentLength));
-    if (line.size() < 2) {
-        return Path();
-    }
+    if (line.size() < 2) { return Path(); }
 
     // ---------- No Settings Regions ----------
     if (m_settings_polygons.isEmpty()) {
         Path path;
 
         for (size_t i = 0; i < line.size() - 1; ++i) {
-            for (const LSegmentPtr& segment : createSegments(line[i], line[i + 1], m_sb)) {
-                path.append(segment);
-            }
+            for (const LSegmentPtr& segment : createSegments(line[i], line[i + 1], m_sb)) { path.append(segment); }
         }
         return path;
     }
@@ -778,13 +734,11 @@ Path Skeleton::createPathWithLocalizedSettings(const Polyline& line) {
     // Iterate through each segment of the polyline
     for (size_t i = 0; i < line.size() - 1; ++i) {
         const Point& start = line[i];
-        const Point& end = line[i + 1];
+        const Point& end   = line[i + 1];
 
         // Clip the segment against the settings polygons
         QVector<Point> cuts;
-        for (const SettingsPolygon& polygon : m_settings_polygons) {
-            cuts += polygon.clipLine(start, end);
-        }
+        for (const SettingsPolygon& polygon : m_settings_polygons) { cuts += polygon.clipLine(start, end); }
 
         // Sort cuts based on their distance from the start point
         std::sort(cuts.begin(), cuts.end(),
@@ -811,9 +765,7 @@ Path Skeleton::createPathWithLocalizedSettings(const Polyline& line) {
                 }
             }
 
-            for (const LSegmentPtr& segment : createSegments(p0, p1, parent_sb)) {
-                path.append(segment);
-            }
+            for (const LSegmentPtr& segment : createSegments(p0, p1, parent_sb)) { path.append(segment); }
         }
     }
 
@@ -836,9 +788,7 @@ QVector<Path> Skeleton::filterPath(const Path& path) {
             }
 
             // Ensure closed paths have correct orientation
-            if (filtered_path.isClosed()) {
-                filtered_path.setCCW(Polygon(filtered_path).orientation());
-            }
+            if (filtered_path.isClosed()) { filtered_path.setCCW(Polygon(filtered_path).orientation()); }
             filtered_paths.append(filtered_path);
             filtered_path.clear();
         }
@@ -859,11 +809,11 @@ QVector<Path> Skeleton::filterPath(const Path& path) {
         const Distance max_width = segment_sb->setting<Distance>(PS::Skeleton::kSkeletonAdaptMaxWidth);
 
         // Compute adapted speed limits based on min/max widths
-        const Distance ref_width = segment_sb->setting<Distance>(PS::Skeleton::kBeadWidth);
-        const Velocity ref_speed = segment_sb->setting<Velocity>(PS::Skeleton::kSpeed);
-        const double speed_factor = ref_speed() * ref_width(); // Inverse-proportional speed factor
-        const Velocity min_speed = speed_factor / min_width();
-        const Velocity max_speed = speed_factor / max_width();
+        const Distance ref_width  = segment_sb->setting<Distance>(PS::Skeleton::kBeadWidth);
+        const Velocity ref_speed  = segment_sb->setting<Velocity>(PS::Skeleton::kSpeed);
+        const double speed_factor = ref_speed() * ref_width();  // Inverse-proportional speed factor
+        const Velocity min_speed  = speed_factor / min_width();
+        const Velocity max_speed  = speed_factor / max_width();
 
         // Retrieve the segment's width and filters
         const Distance width = segment_sb->setting<Distance>(SS::kWidth);
@@ -873,25 +823,25 @@ QVector<Path> Skeleton::filterPath(const Path& path) {
             segment_sb->setting<SkeletonFilter>(PS::Skeleton::kSkeletonAdaptMaxWidthFilter);
 
         // Apply filtering logic
-        if (width >= min_width && width <= max_width) { // Within bounds
+        if (width >= min_width && width <= max_width) {  // Within bounds
             filtered_path.append(segment);
         }
-        else if (width < min_width && min_filter == SkeletonFilter::kClamp) { // Below minimum width
+        else if (width < min_width && min_filter == SkeletonFilter::kClamp) {  // Below minimum width
             segment_sb->setSetting(SS::kWidth, min_width);
             segment_sb->setSetting(SS::kSpeed, min_speed);
             filtered_path.append(segment);
         }
-        else if (width > max_width && max_filter == SkeletonFilter::kClamp) { // Above maximum width
+        else if (width > max_width && max_filter == SkeletonFilter::kClamp) {  // Above maximum width
             segment_sb->setSetting(SS::kWidth, max_width);
             segment_sb->setSetting(SS::kSpeed, max_speed);
             filtered_path.append(segment);
         }
-        else { // Outside bounds and not clamped
+        else {  // Outside bounds and not clamped
             flushPath();
         }
     }
 
-    flushPath(); // Push any trailing path
+    flushPath();  // Push any trailing path
     return filtered_paths;
 }
 
@@ -966,11 +916,11 @@ void Skeleton::calculateModifiers(Path& path, bool supportsG3) {
     // Tip Wipe
     if (m_sb->setting<bool>(MS::TipWipe::kSkeletonEnable)) {
         const auto& tw_direction = static_cast<TipWipeDirection>(m_sb->setting<int>(MS::TipWipe::kSkeletonDirection));
-        const auto& tw_distance = m_sb->setting<Distance>(MS::TipWipe::kSkeletonDistance);
-        const auto& tw_speed = m_sb->setting<Velocity>(MS::TipWipe::kSkeletonSpeed);
-        const auto& tw_extruder_speed = m_sb->setting<AngularVelocity>(MS::TipWipe::kSkeletonExtruderSpeed);
-        const auto& tw_angle = m_sb->setting<Angle>(MS::TipWipe::kSkeletonAngle);
-        const auto& tw_lift_height = m_sb->setting<Distance>(MS::TipWipe::kSkeletonLiftHeight);
+        const auto& tw_distance  = m_sb->setting<Distance>(MS::TipWipe::kSkeletonDistance);
+        const auto& tw_speed     = m_sb->setting<Velocity>(MS::TipWipe::kSkeletonSpeed);
+        const auto& tw_extruder_speed  = m_sb->setting<AngularVelocity>(MS::TipWipe::kSkeletonExtruderSpeed);
+        const auto& tw_angle           = m_sb->setting<Angle>(MS::TipWipe::kSkeletonAngle);
+        const auto& tw_lift_height     = m_sb->setting<Distance>(MS::TipWipe::kSkeletonLiftHeight);
         const auto& tw_cutoff_distance = m_sb->setting<Distance>(MS::TipWipe::kSkeletonCutoffDistance);
 
         if (tw_direction == TipWipeDirection::kForward || tw_direction == TipWipeDirection::kOptimal) {
@@ -990,14 +940,14 @@ void Skeleton::calculateModifiers(Path& path, bool supportsG3) {
 
     // Startup
     if (m_sb->setting<bool>(MS::Startup::kSkeletonEnable)) {
-        const auto& su_distance = m_sb->setting<Distance>(MS::Startup::kSkeletonDistance);
-        const auto& su_speed = m_sb->setting<Velocity>(MS::Startup::kSkeletonSpeed);
-        const auto& speed = m_sb->setting<Velocity>(PS::Skeleton::kSpeed);
-        const auto& su_extruder_speed = m_sb->setting<AngularVelocity>(MS::Startup::kSkeletonExtruderSpeed);
-        const auto& extruder_speed = m_sb->setting<AngularVelocity>(PS::Skeleton::kExtruderSpeed);
-        const auto& su_steps = m_sb->setting<int>(MS::Startup::kSkeletonSteps);
+        const auto& su_distance            = m_sb->setting<Distance>(MS::Startup::kSkeletonDistance);
+        const auto& su_speed               = m_sb->setting<Velocity>(MS::Startup::kSkeletonSpeed);
+        const auto& speed                  = m_sb->setting<Velocity>(PS::Skeleton::kSpeed);
+        const auto& su_extruder_speed      = m_sb->setting<AngularVelocity>(MS::Startup::kSkeletonExtruderSpeed);
+        const auto& extruder_speed         = m_sb->setting<AngularVelocity>(PS::Skeleton::kExtruderSpeed);
+        const auto& su_steps               = m_sb->setting<int>(MS::Startup::kSkeletonSteps);
         const auto& sm_enable_width_height = m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight);
-        const auto& su_area_modifier = m_sb->setting<double>(MS::Startup::kStartUpAreaModifier);
+        const auto& su_area_modifier       = m_sb->setting<double>(MS::Startup::kStartUpAreaModifier);
 
         if (m_sb->setting<bool>(MS::Startup::kSkeletonRampUpEnable)) {
             PathModifierGenerator::GenerateInitialStartupWithRampUp(path, su_distance, su_speed, speed,
@@ -1012,24 +962,24 @@ void Skeleton::calculateModifiers(Path& path, bool supportsG3) {
 
     // Prestart
     if (m_sb->setting<bool>(PS::Skeleton::kPrestartEnable)) {
-        const auto& ps_distance = m_sb->setting<Distance>(PS::Skeleton::kPrestartDistance);
-        const auto& ps_speed = m_sb->setting<Velocity>(PS::Skeleton::kPrestartSpeed);
-        const auto& ps_extruder_speed = m_sb->setting<AngularVelocity>(PS::Skeleton::kPrestartExtruderSpeed);
+        const auto& ps_distance            = m_sb->setting<Distance>(PS::Skeleton::kPrestartDistance);
+        const auto& ps_speed               = m_sb->setting<Velocity>(PS::Skeleton::kPrestartSpeed);
+        const auto& ps_extruder_speed      = m_sb->setting<AngularVelocity>(PS::Skeleton::kPrestartExtruderSpeed);
         const auto& ps_enable_width_height = m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight);
-        const auto& ps_area_modifier = m_sb->setting<double>(PS::Skeleton::kPrestartAreaModifier);
+        const auto& ps_area_modifier       = m_sb->setting<double>(PS::Skeleton::kPrestartAreaModifier);
         PathModifierGenerator::GeneratePrestart(path, ps_distance, ps_speed, ps_extruder_speed, ps_enable_width_height,
                                                 ps_area_modifier);
     }
 
     // Lead In
     if (m_sb->setting<bool>(PS::Skeleton::kLeadInEnable)) {
-        const auto& li_distance = m_sb->setting<Distance>(PS::Skeleton::kLeadInDistance);
-        const auto& li_speed = m_sb->setting<Velocity>(PS::Skeleton::kLeadInSpeed);
-        const auto& li_extruder_speed = m_sb->setting<AngularVelocity>(PS::Skeleton::kLeadInExtruderSpeed);
+        const auto& li_distance            = m_sb->setting<Distance>(PS::Skeleton::kLeadInDistance);
+        const auto& li_speed               = m_sb->setting<Velocity>(PS::Skeleton::kLeadInSpeed);
+        const auto& li_extruder_speed      = m_sb->setting<AngularVelocity>(PS::Skeleton::kLeadInExtruderSpeed);
         const auto& li_enable_width_height = m_sb->setting<bool>(PS::SpecialModes::kEnableWidthHeight);
-        const auto& li_area_modifier = m_sb->setting<double>(PS::Skeleton::kLeadInAreaModifier);
+        const auto& li_area_modifier       = m_sb->setting<double>(PS::Skeleton::kLeadInAreaModifier);
         PathModifierGenerator::GenerateOpenLoopLeadIn(path, li_distance, li_speed, li_extruder_speed,
                                                       li_enable_width_height, li_area_modifier);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/skin.cpp
+++ b/src/step/layer/regions/skin.cpp
@@ -26,8 +26,7 @@ namespace {
 PolygonList polylineFootprint(const Polyline& line, Distance bead_width, const PolygonList& clipping_geometry) {
     PolygonList footprint;
     for (int i = 0, end = line.size() - 1; i < end; ++i) {
-        if (line[i] == line[i + 1])
-            continue;
+        if (line[i] == line[i + 1]) continue;
 
         footprint += Polyline({line[i], line[i + 1]}).makeReal(bead_width);
     }
@@ -52,22 +51,20 @@ QVector<Polyline> printableLines(const QVector<Polyline>& lines, Distance min_pa
 PolygonList printableFootprint(const QVector<Polyline>& lines, Distance bead_width,
                                const PolygonList& clipping_geometry) {
     PolygonList footprint;
-    for (const Polyline& line : lines)
-        footprint += polylineFootprint(line, bead_width, clipping_geometry);
+    for (const Polyline& line : lines) footprint += polylineFootprint(line, bead_width, clipping_geometry);
 
     return footprint;
 }
 
 PolygonList futurePerimeterSupport(const PolygonList& current_geometry, const PolygonList& upper_geometry,
                                    Distance support_width) {
-    if (support_width <= 0 || upper_geometry.isEmpty())
-        return PolygonList();
+    if (support_width <= 0 || upper_geometry.isEmpty()) return PolygonList();
 
     // Extract the upper layer's perimeter band so top skin can support future walls.
     PolygonList support_geometry = upper_geometry - upper_geometry.offset(-support_width);
     return support_geometry & current_geometry;
 }
-} // namespace
+}  // namespace
 
 Skin::Skin(const QSharedPointer<SettingsBase>& sb, const int index, const QVector<SettingsPolygon>& settings_polygons)
     : RegionBase(sb, index, settings_polygons, PolygonList(), RegionType::kSkin) {
@@ -79,9 +76,7 @@ QString Skin::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kSkin);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kSkin);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kSkin);
     }
     gcode += writer->writeAfterRegion(RegionType::kSkin);
@@ -94,15 +89,15 @@ void Skin::compute(uint layer_num) {
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kSkinNum));
 
     Distance overlap = m_sb->setting<Distance>(PS::Skin::kOverlap);
-    m_geometry = m_geometry.offset(overlap);
+    m_geometry       = m_geometry.offset(overlap);
 
-    Distance beadWidth = m_sb->setting<Distance>(PS::Skin::kBeadWidth);
-    Distance minPathLength = m_sb->setting<Distance>(PS::Skin::kMinPathLength);
+    Distance beadWidth        = m_sb->setting<Distance>(PS::Skin::kBeadWidth);
+    Distance minPathLength    = m_sb->setting<Distance>(PS::Skin::kMinPathLength);
     Distance minSegmentLength = m_sb->setting<Distance>(PS::Skin::kMinSegmentLength);
-    Angle patternAngle = m_sb->setting<Angle>(PS::Skin::kAngle);
+    Angle patternAngle        = m_sb->setting<Angle>(PS::Skin::kAngle);
 
-    int top_count = m_sb->setting<int>(PS::Skin::kTopCount);
-    int bottom_count = m_sb->setting<int>(PS::Skin::kBottomCount);
+    int top_count     = m_sb->setting<int>(PS::Skin::kTopCount);
+    int bottom_count  = m_sb->setting<int>(PS::Skin::kBottomCount);
     int gradual_count = m_sb->setting<int>(PS::Skin::kInfillSteps);
 
     //! If skin region belongs to top or bottom layer there is no need to compute top or bottom skin
@@ -116,11 +111,10 @@ void Skin::compute(uint layer_num) {
             { computeBottomSkin(bottom_count); }
         }
     }
-    if (m_sb->setting<bool>(PS::Skin::kInfillEnable))
-        computeGradualSkinSteps(gradual_count);
+    if (m_sb->setting<bool>(PS::Skin::kInfillEnable)) computeGradualSkinSteps(gradual_count);
 
     if (!m_skin_geometry.isEmpty()) {
-        PolygonList skin_offset = m_skin_geometry.offset(-beadWidth / 2);
+        PolygonList skin_offset           = m_skin_geometry.offset(-beadWidth / 2);
         const InfillPatterns skin_pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern));
         QVector<Polyline> lines = createPatternForArea(skin_pattern, skin_offset, beadWidth, beadWidth, patternAngle);
         m_computed_geometry =
@@ -129,9 +123,9 @@ void Skin::compute(uint layer_num) {
     }
 
     if (!m_gradual_skin_geometry.isEmpty()) {
-        Angle infillPatternAngle = m_sb->setting<Angle>(PS::Skin::kInfillAngle);
+        Angle infillPatternAngle      = m_sb->setting<Angle>(PS::Skin::kInfillAngle);
         InfillPatterns gradualPattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kInfillPattern));
-        double percentage = 0;
+        double percentage             = 0;
         if (m_sb->setting<bool>(PS::Infill::kEnable))
             percentage =
                 m_sb->setting<double>(PS::Infill::kBeadWidth) / m_sb->setting<double>(PS::Infill::kLineSpacing);
@@ -198,8 +192,7 @@ void Skin::computeTopSkin(const int& top_count) {
 
     //! If skin is within top_count of top layer, compute common geometry
     if (m_upper_geometry_includes_top && m_upper_geometry.size() < top_count)
-        for (const PolygonList& poly : m_upper_geometry)
-            temp_geometry &= poly;
+        for (const PolygonList& poly : m_upper_geometry) temp_geometry &= poly;
     else
         temp_geometry.clear();
 
@@ -213,21 +206,18 @@ void Skin::computeTopSkin(const int& top_count) {
 }
 
 void Skin::computeBottomSkin(const int& bottom_count) {
-    if (bottom_count <= 0)
-        return;
+    if (bottom_count <= 0) return;
 
     PolygonList temp_geometry = m_geometry;
 
     //! If skin is within bottom_count of botton layer, compute common geometry
     if (m_lower_geometry_includes_bottom && m_lower_geometry.size() < bottom_count)
-        for (const PolygonList& poly : m_lower_geometry)
-            temp_geometry &= poly;
+        for (const PolygonList& poly : m_lower_geometry) temp_geometry &= poly;
     else
         temp_geometry.clear();
 
     //! Compute difference geometry
-    for (const PolygonList& poly : m_lower_geometry)
-        temp_geometry += m_geometry - poly;
+    for (const PolygonList& poly : m_lower_geometry) temp_geometry += m_geometry - poly;
 
     m_skin_geometry += temp_geometry;
 }
@@ -241,8 +231,7 @@ void Skin::computeGradualSkinSteps(const int& gradual_count) {
     if (m_gradual_geometry_includes_top && m_gradual_geometry.size() < gradual_count) {
         m_gradual_skin_geometry.push_back(m_geometry - m_skin_geometry - currentGradual);
 
-        while (m_gradual_skin_geometry.size() < gradual_count)
-            m_gradual_skin_geometry.push_back(PolygonList());
+        while (m_gradual_skin_geometry.size() < gradual_count) m_gradual_skin_geometry.push_back(PolygonList());
     }
 }
 
@@ -274,7 +263,7 @@ void Skin::optimize(int layerNumber, Point& current_location, bool& shouldNextPa
     poo.setConsecutiveReferencePoint(getPreviousLayerStartPoint());
 
     m_paths.clear();
-    bool supportsG3 = m_sb->setting<bool>(PRS::MachineSetup::kSupportG3);
+    bool supportsG3            = m_sb->setting<bool>(PRS::MachineSetup::kSupportG3);
     InfillPatterns skinPattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Skin::kPattern));
     optimizeHelper(poo, supportsG3, current_location, skinPattern, m_computed_geometry, m_skin_geometry,
                    pathOrderOptimization);
@@ -321,16 +310,14 @@ Path Skin::createPath(Polyline line, InfillPatterns pattern) {
     const bool is_closed_path = pattern == InfillPatterns::kConcentric;
 
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Skin::kMinSegmentLength), is_closed_path);
-    if (line.size() < (is_closed_path ? 3 : 2)) {
-        return Path();
-    }
+    if (line.size() < (is_closed_path ? 3 : 2)) { return Path(); }
 
-    Distance width = m_sb->setting<Distance>(PS::Skin::kBeadWidth);
-    Distance height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    Velocity speed = m_sb->setting<Velocity>(PS::Skin::kSpeed);
-    Acceleration acceleration = m_sb->setting<Acceleration>(PRS::Acceleration::kInfill);
+    Distance width                 = m_sb->setting<Distance>(PS::Skin::kBeadWidth);
+    Distance height                = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    Velocity speed                 = m_sb->setting<Velocity>(PS::Skin::kSpeed);
+    Acceleration acceleration      = m_sb->setting<Acceleration>(PRS::Acceleration::kInfill);
     AngularVelocity extruder_speed = m_sb->setting<AngularVelocity>(PS::Skin::kExtruderSpeed);
-    int material_number = m_sb->setting<int>(MS::MultiMaterial::kSkinNum);
+    int material_number            = m_sb->setting<int>(MS::MultiMaterial::kSkinNum);
 
     Path newPath;
     for (int i = 0; i < line.size() - 1; i++) {
@@ -367,16 +354,22 @@ Path Skin::createPath(Polyline line, InfillPatterns pattern) {
     return newPath;
 }
 
-void Skin::addUpperGeometry(const PolygonList& poly_list) { m_upper_geometry.push_back(poly_list); }
+void Skin::addUpperGeometry(const PolygonList& poly_list) {
+    m_upper_geometry.push_back(poly_list);
+}
 
-void Skin::addLowerGeometry(const PolygonList& poly_list) { m_lower_geometry.push_back(poly_list); }
+void Skin::addLowerGeometry(const PolygonList& poly_list) {
+    m_lower_geometry.push_back(poly_list);
+}
 
-void Skin::addGradualGeometry(const PolygonList& poly_list) { m_gradual_geometry.push_back(poly_list); }
+void Skin::addGradualGeometry(const PolygonList& poly_list) {
+    m_gradual_geometry.push_back(poly_list);
+}
 
 void Skin::setGeometryIncludes(bool top, bool bottom, bool gradual) {
-    m_upper_geometry_includes_top = top;
+    m_upper_geometry_includes_top    = top;
     m_lower_geometry_includes_bottom = bottom;
-    m_gradual_geometry_includes_top = gradual;
+    m_gradual_geometry_includes_top  = gradual;
 }
 
 void Skin::calculateModifiers(Path& path, bool supportsG3) {
@@ -464,4 +457,4 @@ void Skin::calculateModifiers(Path& path, bool supportsG3) {
         }
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/skirt.cpp
+++ b/src/step/layer/regions/skirt.cpp
@@ -34,9 +34,7 @@ QString Skirt::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kSkirt);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kSkirt);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kSkirt);
     }
     gcode += writer->writeAfterRegion(RegionType::kSkirt);
@@ -48,11 +46,11 @@ void Skirt::compute(uint layer_num) {
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum));
 
-    Distance beadWidth = m_sb->setting<Distance>(MS::PlatformAdhesion::kSkirtBeadWidth);
-    int rings = m_sb->setting<int>(MS::PlatformAdhesion::kSkirtLoops);
+    Distance beadWidth    = m_sb->setting<Distance>(MS::PlatformAdhesion::kSkirtBeadWidth);
+    int rings             = m_sb->setting<int>(MS::PlatformAdhesion::kSkirtLoops);
     Distance skirt_offset = m_sb->setting<Distance>(MS::PlatformAdhesion::kSkirtDistanceFromObject);
-    Distance min_length = m_sb->setting<Distance>(MS::PlatformAdhesion::kSkirtMinLength);
-    Distance totalDist = 0;
+    Distance min_length   = m_sb->setting<Distance>(MS::PlatformAdhesion::kSkirtMinLength);
+    Distance totalDist    = 0;
 
     // construct skirp loops from the inner most loop, going outwards
     QVector<PolygonList> skirtLoops;
@@ -65,8 +63,7 @@ void Skirt::compute(uint layer_num) {
         totalDist += path_line.totalLength();
         // on the outer most loop, check if the total printed distance is long enough, if not, add loops
         if (ring_nr == rings - 1) {
-            if (min_length > totalDist)
-                rings++;
+            if (min_length > totalDist) rings++;
         }
     }
 
@@ -114,7 +111,7 @@ void Skirt::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
     while (poo.getCurrentPolylineCount() > 0) {
         Polyline result = poo.linkNextPolyline();
-        Path newPath = createPath(result);
+        Path newPath    = createPath(result);
 
         if (newPath.size() > 0) {
             calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3));
@@ -133,16 +130,16 @@ void Skirt::calculateModifiers(Path& path, bool supportsG3) {
 Path Skirt::createPath(Polyline line) {
     Path new_path;
 
-    Distance default_width = m_sb->setting<Distance>(MS::PlatformAdhesion::kRaftBeadWidth);
-    Distance default_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    Velocity default_speed = m_sb->setting<Velocity>(PS::Layer::kSpeed);
-    Acceleration default_acceleration = m_sb->setting<Acceleration>(PRS::Acceleration::kDefault);
+    Distance default_width                 = m_sb->setting<Distance>(MS::PlatformAdhesion::kRaftBeadWidth);
+    Distance default_height                = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    Velocity default_speed                 = m_sb->setting<Velocity>(PS::Layer::kSpeed);
+    Acceleration default_acceleration      = m_sb->setting<Acceleration>(PRS::Acceleration::kDefault);
     AngularVelocity default_extruder_speed = m_sb->setting<AngularVelocity>(PS::Layer::kExtruderSpeed);
-    int material_number = m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum);
+    int material_number                    = m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum);
 
     for (int i = 0, end_cond = line.size(); i < end_cond; ++i) {
         Point start = line[i];
-        Point end = line[(i + 1) % end_cond];
+        Point end   = line[(i + 1) % end_cond];
 
         bool is_settings_region = false;
 
@@ -155,12 +152,9 @@ Path Skirt::createPath(Polyline line) {
                 start.setSettings(updatedBase);
                 is_settings_region = true;
             }
-            else {
-                start.setSettings(m_sb);
-            }
+            else { start.setSettings(m_sb); }
 
-            if (settings_poly.inside(end))
-                end.setSettings(updatedBase);
+            if (settings_poly.inside(end)) end.setSettings(updatedBase);
 
             // Find if/ where this line intersects with a settings polygon
             QVector<Point> poly_intersect = settings_poly.clipLine(start, end);
@@ -175,8 +169,7 @@ Path Skirt::createPath(Polyline line) {
 
             for (Point& point : intersections) {
                 // If no settings change, skip this point
-                if (point.getSettings()->json() == m_sb->json())
-                    continue;
+                if (point.getSettings()->json() == m_sb->json()) continue;
 
                 QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(start, point);
 
@@ -205,7 +198,7 @@ Path Skirt::createPath(Polyline line) {
 
                 new_path.append(segment);
                 is_settings_region = !is_settings_region;
-                start = point;
+                start              = point;
             }
         }
 
@@ -235,11 +228,7 @@ Path Skirt::createPath(Polyline line) {
         new_path.append(segment);
     }
 
-    if (new_path.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) {
-        return new_path;
-    }
-    else {
-        return Path();
-    }
+    if (new_path.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) { return new_path; }
+    else { return Path(); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/support.cpp
+++ b/src/step/layer/regions/support.cpp
@@ -33,9 +33,7 @@ QString Support::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kSupport);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kSupport);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kSupport);
     }
     gcode += writer->writeAfterRegion(RegionType::kSupport);
@@ -49,29 +47,27 @@ void Support::compute(uint layer_num) {
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum));
 
-    Distance bead_width = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
-    Distance line_spacing = m_sb->setting<Distance>(PS::Support::kLineSpacing);
-    Area min_infill_area = m_sb->setting<Area>(PS::Support::kMinInfillArea);
-    InfillPatterns infill_pattern = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Support::kPattern));
-    const bool is_interface = m_sb->setting<bool>(PS::Support::kInterfaceRegion);
-    const bool is_base = m_sb->setting<bool>(PS::Support::kBaseRegion);
-    const bool is_tube_wall = m_sb->setting<bool>(PS::Support::kTubeWallRegion);
-    const bool is_dense = is_interface || is_base;
+    Distance bead_width            = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
+    Distance line_spacing          = m_sb->setting<Distance>(PS::Support::kLineSpacing);
+    Area min_infill_area           = m_sb->setting<Area>(PS::Support::kMinInfillArea);
+    InfillPatterns infill_pattern  = static_cast<InfillPatterns>(m_sb->setting<int>(PS::Support::kPattern));
+    const bool is_interface        = m_sb->setting<bool>(PS::Support::kInterfaceRegion);
+    const bool is_base             = m_sb->setting<bool>(PS::Support::kBaseRegion);
+    const bool is_tube_wall        = m_sb->setting<bool>(PS::Support::kTubeWallRegion);
+    const bool is_dense            = is_interface || is_base;
     const Angle interface_rotation = is_dense && layer_num % 2 == 1 ? 90 * deg : 0 * deg;
 
-    if (bead_width <= 0)
-        return;
+    if (bead_width <= 0) return;
 
     if (is_tube_wall) {
-        const int contour_count = qMax(1, m_sb->setting<int>(PS::Support::kTaperWallContours));
+        const int contour_count            = qMax(1, m_sb->setting<int>(PS::Support::kTaperWallContours));
         const PolygonList outer_boundaries = m_geometry.externalPolygonBoundaries();
         for (int contour = 0; contour < contour_count; ++contour) {
-            const Distance inset = bead_width / 2.0 + bead_width * contour;
+            const Distance inset               = bead_width / 2.0 + bead_width * contour;
             const PolygonList contour_geometry = outer_boundaries.offset(-inset);
             for (Polygon polygon : contour_geometry) {
                 Polyline line = polygon.toPolyline();
-                if (line.size() > 1)
-                    m_computed_perimeter_geometry.push_back(line);
+                if (line.size() > 1) m_computed_perimeter_geometry.push_back(line);
             }
         }
         return;
@@ -80,17 +76,15 @@ void Support::compute(uint layer_num) {
     // Invalid spacing previously caused an endless loop in support pattern
     // generation.  Falling back to two bead widths keeps old/incomplete
     // profiles printable while preserving sparse support.
-    if (line_spacing <= 0)
-        line_spacing = bead_width * 2.0;
+    if (line_spacing <= 0) line_spacing = bead_width * 2.0;
 
     const PolygonList support_geometry = m_geometry;
-    const int wall_contours = is_dense ? 1 : qMax(1, m_sb->setting<int>(PS::Support::kWallContours));
+    const int wall_contours            = is_dense ? 1 : qMax(1, m_sb->setting<int>(PS::Support::kWallContours));
     for (int contour = 0; contour < wall_contours; ++contour) {
         const Distance inset = bead_width / 2.0 + bead_width * contour;
         for (Polygon poly : support_geometry.offset(-inset)) {
             Polyline line = poly.toPolyline();
-            if (line.size() > 1)
-                m_computed_perimeter_geometry.push_back(line);
+            if (line.size() > 1) m_computed_perimeter_geometry.push_back(line);
         }
     }
 
@@ -103,7 +97,7 @@ void Support::compute(uint layer_num) {
                 computeLine(line_spacing, interface_rotation);
                 break;
             case InfillPatterns::kGrid:
-                computeGrid(line_spacing); // Default rotation angle = 0 deg
+                computeGrid(line_spacing);  // Default rotation angle = 0 deg
                 break;
             default:
                 // Support exposes Lines and Grid.  Treat stale or malformed
@@ -115,12 +109,11 @@ void Support::compute(uint layer_num) {
 }
 
 void Support::computeLine(Distance line_spacing, Angle rotation) {
-    const Distance bead_width = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
+    const Distance bead_width   = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
     PolygonList border_polygons = m_geometry.offset(-bead_width);
     if (!border_polygons.isEmpty()) {
         QVector<Polyline> lines = PatternGenerator::GenerateLines(border_polygons, line_spacing, rotation);
-        if (!lines.isEmpty())
-            m_computed_infill_geometry.push_back(lines);
+        if (!lines.isEmpty()) m_computed_infill_geometry.push_back(lines);
     }
 }
 
@@ -167,8 +160,7 @@ void Support::optimize(int layerNumber, Point& current_location, bool& shouldNex
 
     while (poo.getCurrentPolylineCount() > 0) {
         Polyline result = poo.linkNextPolyline();
-        if (result.size() > 2 && result.first() != result.last())
-            result.push_back(result.first());
+        if (result.size() > 2 && result.first() != result.last()) result.push_back(result.first());
         Path newPath = createPath(result);
 
         if (newPath.size() > 0) {
@@ -218,23 +210,19 @@ void Support::calculateModifiers(Path& path, bool supportsG3) {
 Path Support::createPath(Polyline line) {
     const bool is_closed_path = line.size() > 2 && line.first() == line.last();
     line = line.removeShortSegments(m_sb->setting<Distance>(PS::Support::kMinSegmentLength), is_closed_path);
-    if (line.size() < (is_closed_path ? 4 : 2)) {
-        return Path();
-    }
+    if (line.size() < (is_closed_path ? 4 : 2)) { return Path(); }
 
-    Distance bead_width = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
-    Distance layer_height = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
-    Velocity speed = m_sb->setting<Velocity>(PS::Layer::kSpeed);
-    Acceleration acceleration = m_sb->setting<Acceleration>(PRS::Acceleration::kSupport);
+    Distance bead_width            = m_sb->setting<Distance>(PS::Layer::kBeadWidth);
+    Distance layer_height          = m_sb->setting<Distance>(PS::Layer::kLayerHeight);
+    Velocity speed                 = m_sb->setting<Velocity>(PS::Layer::kSpeed);
+    Acceleration acceleration      = m_sb->setting<Acceleration>(PRS::Acceleration::kSupport);
     AngularVelocity extruder_speed = m_sb->setting<AngularVelocity>(PS::Layer::kExtruderSpeed);
-    int material_number = m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum);
+    int material_number            = m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum);
 
     Path newPath;
 
     for (int i = 0; i + 1 < line.size(); ++i) {
-        if (line[i] == line[i + 1]) {
-            continue;
-        }
+        if (line[i] == line[i + 1]) { continue; }
 
         QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(line[i], line[i + 1]);
         segment->getSb()->setSetting(MS::Extruder::kInitialSpeed, m_sb->setting<int>(MS::Extruder::kInitialSpeed));
@@ -248,11 +236,7 @@ Path Support::createPath(Polyline line) {
         newPath.append(segment);
     }
 
-    if (newPath.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) {
-        return newPath;
-    }
-    else {
-        return Path();
-    }
+    if (newPath.calculateLength() > m_sb->setting<Distance>(PS::Layer::kMinExtrudeLength)) { return newPath; }
+    else { return Path(); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/regions/thermal_scan.cpp
+++ b/src/step/layer/regions/thermal_scan.cpp
@@ -27,9 +27,7 @@ QString ThermalScan::writeGCode(QSharedPointer<WriterBase> writer) {
     gcode += writer->writeBeforeRegion(RegionType::kThermalScan);
     for (Path path : m_paths) {
         gcode += writer->writeBeforePath(RegionType::kThermalScan);
-        for (QSharedPointer<SegmentBase> segment : path.getSegments()) {
-            gcode += segment->writeGCode(writer);
-        }
+        for (QSharedPointer<SegmentBase> segment : path.getSegments()) { gcode += segment->writeGCode(writer); }
         gcode += writer->writeAfterPath(RegionType::kThermalScan);
     }
     gcode += writer->writeAfterRegion(RegionType::kThermalScan);
@@ -69,4 +67,4 @@ Path ThermalScan::createPath(Polyline line) {
 
     return newPath;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/step/layer/scan_layer.cpp
+++ b/src/step/layer/scan_layer.cpp
@@ -28,7 +28,7 @@
 namespace ORNL {
 
 ScanLayer::ScanLayer(int layer, const QSharedPointer<SettingsBase>& sb) : m_layer_num(layer), Step(sb) {
-    m_type = StepType::kScan;
+    m_type          = StepType::kScan;
     m_first_connect = false;
 }
 
@@ -62,8 +62,8 @@ QString ScanLayer::writeGCode(QSharedPointer<WriterBase> writer) {
     if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QTextStream stream(&file);
 
-        Point widthHeight = m_geometry.max() - m_geometry.min();
-        Distance stepDistance = getSb()->setting<Distance>(PS::LaserScanner::kLaserScannerStepDistance);
+        Point widthHeight       = m_geometry.max() - m_geometry.min();
+        Distance stepDistance   = getSb()->setting<Distance>(PS::LaserScanner::kLaserScannerStepDistance);
         Distance lineResolution = getSb()->setting<Distance>(PS::LaserScanner::kLaserScanLineResolution);
 
         stream << "P||" % QString::number(Distance(m_geometry.min().x()).to(mm), 'f', 4) % '|' %
@@ -95,9 +95,7 @@ QString ScanLayer::writeGCode(QSharedPointer<WriterBase> writer) {
 }
 
 void ScanLayer::compute() {
-    for (QSharedPointer<IslandBase> island : m_islands) {
-        island->compute(m_layer_num);
-    }
+    for (QSharedPointer<IslandBase> island : m_islands) { island->compute(m_layer_num); }
 }
 
 void ScanLayer::connectPaths(Point& start, int& start_index, QVector<QSharedPointer<RegionBase>>& previousRegions) {
@@ -134,15 +132,13 @@ void ScanLayer::calculateModifiers(Point& point) {
 }
 
 Point ScanLayer::getEndLocation() {
-
     for (auto& island : m_islands) {
         auto regions = island->getRegions();
         for (int region_index = regions.size() - 1; region_index >= 0; region_index--) {
             auto paths = regions[region_index]->getPaths();
             for (int path_index = paths.size() - 1; path_index >= 0; path_index--) {
                 auto path = paths[path_index];
-                if (path.size() > 0)
-                    return path.back()->end();
+                if (path.size() > 0) return path.back()->end();
             }
         }
     }
@@ -152,8 +148,7 @@ Point ScanLayer::getEndLocation() {
 void ScanLayer::unorient() {
     if (!this->isDirty()) {
         for (QSharedPointer<IslandBase> island : m_islands) {
-
-            Point m_half_shift = m_shift_amount;
+            Point m_half_shift   = m_shift_amount;
             Distance scan_height = island->getSb()->setting<Distance>(PS::LaserScanner::kLaserScannerHeight) -
                                    island->getSb()->setting<Distance>(PS::LaserScanner::kLaserScannerHeightOffset);
 
@@ -177,13 +172,11 @@ void ScanLayer::reorient() {
     // unapply origin shift
     Point m_origin_shift = Point(.0, .0, .0) - m_shift_amount;
     m_origin_shift.z(.0);
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(QQuaternion(), m_origin_shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(QQuaternion(), m_origin_shift); }
 
     // raise the layer by half the layer height, because cross-sections are taken at the center of a layer
     // but the path for the extruder should be at a full layer height
-    Point m_half_shift = m_shift_amount;
+    Point m_half_shift   = m_shift_amount;
     Distance scan_height = m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerHeight) -
                            m_sb->setting<Distance>(PS::LaserScanner::kLaserScannerHeightOffset);
 
@@ -193,20 +186,19 @@ void ScanLayer::reorient() {
 
     // rotate and then shift every island in the layer
     QQuaternion rotation = MathUtils::CreateQuaternion(QVector3D(0, 0, 1), m_slicing_plane.normal());
-    for (QSharedPointer<IslandBase> island : getIslands()) {
-        island->transform(rotation, m_half_shift);
-    }
+    for (QSharedPointer<IslandBase> island : getIslands()) { island->transform(rotation, m_half_shift); }
 }
 
 float ScanLayer::getMinZ() {
     float min_z = std::numeric_limits<float>::max();
     for (QSharedPointer<IslandBase> island : m_islands) {
         float island_min = island->getMinZ();
-        if (island_min < min_z)
-            min_z = island_min;
+        if (island_min < min_z) min_z = island_min;
     }
     return min_z;
 }
 
-void ScanLayer::setFirst() { m_first_connect = true; }
-} // namespace ORNL
+void ScanLayer::setFirst() {
+    m_first_connect = true;
+}
+}  // namespace ORNL

--- a/src/step/step.cpp
+++ b/src/step/step.cpp
@@ -1,6 +1,7 @@
 #include "step/step.h"
 
 #include <QFileInfo>
+
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qsharedpointer.h>
@@ -18,30 +19,42 @@ Step::Step(const QSharedPointer<SettingsBase>& sb) : m_sb(sb), m_dirty_bit(true)
     // NOP
 }
 
-QSharedPointer<SettingsBase> Step::getSb() const { return m_sb; }
+QSharedPointer<SettingsBase> Step::getSb() const {
+    return m_sb;
+}
 
-void Step::setSb(const QSharedPointer<SettingsBase>& sb) { m_sb = sb; }
+void Step::setSb(const QSharedPointer<SettingsBase>& sb) {
+    m_sb = sb;
+}
 
-void Step::setDirtyBit(bool dirty) { m_dirty_bit = dirty; }
+void Step::setDirtyBit(bool dirty) {
+    m_dirty_bit = dirty;
+}
 
-bool Step::isDirty() { return m_dirty_bit; }
+bool Step::isDirty() {
+    return m_dirty_bit;
+}
 
-StepType Step::getType() { return m_type; }
+StepType Step::getType() {
+    return m_type;
+}
 
-void Step::setType(StepType type) { m_type = type; }
+void Step::setType(StepType type) {
+    m_type = type;
+}
 
 void Step::flagIfDirtySettings(const QSharedPointer<SettingsBase>& sb) {
-    if (m_sb->json() != sb->json()) {
-        this->setDirtyBit(true);
-    }
+    if (m_sb->json() != sb->json()) { this->setDirtyBit(true); }
 }
 
 void Step::setOrientation(Plane slicing_plane, Point shift) {
     m_slicing_plane = slicing_plane;
-    m_shift_amount = shift;
+    m_shift_amount  = shift;
 }
 
-void Step::setGeometry(const PolygonList& geometry, const QVector3D& averageNormal) { m_geometry = geometry; }
+void Step::setGeometry(const PolygonList& geometry, const QVector3D& averageNormal) {
+    m_geometry = geometry;
+}
 
 void Step::addIsland(IslandType type, QSharedPointer<IslandBase> island) {
     m_islands.insert(static_cast<int>(type), island);
@@ -50,37 +63,37 @@ void Step::addIsland(IslandType type, QSharedPointer<IslandBase> island) {
 void Step::updateIslands(IslandType type, QVector<QSharedPointer<IslandBase>> islands) {
     m_islands.remove(static_cast<int>(type));
 
-    for (QSharedPointer<IslandBase> isl : islands) {
-        m_islands.insert(static_cast<int>(type), isl);
-    }
+    for (QSharedPointer<IslandBase> isl : islands) { m_islands.insert(static_cast<int>(type), isl); }
 }
 
-const PolygonList& Step::getGeometry() const { return m_geometry; }
+const PolygonList& Step::getGeometry() const {
+    return m_geometry;
+}
 
-QVector3D Step::getNormal() { return m_slicing_plane.normal(); }
+QVector3D Step::getNormal() {
+    return m_slicing_plane.normal();
+}
 
-Point Step::getShift() { return m_shift_amount; }
+Point Step::getShift() {
+    return m_shift_amount;
+}
 
-Plane Step::getSlicingPlane() { return m_slicing_plane; }
+Plane Step::getSlicingPlane() {
+    return m_slicing_plane;
+}
 
 void Step::setCompanionFileLocation(QDir path) {
     path.setNameFilters(QStringList() << "*.dat");
     path.setFilter(QDir::Files);
 
-    for (QString oldFile : path.entryList()) {
-        path.remove(oldFile);
-    }
+    for (QString oldFile : path.entryList()) { path.remove(oldFile); }
 
     m_path = path;
 }
 
 QList<QSharedPointer<IslandBase>> Step::getIslands(IslandType type) {
-    if (type == IslandType::kAll) {
-        return m_islands.values();
-    }
-    else {
-        return m_islands.values(static_cast<int>(type));
-    }
+    if (type == IslandType::kAll) { return m_islands.values(); }
+    else { return m_islands.values(static_cast<int>(type)); }
 }
 
 void Step::setRaftShift(QVector3D shift) {
@@ -88,5 +101,7 @@ void Step::setRaftShift(QVector3D shift) {
     m_shift_amount += shift;
 }
 
-QVector3D Step::getRaftShift() { return m_raft_shift; }
-} // namespace ORNL
+QVector3D Step::getRaftShift() {
+    return m_raft_shift;
+}
+}  // namespace ORNL

--- a/src/threading/abs_slicing_thread.cpp
+++ b/src/threading/abs_slicing_thread.cpp
@@ -1,14 +1,14 @@
 #include "threading/abs_slicing_thread.h"
 
+#include <QApplication>
+#include <QStringBuilder>
+#include <QTextStream>
 #include <algorithm>
 #include <climits>
 #include <exception>
 #include <limits>
 #include <memory>
 
-#include <QApplication>
-#include <QStringBuilder>
-#include <QTextStream>
 #include <qdebug.h>
 #include <qfiledevice.h>
 #include <qfileinfo.h>
@@ -134,7 +134,7 @@ GcodeMeta metaForSyntax(GcodeSyntax syntax) {
 std::unique_ptr<CommonParser> makeLayerTimeParser(GcodeSyntax syntax, QStringList& original_lines,
                                                   QStringList& upper_lines) {
     constexpr bool kAllowLayerAlter = true;
-    const GcodeMeta meta = metaForSyntax(syntax);
+    const GcodeMeta meta            = metaForSyntax(syntax);
 
     switch (syntax) {
         case GcodeSyntax::kAML3D:
@@ -174,7 +174,7 @@ QString layerTimeComment(const GcodeMeta& meta, Time layer_time) {
            QString("ORNL_SLICER_LAYER_TIME_ESTIMATE=%1").arg(layer_time.to(s), 0, 'f', 3) %
            meta.m_comment_ending_delimiter;
 }
-} // namespace
+}  // namespace
 
 AbstractSlicingThread::AbstractSlicingThread(QString outputLocation, bool skipGcode)
     : QObject(), m_min(0), m_max(INT_MAX), m_should_cancel(false) {
@@ -195,11 +195,17 @@ void AbstractSlicingThread::setBounds(int min, int max) {
     m_max = max;
 }
 
-int AbstractSlicingThread::getMinBound() { return m_min; }
+int AbstractSlicingThread::getMinBound() {
+    return m_min;
+}
 
-int AbstractSlicingThread::getMaxBound() { return m_max; }
+int AbstractSlicingThread::getMaxBound() {
+    return m_max;
+}
 
-qint64 AbstractSlicingThread::getTimeElapsed() { return m_elapsed_time; }
+qint64 AbstractSlicingThread::getTimeElapsed() {
+    return m_elapsed_time;
+}
 
 void AbstractSlicingThread::setGcodeOutput(QString output) {
     m_syntax = GSM->getGlobal()->setting<GcodeSyntax>(PRS::MachineSetup::kSyntax);
@@ -317,7 +323,9 @@ void AbstractSlicingThread::setGcodeOutput(QString output) {
     m_temp_gcode_dir = fi.absoluteDir();
 }
 
-void AbstractSlicingThread::setCancel() { m_should_cancel = true; }
+void AbstractSlicingThread::setCancel() {
+    m_should_cancel = true;
+}
 
 bool AbstractSlicingThread::shouldCancel() {
     if (m_should_cancel) {
@@ -329,9 +337,13 @@ bool AbstractSlicingThread::shouldCancel() {
     return false;
 }
 
-void AbstractSlicingThread::setMaxSteps(int steps) { m_max_steps = steps; }
+void AbstractSlicingThread::setMaxSteps(int steps) {
+    m_max_steps = steps;
+}
 
-int AbstractSlicingThread::getMaxSteps() { return m_max_steps; }
+int AbstractSlicingThread::getMaxSteps() {
+    return m_max_steps;
+}
 
 void AbstractSlicingThread::forwardStatus(StatusUpdateStepType type, int completedPercentage) {
     emit statusUpdate(type, completedPercentage);
@@ -346,20 +358,18 @@ void AbstractSlicingThread::writeGCodeSetup() {
     bool has_part_bounds = false;
 
     for (QSharedPointer<Part> curr_part : CSM->parts()) {
-        if (curr_part->rootMesh()->type() == MeshType::kClipping) // Skip parts that were used for clipping
+        if (curr_part->rootMesh()->type() == MeshType::kClipping)  // Skip parts that were used for clipping
             continue;
 
-        minimum_x = std::min(minimum_x, curr_part->rootMesh()->min().x());
-        minimum_y = std::min(minimum_y, curr_part->rootMesh()->min().y());
-        maximum_x = std::max(maximum_x, curr_part->rootMesh()->max().x());
-        maximum_y = std::max(maximum_y, curr_part->rootMesh()->max().y());
-        maximum_z = std::max(maximum_z, curr_part->rootMesh()->max().z());
+        minimum_x       = std::min(minimum_x, curr_part->rootMesh()->min().x());
+        minimum_y       = std::min(minimum_y, curr_part->rootMesh()->min().y());
+        maximum_x       = std::max(maximum_x, curr_part->rootMesh()->max().x());
+        maximum_y       = std::max(maximum_y, curr_part->rootMesh()->max().y());
+        maximum_z       = std::max(maximum_z, curr_part->rootMesh()->max().z());
         has_part_bounds = true;
     }
 
-    if (has_part_bounds) {
-        m_base->setBuildMaximumZ(Distance(maximum_z));
-    }
+    if (has_part_bounds) { m_base->setBuildMaximumZ(Distance(maximum_z)); }
 
     stream << m_base->writeSlicerHeader(toString(m_syntax));
     stream << m_base->writeSettingsHeader(m_syntax);
@@ -371,8 +381,7 @@ void AbstractSlicingThread::writeGCodeShutdown() {
     {
         QTextStream stream(&m_temp_gcode_output_file);
         stream << m_base->writeShutdown();
-        if (m_syntax != GcodeSyntax::kMVP)
-            stream << m_base->writeSettingsFooter();
+        if (m_syntax != GcodeSyntax::kMVP) stream << m_base->writeSettingsFooter();
         stream.flush();
     }
     writeLayerTimeComments();
@@ -380,9 +389,7 @@ void AbstractSlicingThread::writeGCodeShutdown() {
 }
 
 void AbstractSlicingThread::writeLayerTimeComments() {
-    if (!GSM->getGlobal()->setting<bool>(PRS::GCode::kLayerTimeComments)) {
-        return;
-    }
+    if (!GSM->getGlobal()->setting<bool>(PRS::GCode::kLayerTimeComments)) { return; }
 
     const QString file_name = m_temp_gcode_output_file.fileName();
     if (!m_temp_gcode_output_file.isOpen() || !m_temp_gcode_output_file.flush() || !m_temp_gcode_output_file.seek(0)) {
@@ -398,7 +405,7 @@ void AbstractSlicingThread::writeLayerTimeComments() {
 
     try {
         QStringList original_lines = text.split('\n');
-        QStringList upper_lines = text.toUpper().split('\n');
+        QStringList upper_lines    = text.toUpper().split('\n');
 
         std::unique_ptr<CommonParser> parser = makeLayerTimeParser(m_syntax, original_lines, upper_lines);
         parser->parseHeader();
@@ -406,9 +413,7 @@ void AbstractSlicingThread::writeLayerTimeComments() {
         parser->parseLines();
 
         const QList<Time> adjusted_layer_times = parser->getAdjustedLayerTimes();
-        if (adjusted_layer_times.isEmpty()) {
-            return;
-        }
+        if (adjusted_layer_times.isEmpty()) { return; }
 
         const GcodeMeta meta = metaForSyntax(m_syntax);
         const QRegularExpression layer_marker("^\\s*" + QRegularExpression::escape(meta.m_comment_starting_delimiter) +
@@ -416,25 +421,19 @@ void AbstractSlicingThread::writeLayerTimeComments() {
                                               QRegularExpression::CaseInsensitiveOption);
 
         QStringList annotated_lines = text.split('\n');
-        int layer_marker_count = 0;
+        int layer_marker_count      = 0;
         for (const QString& line : annotated_lines) {
-            if (layer_marker.match(line).hasMatch()) {
-                ++layer_marker_count;
-            }
+            if (layer_marker.match(line).hasMatch()) { ++layer_marker_count; }
         }
 
         const int layer_time_offset = adjusted_layer_times.size() > layer_marker_count ? 1 : 0;
         for (int line_index = 0; line_index < annotated_lines.size(); ++line_index) {
             const QRegularExpressionMatch match = layer_marker.match(annotated_lines[line_index]);
-            if (!match.hasMatch()) {
-                continue;
-            }
+            if (!match.hasMatch()) { continue; }
 
-            bool converted = false;
+            bool converted             = false;
             const int layer_time_index = match.captured(1).toInt(&converted) - 1 + layer_time_offset;
-            if (!converted || layer_time_index < 0 || layer_time_index >= adjusted_layer_times.size()) {
-                continue;
-            }
+            if (!converted || layer_time_index < 0 || layer_time_index >= adjusted_layer_times.size()) { continue; }
 
             annotated_lines.insert(line_index + 1, layerTimeComment(meta, adjusted_layer_times[layer_time_index]));
             ++line_index;
@@ -453,4 +452,4 @@ void AbstractSlicingThread::writeLayerTimeComments() {
         return;
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_adamantine_saver.cpp
+++ b/src/threading/gcode_adamantine_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 
 #include "gcode/gcode_meta.h"
@@ -30,7 +31,7 @@ void GCodeAdamantineSaver::run() {
         // modify m_text to remove comments and triple returns
         m_text.remove(comments)
             .remove(tripleReturns)
-            .replace(doubleReturns, "\n"); //.remove(tripleReturns).remove(doubleReturns);
+            .replace(doubleReturns, "\n");  //.remove(tripleReturns).remove(doubleReturns);
         // move the last two lines to the top of the file
         QStringList lines = m_text.split("\n");
         lines.removeFirst();
@@ -42,13 +43,11 @@ void GCodeAdamantineSaver::run() {
         lines.prepend(lastLine);
         lines.prepend(secondToLastLine);
         // write text to out file
-        for (QString line : lines) {
-            out << line << "\n";
-        }
+        for (QString line : lines) { out << line << "\n"; }
         // close file
         tempFile.close();
         QFile::rename(tempFile.fileName(), m_filename);
     }
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_amcm_saver.cpp
+++ b/src/threading/gcode_amcm_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qmath.h>
@@ -107,9 +108,7 @@ void GCodeAMCMSaver::run() {
                newline;
     out << "PTP {A1 2.22261,A2 -70.64010,A3 83.97050,A4 103.99200,A5 44.42060,A6 -109.23300,E1 0.00000} C_PTP" %
                newline;
-    if (GSM->getGlobal()->setting<int>(ES::FileOutput::kAMCMDataLogging)) {
-        out << "Logging_Enabled=TRUE" % newline;
-    }
+    if (GSM->getGlobal()->setting<int>(ES::FileOutput::kAMCMDataLogging)) { out << "Logging_Enabled=TRUE" % newline; }
 
     QString line;
 
@@ -119,8 +118,8 @@ void GCodeAMCMSaver::run() {
             velocity = QString::number(
                 GSM->getGlobal()->setting<Velocity>(PS::Travel::kSpeed).to(m_selected_meta.m_velocity_unit) / 1000.0 /
                     60.0,
-                'f', 4); // Meta uses mm/min, but AMCM needs m/s
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+                'f', 4);  // Meta uses mm/min, but AMCM needs m/s
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G0) {
@@ -143,7 +142,7 @@ void GCodeAMCMSaver::run() {
                        ", E1 0.000} C_DIS" % newline;
         }
         else if (line.startsWith(G1)) {
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G1) {
@@ -202,11 +201,9 @@ void GCodeAMCMSaver::run() {
     }
 
     out << "CHAMP_EXTR_SYNC=FALSE" % newline;
-    if (GSM->getGlobal()->setting<int>(ES::FileOutput::kAMCMDataLogging)) {
-        out << "Logging_Enabled=FALSE" % newline;
-    }
+    if (GSM->getGlobal()->setting<int>(ES::FileOutput::kAMCMDataLogging)) { out << "Logging_Enabled=FALSE" % newline; }
     out << newline % "END";
     file.close();
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_aml3d_saver.cpp
+++ b/src/threading/gcode_aml3d_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qobject.h>
@@ -33,9 +34,9 @@ void GCodeAML3DSaver::run() {
         4);
     zval = QString::number(
         GSM->getGlobal()->setting<Distance>(PRS::Dimensions::kZMax).to(m_selected_meta.m_distance_unit), 'f', 4);
-    feedrate = QString::number(0);
-    layerNum = 0;
-    pointNum = 0;
+    feedrate    = QString::number(0);
+    layerNum    = 0;
+    pointNum    = 0;
     weaveLength = QString::number(
         GSM->getGlobal()->setting<Distance>(ES::FileOutput::kAML3DWeaveLength).to(m_selected_meta.m_distance_unit), 'f',
         4);
@@ -43,7 +44,7 @@ void GCodeAML3DSaver::run() {
         GSM->getGlobal()->setting<Distance>(ES::FileOutput::kAML3DWeaveWidth).to(m_selected_meta.m_distance_unit), 'f',
         4);
 
-    int start = 0;
+    int start      = 0;
     bool endOfFile = false;
     // While loop should always evaluate true, but need a way to contain the file operations
     // so that multiple files can be opened, written to, and closed within the parsing of the g-code lines
@@ -82,9 +83,7 @@ void GCodeAML3DSaver::run() {
             // The BEGINNING LAYER string denotes the start of a new layer which means we need a new file
             if (lines[i].contains("BEGINNING LAYER")) {
                 // Ignore the start of the first layer
-                if (lines[i].contains("(BEGINNING LAYER: 1)")) {
-                    continue;
-                }
+                if (lines[i].contains("(BEGINNING LAYER: 1)")) { continue; }
 
                 break;
             }
@@ -128,12 +127,10 @@ void GCodeAML3DSaver::run() {
                 }
 
                 // Read the travel lower Z line just to extract the Z height and save it for future lines
-                if (lines[i].contains("TRAVEL LOWER Z")) {
-                    continue;
-                }
+                if (lines[i].contains("TRAVEL LOWER Z")) { continue; }
 
                 pointNum++;
-                beadOutput = QString::number(beadNum);
+                beadOutput  = QString::number(beadNum);
                 pointOutput = QString::number(pointNum);
                 out << beadOutput % comma % pointOutput % comma % xval % comma % yval % comma % zval % comma %
                            zeroString % comma % zeroString % comma % zeroString % comma % zeroString % comma %
@@ -144,9 +141,8 @@ void GCodeAML3DSaver::run() {
 
         file.close();
 
-        if (endOfFile)
-            break;
+        if (endOfFile) break;
     }
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -1,15 +1,15 @@
 #include "threading/gcode_loader.h"
 
-#include <cmath>
-#include <limits>
-#include <optional>
-#include <tuple>
-
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
 #include <QStringBuilder>
 #include <QTextStream>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <tuple>
+
 #include <qcolor.h>
 #include <qcontainerfwd.h>
 #include <qdatetime.h>
@@ -64,24 +64,18 @@ namespace {
 Distance beadWidthFromRegionComment(const QString& comment, const QString& region_name, Distance fallback_width,
                                     Distance distance_unit) {
     const int region_start = comment.indexOf(region_name);
-    if (region_start < 0) {
-        return fallback_width;
-    }
+    if (region_start < 0) { return fallback_width; }
 
     const int width_start = comment.indexOf('-', region_start + region_name.size());
 
     if (width_start >= 0) {
         const int value_start = width_start + 1;
-        int value_end = comment.indexOf(' ', value_start);
-        if (value_end < 0) {
-            value_end = comment.size();
-        }
+        int value_end         = comment.indexOf(' ', value_start);
+        if (value_end < 0) { value_end = comment.size(); }
 
-        bool ok = false;
+        bool ok                   = false;
         const double parsed_width = comment.mid(value_start, value_end - value_start).toDouble(&ok);
-        if (ok && parsed_width > 0) {
-            return parsed_width * distance_unit;
-        }
+        if (ok && parsed_width > 0) { return parsed_width * distance_unit; }
     }
 
     return fallback_width;
@@ -91,25 +85,21 @@ float beadDisplayWidth(Distance bead_width) {
     return static_cast<float>(bead_width()) * Constants::OpenGL::kObjectToView;
 }
 
-const QString kCylindricalAxisXComment = "AXIS_X=";
-const QString kCylindricalAxisYComment = "AXIS_Y=";
-const QString kWorldApproachTravelComment = "WORLD APPROACH TRAVEL";
+const QString kCylindricalAxisXComment            = "AXIS_X=";
+const QString kCylindricalAxisYComment            = "AXIS_Y=";
+const QString kWorldApproachTravelComment         = "WORLD APPROACH TRAVEL";
 constexpr char kArcSpecialtiesCpOptionalParameter = 'C';
 
 bool commentFieldValue(const QString& comment, const QString& field, double& value) {
     const int field_start = comment.indexOf(field, 0, Qt::CaseInsensitive);
-    if (field_start < 0) {
-        return false;
-    }
+    if (field_start < 0) { return false; }
 
     const int value_start = field_start + field.size();
-    int value_end = value_start;
-    while (value_end < comment.size() && !comment[value_end].isSpace()) {
-        ++value_end;
-    }
+    int value_end         = value_start;
+    while (value_end < comment.size() && !comment[value_end].isSpace()) { ++value_end; }
 
     bool ok = false;
-    value = comment.mid(value_start, value_end - value_start).toDouble(&ok);
+    value   = comment.mid(value_start, value_end - value_start).toDouble(&ok);
     return ok;
 }
 
@@ -133,23 +123,23 @@ bool isCylindricalPrintComment(const QString& comment) {
             comment.contains(Constants::RegionTypeStrings::kHelical, Qt::CaseInsensitive)) &&
            !comment.contains(Constants::RegionTypeStrings::kTravel, Qt::CaseInsensitive);
 }
-} // namespace
+}  // namespace
 
 GCodeLoader::GCodeLoader(QString filename, bool alterFile)
     : m_filename(filename), m_adjust_file(alterFile), m_should_cancel(false) {
     m_sb = GSM->getGlobal();
 
-    m_prestart = QStringMatcher(Constants::PathModifierStrings::kPrestart.toUpper());
+    m_prestart        = QStringMatcher(Constants::PathModifierStrings::kPrestart.toUpper());
     m_initial_startup = QStringMatcher(Constants::PathModifierStrings::kInitialStartup.toUpper());
-    m_slowdown = QStringMatcher(Constants::PathModifierStrings::kSlowDown.toUpper());
+    m_slowdown        = QStringMatcher(Constants::PathModifierStrings::kSlowDown.toUpper());
     m_forward_tipwipe = QStringMatcher(Constants::PathModifierStrings::kForwardTipWipe.toUpper());
     m_reverse_tipwipe = QStringMatcher(Constants::PathModifierStrings::kReverseTipWipe.toUpper());
-    m_angled_tipwipe = QStringMatcher(Constants::PathModifierStrings::kAngledTipWipe.toUpper());
-    m_coasting = QStringMatcher(Constants::PathModifierStrings::kCoasting.toUpper());
-    m_spirallift = QStringMatcher(Constants::PathModifierStrings::kSpiralLift.toUpper());
-    m_rampingup = QStringMatcher(Constants::PathModifierStrings::kRampingUp.toUpper());
-    m_rampingdown = QStringMatcher(Constants::PathModifierStrings::kRampingDown.toUpper());
-    m_leadin = QStringMatcher(Constants::PathModifierStrings::kLeadIn.toUpper());
+    m_angled_tipwipe  = QStringMatcher(Constants::PathModifierStrings::kAngledTipWipe.toUpper());
+    m_coasting        = QStringMatcher(Constants::PathModifierStrings::kCoasting.toUpper());
+    m_spirallift      = QStringMatcher(Constants::PathModifierStrings::kSpiralLift.toUpper());
+    m_rampingup       = QStringMatcher(Constants::PathModifierStrings::kRampingUp.toUpper());
+    m_rampingdown     = QStringMatcher(Constants::PathModifierStrings::kRampingDown.toUpper());
+    m_leadin          = QStringMatcher(Constants::PathModifierStrings::kLeadIn.toUpper());
 
     m_modifier_colors.push_back(
         PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kPrestart));
@@ -173,24 +163,24 @@ GCodeLoader::GCodeLoader(QString filename, bool alterFile)
         PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kRampingDown));
     m_modifier_colors.push_back(PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kLeadIn));
 
-    m_perimeter = QStringMatcher(Constants::RegionTypeStrings::kPerimeter.toUpper());
-    m_radial = QStringMatcher(Constants::RegionTypeStrings::kRadial.toUpper());
-    m_helical = QStringMatcher(Constants::RegionTypeStrings::kHelical.toUpper());
-    m_inset = QStringMatcher(Constants::RegionTypeStrings::kInset.toUpper());
-    m_infill = QStringMatcher(Constants::RegionTypeStrings::kInfill.toUpper());
-    m_skin = QStringMatcher(Constants::RegionTypeStrings::kSkin.toUpper());
-    m_skeleton = QStringMatcher(Constants::RegionTypeStrings::kSkeleton.toUpper());
-    m_support = QStringMatcher(Constants::RegionTypeStrings::kSupport.toUpper());
+    m_perimeter    = QStringMatcher(Constants::RegionTypeStrings::kPerimeter.toUpper());
+    m_radial       = QStringMatcher(Constants::RegionTypeStrings::kRadial.toUpper());
+    m_helical      = QStringMatcher(Constants::RegionTypeStrings::kHelical.toUpper());
+    m_inset        = QStringMatcher(Constants::RegionTypeStrings::kInset.toUpper());
+    m_infill       = QStringMatcher(Constants::RegionTypeStrings::kInfill.toUpper());
+    m_skin         = QStringMatcher(Constants::RegionTypeStrings::kSkin.toUpper());
+    m_skeleton     = QStringMatcher(Constants::RegionTypeStrings::kSkeleton.toUpper());
+    m_support      = QStringMatcher(Constants::RegionTypeStrings::kSupport.toUpper());
     m_support_roof = QStringMatcher(Constants::RegionTypeStrings::kSupportRoof.toUpper());
-    m_travel = QStringMatcher(Constants::RegionTypeStrings::kTravel.toUpper());
-    m_raft = QStringMatcher(Constants::RegionTypeStrings::kRaft.toUpper());
-    m_brim = QStringMatcher(Constants::RegionTypeStrings::kBrim.toUpper());
-    m_skirt = QStringMatcher(Constants::RegionTypeStrings::kSkirt.toUpper());
-    m_laserscan = QStringMatcher(Constants::RegionTypeStrings::kLaserScan.toUpper());
-    m_thermalscan = QStringMatcher(Constants::RegionTypeStrings::kThermalScan.toUpper());
+    m_travel       = QStringMatcher(Constants::RegionTypeStrings::kTravel.toUpper());
+    m_raft         = QStringMatcher(Constants::RegionTypeStrings::kRaft.toUpper());
+    m_brim         = QStringMatcher(Constants::RegionTypeStrings::kBrim.toUpper());
+    m_skirt        = QStringMatcher(Constants::RegionTypeStrings::kSkirt.toUpper());
+    m_laserscan    = QStringMatcher(Constants::RegionTypeStrings::kLaserScan.toUpper());
+    m_thermalscan  = QStringMatcher(Constants::RegionTypeStrings::kThermalScan.toUpper());
 
     m_color_space_conversion = 1.0 / 255.0;
-    m_layer_pattern = QRegularExpression("W*(\\d+)W*");
+    m_layer_pattern          = QRegularExpression("W*(\\d+)W*");
 }
 
 QString GCodeLoader::additionalExportComments() {
@@ -215,16 +205,16 @@ QString GCodeLoader::additionalExportComments() {
                              QString::number(translationMin.z() / 1000000, 'f', 4) % " m" % closingDelim % "\n";
     }
 
-    QString travelTypes = openingDelim % "Travel Types:";
+    QString travelTypes  = openingDelim % "Travel Types:";
     QString travelColors = openingDelim % "Travel Colors:";
     for (const auto& color : PreferencesManager::getInstance()->getVisualizationHexColors()) {
-        travelTypes = travelTypes % " " % QString::fromStdString(color.first);
+        travelTypes  = travelTypes % " " % QString::fromStdString(color.first);
         travelColors = travelColors % " " % QString::fromStdString(color.second).right(6);
     }
-    travelTypes = travelTypes % closingDelim % "\n";
+    travelTypes  = travelTypes % closingDelim % "\n";
     travelColors = travelColors % closingDelim % "\n";
 
-    if (m_selected_meta == GcodeMetaList::TormachMeta) // Tormach can't handle parsing the travel types and colors
+    if (m_selected_meta == GcodeMetaList::TormachMeta)  // Tormach can't handle parsing the travel types and colors
     {
         return partMinTranslation;
     }
@@ -242,9 +232,9 @@ void GCodeLoader::run() {
             QFile inputFile(m_filename);
             if (inputFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
                 QTextStream in(&inputFile);
-                text = in.readAll();
+                text             = in.readAll();
                 m_original_lines = text.split("\n");
-                m_lines = text.toUpper().split("\n");
+                m_lines          = text.toUpper().split("\n");
                 inputFile.close();
             }
             else {
@@ -266,18 +256,18 @@ void GCodeLoader::run() {
             QList<QList<GcodeCommand>> m_motion_commands = m_parser->parseLines();
 
             if (m_parser->getWasModified()) {
-                text = m_original_lines.join("\n");
+                text    = m_original_lines.join("\n");
                 m_lines = text.toUpper().split("\n");
             }
 
-            QList<Time> layer_times = m_parser->getLayerTimes();
+            QList<Time> layer_times          = m_parser->getLayerTimes();
             QList<Time> adjusted_layer_times = m_parser->getAdjustedLayerTimes();
             QList<double> layer_FR_modifiers = m_parser->getLayerFeedRateModifiers();
-            QList<Volume> layer_volumes = m_parser->getLayerVolumes();
+            QList<Volume> layer_volumes      = m_parser->getLayerVolumes();
 
             Volume total_volume;
-            min_time = std::numeric_limits<int>::max();
-            max_time = std::numeric_limits<int>::min();
+            min_time          = std::numeric_limits<int>::max();
+            max_time          = std::numeric_limits<int>::min();
             adjusted_min_time = std::numeric_limits<int>::max();
             adjusted_max_time = std::numeric_limits<int>::min();
 
@@ -287,7 +277,7 @@ void GCodeLoader::run() {
                 min_time = qMin(current, min_time);
                 max_time = qMax(current, max_time);
 
-                temp_time = adjusted_layer_times[i];
+                temp_time         = adjusted_layer_times[i];
                 adjusted_min_time = qMin(temp_time, adjusted_min_time);
                 adjusted_max_time = qMax(temp_time, adjusted_max_time);
 
@@ -341,31 +331,30 @@ void GCodeLoader::run() {
                       QString::number(travelDistanceValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" %
                       "Total Travel Time Estimate: " % MathUtils::formattedTimeSpan(m_parser->getTravelTime()()) %
-                      "\n" % "Total Distance: " %
-                      QString::number(distanceValue) % " " %
+                      "\n" % "Total Distance: " % QString::number(distanceValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" % "Approximate Weight (" %
                       toString(m_material) % "): " % QString::number(massValue) % " " %
                       PreferencesManager::getInstance()->getMassUnit().toString() % "\n";
 
             QTime qt(0, 0);
-            qt = qt.addMSecs(CSM->getSliceTimeElapsed());
+            qt      = qt.addMSecs(CSM->getSliceTimeElapsed());
             keyInfo = keyInfo % "Total Slice Time (excluding gcode writing/parsing): " % qt.toString("hh:mm:ss.zzz");
 
             emit forwardInfoToMainWindow(keyInfo);
 
-            m_x_offset = visualizationSettings[PRS::Dimensions::kXOffset];
-            m_y_offset = visualizationSettings[PRS::Dimensions::kYOffset];
-            const Distance& z_offset = visualizationSettings[PRS::Dimensions::kZOffset];
-            const Distance& z_min = GSM->getGlobal()->setting<Distance>(PRS::Dimensions::kZMin);
-            m_z_offset = (z_min - z_offset)() * Constants::OpenGL::kObjectToView;
-            m_start_pos = QVector3D(m_x_offset * Constants::OpenGL::kObjectToView,
-                                    m_y_offset * Constants::OpenGL::kObjectToView, 0.0f);
-            m_origin = QVector3D(m_x_offset, m_y_offset, 0.0f);
-            m_table_offset = 0.0f;
-            m_prev_table_offset = 0.0f;
+            m_x_offset                             = visualizationSettings[PRS::Dimensions::kXOffset];
+            m_y_offset                             = visualizationSettings[PRS::Dimensions::kYOffset];
+            const Distance& z_offset               = visualizationSettings[PRS::Dimensions::kZOffset];
+            const Distance& z_min                  = GSM->getGlobal()->setting<Distance>(PRS::Dimensions::kZMin);
+            m_z_offset                             = (z_min - z_offset)() * Constants::OpenGL::kObjectToView;
+            m_start_pos                            = QVector3D(m_x_offset * Constants::OpenGL::kObjectToView,
+                                                               m_y_offset * Constants::OpenGL::kObjectToView, 0.0f);
+            m_origin                               = QVector3D(m_x_offset, m_y_offset, 0.0f);
+            m_table_offset                         = 0.0f;
+            m_prev_table_offset                    = 0.0f;
             m_has_arc_specialties_cylindrical_axis = false;
             m_arc_specialties_cylindrical_axis_matches_current_path = false;
-            m_has_previous_arc_specialties_cp = false;
+            m_has_previous_arc_specialties_cp                       = false;
 
             // reserve more memory than the hash will need to guarantee no reallocation
             QHash<QString, QTextCharFormat> fontColors;
@@ -380,7 +369,7 @@ void GCodeLoader::run() {
             // Set layer specific settings. Currently only supports a single part.
             if (CSM->parts().size() == 1) {
                 // Retrieve the settings ranges for the first part
-                const QSharedPointer<Part>& part = CSM->parts().first();
+                const QSharedPointer<Part>& part                   = CSM->parts().first();
                 const QList<QSharedPointer<SettingsRange>>& ranges = part->getSettingsRanges().values();
 
                 // Populate the layer settings for each range
@@ -389,9 +378,7 @@ void GCodeLoader::run() {
                     sb->populate(GSM->getGlobal());
                     sb->populate(range->getSb());
 
-                    for (uint layer = range->low(); layer <= range->high(); layer++) {
-                        layer_settings[layer + 1] = sb;
-                    }
+                    for (uint layer = range->low(); layer <= range->high(); layer++) { layer_settings[layer + 1] = sb; }
                 }
             }
 
@@ -403,9 +390,9 @@ void GCodeLoader::run() {
                 total_commands += layer_commands.size();
             }
 
-            qint64 commands_processed = 0;
+            qint64 commands_processed       = 0;
             int last_visualization_progress = -1;
-            auto emitVisualizationProgress = [this, &last_visualization_progress](int progress) {
+            auto emitVisualizationProgress  = [this, &last_visualization_progress](int progress) {
                 progress = qBound(0, progress, 99);
                 if (progress != last_visualization_progress) {
                     emit updateDialog(StatusUpdateStepType::kVisualization, progress);
@@ -458,9 +445,7 @@ void GCodeLoader::run() {
                             (static_cast<double>(commands_processed) / static_cast<double>(total_commands)) * 100.0));
                     }
 
-                    if (m_should_cancel) {
-                        return;
-                    }
+                    if (m_should_cancel) { return; }
                 }
                 layers.push_back(layer);
                 ++current_layer;
@@ -469,9 +454,7 @@ void GCodeLoader::run() {
                     emitVisualizationProgress(static_cast<int>((double)current_layer / (double)total_layer * 100.0));
                 }
 
-                if (m_should_cancel) {
-                    return;
-                }
+                if (m_should_cancel) { return; }
             }
 
             // emit vector for visualization
@@ -481,8 +464,8 @@ void GCodeLoader::run() {
             // send text and font colors for display, and line numbers for easy editor navigation
             emit gcodeLoadedText(text, fontColors, m_parser->getLayerStartLines());
 
-            QString openingDelim = m_selected_meta.m_comment_starting_delimiter;
-            QString closingDelim = m_selected_meta.m_comment_ending_delimiter;
+            QString openingDelim          = m_selected_meta.m_comment_starting_delimiter;
+            QString closingDelim          = m_selected_meta.m_comment_ending_delimiter;
             QString additionalHeaderBlock = openingDelim % "Sliced on: " %
                                             QDateTime::currentDateTime().toString("MM/dd/yyyy") % closingDelim % "\n" %
                                             openingDelim % "Expected Weight: " % weightInfo % closingDelim % "\n";
@@ -511,11 +494,9 @@ void GCodeLoader::run() {
                 if (tempFile.open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
                     QTextStream out(&tempFile);
                     out << additionalHeaderBlock;
-                    for (QString& line : m_original_lines) {
-                        out << line << "\n";
-                    }
+                    for (QString& line : m_original_lines) { out << line << "\n"; }
                     tempFile.close();
-                    bool ret = QFile::remove(m_filename);
+                    bool ret        = QFile::remove(m_filename);
                     QString tempStr = tempFile.fileName();
 
                     ret = QFile::rename(tempFile.fileName(), m_filename);
@@ -531,9 +512,7 @@ void GCodeLoader::run() {
 
 void GCodeLoader::cancelSlice() {
     m_should_cancel = true;
-    if (m_parser.get() != nullptr) {
-        m_parser->cancelSlice();
-    }
+    if (m_parser.get() != nullptr) { m_parser->cancelSlice(); }
 }
 
 void GCodeLoader::forwardDialogUpdate(StatusUpdateStepType type, int percentComplete) {
@@ -543,7 +522,7 @@ void GCodeLoader::forwardDialogUpdate(StatusUpdateStepType type, int percentComp
 // at this moment, parsing the header is simply to find the syntax
 void GCodeLoader::setParser(QStringList& originalLines, QStringList& lines) {
     int m_current_line = 0;
-    bool foundSyntax = false;
+    bool foundSyntax   = false;
     QStringMatcher syntaxIdentifier1("G-CODE SYNTAX");
     QStringMatcher syntaxIdentifier2("GCODE SYNTAX");
     while (m_current_line < m_lines.size()) {
@@ -598,11 +577,12 @@ void GCodeLoader::setParser(QStringList& originalLines, QStringList& lines) {
                 m_parser.reset(new MarlinParser(GcodeMetaList::MarlinMeta, m_adjust_file, originalLines, lines));
                 m_selected_meta = GcodeMetaList::MarlinMeta;
             }
-            else if (m_lines[m_current_line].contains(toString(GcodeSyntax::kMach4).toUpper())) { // Mach4 uses Marlin
+            else if (m_lines[m_current_line].contains(toString(GcodeSyntax::kMach4).toUpper())) {  // Mach4 uses Marlin
                 m_parser.reset(new MarlinParser(GcodeMetaList::MarlinMeta, m_adjust_file, originalLines, lines));
                 m_selected_meta = GcodeMetaList::MarlinMeta;
             }
-            else if (m_lines[m_current_line].contains(toString(GcodeSyntax::kRepRap).toUpper())) { // RepRap uses Marlin
+            else if (m_lines[m_current_line].contains(
+                         toString(GcodeSyntax::kRepRap).toUpper())) {  // RepRap uses Marlin
                 m_parser.reset(new MarlinParser(GcodeMetaList::RepRapMeta, m_adjust_file, originalLines, lines));
                 m_selected_meta = GcodeMetaList::RepRapMeta;
             }
@@ -681,9 +661,7 @@ void GCodeLoader::setParser(QStringList& originalLines, QStringList& lines) {
             foundSyntax = true;
         }
         ++m_current_line;
-        if (foundSyntax) {
-            break;
-        }
+        if (foundSyntax) { break; }
     }
 
     if (!foundSyntax) {
@@ -693,7 +671,6 @@ void GCodeLoader::setParser(QStringList& originalLines, QStringList& lines) {
 }
 
 QColor GCodeLoader::determineFontColor(const QString& comment) {
-
     if (m_prestart.indexIn(comment) != -1) {
         return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kPrestart);
     }
@@ -775,13 +752,9 @@ QColor GCodeLoader::determineFontColor(const QString& comment) {
 
 QColor GCodeLoader::determineSegmentColor(int command_id, const QString& comment) {
     QColor color = determineFontColor(comment);
-    if (command_id != 2 && command_id != 3) {
-        return color;
-    }
+    if (command_id != 2 && command_id != 3) { return color; }
 
-    if (containsColorPriorityModifier(comment)) {
-        return color;
-    }
+    if (containsColorPriorityModifier(comment)) { return color; }
 
     if (m_perimeter.indexIn(comment) != -1) {
         return PreferencesManager::getInstance()->getVisualizationColor(VisualizationColors::kPerimeterArc);
@@ -806,12 +779,8 @@ bool GCodeLoader::containsColorPriorityModifier(const QString& comment) const {
 SegmentDisplayType GCodeLoader::determineSegmentDisplayType(const QString& comment) {
     SegmentDisplayType type = SegmentDisplayType::kNone;
 
-    if (m_travel.indexIn(comment) != -1) {
-        type |= SegmentDisplayType::kTravel;
-    }
-    if (m_support.indexIn(comment) != -1) {
-        type |= SegmentDisplayType::kSupport;
-    }
+    if (m_travel.indexIn(comment) != -1) { type |= SegmentDisplayType::kTravel; }
+    if (m_support.indexIn(comment) != -1) { type |= SegmentDisplayType::kSupport; }
 
     return type == SegmentDisplayType::kNone ? SegmentDisplayType::kLine : type;
 }
@@ -820,11 +789,11 @@ void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, Se
                                         const QColor& color, const QString& comment, const QVector3D& start_pos,
                                         const QVector3D& end_pos, const int& line_num, const int& layer_num) {
     // Set the display info of the segment
-    float display_width = 0.0f;
+    float display_width  = 0.0f;
     float display_height = m_sb->setting<float>(PS::Layer::kLayerHeight) * Constants::OpenGL::kObjectToView;
     float display_length = start_pos.distanceToPoint(end_pos);
     float scale =
-        m_modifier_colors.contains(color) ? 1.1f : 1.0f; // Scale modifier segments by 1.1 for better visibility
+        m_modifier_colors.contains(color) ? 1.1f : 1.0f;  // Scale modifier segments by 1.1 for better visibility
 
     // Set the display width of the segment based on its region type
     if (comment.contains(Constants::RegionTypeStrings::kRadial) ||
@@ -858,7 +827,7 @@ void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, Se
     else if (comment.contains("INFILL")) {
         display_width = m_sb->setting<float>(PS::Infill::kBeadWidth) * Constants::OpenGL::kObjectToView;
     }
-    else { // Default to layer bead width
+    else {  // Default to layer bead width
         display_width = m_sb->setting<float>(PS::Layer::kBeadWidth) * Constants::OpenGL::kObjectToView;
     }
 
@@ -875,28 +844,20 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
 
     // Set the start and end position info of the segment
     segment->m_segment_info_meta.start = m_info_start_pos;
-    segment->m_segment_info_meta.end = info_end_pos;
+    segment->m_segment_info_meta.end   = info_end_pos;
 
     // If deposition is active, retain the current speed metadata for the segment.
-    if (!deposition_active && !info_speed_set) {
-        segment->m_segment_info_meta.speed = "";
-    }
-    else {
-        segment->m_segment_info_meta.speed = m_info_speed;
-    }
+    if (!deposition_active && !info_speed_set) { segment->m_segment_info_meta.speed = ""; }
+    else { segment->m_segment_info_meta.speed = m_info_speed; }
 
     // If deposition is active, set the material feed speed metadata.
     if (deposition_active) {
         if (m_info_extruder_speed.isEmpty()) {
             segment->m_segment_info_meta.extruderSpeed = QString().asprintf("%0.4f", extruder_speed) % " rpm";
         }
-        else {
-            segment->m_segment_info_meta.extruderSpeed = m_info_extruder_speed;
-        }
+        else { segment->m_segment_info_meta.extruderSpeed = m_info_extruder_speed; }
     }
-    else {
-        segment->m_segment_info_meta.extruderSpeed = "";
-    }
+    else { segment->m_segment_info_meta.extruderSpeed = ""; }
 
     // Set the length info of the segment
 
@@ -906,24 +867,23 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
         QString().asprintf("%0.2f", length) % " " % PreferencesManager::getInstance()->getDistanceUnitText();
 }
 
-QVector<QSharedPointer<SegmentBase>>
-GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& color, int command_id,
-                                   const QMap<char, double>& parameters, bool deposition_active, double extruder_speed,
-                                   bool include_non_deposition_moves, QString comment,
-                                   const QMap<char, double>& optional_parameters) {
+QVector<QSharedPointer<SegmentBase>> GCodeLoader::generateVisualSegment(
+    int line_num, int layer_num, const QColor& color, int command_id, const QMap<char, double>& parameters,
+    bool deposition_active, double extruder_speed, bool include_non_deposition_moves, QString comment,
+    const QMap<char, double>& optional_parameters) {
     // Parameters for drawing and placing each segment in the world correctly
-    QVector3D end_pos = m_start_pos;
-    QVector3D info_end_pos = m_info_start_pos;
-    bool info_speed_set = false;
+    QVector3D end_pos             = m_start_pos;
+    QVector3D info_end_pos        = m_info_start_pos;
+    bool info_speed_set           = false;
     const bool is_arc_specialties = m_selected_meta.m_syntax_id == GcodeSyntax::kArcSpecialties;
-    const bool has_current_cp = optional_parameters.contains(kArcSpecialtiesCpOptionalParameter);
+    const bool has_current_cp     = optional_parameters.contains(kArcSpecialtiesCpOptionalParameter);
     const double current_cp = has_current_cp ? optional_parameters.value(kArcSpecialtiesCpOptionalParameter) : 0.0;
 
     if (parameters.contains('F')) {
         info_speed_set = true;
-        m_info_speed = QString().asprintf("%0.4f", (Velocity(parameters['F']) /
-                                                    PreferencesManager::getInstance()->getVelocityUnit())()) %
-                       " " % PreferencesManager::getInstance()->getVelocityUnitText();
+        m_info_speed   = QString().asprintf("%0.4f", (Velocity(parameters['F']) /
+                                                      PreferencesManager::getInstance()->getVelocityUnit())()) %
+                         " " % PreferencesManager::getInstance()->getVelocityUnitText();
     }
     if (parameters.contains('S')) {
         m_info_extruder_speed = QString().asprintf("%0.4f", (AngularVelocity(parameters['S']) /
@@ -932,14 +892,14 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
     }
     if (parameters.contains('W')) {
         m_prev_table_offset = m_table_offset;
-        m_table_offset = parameters['W'] * Constants::OpenGL::kObjectToView;
+        m_table_offset      = parameters['W'] * Constants::OpenGL::kObjectToView;
 
         // we don't draw segments for commands that are just table shifts, so only update end_pos if XY changes too
         if (parameters.contains('X') || parameters.contains('Y')) {
             end_pos.setZ(m_start_pos.z() + m_prev_table_offset - m_table_offset);
             m_prev_table_offset =
                 parameters['W'] *
-                Constants::OpenGL::kObjectToView; // accounted for the table offset, so no need for prev
+                Constants::OpenGL::kObjectToView;  // accounted for the table offset, so no need for prev
         }
     }
 
@@ -990,8 +950,8 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
     const bool is_world_approach_travel =
         is_arc_specialties && comment.compare(kWorldApproachTravelComment, Qt::CaseInsensitive) == 0;
     if (is_world_approach_travel && parameters.contains('X') && parameters.contains('Y')) {
-        m_arc_specialties_cylindrical_axis = Point(end_pos.x(), end_pos.y(), 0.0);
-        m_has_arc_specialties_cylindrical_axis = true;
+        m_arc_specialties_cylindrical_axis                      = Point(end_pos.x(), end_pos.y(), 0.0);
+        m_has_arc_specialties_cylindrical_axis                  = true;
         m_arc_specialties_cylindrical_axis_matches_current_path = true;
     }
 
@@ -1005,27 +965,27 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
         QSharedPointer<SegmentBase> segment;
 
         // Builds and draws segments according to their type (Line, Arc, Spline)
-        if (command_id == 2 || command_id == 3) { // G2 clockwise arc & G3 counter-clockwise arc
+        if (command_id == 2 || command_id == 3) {  // G2 clockwise arc & G3 counter-clockwise arc
             // Parse extra params
             Point center;
 
             if (parameters.contains('R') && !parameters.contains('I') && !parameters.contains('J')) {
-                const double radius = parameters['R'] * Constants::OpenGL::kObjectToView;
-                const double abs_radius = qAbs(radius);
-                const double dx = end_pos.x() - m_start_pos.x();
-                const double dy = end_pos.y() - m_start_pos.y();
-                const double chord_length = std::hypot(dx, dy);
-                const double half_chord = chord_length / 2.0;
+                const double radius                = parameters['R'] * Constants::OpenGL::kObjectToView;
+                const double abs_radius            = qAbs(radius);
+                const double dx                    = end_pos.x() - m_start_pos.x();
+                const double dy                    = end_pos.y() - m_start_pos.y();
+                const double chord_length          = std::hypot(dx, dy);
+                const double half_chord            = chord_length / 2.0;
                 const double center_offset_squared = (abs_radius * abs_radius) - (half_chord * half_chord);
 
                 if (chord_length > std::numeric_limits<double>::epsilon() && center_offset_squared >= 0.0) {
                     const double center_offset = qSqrt(center_offset_squared);
-                    const double mid_x = (m_start_pos.x() + end_pos.x()) / 2.0;
-                    const double mid_y = (m_start_pos.y() + end_pos.y()) / 2.0;
+                    const double mid_x         = (m_start_pos.x() + end_pos.x()) / 2.0;
+                    const double mid_y         = (m_start_pos.y() + end_pos.y()) / 2.0;
                     const double left_normal_x = -dy / chord_length;
                     const double left_normal_y = dx / chord_length;
                     const bool use_left_center = (command_id == 3) == (radius >= 0.0);
-                    const double direction = use_left_center ? 1.0 : -1.0;
+                    const double direction     = use_left_center ? 1.0 : -1.0;
 
                     center.x(mid_x + (direction * left_normal_x * center_offset));
                     center.y(mid_y + (direction * left_normal_y * center_offset));
@@ -1041,14 +1001,12 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
                 if (parameters.contains('K')) {
                     center.z(m_start_pos.z() + ((parameters['K']) * Constants::OpenGL::kObjectToView));
                 }
-                else {
-                    center.z(m_start_pos.z());
-                }
+                else { center.z(m_start_pos.z()); }
 
                 segment = QSharedPointer<ArcSegment>::create(m_start_pos, end_pos, center, (command_id == 3));
             }
         }
-        else if (command_id == 5) { // G5 splines
+        else if (command_id == 5) {  // G5 splines
             Point control_a;
             Point control_b;
 
@@ -1062,13 +1020,11 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
                 segment = QSharedPointer<BezierSegment>::create(m_start_pos, control_a, control_b, end_pos);
             }
         }
-        else { // G0, G1, or anything else is drawn as a line
+        else {  // G0, G1, or anything else is drawn as a line
             segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos);
         }
 
-        if (segment.isNull()) {
-            segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos);
-        }
+        if (segment.isNull()) { segment = QSharedPointer<LineSegment>::create(m_start_pos, end_pos); }
 
         segment->setDepositionActive(deposition_active);
 
@@ -1084,7 +1040,7 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
                 has_cylindrical_axis = true;
             }
             else if (ArcSegment* arc_segment = dynamic_cast<ArcSegment*>(segment.data())) {
-                cylindrical_axis = arc_segment->center();
+                cylindrical_axis     = arc_segment->center();
                 has_cylindrical_axis = true;
             }
             else if (is_arc_specialties && m_has_previous_arc_specialties_cp && has_current_cp) {
@@ -1102,15 +1058,15 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
             }
             if (!has_cylindrical_axis && is_arc_specialties && m_has_arc_specialties_cylindrical_axis &&
                 m_arc_specialties_cylindrical_axis_matches_current_path) {
-                cylindrical_axis = m_arc_specialties_cylindrical_axis;
+                cylindrical_axis     = m_arc_specialties_cylindrical_axis;
                 has_cylindrical_axis = true;
             }
 
             if (has_cylindrical_axis) {
                 segment->setCylindricalBeadCenter(cylindrical_axis);
                 if (is_arc_specialties) {
-                    m_arc_specialties_cylindrical_axis = cylindrical_axis;
-                    m_has_arc_specialties_cylindrical_axis = true;
+                    m_arc_specialties_cylindrical_axis                      = cylindrical_axis;
+                    m_has_arc_specialties_cylindrical_axis                  = true;
                     m_arc_specialties_cylindrical_axis_matches_current_path = true;
                 }
             }
@@ -1123,13 +1079,13 @@ GCodeLoader::generateVisualSegment(int line_num, int layer_num, const QColor& co
         generated_segments.append(segment);
     }
     // Update our start position for the next command
-    m_start_pos = end_pos;
+    m_start_pos      = end_pos;
     m_info_start_pos = info_end_pos;
     if (is_arc_specialties && has_current_cp) {
-        m_previous_arc_specialties_cp = current_cp;
+        m_previous_arc_specialties_cp     = current_cp;
         m_has_previous_arc_specialties_cp = true;
     }
 
     return generated_segments;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_marlin_saver.cpp
+++ b/src/threading/gcode_marlin_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qobject.h>
@@ -56,12 +57,12 @@ void GCodeMarlinSaver::run() {
     for (QString line : lines) {
         isTravel = "0";
         if (line.startsWith(G1)) {
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (line.contains("TRAVEL") || line.contains("TIP WIPE") || line.contains("COAST") ||
                 line.contains("LIFT") || line.contains("FLYING START")) {
-                isTravel = "1";
+                isTravel        = "1";
                 extrusionAmount = "0.0";
             }
 
@@ -75,7 +76,7 @@ void GCodeMarlinSaver::run() {
                         zval = params[i].mid(1);
                     else if (params[i].startsWith(f))
                         feedrate = params[i].mid(1);
-                    else if (params[i].startsWith(e)) // Note that extrusion values aren't currently being used
+                    else if (params[i].startsWith(e))  // Note that extrusion values aren't currently being used
                         extrusionAmount = params[i].mid(1);
                 }
             }
@@ -93,27 +94,26 @@ void GCodeMarlinSaver::run() {
                 zFeedrate = "0.0";
             else
                 zFeedrate = feedrate;
-            if (previousExtrusionAmount == extrusionAmount)
-                extrusionAmount = "0.0";
+            if (previousExtrusionAmount == extrusionAmount) extrusionAmount = "0.0";
 
             // Convert mm to m and mm/min to m/s
-            double mm = xval.toDouble();
-            mm = mm / 1000;
-            xOut = QString::number(mm);
-            mm = yval.toDouble();
-            mm = mm / 1000;
-            yOut = QString::number(mm);
-            mm = zval.toDouble();
-            mm = mm / 1000;
-            zOut = QString::number(mm);
-            mm = xFeedrate.toDouble();
-            mm = mm / 60 / 1000;
+            double mm    = xval.toDouble();
+            mm           = mm / 1000;
+            xOut         = QString::number(mm);
+            mm           = yval.toDouble();
+            mm           = mm / 1000;
+            yOut         = QString::number(mm);
+            mm           = zval.toDouble();
+            mm           = mm / 1000;
+            zOut         = QString::number(mm);
+            mm           = xFeedrate.toDouble();
+            mm           = mm / 60 / 1000;
             xFeedrateOut = QString::number(mm);
-            mm = yFeedrate.toDouble();
-            mm = mm / 60 / 1000;
+            mm           = yFeedrate.toDouble();
+            mm           = mm / 60 / 1000;
             yFeedrateOut = QString::number(mm);
-            mm = zFeedrate.toDouble();
-            mm = mm / 60 / 1000;
+            mm           = zFeedrate.toDouble();
+            mm           = mm / 60 / 1000;
             zFeedrateOut = QString::number(mm);
 
             // Write output
@@ -131,13 +131,13 @@ void GCodeMarlinSaver::run() {
             }
 
             // Store current value as previous value
-            previousX = xval;
-            previousY = yval;
-            previousZ = zval;
+            previousX               = xval;
+            previousY               = yval;
+            previousZ               = zval;
             previousExtrusionAmount = extrusionAmount;
         }
     }
     file.close();
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_meld_saver.cpp
+++ b/src/threading/gcode_meld_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qobject.h>
@@ -53,7 +54,7 @@ void GCodeMeldSaver::run() {
 
     for (QString line : lines) {
         if (line.startsWith(G0) || line.startsWith(G1) || line.startsWith(M24) || line.startsWith(M25)) {
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G0) {
@@ -80,13 +81,11 @@ void GCodeMeldSaver::run() {
                     }
                 }
             }
-            if (params[0] == M25) {
-                feedrate = QString::number(0);
-            }
+            if (params[0] == M25) { feedrate = QString::number(0); }
             out << xval % comma % yval % comma % zval % comma % velocity % comma % feedrate % newline;
         }
     }
     file.close();
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_sandia_saver.cpp
+++ b/src/threading/gcode_sandia_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qobject.h>
@@ -25,7 +26,7 @@ GCodeSandiaSaver::GCodeSandiaSaver(QString tempLocation, QString path, QString f
 void GCodeSandiaSaver::run() {
     // First, get necessary parameters from settings to rotate all pathing
     QChar comma(','), newline('\n'), space(' '), x('X'), y('Y'), z('Z'), f('F'), s('S'), zero('0');
-    qint16 layerNum = 0;
+    qint16 layerNum   = 0;
     QStringList lines = m_text.split(newline);
     QString G0("G0"), G1("G1"), M3("M3 "), M5("M5"), commaSpace(", ");
     QString xval, yval, zval, velocity, feedrate;
@@ -61,12 +62,12 @@ void GCodeSandiaSaver::run() {
 
     QString line;
 
-    for (int i = 0; i < lines.size(); i++) //(QString line : lines)
+    for (int i = 0; i < lines.size(); i++)  //(QString line : lines)
     {
         line = lines[i];
         if (line.startsWith(G0)) {
             out << "$VEL.CP" % newline;
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G0) {
@@ -96,11 +97,9 @@ void GCodeSandiaSaver::run() {
                 if (!(GSM->getGlobal()->setting<int>(ES::FileOutput::kSandiaMetalFile))) {
                     out << "dEarlyStop()" % newline;
                 }
-                else {
-                    out << "fEarlyOff()" % newline;
-                }
+                else { out << "fEarlyOff()" % newline; }
             }
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G1) {
@@ -136,25 +135,19 @@ void GCodeSandiaSaver::run() {
             if (!(GSM->getGlobal()->setting<int>(ES::FileOutput::kSandiaMetalFile))) {
                 out << "dStartPrinting()" % newline;
             }
-            else {
-                out << "fDelayStart()" % newline;
-            }
+            else { out << "fDelayStart()" % newline; }
         }
         else if (line.startsWith(M5)) {
             if (!(GSM->getGlobal()->setting<int>(ES::FileOutput::kSandiaMetalFile))) {
                 out << "dWaitForStop()" % newline;
             }
-            else {
-                out << "fWaitForOff()" % newline;
-            }
+            else { out << "fWaitForOff()" % newline; }
         }
     }
-    if (!(GSM->getGlobal()->setting<int>(ES::FileOutput::kSandiaMetalFile))) {
-        out << newline % "dShutdown()";
-    }
+    if (!(GSM->getGlobal()->setting<int>(ES::FileOutput::kSandiaMetalFile))) { out << newline % "dShutdown()"; }
 
     out << newline % "END";
     file.close();
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_simulation_output.cpp
+++ b/src/threading/gcode_simulation_output.cpp
@@ -1,13 +1,13 @@
 #include "threading/gcode_simulation_output.h"
 
-#include <cstddef>
-
 #include <QDir>
 #include <QFile>
 #include <QRegularExpression>
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+#include <cstddef>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qobject.h>
@@ -28,7 +28,7 @@ GCodeSimulationOutput::GCodeSimulationOutput(const QString& temp_location, const
 void GCodeSimulationOutput::run() {
     constexpr QChar comma(','), new_line('\n'), space(' '), x('X'), y('Y'), z('Z'), w('W'), f('F'), s('S'), zero('0');
     constexpr qint16 layer_num = 0;
-    QStringList lines = m_text.split(new_line);
+    QStringList lines          = m_text.split(new_line);
     QString g0("G0"), g1("G1"), m3("M3"), m5("M5"), m64("M64"), comma_space(", ");
     QString xval("0"), yval("0"), zval, wval, sval("0"), extruding("0"), velocity, rapid_velocity;
     zval = QString::number(
@@ -38,13 +38,13 @@ void GCodeSimulationOutput::run() {
     rapid_velocity = QString::number(
         GSM->getGlobal()->setting<Velocity>(PS::Travel::kSpeed).to(m_selected_meta.m_velocity_unit), 'f', 4);
 
-    m_current_x = 0;
-    m_current_y = 0;
-    m_current_z = zval.toDouble();
-    m_current_w = wval.toDouble();
+    m_current_x    = 0;
+    m_current_y    = 0;
+    m_current_z    = zval.toDouble();
+    m_current_w    = wval.toDouble();
     m_current_time = 0;
-    m_use_metric = true;
-    m_is_g0 = false;
+    m_use_metric   = true;
+    m_is_g0        = false;
 
     QFile temp_file(m_temp_location % "temp");
     if (temp_file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
@@ -66,60 +66,44 @@ void GCodeSimulationOutput::run() {
 
     for (size_t i = 0; i < lines.size(); i++) {
         line = lines[i];
-        sval = "1"; // reset sval
+        sval = "1";  // reset sval
 
         // Cincinnati uses inches and inches/minute
-        if (line.contains("Cincinnati")) {
-            m_use_metric = false;
-        }
+        if (line.contains("Cincinnati")) { m_use_metric = false; }
 
         // Extrusion on/off needs to appear in the simulation txt file 1 line before it happens in the g-code\
         // Look at the next line to determine the proper value for the "extruding" flag
         if (i + 1 < lines.size() &&
-            lines[i + 1].startsWith(g1)) // Check next motion to see if extrusion turns off with S0
+            lines[i + 1].startsWith(g1))  // Check next motion to see if extrusion turns off with S0
         {
-            QString temp = lines[i + 1].mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = lines[i + 1].mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == g1) {
                 for (size_t i = 1, end = params.size(); i < end; i++) {
-                    if (params[i].startsWith(s)) {
-                        sval = params[i].mid(1);
-                    }
+                    if (params[i].startsWith(s)) { sval = params[i].mid(1); }
                 }
                 m_is_g0 = false;
             }
 
-            if (sval == "0" || sval == "0.0000") {
-                extruding = "0";
-            }
+            if (sval == "0" || sval == "0.0000") { extruding = "0"; }
         }
         else if (i + 1 < lines.size() && (lines[i + 1].startsWith(m3) || lines[i + 1].startsWith(m64))) {
             extruding = "1";
         }
-        else if (i + 1 < lines.size() && lines[i + 1].startsWith(m5)) {
-            extruding = "0";
-        }
+        else if (i + 1 < lines.size() && lines[i + 1].startsWith(m5)) { extruding = "0"; }
 
         // Look at current line to create the output
         if (line.startsWith(g0)) {
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == g0) {
                 for (size_t i = 1, end = params.size(); i < end; i++) {
-                    if (params[i].startsWith(x)) {
-                        xval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(y)) {
-                        yval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(z)) {
-                        zval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(w)) {
-                        wval = params[i].mid(1);
-                    }
+                    if (params[i].startsWith(x)) { xval = params[i].mid(1); }
+                    else if (params[i].startsWith(y)) { yval = params[i].mid(1); }
+                    else if (params[i].startsWith(z)) { zval = params[i].mid(1); }
+                    else if (params[i].startsWith(w)) { wval = params[i].mid(1); }
                 }
                 m_is_g0 = true;
             }
@@ -130,36 +114,22 @@ void GCodeSimulationOutput::run() {
                 << comma_space % extruding % new_line;
         }
         else if (line.startsWith(g1)) {
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == g1) {
                 for (size_t i = 1, end = params.size(); i < end; i++) {
-                    if (params[i].startsWith(x)) {
-                        xval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(y)) {
-                        yval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(z)) {
-                        zval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(w)) {
-                        wval = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(f)) {
-                        velocity = params[i].mid(1);
-                    }
-                    else if (params[i].startsWith(s)) {
-                        sval = params[i].mid(1);
-                    }
+                    if (params[i].startsWith(x)) { xval = params[i].mid(1); }
+                    else if (params[i].startsWith(y)) { yval = params[i].mid(1); }
+                    else if (params[i].startsWith(z)) { zval = params[i].mid(1); }
+                    else if (params[i].startsWith(w)) { wval = params[i].mid(1); }
+                    else if (params[i].startsWith(f)) { velocity = params[i].mid(1); }
+                    else if (params[i].startsWith(s)) { sval = params[i].mid(1); }
                 }
                 m_is_g0 = false;
             }
 
-            if (sval == "0" || sval == "0.0000") {
-                extruding = "0";
-            }
+            if (sval == "0" || sval == "0.0000") { extruding = "0"; }
 
             calculateTime(xval, yval, zval, wval, velocity);
 
@@ -173,27 +143,27 @@ void GCodeSimulationOutput::run() {
 
 void GCodeSimulationOutput::calculateTime(const QString& x, const QString& y, const QString& z, const QString& w,
                                           const QString& f) {
-    Distance dist = 0;
+    Distance dist   = 0;
     Distance temp_x = x.toDouble();
     Distance temp_y = y.toDouble();
     Distance temp_z = z.toDouble();
     Distance temp_w = w.toDouble();
     Velocity temp_f = f.toDouble();
     Velocity temp_f_seconds;
-    Distance dx = temp_x - m_current_x;
-    Distance dy = temp_y - m_current_y;
-    Distance dz = temp_z - m_current_z;
-    Distance dw = temp_w - m_current_w;
+    Distance dx    = temp_x - m_current_x;
+    Distance dy    = temp_y - m_current_y;
+    Distance dz    = temp_z - m_current_z;
+    Distance dw    = temp_w - m_current_w;
     Time temp_time = 0;
 
     // Set acceleration default value
     Acceleration current_accel;
 
     if (m_use_metric) {
-        current_accel = 1500; // units mm/s^2 - this is ~0.153g for JuggerBot3D
+        current_accel = 1500;  // units mm/s^2 - this is ~0.153g for JuggerBot3D
     }
     else {
-        current_accel = 23.165; // units in/s^2 - this is ~0.06g for CI
+        current_accel = 23.165;  // units in/s^2 - this is ~0.06g for CI
     }
 
     // Calculate distance to be used for time calculation
@@ -217,29 +187,23 @@ void GCodeSimulationOutput::calculateTime(const QString& x, const QString& y, co
         }
         // For Z only moves, set acceleration to 200mm/s^2 or 7.87in/s*2
         if (m_use_metric) {
-            current_accel = 200; // units mm/s^2
+            current_accel = 200;  // units mm/s^2
         }
         else {
-            current_accel = 7.87; // units in/s^2
+            current_accel = 7.87;  // units in/s^2
         }
     }
     // Predominantly X and Y motion
-    else {
-        dist = sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
-    }
+    else { dist = sqrt(dx * dx + dy * dy + dz * dz + dw * dw); }
 
-    dist = abs(dist);
+    dist           = abs(dist);
     temp_f_seconds = temp_f / 60.0;
 
-    Time accel_time = temp_f_seconds / current_accel;
+    Time accel_time     = temp_f_seconds / current_accel;
     Distance accel_dist = (temp_f_seconds * temp_f_seconds) / (2.0 * current_accel);
 
-    if (dist > 2.0 * accel_dist) {
-        temp_time = 2 * accel_time + (dist - 2.0 * accel_dist) / temp_f_seconds;
-    }
-    else {
-        temp_time = sqrt(2.0 * dist / current_accel);
-    }
+    if (dist > 2.0 * accel_dist) { temp_time = 2 * accel_time + (dist - 2.0 * accel_dist) / temp_f_seconds; }
+    else { temp_time = sqrt(2.0 * dist / current_accel); }
 
     // Add time to the total time
     m_current_time += temp_time;
@@ -250,4 +214,4 @@ void GCodeSimulationOutput::calculateTime(const QString& x, const QString& y, co
     m_current_z = temp_z + abs(temp_w);
     m_current_w = temp_w;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/gcode_tormach_saver.cpp
+++ b/src/threading/gcode_tormach_saver.cpp
@@ -6,6 +6,7 @@
 #include <QStringBuilder>
 #include <QStringList>
 #include <QTextStream>
+
 #include <qcontainerfwd.h>
 #include <qfileinfo.h>
 #include <qobject.h>
@@ -25,7 +26,7 @@ GCodeTormachSaver::GCodeTormachSaver(QString tempLocation, QString path, QString
 void GCodeTormachSaver::run() {
     // First, get necessary parameters from settings to rotate all pathing
     QChar comma(','), newline('\n'), space(' '), x('X'), y('Y'), z('Z'), f('F'), s('S'), zero('0');
-    qint16 layerNum = 0;
+    qint16 layerNum   = 0;
     QStringList lines = m_text.split(newline);
     QString G0("G0"), G1("G1"), M3("M3"), M5("M5"), M64("M64"), M65("M65"), commaSpace(", ");
     QString xval, yval, zval, velocity, feedrate;
@@ -123,7 +124,7 @@ void GCodeTormachSaver::run() {
     for (QString line : lines) {
         if (line.startsWith(G0)) {
             out << "RAPID" % newline;
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G0) {
@@ -140,7 +141,7 @@ void GCodeTormachSaver::run() {
                        newline;
         }
         else if (line.startsWith(G1)) {
-            QString temp = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
+            QString temp            = line.mid(0, line.indexOf(m_selected_meta.m_comment_starting_delimiter));
             QVector<QString> params = temp.split(space);
 
             if (params[0] == G1) {
@@ -173,9 +174,7 @@ void GCodeTormachSaver::run() {
             layerNum++;
             out << "$$ Layer: " << layerNum << "\n";
         }
-        else if (line.startsWith("(UPDATE VOLTAGE FOR TIP WIPE)")) {
-            out << "$$ Set New Welder Voltage\n";
-        }
+        else if (line.startsWith("(UPDATE VOLTAGE FOR TIP WIPE)")) { out << "$$ Set New Welder Voltage\n"; }
     }
 
     out << "PPRINT/  files_x\\job_end.txt" % newline;
@@ -188,4 +187,4 @@ void GCodeTormachSaver::run() {
     file.close();
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/mesh_loader.cpp
+++ b/src/threading/mesh_loader.cpp
@@ -1,5 +1,9 @@
 #include "threading/mesh_loader.h"
 
+#include <QLinkedList>
+#include <QStack>
+#include <QTemporaryFile>
+#include <QtDebug>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -19,10 +23,6 @@
 #include <Interface_Static.hxx>
 #include <Poly_Triangle.hxx>
 #include <Poly_Triangulation.hxx>
-#include <QLinkedList>
-#include <QStack>
-#include <QTemporaryFile>
-#include <QtDebug>
 #include <STEPControl_Reader.hxx>
 #include <TopAbs_Orientation.hxx>
 #include <TopExp_Explorer.hxx>
@@ -55,7 +55,7 @@
 
 namespace ORNL {
 namespace {
-constexpr double kStepLinearDeflectionMm = 0.1;
+constexpr double kStepLinearDeflectionMm       = 0.1;
 constexpr double kStepAngularDeflectionRadians = 0.1;
 
 bool isStepFile(const QString& suffix) {
@@ -72,8 +72,7 @@ void applyInitialTransform(const QSharedPointer<MeshBase>& mesh, QMatrix4x4 tran
         transform.scale(QVector3D(conv(), conv(), conv()));
         mesh->setUnit(unit);
 
-        if (PreferencesManager::getInstance()->getUseImplicitTransforms())
-            transform.translate(center.toQVector3D());
+        if (PreferencesManager::getInstance()->getUseImplicitTransforms()) transform.translate(center.toQVector3D());
     }
 
     mesh->setTransformation(transform);
@@ -86,20 +85,16 @@ MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
 
     STEPControl_Reader reader;
     const QByteArray file_path_data = file_path.toUtf8();
-    if (reader.ReadFile(file_path_data.constData()) != IFSelect_RetDone)
-        return surface_mesh;
+    if (reader.ReadFile(file_path_data.constData()) != IFSelect_RetDone) return surface_mesh;
 
-    if (reader.TransferRoots() == 0)
-        return surface_mesh;
+    if (reader.TransferRoots() == 0) return surface_mesh;
 
     TopoDS_Shape shape = reader.OneShape();
-    if (shape.IsNull())
-        return surface_mesh;
+    if (shape.IsNull()) return surface_mesh;
 
     BRepMesh_IncrementalMesh mesher(shape, kStepLinearDeflectionMm, false, kStepAngularDeflectionRadians, true);
     mesher.Perform();
-    if (!mesher.IsDone())
-        return surface_mesh;
+    if (!mesher.IsDone()) return surface_mesh;
 
     using VertexIndex = MeshTypes::SurfaceMesh::Vertex_index;
     std::map<std::tuple<long long, long long, long long>, VertexIndex> vertex_lookup;
@@ -108,14 +103,13 @@ MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
         const long long x = std::llround(point.X() * 1000.0);
         const long long y = std::llround(point.Y() * 1000.0);
         const long long z = std::llround(point.Z() * 1000.0);
-        const auto key = std::make_tuple(x, y, z);
+        const auto key    = std::make_tuple(x, y, z);
 
         auto existing = vertex_lookup.find(key);
-        if (existing != vertex_lookup.end())
-            return existing->second;
+        if (existing != vertex_lookup.end()) return existing->second;
 
         const VertexIndex index = surface_mesh.add_vertex(MeshTypes::Point_3(x, y, z));
-        vertex_lookup[key] = index;
+        vertex_lookup[key]      = index;
         return index;
     };
 
@@ -124,8 +118,7 @@ MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
 
         TopLoc_Location location;
         Handle(Poly_Triangulation) triangulation = BRep_Tool::Triangulation(face, location);
-        if (triangulation.IsNull())
-            continue;
+        if (triangulation.IsNull()) continue;
 
         const gp_Trsf& transform = location.Transformation();
         for (int triangle_index = 1; triangle_index <= triangulation->NbTriangles(); ++triangle_index) {
@@ -135,8 +128,7 @@ MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
             triangulation->Triangle(triangle_index).Get(n1, n2, n3);
 
             std::array<Standard_Integer, 3> node_ids = {n1, n2, n3};
-            if (face.Orientation() == TopAbs_REVERSED)
-                std::swap(node_ids[1], node_ids[2]);
+            if (face.Orientation() == TopAbs_REVERSED) std::swap(node_ids[1], node_ids[2]);
 
             std::array<VertexIndex, 3> indices;
             for (int i = 0; i < 3; ++i) {
@@ -145,8 +137,7 @@ MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
                 indices[i] = add_vertex(point);
             }
 
-            if (indices[0] == indices[1] || indices[1] == indices[2] || indices[2] == indices[0])
-                continue;
+            if (indices[0] == indices[1] || indices[1] == indices[2] || indices[2] == indices[0]) continue;
 
             auto face_index = surface_mesh.add_face(indices[0], indices[1], indices[2]);
             if (face_index == MeshTypes::SurfaceMesh::null_face())
@@ -159,8 +150,7 @@ MeshTypes::SurfaceMesh buildSurfaceMeshFromStep(const QString& file_path) {
 
 QSharedPointer<MeshBase> buildMeshFromStepSurfaceMesh(MeshTypes::SurfaceMesh& surface_mesh, const QFileInfo& file_info,
                                                       MeshType mesh_type) {
-    if (surface_mesh.number_of_faces() == 0 || surface_mesh.number_of_vertices() == 0)
-        return nullptr;
+    if (surface_mesh.number_of_faces() == 0 || surface_mesh.number_of_vertices() == 0) return nullptr;
 
     QSharedPointer<MeshBase> mesh;
     if (CGAL::is_closed(surface_mesh)) {
@@ -171,9 +161,7 @@ QSharedPointer<MeshBase> buildMeshFromStepSurfaceMesh(MeshTypes::SurfaceMesh& su
             MeshTypes::Polyhedron repaired_polyhedron = polyhedron;
             try {
                 ClosedMesh::RepairResult repair_result = ClosedMesh::CleanPolyhedronWithStatus(repaired_polyhedron);
-                if (repair_result == ClosedMesh::RepairResult::kSuccess) {
-                    polyhedron = repaired_polyhedron;
-                }
+                if (repair_result == ClosedMesh::RepairResult::kSuccess) { polyhedron = repaired_polyhedron; }
                 else {
                     qWarning() << "Model repair did not complete for" << file_info.fileName() << "-"
                                << ClosedMesh::RepairResultDescription(repair_result) << "Importing unrepaired mesh.";
@@ -207,8 +195,7 @@ QVector<MeshLoader::MeshData> loadStepMeshes(const QFileInfo& file_info, MeshTyp
     if (read_from_memory) {
         temporary_step_file.setFileTemplate(
             QDir::temp().filePath("ornlslicer_step_XXXXXX." + file_info.suffix().toLower()));
-        if (!temporary_step_file.open())
-            return loaded_meshes;
+        if (!temporary_step_file.open()) return loaded_meshes;
 
         if (temporary_step_file.write(static_cast<const char*>(file_data.first), file_data.second) !=
             static_cast<qint64>(file_data.second))
@@ -219,16 +206,15 @@ QVector<MeshLoader::MeshData> loadStepMeshes(const QFileInfo& file_info, MeshTyp
     }
 
     MeshTypes::SurfaceMesh surface_mesh = buildSurfaceMeshFromStep(step_path);
-    QSharedPointer<MeshBase> mesh = buildMeshFromStepSurfaceMesh(surface_mesh, file_info, mesh_type);
-    if (mesh.isNull())
-        return loaded_meshes;
+    QSharedPointer<MeshBase> mesh       = buildMeshFromStepSurfaceMesh(surface_mesh, file_info, mesh_type);
+    if (mesh.isNull()) return loaded_meshes;
 
     applyInitialTransform(mesh, transform, unit);
     loaded_meshes.push_back({mesh, file_data.first, file_data.second});
 
     return loaded_meshes;
 }
-} // namespace
+}  // namespace
 
 MeshLoader::MeshLoader(QString file_path, MeshType mt, QMatrix4x4 transform, Distance unit)
     : m_file_path(file_path), m_mesh_type(mt), m_transform(transform), m_unit(unit) {}
@@ -236,11 +222,9 @@ MeshLoader::MeshLoader(QString file_path, MeshType mt, QMatrix4x4 transform, Dis
 void MeshLoader::run() {
     auto meshes = LoadMeshes(m_file_path, m_mesh_type, m_transform, m_unit);
 
-    if (meshes.isEmpty())
-        emit error("Error importing mesh: " + QFileInfo(m_file_path).fileName());
+    if (meshes.isEmpty()) emit error("Error importing mesh: " + QFileInfo(m_file_path).fileName());
 
-    for (auto mesh_data : meshes)
-        emit newMesh(mesh_data);
+    for (auto mesh_data : meshes) emit newMesh(mesh_data);
 }
 
 QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType mt, QMatrix4x4 transform,
@@ -252,10 +236,9 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
     std::pair<void*, size_t> file_data;
     const bool read_from_memory = raw_data != nullptr && file_size != 0;
 
-    if (raw_data == nullptr || file_size == 0) // Data not provided, so load from file
+    if (raw_data == nullptr || file_size == 0)  // Data not provided, so load from file
     {
-        if (!file_info.exists())
-            return loaded_meshes;
+        if (!file_info.exists()) return loaded_meshes;
 
         file_data = LoadRawData(file_info.absoluteFilePath());
     }
@@ -263,8 +246,7 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
         file_data = std::make_pair(raw_data, file_size);
 
     if (file_data.first == nullptr || file_data.second == 0) {
-        if (!read_from_memory && file_data.first != nullptr)
-            free(file_data.first);
+        if (!read_from_memory && file_data.first != nullptr) free(file_data.first);
         return loaded_meshes;
     }
 
@@ -276,8 +258,7 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
 
     if (isStepFile(model_type)) {
         auto step_meshes = loadStepMeshes(file_info, mt, transform, unit, file_data, read_from_memory);
-        if (step_meshes.isEmpty() && !read_from_memory)
-            free(file_data.first);
+        if (step_meshes.isEmpty() && !read_from_memory) free(file_data.first);
         return step_meshes;
     }
 
@@ -285,35 +266,34 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
         scene =
             importer.ReadFileFromMemory(file_data.first, file_data.second,
                                         aiProcess_DropNormals | aiProcess_JoinIdenticalVertices | aiProcess_SortByPType,
-                                        "stl"); // Tell assimp we are using STL.
+                                        "stl");  // Tell assimp we are using STL.
     }
     else if (model_type == "3mf" || model_type == "3MF") {
         scene =
             importer.ReadFileFromMemory(file_data.first, file_data.second,
                                         aiProcess_DropNormals | aiProcess_JoinIdenticalVertices | aiProcess_SortByPType,
-                                        "3mf"); // Tell assimp we are using 3mf.
+                                        "3mf");  // Tell assimp we are using 3mf.
     }
     else if (model_type == "obj" || model_type == "OBJ") {
-        scene = importer.ReadFileFromMemory(file_data.first, file_data.second,
-                                            aiProcess_DropNormals | aiProcess_JoinIdenticalVertices |
-                                                aiProcess_Triangulate | aiProcess_SortByPType,
-                                            "obj"); // Tell assimp we are using obj.
+        scene = importer.ReadFileFromMemory(
+            file_data.first, file_data.second,
+            aiProcess_DropNormals | aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType,
+            "obj");  // Tell assimp we are using obj.
     }
     else if (model_type == "amf" || model_type == "AMF") {
-        scene = importer.ReadFileFromMemory(file_data.first, file_data.second,
-                                            aiProcess_DropNormals | aiProcess_JoinIdenticalVertices |
-                                                aiProcess_Triangulate | aiProcess_SortByPType,
-                                            "amf"); // Tell assimp we are using obj.
+        scene = importer.ReadFileFromMemory(
+            file_data.first, file_data.second,
+            aiProcess_DropNormals | aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType,
+            "amf");  // Tell assimp we are using obj.
     }
     else {
-        scene = importer.ReadFileFromMemory(file_data.first, file_data.second,
-                                            aiProcess_DropNormals | aiProcess_JoinIdenticalVertices |
-                                                aiProcess_SortByPType);
+        scene = importer.ReadFileFromMemory(
+            file_data.first, file_data.second,
+            aiProcess_DropNormals | aiProcess_JoinIdenticalVertices | aiProcess_SortByPType);
     }
 
     if (scene == nullptr) {
-        if (!read_from_memory)
-            free(file_data.first);
+        if (!read_from_memory) free(file_data.first);
         return loaded_meshes;
     }
 
@@ -324,8 +304,7 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
             if (mesh->mNumFaces > 0 && mesh->mNumVertices > 0) {
                 QString name = file_info.baseName();
 
-                if (scene->mNumMeshes > 1)
-                    name += "_" + QString::number(num_models_added);
+                if (scene->mNumMeshes > 1) name += "_" + QString::number(num_models_added);
 
                 QSharedPointer<MeshBase> new_mesh;
 
@@ -339,9 +318,7 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
                     try {
                         ClosedMesh::RepairResult repair_result =
                             ClosedMesh::CleanPolyhedronWithStatus(repaired_polyhedron);
-                        if (repair_result == ClosedMesh::RepairResult::kSuccess) {
-                            polyhedron = repaired_polyhedron;
-                        }
+                        if (repair_result == ClosedMesh::RepairResult::kSuccess) { polyhedron = repaired_polyhedron; }
                         else {
                             qWarning() << "Model repair did not complete for" << file_info.fileName() << "-"
                                        << ClosedMesh::RepairResultDescription(repair_result)
@@ -358,18 +335,16 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
 
                 if (builder.wasError() || !polyhedron.is_closed()) {
                     MeshTypes::SurfaceMesh sm = BuildSurfaceMesh(mesh);
-                    new_mesh = QSharedPointer<OpenMesh>::create(sm, name, file_info.fileName());
+                    new_mesh                  = QSharedPointer<OpenMesh>::create(sm, name, file_info.fileName());
                 }
-                else {
-                    new_mesh = QSharedPointer<ClosedMesh>::create(polyhedron, name, file_info.fileName());
-                }
+                else { new_mesh = QSharedPointer<ClosedMesh>::create(polyhedron, name, file_info.fileName()); }
                 new_mesh->setType(mt);
 
                 // Center the mesh about itself
                 auto center = new_mesh->originalCentroid();
                 new_mesh->center();
 
-                if (transform.isIdentity()) // If the transform was not provided
+                if (transform.isIdentity())  // If the transform was not provided
                 {
                     // Scale to the default unit
                     Distance conv(unit);
@@ -392,14 +367,12 @@ QVector<MeshLoader::MeshData> MeshLoader::LoadMeshes(QString file_path, MeshType
         }
     }
 
-    if (loaded_meshes.isEmpty() && !read_from_memory)
-        free(file_data.first);
+    if (loaded_meshes.isEmpty() && !read_from_memory) free(file_data.first);
 
     return loaded_meshes;
 }
 
 std::pair<void*, size_t> MeshLoader::LoadRawData(QString file_path) {
-
     // Load raw data
     // Some C here to get a void pointer of the model.
     FILE* fptr = fopen(file_path.toUtf8(), "rb");
@@ -409,13 +382,11 @@ std::pair<void*, size_t> MeshLoader::LoadRawData(QString file_path) {
     fseek(fptr, 0L, SEEK_SET);
 
     void* data = malloc(fsize);
-    if (data == nullptr)
-        return std::make_pair(nullptr, 0);
+    if (data == nullptr) return std::make_pair(nullptr, 0);
 
     int readres = fread(data, 1, fsize, fptr);
 
-    if (readres != fsize)
-        return std::make_pair(nullptr, 0);
+    if (readres != fsize) return std::make_pair(nullptr, 0);
 
     fclose(fptr);
 
@@ -432,9 +403,9 @@ MeshTypes::SurfaceMesh MeshLoader::BuildSurfaceMesh(aiMesh* mesh) {
             MeshTypes::Point_3(mesh->mVertices[i].x * 1000, mesh->mVertices[i].y * 1000, mesh->mVertices[i].z * 1000));
 
     for (uint i = 0, end = mesh->mNumFaces; i < end; ++i) {
-        auto& face = mesh->mFaces[i];
+        auto& face     = mesh->mFaces[i];
         auto face_desc = sm.add_face(points[face.mIndices[0]], points[face.mIndices[1]], points[face.mIndices[2]]);
     }
     return sm;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/session_loader.cpp
+++ b/src/threading/session_loader.cpp
@@ -36,21 +36,18 @@ void SessionLoader::run() {
 
 void SessionLoader::saveSession() {
     struct zip_t* zip = zip_open(m_filename.toUtf8(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
-    if (zip == nullptr)
-        return;
+    if (zip == nullptr) return;
 
     QSet<QString> active_model_names;
     auto addActiveModelName = [&active_model_names](const QString& name) {
-        if (name.isEmpty())
-            return;
+        if (name.isEmpty()) return;
 
         QFileInfo file_info(name);
         active_model_names.insert(name);
         active_model_names.insert(file_info.fileName());
 
         QString base_name = file_info.baseName();
-        if (!base_name.isEmpty())
-            active_model_names.insert(base_name);
+        if (!base_name.isEmpty()) active_model_names.insert(base_name);
     };
 
     auto parts = CSM->parts();
@@ -95,7 +92,7 @@ void SessionLoader::saveSession() {
 
     // Add part transforms
     jsons.append({Constants::Settings::Session::Files::kSession,
-                  CSM->partsJson()}); // TODO: this need updated to reflect parent/ child relationships
+                  CSM->partsJson()});  // TODO: this need updated to reflect parent/ child relationships
 
     // Add global settings
     jsons.append({Constants::Settings::Session::Files::kGlobal, GSM->globalJson()});
@@ -104,9 +101,9 @@ void SessionLoader::saveSession() {
     json part_jsons;
     for (auto& part : CSM->parts()) {
         json json;
-        json[Constants::Settings::Session::LocalFile::kName] = part->name();
+        json[Constants::Settings::Session::LocalFile::kName]     = part->name();
         json[Constants::Settings::Session::LocalFile::kSettings] = part->getSb()->json();
-        json[Constants::Settings::Session::LocalFile::kRanges] = part->SettingsRangesToJson();
+        json[Constants::Settings::Session::LocalFile::kRanges]   = part->SettingsRangesToJson();
         part_jsons.push_back(json);
     }
     jsons.append({Constants::Settings::Session::Files::kLocal, part_jsons});
@@ -133,26 +130,24 @@ void SessionLoader::saveSession() {
 
 fifojson SessionLoader::getSettingsFromZip() {
     struct zip_t* zip = zip_open(m_filename.toUtf8(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'r');
-    fifojson result = fifojson::parse(loadStringFromZip(zip, Constants::Settings::Session::Files::kGlobal));
+    fifojson result   = fifojson::parse(loadStringFromZip(zip, Constants::Settings::Session::Files::kGlobal));
     zip_close(zip);
     return result;
 }
 
 void SessionLoader::updateSettingsJson(fifojson j, bool writeToProject) {
-    m_new_json = j;
-    m_has_new_json = true;
+    m_new_json              = j;
+    m_has_new_json          = true;
     m_should_write_new_json = writeToProject;
 }
 
 void SessionLoader::loadSession() {
-
     if (m_has_new_json && m_should_write_new_json) {
         struct zip_t* zip = zip_open(m_filename.toUtf8(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'd');
-        if (zip == nullptr)
-            return;
+        if (zip == nullptr) return;
 
         std::string entry = Constants::Settings::Session::Files::kGlobal;
-        char* entries[] = {&entry[0]};
+        char* entries[]   = {&entry[0]};
         zip_entries_delete(zip, entries, 1);
 
         std::string dump = m_new_json.dump(4);
@@ -165,8 +160,7 @@ void SessionLoader::loadSession() {
 
     struct zip_t* zip = zip_open(m_filename.toUtf8(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'r');
 
-    if (zip == nullptr)
-        return;
+    if (zip == nullptr) return;
 
     // Load every model in the project file.
     int entries = zip_entries_total(zip);
@@ -181,7 +175,7 @@ void SessionLoader::loadSession() {
             continue;
         }
 
-        QString int_name = name.split("/").back(); //"#SESSION#/" + name.split("/").back();
+        QString int_name = name.split("/").back();  //"#SESSION#/" + name.split("/").back();
 
         // Load a mesh.
         void* data = nullptr;
@@ -194,10 +188,9 @@ void SessionLoader::loadSession() {
     }
 
     // Load global settings
-    fifojson global_settings = m_has_new_json
-                                   ? m_new_json
-                                   : fifojson::parse(
-                                         loadStringFromZip(zip, Constants::Settings::Session::Files::kGlobal));
+    fifojson global_settings =
+        m_has_new_json ? m_new_json
+                       : fifojson::parse(loadStringFromZip(zip, Constants::Settings::Session::Files::kGlobal));
     GSM->loadGlobalJson(global_settings);
 
     // Load transforms
@@ -206,7 +199,7 @@ void SessionLoader::loadSession() {
     // Load part settings and ranges
     auto parts_and_ranges = json::parse(loadStringFromZip(zip, Constants::Settings::Session::Files::kLocal));
     for (auto& part_json : parts_and_ranges) {
-        std::string name = part_json[Constants::Settings::Session::LocalFile::kName];
+        std::string name          = part_json[Constants::Settings::Session::LocalFile::kName];
         QSharedPointer<Part> part = CSM->getPart(QString::fromStdString(name));
         if (part.isNull()) {
             emit error("Project references settings for a part that was not loaded: " + QString::fromStdString(name));
@@ -240,4 +233,4 @@ std::string SessionLoader::loadStringFromZip(struct zip_t* zip, const std::strin
 
     return str;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/slicers/helical_slicer.cpp
+++ b/src/threading/slicers/helical_slicer.cpp
@@ -1,11 +1,11 @@
 #include "threading/slicers/helical_slicer.h"
 
+#include <QPair>
+#include <QTextStream>
 #include <algorithm>
 #include <cmath>
 #include <limits>
 
-#include <QPair>
-#include <QTextStream>
 #include <nlohmann/json_fwd.hpp>
 #include <qcontainerfwd.h>
 #include <qdebug.h>
@@ -46,7 +46,9 @@ const QString kRadialCenterX = "radial_center_x";
 const QString kRadialCenterY = "radial_center_y";
 
 //! @brief Returns a positive setting value or a safe fallback.
-Distance positiveOrFallback(Distance value, Distance fallback) { return value > 0 ? value : fallback; }
+Distance positiveOrFallback(Distance value, Distance fallback) {
+    return value > 0 ? value : fallback;
+}
 
 //! @brief Physical fallback used when the radial layer spacing setting is invalid.
 const Distance kDefaultHelicalLayerHeight = 1.0 * mm;
@@ -76,7 +78,7 @@ struct HelicalBoundaryIntersection {
 struct HelixClipResult {
     QVector<Polyline> fragments;
     QVector<HelicalBoundaryIntersection> intersections;
-    bool has_inside_points = false;
+    bool has_inside_points  = false;
     bool has_outside_points = false;
 };
 
@@ -84,13 +86,11 @@ struct HelixClipResult {
 bool meshBounds(const QVector<QSharedPointer<MeshBase>>& meshes, Point& mesh_min, Point& mesh_max) {
     bool has_bounds = false;
     for (const QSharedPointer<MeshBase>& mesh : meshes) {
-        if (mesh == nullptr || mesh->vertices().isEmpty()) {
-            continue;
-        }
+        if (mesh == nullptr || mesh->vertices().isEmpty()) { continue; }
 
         if (!has_bounds) {
-            mesh_min = mesh->min();
-            mesh_max = mesh->max();
+            mesh_min   = mesh->min();
+            mesh_max   = mesh->max();
             has_bounds = true;
             continue;
         }
@@ -117,9 +117,7 @@ Point interpolate(const Point& start, const Point& end, double t) {
 //! @brief Returns the nearest cached cross section index for a point Z.
 int nearestSectionIndex(const QVector<HelicalCrossSection>& sections, const Point& point, Distance first_z,
                         Distance section_spacing) {
-    if (sections.isEmpty()) {
-        return -1;
-    }
+    if (sections.isEmpty()) { return -1; }
 
     const double raw_index = (point.z() - first_z()) / section_spacing();
     return std::clamp(static_cast<int>(std::llround(raw_index)), 0, static_cast<int>(sections.size()) - 1);
@@ -129,9 +127,7 @@ int nearestSectionIndex(const QVector<HelicalCrossSection>& sections, const Poin
 bool pointInsideModel(const QVector<HelicalCrossSection>& sections, const Point& point, Distance first_z,
                       Distance section_spacing) {
     const int index = nearestSectionIndex(sections, point, first_z, section_spacing);
-    if (index < 0 || sections[index].geometry.isEmpty()) {
-        return false;
-    }
+    if (index < 0 || sections[index].geometry.isEmpty()) { return false; }
 
     return sections[index].geometry.inside(point, true);
 }
@@ -139,20 +135,18 @@ bool pointInsideModel(const QVector<HelicalCrossSection>& sections, const Point&
 //! @brief Finds an approximate model-boundary point along a sampled helix segment.
 Point findBoundaryPoint(const Point& start, const Point& end, bool start_inside,
                         const QVector<HelicalCrossSection>& sections, Distance first_z, Distance section_spacing) {
-    Point low = start;
-    Point high = end;
+    Point low       = start;
+    Point high      = end;
     bool low_inside = start_inside;
 
     for (int i = 0; i < 12; ++i) {
-        const Point mid = interpolate(low, high, 0.5);
+        const Point mid       = interpolate(low, high, 0.5);
         const bool mid_inside = pointInsideModel(sections, mid, first_z, section_spacing);
         if (mid_inside == low_inside) {
-            low = mid;
+            low        = mid;
             low_inside = mid_inside;
         }
-        else {
-            high = mid;
-        }
+        else { high = mid; }
     }
 
     return start_inside ? low : high;
@@ -162,30 +156,24 @@ Point findBoundaryPoint(const Point& start, const Point& end, bool start_inside,
 HelixClipResult clipHelixToSections(const Polyline& helix, const QVector<HelicalCrossSection>& sections,
                                     Distance first_z, Distance section_spacing) {
     HelixClipResult result;
-    if (helix.size() < 2 || sections.isEmpty()) {
-        return result;
-    }
+    if (helix.size() < 2 || sections.isEmpty()) { return result; }
 
-    Point previous = helix.first();
-    bool previous_inside = pointInsideModel(sections, previous, first_z, section_spacing);
-    result.has_inside_points = previous_inside;
+    Point previous            = helix.first();
+    bool previous_inside      = pointInsideModel(sections, previous, first_z, section_spacing);
+    result.has_inside_points  = previous_inside;
     result.has_outside_points = !previous_inside;
 
     Polyline current_line;
-    if (previous_inside) {
-        current_line.push_back(previous);
-    }
+    if (previous_inside) { current_line.push_back(previous); }
 
     for (int i = 1, end = helix.size(); i < end; ++i) {
-        const Point current = helix[i];
+        const Point current       = helix[i];
         const bool current_inside = pointInsideModel(sections, current, first_z, section_spacing);
-        result.has_inside_points = result.has_inside_points || current_inside;
+        result.has_inside_points  = result.has_inside_points || current_inside;
         result.has_outside_points = result.has_outside_points || !current_inside;
 
         if (previous_inside && current_inside) {
-            if (current_line.isEmpty()) {
-                current_line.push_back(previous);
-            }
+            if (current_line.isEmpty()) { current_line.push_back(previous); }
             current_line.push_back(current);
         }
         else if (previous_inside && !current_inside) {
@@ -206,7 +194,7 @@ HelixClipResult clipHelixToSections(const Polyline& helix, const QVector<Helical
             current_line.push_back(current);
         }
 
-        previous = current;
+        previous        = current;
         previous_inside = current_inside;
     }
 
@@ -219,9 +207,7 @@ HelixClipResult clipHelixToSections(const Polyline& helix, const QVector<Helical
 
 //! @brief Keeps a continuous helix prefix through its highest-Z model-boundary crossing.
 QVector<Polyline> clipHelixAtHighestIntersection(const Polyline& helix, const HelixClipResult& clip_result) {
-    if (helix.size() < 2) {
-        return {};
-    }
+    if (helix.size() < 2) { return {}; }
 
     if (clip_result.intersections.isEmpty()) {
         return clip_result.has_inside_points && !clip_result.has_outside_points ? QVector<Polyline> {helix}
@@ -236,30 +222,22 @@ QVector<Polyline> clipHelixAtHighestIntersection(const Polyline& helix, const He
 
     Polyline clipped_helix;
     clipped_helix.reserve(highest_intersection->segment_end_index + 1);
-    for (int i = 0; i < highest_intersection->segment_end_index; ++i) {
-        clipped_helix.push_back(helix[i]);
-    }
+    for (int i = 0; i < highest_intersection->segment_end_index; ++i) { clipped_helix.push_back(helix[i]); }
 
     if (clipped_helix.isEmpty() || clipped_helix.last() != highest_intersection->point) {
         clipped_helix.push_back(highest_intersection->point);
     }
 
-    if (clipped_helix.size() < 2 || clipped_helix.length() <= kMinPathSegmentLength) {
-        return {};
-    }
+    if (clipped_helix.size() < 2 || clipped_helix.length() <= kMinPathSegmentLength) { return {}; }
 
     return {clipped_helix};
 }
 
 //! @brief Splits a sampled helical fragment into path-length-limited fragments.
 QVector<Polyline> splitPolylineByLength(const Polyline& polyline, Distance max_path_length) {
-    if (polyline.size() < 2) {
-        return {};
-    }
+    if (polyline.size() < 2) { return {}; }
 
-    if (max_path_length <= kMinPathSegmentLength || polyline.length() <= max_path_length) {
-        return {polyline};
-    }
+    if (max_path_length <= kMinPathSegmentLength || polyline.length() <= max_path_length) { return {polyline}; }
 
     QVector<Polyline> split_lines;
     Polyline current_line;
@@ -267,8 +245,8 @@ QVector<Polyline> splitPolylineByLength(const Polyline& polyline, Distance max_p
     Distance current_length = 0;
 
     for (int i = 1, end = polyline.size(); i < end; ++i) {
-        Point segment_start = polyline[i - 1];
-        const Point segment_end = polyline[i];
+        Point segment_start               = polyline[i - 1];
+        const Point segment_end           = polyline[i];
         Distance remaining_segment_length = segment_start.distance(segment_end);
 
         while (remaining_segment_length > 0) {
@@ -277,48 +255,38 @@ QVector<Polyline> splitPolylineByLength(const Polyline& polyline, Distance max_p
                 split_lines.push_back(current_line);
                 current_line.clear();
                 current_line.push_back(segment_start);
-                current_length = 0;
+                current_length        = 0;
                 remaining_path_length = max_path_length;
             }
 
             if (remaining_segment_length <= remaining_path_length) {
-                if (current_line.last() != segment_end) {
-                    current_line.push_back(segment_end);
-                }
+                if (current_line.last() != segment_end) { current_line.push_back(segment_end); }
                 current_length += remaining_segment_length;
                 remaining_segment_length = 0;
             }
             else {
                 const double split_fraction = remaining_path_length() / remaining_segment_length();
-                const Point split_point = interpolate(segment_start, segment_end, split_fraction);
-                if (current_line.last() != split_point) {
-                    current_line.push_back(split_point);
-                }
-                if (current_line.size() > 1) {
-                    split_lines.push_back(current_line);
-                }
+                const Point split_point     = interpolate(segment_start, segment_end, split_fraction);
+                if (current_line.last() != split_point) { current_line.push_back(split_point); }
+                if (current_line.size() > 1) { split_lines.push_back(current_line); }
 
                 current_line.clear();
                 current_line.push_back(split_point);
-                segment_start = split_point;
-                current_length = 0;
+                segment_start            = split_point;
+                current_length           = 0;
                 remaining_segment_length = segment_start.distance(segment_end);
             }
         }
     }
 
-    if (current_line.size() > 1) {
-        split_lines.push_back(current_line);
-    }
+    if (current_line.size() > 1) { split_lines.push_back(current_line); }
 
     return split_lines;
 }
 
 //! @brief Estimates progress loop iterations for an inclusive Distance range.
 int estimateInclusiveCount(Distance start, Distance end, Distance step) {
-    if (step <= 0 || start > end) {
-        return 1;
-    }
+    if (step <= 0 || start > end) { return 1; }
 
     return std::max(1, static_cast<int>(std::floor((end() - start()) / step())) + 1);
 }
@@ -326,18 +294,16 @@ int estimateInclusiveCount(Distance start, Distance end, Distance step) {
 //! @brief Returns the upper Z limit for generated cylindrical candidates.
 Distance cylindricalTopZ(const QSharedPointer<SettingsBase>& part_sb, Distance base_z, Distance mesh_top_z) {
     const Distance cylinder_height = part_sb->setting<Distance>(PS::Slicing::kCylinderHeight);
-    if (cylinder_height <= 0) {
-        return mesh_top_z;
-    }
+    if (cylinder_height <= 0) { return mesh_top_z; }
 
     const Distance capped_top_z(base_z + cylinder_height);
     return capped_top_z < mesh_top_z ? capped_top_z : mesh_top_z;
 }
-} // namespace
+}  // namespace
 
 HelicalSlicer::HelicalSlicer(QString gcodeLocation) : TraditionalAST(gcodeLocation) {
     m_syntax = GcodeSyntax::kArcSpecialties;
-    m_base = QSharedPointer<ArcSpecialtiesWriter>::create(GcodeMetaList::ArcSpecialtiesMeta, GSM->getGlobal());
+    m_base   = QSharedPointer<ArcSpecialtiesWriter>::create(GcodeMetaList::ArcSpecialtiesMeta, GSM->getGlobal());
 }
 
 void HelicalSlicer::doSlice() {
@@ -351,16 +317,12 @@ void HelicalSlicer::doSlice() {
     this->setMaxSteps(0);
     this->preProcess();
 
-    if (this->shouldCancel()) {
-        return;
-    }
+    if (this->shouldCancel()) { return; }
 
     this->postProcess();
     m_elapsed_time = m_timer.elapsed();
 
-    if (this->shouldCancel()) {
-        return;
-    }
+    if (this->shouldCancel()) { return; }
 
     if (!m_skip_gcode) {
         this->writeGCodeSetup();
@@ -368,9 +330,7 @@ void HelicalSlicer::doSlice() {
         this->writeGCodeShutdown();
     }
 
-    if (this->shouldCancel()) {
-        return;
-    }
+    if (this->shouldCancel()) { return; }
 
     emit sliceComplete();
 }
@@ -389,10 +349,10 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
     QVector<QPair<QString, HelicalPathHandedness>> effective_handedness;
 
     int last_preprocess_percent = -1;
-    int last_compute_percent = -1;
-    auto emitPartProgress = [this, &build_parts](StatusUpdateStepType type, int part_index, double part_fraction,
-                                                 int& last_percent) {
-        const double total_parts = std::max(1, static_cast<int>(build_parts.size()));
+    int last_compute_percent    = -1;
+    auto emitPartProgress       = [this, &build_parts](StatusUpdateStepType type, int part_index, double part_fraction,
+                                                       int& last_percent) {
+        const double total_parts           = std::max(1, static_cast<int>(build_parts.size()));
         const double bounded_part_fraction = std::clamp(part_fraction, 0.0, 1.0);
         const int percent =
             std::clamp(static_cast<int>(((part_index + bounded_part_fraction) / total_parts) * 100.0), 0, 100);
@@ -450,15 +410,13 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
         const HelicalPathHandedness handedness =
             static_cast<HelicalPathHandedness>(part_sb->setting<int>(PS::Slicing::kHelicalPathHandedness));
         const bool helix_counterclockwise = handedness == HelicalPathHandedness::kRightHanded;
-        bool part_generated_paths = false;
-        Distance initial_radius = part_sb->setting<Distance>(PS::Slicing::kCylinderInnerRadius);
-        if (initial_radius < 0) {
-            initial_radius = 0.0 * micron;
-        }
+        bool part_generated_paths         = false;
+        Distance initial_radius           = part_sb->setting<Distance>(PS::Slicing::kCylinderInnerRadius);
+        if (initial_radius < 0) { initial_radius = 0.0 * micron; }
 
         const Distance base_z(mesh_min.z());
         const Distance top_z = cylindricalTopZ(part_sb, base_z, mesh_max.z());
-        Point center = helicalCenterForPart(part_sb, part, base_z);
+        Point center         = helicalCenterForPart(part_sb, part, base_z);
         const Distance max_radius(maxRadiusForMeshes(meshes, center));
 
         const Distance first_radius = initial_radius + (layer_height / 2.0);
@@ -471,9 +429,9 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
         }
 
         QVector<HelicalCrossSection> cross_sections;
-        bool has_geometry = false;
+        bool has_geometry                 = false;
         const int estimated_section_count = estimateInclusiveCount(first_bead_z, top_z, section_spacing);
-        int sections_processed = 0;
+        int sections_processed            = 0;
         for (Distance z = first_bead_z; z <= top_z; z += section_spacing) {
             Plane slicing_plane(Point(center.x(), center.y(), z()), QVector3D(0, 0, 1));
             PolygonList combined_geometry;
@@ -483,16 +441,10 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
                 QVector3D average_normal;
                 PolygonList geometry =
                     CrossSection::doCrossSection(mesh, slicing_plane, shift, average_normal, part_sb);
-                if (geometry.isEmpty()) {
-                    continue;
-                }
+                if (geometry.isEmpty()) { continue; }
 
-                if (combined_geometry.isEmpty()) {
-                    combined_geometry = geometry;
-                }
-                else {
-                    combined_geometry += geometry;
-                }
+                if (combined_geometry.isEmpty()) { combined_geometry = geometry; }
+                else { combined_geometry += geometry; }
             }
 
             has_geometry = has_geometry || !combined_geometry.isEmpty();
@@ -510,16 +462,10 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
                 QVector3D average_normal;
                 PolygonList geometry =
                     CrossSection::doCrossSection(mesh, slicing_plane, shift, average_normal, part_sb);
-                if (geometry.isEmpty()) {
-                    continue;
-                }
+                if (geometry.isEmpty()) { continue; }
 
-                if (combined_geometry.isEmpty()) {
-                    combined_geometry = geometry;
-                }
-                else {
-                    combined_geometry += geometry;
-                }
+                if (combined_geometry.isEmpty()) { combined_geometry = geometry; }
+                else { combined_geometry += geometry; }
             }
 
             has_geometry = has_geometry || !combined_geometry.isEmpty();
@@ -535,9 +481,9 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
 
         emitComputeProgress(parts_processed, 0.0);
         Point current_location(center.x(), center.y(), first_bead_z());
-        int helical_layer_number = 0;
+        int helical_layer_number         = 0;
         const int estimated_radius_count = estimateInclusiveCount(first_radius, max_radius, layer_height);
-        int radii_processed = 0;
+        int radii_processed              = 0;
         for (Distance radius = first_radius; radius <= max_radius; radius += layer_height) {
             QSharedPointer<SettingsBase> layer_settings = QSharedPointer<SettingsBase>::create(*part_sb);
             layer_settings->makeLocalAdjustments(helical_layer_number);
@@ -556,17 +502,13 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
 
             const Distance max_path_length = layer_settings->setting<Distance>(PS::Slicing::kMaxHelicalPathLength);
             for (const Polyline& line : clipped_lines) {
-                if (line.size() < 2) {
-                    continue;
-                }
+                if (line.size() < 2) { continue; }
 
                 const QVector<Polyline> path_lines = splitPolylineByLength(line, max_path_length);
                 for (const Polyline& path_line : path_lines) {
                     Path path =
                         createPath(path_line, layer_settings, center, radius, helix_counterclockwise, current_location);
-                    if (path.size() > 0) {
-                        helical_layer->addPath(path);
-                    }
+                    if (path.size() > 0) { helical_layer->addPath(path); }
                 }
             }
 
@@ -630,7 +572,7 @@ void HelicalSlicer::writeGCode() {
     QTextStream stream(&m_temp_gcode_output_file);
 
     const double num_layers = std::max(1.0, static_cast<double>(m_helical_layers.size()));
-    int layer_number = 0;
+    int layer_number        = 0;
     for (const QSharedPointer<HelicalLayer>& layer : m_helical_layers) {
         stream << m_base->writeLayerChange(layer_number);
         stream << m_base->writeBeforeLayer(layer->getMinZ(), layer->getSb());
@@ -646,9 +588,7 @@ void HelicalSlicer::writeGCode() {
 }
 
 QSharedPointer<MeshBase> HelicalSlicer::copyMesh(const QSharedPointer<MeshBase>& mesh) {
-    if (mesh == nullptr) {
-        return nullptr;
-    }
+    if (mesh == nullptr) { return nullptr; }
 
     if (ClosedMesh* closed_mesh = dynamic_cast<ClosedMesh*>(mesh.get())) {
         return QSharedPointer<ClosedMesh>::create(*closed_mesh);
@@ -679,14 +619,12 @@ Point HelicalSlicer::helicalCenterForPart(const QSharedPointer<SettingsBase>& pa
 double HelicalSlicer::maxRadiusForMeshes(const QVector<QSharedPointer<MeshBase>>& meshes, const Point& center) {
     double max_radius = 0.0;
     for (const QSharedPointer<MeshBase>& mesh : meshes) {
-        if (mesh == nullptr) {
-            continue;
-        }
+        if (mesh == nullptr) { continue; }
 
         for (const MeshVertex& vertex : mesh->vertices()) {
             const double dx = static_cast<double>(vertex.location.x() - center.x());
             const double dy = static_cast<double>(vertex.location.y() - center.y());
-            max_radius = std::max(max_radius, std::hypot(dx, dy));
+            max_radius      = std::max(max_radius, std::hypot(dx, dy));
         }
     }
     return max_radius;
@@ -695,15 +633,11 @@ double HelicalSlicer::maxRadiusForMeshes(const QVector<QSharedPointer<MeshBase>>
 Polyline HelicalSlicer::createHelix(const Point& center, Distance radius, Distance start_z, Distance top_z,
                                     Distance bead_width, HelicalPathHandedness handedness, Angle start_angle) {
     Polyline helix;
-    if (top_z <= start_z || bead_width <= 0) {
-        return helix;
-    }
+    if (top_z <= start_z || bead_width <= 0) { return helix; }
 
     const double vertical_rise_per_radian = bead_width() / (2.0 * M_PI);
-    const double max_t = (top_z() - start_z()) / vertical_rise_per_radian;
-    if (max_t <= 0.0) {
-        return helix;
-    }
+    const double max_t                    = (top_z() - start_z()) / vertical_rise_per_radian;
+    if (max_t <= 0.0) { return helix; }
 
     const double length_per_radian = std::hypot(radius(), vertical_rise_per_radian);
     const Distance target_segment_length =
@@ -714,7 +648,7 @@ Polyline HelicalSlicer::createHelix(const Point& center, Distance radius, Distan
     helix.reserve(segments + 1);
     const double direction = handedness == HelicalPathHandedness::kLeftHanded ? -1.0 : 1.0;
     for (int i = 0; i <= segments; ++i) {
-        const double t = max_t * static_cast<double>(i) / static_cast<double>(segments);
+        const double t     = max_t * static_cast<double>(i) / static_cast<double>(segments);
         const double angle = start_angle() + direction * t;
         helix.push_back(Point(center.x() + radius() * std::cos(angle), center.y() + radius() * std::sin(angle),
                               start_z() + vertical_rise_per_radian * t));
@@ -743,35 +677,28 @@ QSharedPointer<SettingsBase> HelicalSlicer::createSegmentSettings(const QSharedP
 Path HelicalSlicer::createPath(const Polyline& polyline, const QSharedPointer<SettingsBase>& layer_settings,
                                const Point& center, Distance radius, bool counterclockwise, Point& current_location) {
     Path path;
-    if (polyline.size() < 2) {
-        return path;
-    }
+    if (polyline.size() < 2) { return path; }
 
-    const bool write_arcs = layer_settings->setting<bool>(PRS::MachineSetup::kSupportG3);
-    const int arcs_per_revolution = std::max(1, layer_settings->setting<int>(PS::Slicing::kArcsPerRevolution));
-    const QVector<Point> arc_points =
-        write_arcs
-            ? SlicingUtilities::GetCylindricalArcPoints(polyline, center, radius, arcs_per_revolution, counterclockwise)
-            : QVector<Point>();
-    const Point path_start = arc_points.size() > 1 ? arc_points.first() : polyline.first();
-    const Point path_end = arc_points.size() > 1 ? arc_points.last() : polyline.last();
+    const bool write_arcs           = layer_settings->setting<bool>(PRS::MachineSetup::kSupportG3);
+    const int arcs_per_revolution   = std::max(1, layer_settings->setting<int>(PS::Slicing::kArcsPerRevolution));
+    const QVector<Point> arc_points = write_arcs ? SlicingUtilities::GetCylindricalArcPoints(
+                                                       polyline, center, radius, arcs_per_revolution, counterclockwise)
+                                                 : QVector<Point>();
+    const Point path_start          = arc_points.size() > 1 ? arc_points.first() : polyline.first();
+    const Point path_end            = arc_points.size() > 1 ? arc_points.last() : polyline.last();
 
     QSharedPointer<SettingsBase> region_start_settings = createSegmentSettings(layer_settings, center, true);
-    QSharedPointer<SettingsBase> print_settings = createSegmentSettings(layer_settings, center, false);
+    QSharedPointer<SettingsBase> print_settings        = createSegmentSettings(layer_settings, center, false);
     QSharedPointer<TravelSegment> travel = QSharedPointer<TravelSegment>::create(current_location, path_start);
     travel->setSb(region_start_settings);
 
-    if (current_location.distance(path_start) > kMinPathSegmentLength) {
-        path.add(travel);
-    }
+    if (current_location.distance(path_start) > kMinPathSegmentLength) { path.add(travel); }
 
     if (arc_points.size() > 1) {
         for (int i = 1, end = arc_points.size(); i < end; ++i) {
             const bool is_arc = SlicingUtilities::IsCylindricalArcSegment(
                 arc_points[i - 1], arc_points[i], center, radius, arcs_per_revolution, counterclockwise);
-            if (!is_arc && arc_points[i - 1].distance(arc_points[i]) <= kMinPathSegmentLength) {
-                continue;
-            }
+            if (!is_arc && arc_points[i - 1].distance(arc_points[i]) <= kMinPathSegmentLength) { continue; }
 
             QSharedPointer<SegmentBase> segment;
             if (is_arc) {
@@ -780,9 +707,7 @@ Path HelicalSlicer::createPath(const Polyline& polyline, const QSharedPointer<Se
                 segment =
                     QSharedPointer<ArcSegment>::create(arc_points[i - 1], arc_points[i], arc_center, counterclockwise);
             }
-            else {
-                segment = QSharedPointer<LineSegment>::create(arc_points[i - 1], arc_points[i]);
-            }
+            else { segment = QSharedPointer<LineSegment>::create(arc_points[i - 1], arc_points[i]); }
 
             segment->setSb(i == 1 ? region_start_settings : print_settings);
             path.add(segment);
@@ -790,9 +715,7 @@ Path HelicalSlicer::createPath(const Polyline& polyline, const QSharedPointer<Se
     }
     else {
         for (int i = 1, end = polyline.size(); i < end; ++i) {
-            if (polyline[i - 1].distance(polyline[i]) <= kMinPathSegmentLength) {
-                continue;
-            }
+            if (polyline[i - 1].distance(polyline[i]) <= kMinPathSegmentLength) { continue; }
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(polyline[i - 1], polyline[i]);
             segment->setSb(i == 1 ? region_start_settings : print_settings);
@@ -800,10 +723,8 @@ Path HelicalSlicer::createPath(const Polyline& polyline, const QSharedPointer<Se
         }
     }
 
-    if (path.size() > 0) {
-        current_location = path_end;
-    }
+    if (path.size() > 0) { current_location = path_end; }
 
     return path;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/slicers/image_slicer.cpp
+++ b/src/threading/slicers/image_slicer.cpp
@@ -59,7 +59,7 @@ namespace ORNL {
 ImageSlicer::ImageSlicer(QString gcodeLocation) : TraditionalAST(gcodeLocation, true) {}
 
 void ImageSlicer::preProcess(nlohmann::json opt_data) {
-    QVector<QSharedPointer<Part>> parts = SlicingUtilities::GetPartsByType(CSM->parts(), MeshType::kBuild);
+    QVector<QSharedPointer<Part>> parts     = SlicingUtilities::GetPartsByType(CSM->parts(), MeshType::kBuild);
     QVector<QSharedPointer<Part>> moreParts = SlicingUtilities::GetPartsByType(CSM->parts(), MeshType::kSupport);
     parts += moreParts;
 
@@ -98,8 +98,7 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
 
         std::tie(slicing_plane, mesh_min, mesh_max) = SlicingUtilities::GetDefaultSlicingAxis(GSM->getGlobal(), mesh);
 
-        if (slicing_plane.point().z() < lowestSlicingPlane.point().z())
-            lowestSlicingPlane = slicing_plane;
+        if (slicing_plane.point().z() < lowestSlicingPlane.point().z()) lowestSlicingPlane = slicing_plane;
 
         currentMesh.m_min = mesh->min();
         currentMesh.m_max = mesh->max();
@@ -107,8 +106,7 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
         QFileInfo fi(part->sourceFilePath());
         currentMesh.m_original_name = fi.completeBaseName();
 
-        if (mesh_max.z() > globalMax.z())
-            globalMax = mesh_max;
+        if (mesh_max.z() > globalMax.z()) globalMax = mesh_max;
 
         if (mesh->type() == MeshType::kSupport) {
             currentMesh.m_id = 65535;
@@ -130,8 +128,7 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
     });
 
     // Ids are now conveniently mesh location in vector
-    for (int i = 0; i < allMeshes.size(); ++i)
-        allMeshes[i].m_id = i + 1;
+    for (int i = 0; i < allMeshes.size(); ++i) allMeshes[i].m_id = i + 1;
 
     // include support meshes, id was previously set to static value
     allMeshes += supportMeshes;
@@ -148,8 +145,7 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
             QVector<double> heights = QVector<double>(vec.begin(), vec.end());
             for (double height : heights) {
                 int layer = qRound(height / layerHeight()) - 1;
-                if (layer < 0)
-                    layer = 0;
+                if (layer < 0) layer = 0;
                 layers.push_back(layer);
             }
         }
@@ -172,8 +168,7 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
             if (i == layers[0]) {
                 slicing_planes.push_back(SlicingPlaneWithLayer(i, next_plane));
                 layers.pop_front();
-                if (layers.size() == 0)
-                    break;
+                if (layers.size() == 0) break;
             }
         }
         else
@@ -184,10 +179,10 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
 
     double xResolution = GSM->getGlobal()->setting<double>(PS::Slicing::kImagePixelSizeX);
     double yResolution = GSM->getGlobal()->setting<double>(PS::Slicing::kImagePixelSizeY);
-    int volumeXDim = std::ceil((GSM->getGlobal()->setting<double>(PRS::Dimensions::kXMax) -
-                                GSM->getGlobal()->setting<double>(PRS::Dimensions::kXMin)) /
-                               xResolution) +
-                     1;
+    int volumeXDim     = std::ceil((GSM->getGlobal()->setting<double>(PRS::Dimensions::kXMax) -
+                                    GSM->getGlobal()->setting<double>(PRS::Dimensions::kXMin)) /
+                                   xResolution) +
+                         1;
 
     int volumeYDim = std::ceil((GSM->getGlobal()->setting<double>(PRS::Dimensions::kYMax) -
                                 GSM->getGlobal()->setting<double>(PRS::Dimensions::kYMin)) /
@@ -208,12 +203,10 @@ void ImageSlicer::preProcess(nlohmann::json opt_data) {
                                                                   average_normal, GSM->getGlobal());
 
                 for (int k = result.size() - 1; k >= 0; --k) {
-                    if (result[k].size() <= 2)
-                        result.removeAt(k);
+                    if (result[k].size() <= 2) result.removeAt(k);
                 }
 
-                if (!result.empty())
-                    currentCrossSections.push_back(PolygonListAndColor(result, allMeshes[j].m_id));
+                if (!result.empty()) currentCrossSections.push_back(PolygonListAndColor(result, allMeshes[j].m_id));
             }
         }
 
@@ -306,8 +299,7 @@ void ImageSlicer::createImageStencilVTK(QVector<PolygonListAndColor> geometryAnd
             for (int y = minPt.y(); y < maxPt.y(); ++y) {
                 double val =
                     imageStencilToImage->GetOutput()->GetScalarComponentAsDouble(x - minPt.x(), y - minPt.y(), 0, 0);
-                if (val > 0)
-                    fullImage->SetScalarComponentFromDouble(x, y, 0, 0, val);
+                if (val > 0) fullImage->SetScalarComponentFromDouble(x, y, 0, 0, val);
             }
         }
     }
@@ -333,19 +325,20 @@ void ImageSlicer::parallelForDynamic(int start, int end, int batchSize, const st
         threads.emplace_back([&]() {
             while (true) {
                 int i = index.fetch_add(batchSize);
-                if (i >= end)
-                    break;
+                if (i >= end) break;
 
                 int i_end = std::min(i + batchSize, end);
-                for (int j = i; j < i_end; ++j) {
-                    func(j);
-                }
+                for (int j = i; j < i_end; ++j) { func(j); }
             }
         });
     }
 }
 
-void ImageSlicer::postProcess(nlohmann::json opt_data) { emit statusUpdate(StatusUpdateStepType::kPostProcess, 100); }
+void ImageSlicer::postProcess(nlohmann::json opt_data) {
+    emit statusUpdate(StatusUpdateStepType::kPostProcess, 100);
+}
 
-void ImageSlicer::writeGCode() { emit statusUpdate(StatusUpdateStepType::kGcodeGeneraton, 100); }
-} // namespace ORNL
+void ImageSlicer::writeGCode() {
+    emit statusUpdate(StatusUpdateStepType::kGcodeGeneraton, 100);
+}
+}  // namespace ORNL

--- a/src/threading/slicers/planar_slicer.cpp
+++ b/src/threading/slicers/planar_slicer.cpp
@@ -50,10 +50,10 @@ void PlanarSlicer::preProcess(nlohmann::json opt_data) {
 
             // Check for overlaps of settings parts and prevent them
             if (SlicingUtilities::doPartsOverlap(parts.settings_parts, Plane(Point(1, 1, 1), QVector3D(0, 0, 1)))) {
-                return true; // Cancel Slicing
+                return true;  // Cancel Slicing
             }
 
-            return false; // No error, so continune slicing
+            return false;  // No error, so continune slicing
         });
 
     pp.addPartProcessing([this](QSharedPointer<Part> part, QSharedPointer<SettingsBase> part_sb) {
@@ -70,7 +70,7 @@ void PlanarSlicer::preProcess(nlohmann::json opt_data) {
         auto clipping_meshes = SlicingUtilities::GetMeshesByType(CSM->parts(), MeshType::kClipping);
         SlicingUtilities::ClipMesh(mesh, clipping_meshes);
 
-        return false; // No error, so continune slicing
+        return false;  // No error, so continune slicing
     });
 
     pp.addStepBuilder(
@@ -146,7 +146,7 @@ void PlanarSlicer::preProcess(nlohmann::json opt_data) {
                 }
             }
 
-            return false; // No error, so continune slicing
+            return false;  // No error, so continune slicing
         });
 
     pp.addCrossSectionProcessing([this](Preprocessor::ActivePartMeta& meta) {
@@ -171,11 +171,9 @@ void PlanarSlicer::preProcess(nlohmann::json opt_data) {
         processThermalScan(meta.part, meta.part_sb);
 
         // Update max steps
-        if (meta.part->countStepPairs() > this->getMaxSteps()) {
-            this->setMaxSteps(meta.part->countStepPairs());
-        }
+        if (meta.part->countStepPairs() > this->getMaxSteps()) { this->setMaxSteps(meta.part->countStepPairs()); }
 
-        return false; // No error, so continune slicing
+        return false;  // No error, so continune slicing
     });
 
     pp.addStatusUpdate([this](double percentage) { emit statusUpdate(StatusUpdateStepType::kPreProcess, percentage); });
@@ -185,7 +183,7 @@ void PlanarSlicer::preProcess(nlohmann::json opt_data) {
             // Compute and populate global layers
             processGlobalLayers(parts.build_parts, global_settings);
 
-            return false; // No error, so continune slicing
+            return false;  // No error, so continune slicing
         });
 
     pp.processAll();
@@ -203,11 +201,11 @@ void PlanarSlicer::processSkin(QSharedPointer<Part> part, int part_start, int la
 
                 //! Gather skin counts
                 int bottom_count = layer->getSb()->setting<int>(PS::Skin::kBottomCount);
-                int top_count = layer->getSb()->setting<int>(PS::Skin::kTopCount);
+                int top_count    = layer->getSb()->setting<int>(PS::Skin::kTopCount);
 
                 //! Set bounds
-                int upper_bound = qMin(layer_nr + top_count, last_layer_count + part_start - 1);
-                int lower_bound = qMax(layer_nr - bottom_count, part_start);
+                int upper_bound   = qMin(layer_nr + top_count, last_layer_count + part_start - 1);
+                int lower_bound   = qMax(layer_nr - bottom_count, part_start);
                 int gradual_bound = qMin(upper_bound + gradual_steps, last_layer_count + part_start - 1);
 
                 //! Determine if upper and lower ranges include top and bottom layer respectively
@@ -240,10 +238,10 @@ void PlanarSlicer::processSkin(QSharedPointer<Part> part, int part_start, int la
 void PlanarSlicer::processRaft(QSharedPointer<Part> part, int part_start, QSharedPointer<SettingsBase> part_sb) {
     if (!part->steps(StepType::kLayer).empty()) {
         if (part_sb->setting<bool>(MS::PlatformAdhesion::kRaftEnable)) {
-            int raft_layers = part_sb->setting<int>(MS::PlatformAdhesion::kRaftLayers);
+            int raft_layers        = part_sb->setting<int>(MS::PlatformAdhesion::kRaftLayers);
             Distance height_offset = 0.0;
 
-            auto steps = part->steps(StepType::kLayer);
+            auto steps       = part->steps(StepType::kLayer);
             auto first_layer = steps.first().dynamicCast<Layer>();
             QVector<QSharedPointer<Layer>> new_raft_layers;
             for (int i = 0; i < raft_layers; ++i) {
@@ -257,18 +255,14 @@ void PlanarSlicer::processRaft(QSharedPointer<Part> part, int part_start, QShare
             }
 
             // Offset steps based on height added by raft layers
-            for (auto step : steps)
-                step->setRaftShift(first_layer->getSlicingPlane().normal() * height_offset());
+            for (auto step : steps) step->setRaftShift(first_layer->getSlicingPlane().normal() * height_offset());
 
             // Add new raft steps
-            for (int i = new_raft_layers.size() - 1; i >= 0; --i)
-                part->prependStep(new_raft_layers[i]);
+            for (int i = new_raft_layers.size() - 1; i >= 0; --i) part->prependStep(new_raft_layers[i]);
         }
         else {
             if (part_start != 0) {
-                for (int i = 0; i < part_start; ++i) {
-                    part->removeStepAtIndex(0);
-                }
+                for (int i = 0; i < part_start; ++i) { part->removeStepAtIndex(0); }
             }
         }
     }
@@ -320,9 +314,7 @@ void PlanarSlicer::processLaserScan(QSharedPointer<Part> part, QSharedPointer<Se
             if (m_saved_layer_settings.first()->setting<bool>(PS::LaserScanner::kEnableBedScan)) {
                 LayerAdditions::addLaserScan(part, 0, 0, part->step(0, StepType::kLayer), m_temp_gcode_dir);
             }
-            else {
-                part->removeStepFromGroup(0, StepType::kScan);
-            }
+            else { part->removeStepFromGroup(0, StepType::kScan); }
 
             int scan_layer_skip = m_saved_layer_settings.first()->setting<int>(PS::LaserScanner::kScanLayerSkip);
             for (int current_layer = 1, layer_count = part->countStepPairs(); current_layer < layer_count;
@@ -342,9 +334,7 @@ void PlanarSlicer::processLaserScan(QSharedPointer<Part> part, QSharedPointer<Se
             }
         }
         else {
-            for (int i = part->countStepPairs() - 1; i >= 0; --i) {
-                part->removeStepFromGroup(i, StepType::kScan);
-            }
+            for (int i = part->countStepPairs() - 1; i >= 0; --i) { part->removeStepFromGroup(i, StepType::kScan); }
         }
     }
 }
@@ -369,8 +359,7 @@ bool PlanarSlicer::anythingDirty() {
 }
 
 void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, int partStart) {
-    if (layer_count < 2 || part->steps().isEmpty())
-        return;
+    if (layer_count < 2 || part->steps().isEmpty()) return;
 
     QVector<QSharedPointer<Layer>> layers;
     QVector<PolygonList> model_geometry;
@@ -378,20 +367,17 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
     model_geometry.reserve(layer_count);
     for (int i = 0; i < layer_count; ++i) {
         auto layer = part->step(partStart + i, StepType::kLayer).dynamicCast<Layer>();
-        if (layer.isNull())
-            return;
+        if (layer.isNull()) return;
         layers.push_back(layer);
         model_geometry.push_back(layer->getGeometry());
     }
 
     auto removeSmallAreas = [](PolygonList geometry, Area minimum_area) {
-        if (minimum_area <= 0)
-            return geometry;
+        if (minimum_area <= 0) return geometry;
 
         PolygonList filtered;
         for (PolygonList island : geometry.splitIntoParts(true)) {
-            if (island.netArea() >= minimum_area)
-                filtered |= island;
+            if (island.netArea() >= minimum_area) filtered |= island;
         }
         return filtered;
     };
@@ -428,12 +414,11 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
 
     auto isBridgeable = [&makeRectangle](PolygonList component, const PolygonList& model_below, Distance maximum_length,
                                          Distance anchor_width) {
-        if (component.isEmpty() || model_below.isEmpty() || maximum_length <= 0)
-            return false;
+        if (component.isEmpty() || model_below.isEmpty() || maximum_length <= 0) return false;
 
         const Point minimum = component.min();
         const Point maximum = component.max();
-        const double width = maximum.x() - minimum.x();
+        const double width  = maximum.x() - minimum.x();
         const double height = maximum.y() - minimum.y();
         const double anchor = qMax(anchor_width(), 1.0);
 
@@ -447,8 +432,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
                 makeRectangle(minimum.x() - anchor, minimum.y() - anchor, minimum.x() + anchor, maximum.y() + anchor);
             const PolygonList right =
                 makeRectangle(maximum.x() - anchor, minimum.y() - anchor, maximum.x() + anchor, maximum.y() + anchor);
-            if (intersectsModel(left) && intersectsModel(right))
-                return true;
+            if (intersectsModel(left) && intersectsModel(right)) return true;
         }
 
         if (Distance(height) <= maximum_length) {
@@ -456,8 +440,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
                 makeRectangle(minimum.x() - anchor, minimum.y() - anchor, maximum.x() + anchor, minimum.y() + anchor);
             const PolygonList top =
                 makeRectangle(minimum.x() - anchor, maximum.y() - anchor, maximum.x() + anchor, maximum.y() + anchor);
-            if (intersectsModel(bottom) && intersectsModel(top))
-                return true;
+            if (intersectsModel(bottom) && intersectsModel(top)) return true;
         }
         return false;
     };
@@ -476,8 +459,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
     for (int layer_index = 0; layer_index < layer_count; ++layer_index) {
         for (const SettingsPolygon& polygon : layers[layer_index]->getSettingsPolygons()) {
             const auto settings = polygon.getSettings();
-            if (!settings->contains(PS::Support::kEnable))
-                continue;
+            if (!settings->contains(PS::Support::kEnable)) continue;
             if (settings->setting<bool>(PS::Support::kEnable))
                 enforcer_geometry[layer_index] |= polygon;
             else
@@ -502,11 +484,11 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
         if (!supported_from_below.isEmpty() && self_supporting_offset > 0)
             supported_from_below = supported_from_below.offset(self_supporting_offset);
 
-        PolygonList overhang = model_geometry[upper_index] - supported_from_below;
+        PolygonList overhang    = model_geometry[upper_index] - supported_from_below;
         const Area minimum_area = upper_layer->getSb()->setting<Area>(PS::Support::kMinArea);
-        overhang = removeSmallAreas(overhang, minimum_area);
+        overhang                = removeSmallAreas(overhang, minimum_area);
 
-        const bool suppress_bridges = upper_layer->getSb()->setting<bool>(PS::Support::kBridgeSuppression);
+        const bool suppress_bridges          = upper_layer->getSb()->setting<bool>(PS::Support::kBridgeSuppression);
         const Distance maximum_bridge_length = upper_layer->getSb()->setting<Distance>(PS::Support::kBridgeMaxLength);
         if (suppress_bridges && maximum_bridge_length > 0 && !overhang.isEmpty()) {
             PolygonList unsupported_overhang;
@@ -523,12 +505,10 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
 
         const int layer_offset = qMax(0, upper_layer->getSb()->setting<int>(PS::Support::kLayerOffset));
         const int target_layer = upper_index - layer_offset - 1;
-        if (target_layer < 0)
-            continue;
+        if (target_layer < 0) continue;
 
         overhang -= blocker_geometry[target_layer];
-        if (overhang.isEmpty())
-            continue;
+        if (overhang.isEmpty()) continue;
 
         support_geometry[target_layer] |= overhang;
 
@@ -545,29 +525,24 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
         // Anchor the taper directly below the dense interface.  With no
         // interface configured, the taper begins at the top support layer.
         const int taper_start_layer = target_layer - interface_layers;
-        if (taper_start_layer >= 0)
-            taper_start_geometry[taper_start_layer] |= interface_contact;
+        if (taper_start_layer >= 0) taper_start_geometry[taper_start_layer] |= interface_contact;
 
         if (upper_layer->getSb()->setting<int>(PS::Support::kStructure) == 1) {
-            Distance diameter = upper_layer->getSb()->setting<Distance>(PS::Support::kOrganicBranchDiameter);
+            Distance diameter         = upper_layer->getSb()->setting<Distance>(PS::Support::kOrganicBranchDiameter);
             const Distance bead_width = upper_layer->getSb()->setting<Distance>(PS::Layer::kBeadWidth);
-            if (diameter <= 0)
-                diameter = bead_width * 3.0;
+            if (diameter <= 0) diameter = bead_width * 3.0;
 
             Distance spacing = upper_layer->getSb()->setting<Distance>(PS::Support::kOrganicBranchSpacing);
             if (spacing <= 0)
                 spacing = max(diameter * 4.0, upper_layer->getSb()->setting<Distance>(PS::Support::kLineSpacing) * 4.0);
-            if (spacing <= 0)
-                spacing = diameter * 2.0;
+            if (spacing <= 0) spacing = diameter * 2.0;
 
             Angle branch_angle = upper_layer->getSb()->setting<Angle>(PS::Support::kOrganicBranchAngle);
-            if (branch_angle <= 0)
-                branch_angle = 25.0 * deg;
+            if (branch_angle <= 0) branch_angle = 25.0 * deg;
 
             for (PolygonList contact_area : overhang.splitIntoParts(true)) {
                 Point root = contact_area.boundingRectCenter();
-                if (!contact_area.inside(root, true))
-                    root = contact_area.first().first();
+                if (!contact_area.inside(root, true)) root = contact_area.first().first();
 
                 QVector<Point> contacts;
                 const Point minimum = contact_area.min();
@@ -575,12 +550,10 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
                 for (double x = minimum.x() + spacing() / 2.0; x < maximum.x(); x += spacing()) {
                     for (double y = minimum.y() + spacing() / 2.0; y < maximum.y(); y += spacing()) {
                         Point candidate(x, y);
-                        if (contact_area.inside(candidate, true))
-                            contacts.push_back(candidate);
+                        if (contact_area.inside(candidate, true)) contacts.push_back(candidate);
                     }
                 }
-                if (contacts.isEmpty())
-                    contacts.push_back(root);
+                if (contacts.isEmpty()) contacts.push_back(root);
 
                 for (const Point& contact : contacts)
                     organic_branches.push_back({target_layer, contact, root, diameter, branch_angle});
@@ -605,8 +578,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
             max(Distance(0), layers[layer_index]->getSb()->setting<Distance>(PS::Support::kXYDistance));
         if (!model_geometry[layer_index].isEmpty()) {
             PolygonList clearance = model_geometry[layer_index];
-            if (xy_distance > 0)
-                clearance = clearance.offset(xy_distance);
+            if (xy_distance > 0) clearance = clearance.offset(xy_distance);
             support_geometry[layer_index] -= clearance;
         }
     }
@@ -619,17 +591,16 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
         QVector<PolygonList> organic_geometry(layer_count);
         for (int layer_index = 0; layer_index < layer_count; ++layer_index) {
             for (const OrganicBranch& branch : organic_branches) {
-                if (layer_index > branch.target_layer || support_geometry[layer_index].isEmpty())
-                    continue;
+                if (layer_index > branch.target_layer || support_geometry[layer_index].isEmpty()) continue;
 
                 const double vertical_distance = layers[branch.target_layer]->getSlicingPlane().point().distance(
                     layers[layer_index]->getSlicingPlane().point())();
-                const double dx = branch.root.x() - branch.contact.x();
-                const double dy = branch.root.y() - branch.contact.y();
+                const double dx               = branch.root.x() - branch.contact.x();
+                const double dy               = branch.root.y() - branch.contact.y();
                 const double distance_to_root = std::hypot(dx, dy);
                 const double max_shift = vertical_distance * std::tan(qBound(0.0, branch.angle(), (60.0 * deg)()));
-                const double shift = qMin(distance_to_root, max_shift);
-                const double ratio = distance_to_root > 0.0 ? shift / distance_to_root : 0.0;
+                const double shift     = qMin(distance_to_root, max_shift);
+                const double ratio     = distance_to_root > 0.0 ? shift / distance_to_root : 0.0;
                 Point center(branch.contact.x() + dx * ratio, branch.contact.y() + dy * ratio);
 
                 // Branches widen gently toward the bed and naturally merge when
@@ -661,8 +632,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
             max(Distance(0), layers[layer_index]->getSb()->setting<Distance>(PS::Support::kXYDistance));
         if (!model_geometry[layer_index].isEmpty()) {
             PolygonList model_clearance = model_geometry[layer_index];
-            if (xy_distance > 0)
-                model_clearance = model_clearance.offset(xy_distance);
+            if (xy_distance > 0) model_clearance = model_clearance.offset(xy_distance);
             forbidden |= model_clearance;
         }
         support_geometry[layer_index] -= forbidden;
@@ -677,8 +647,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
         const Distance base_expansion =
             max(Distance(0), layers[0]->getSb()->setting<Distance>(PS::Support::kBaseExpansion));
         PolygonList base_footprint = support_geometry[0];
-        if (base_expansion > 0)
-            base_footprint = base_footprint.offset(base_expansion);
+        if (base_expansion > 0) base_footprint = base_footprint.offset(base_expansion);
 
         for (int layer_index = 0; layer_index < qMin(layer_count, base_layers); ++layer_index) {
             PolygonList layer_base = base_footprint;
@@ -688,8 +657,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
                 const Distance xy_distance =
                     max(Distance(0), layers[layer_index]->getSb()->setting<Distance>(PS::Support::kXYDistance));
                 PolygonList model_clearance = model_geometry[layer_index];
-                if (xy_distance > 0)
-                    model_clearance = model_clearance.offset(xy_distance);
+                if (xy_distance > 0) model_clearance = model_clearance.offset(xy_distance);
                 layer_base -= model_clearance;
             }
 
@@ -702,7 +670,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
     // component may also land on model geometry; Build Plate Only deliberately
     // excludes that foundation.  Invalid components are removed before path
     // generation so disconnected islands cannot silently print in midair.
-    const int placement = layers[0]->getSb()->setting<int>(PS::Support::kPlacement);
+    const int placement         = layers[0]->getSb()->setting<int>(PS::Support::kPlacement);
     const bool build_plate_only = placement == 1;
     const bool validate_support = layers[0]->getSb()->setting<bool>(PS::Support::kValidation);
     if (validate_support || build_plate_only) {
@@ -723,12 +691,11 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
 
         for (int layer_index = 1; layer_index < layer_count; ++layer_index) {
             PolygonList foundation = valid_support[layer_index - 1];
-            if (!build_plate_only)
-                foundation |= model_geometry[layer_index - 1];
+            if (!build_plate_only) foundation |= model_geometry[layer_index - 1];
 
             for (PolygonList component : support_geometry[layer_index].splitIntoParts(true)) {
-                PolygonList overlap_source = component;
-                PolygonList overlap = overlap_source & foundation;
+                PolygonList overlap_source  = component;
+                PolygonList overlap         = overlap_source & foundation;
                 const double component_area = component.netArea()();
                 const double overlap_ratio =
                     component_area > 0.0 ? qMax(0.0, overlap.netArea()() / component_area) : 0.0;
@@ -748,8 +715,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
 
     auto makeTaperSeed = [](const PolygonList& geometry, Distance growth) {
         PolygonList seeds;
-        if (geometry.isEmpty() || growth <= 0)
-            return seeds;
+        if (geometry.isEmpty() || growth <= 0) return seeds;
 
         // Erode each component to its innermost region, then back off by one
         // layer of taper growth.  This creates a small central void immediately
@@ -758,8 +724,8 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
         for (PolygonList component : geometry.splitIntoParts(true)) {
             const Point minimum = component.min();
             const Point maximum = component.max();
-            double lower_inset = 0.0;
-            double upper_inset = std::hypot(maximum.x() - minimum.x(), maximum.y() - minimum.y());
+            double lower_inset  = 0.0;
+            double upper_inset  = std::hypot(maximum.x() - minimum.x(), maximum.y() - minimum.y());
 
             for (int iteration = 0; iteration < 32; ++iteration) {
                 const double inset = (lower_inset + upper_inset) / 2.0;
@@ -785,22 +751,19 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
             const auto& settings = layers[layer_index]->getSb();
             const bool hollow_taper =
                 settings->setting<bool>(PS::Support::kTaper) && settings->setting<int>(PS::Support::kStructure) == 0;
-            if (!hollow_taper || support_geometry[layer_index].isEmpty())
-                continue;
+            if (!hollow_taper || support_geometry[layer_index].isEmpty()) continue;
 
-            const Distance bead_width = settings->setting<Distance>(PS::Layer::kBeadWidth);
-            const int wall_contours = qMax(1, settings->setting<int>(PS::Support::kTaperWallContours));
-            const Distance wall_width = bead_width * wall_contours;
+            const Distance bead_width      = settings->setting<Distance>(PS::Layer::kBeadWidth);
+            const int wall_contours        = qMax(1, settings->setting<int>(PS::Support::kTaperWallContours));
+            const Distance wall_width      = bead_width * wall_contours;
             const PolygonList maximum_hole = support_geometry[layer_index].offset(-wall_width);
-            if (maximum_hole.isEmpty())
-                continue;
+            if (maximum_hole.isEmpty()) continue;
 
             PolygonList allowed_hole = maximum_hole;
-            PolygonList dense_mask = interface_geometry[layer_index];
+            PolygonList dense_mask   = interface_geometry[layer_index];
             dense_mask |= base_geometry[layer_index];
             allowed_hole -= support_geometry[layer_index] & dense_mask;
-            if (allowed_hole.isEmpty())
-                continue;
+            if (allowed_hole.isEmpty()) continue;
 
             Distance taper_step(0);
             if (layer_index + 1 < layer_count) {
@@ -814,8 +777,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
             PolygonList holes;
             if (layer_index + 1 < layer_count && !taper_hole_geometry[layer_index + 1].isEmpty()) {
                 PolygonList propagated_holes = taper_hole_geometry[layer_index + 1];
-                if (taper_step > 0)
-                    propagated_holes = propagated_holes.offset(taper_step);
+                if (taper_step > 0) propagated_holes = propagated_holes.offset(taper_step);
                 propagated_holes &= allowed_hole;
                 holes |= propagated_holes;
             }
@@ -831,7 +793,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
     for (int layer_index = 0; layer_index < layer_count; ++layer_index) {
         QVector<QSharedPointer<IslandBase>> support_islands;
         const PolygonList interface_dense_geometry = support_geometry[layer_index] & interface_geometry[layer_index];
-        PolygonList base_dense_geometry = support_geometry[layer_index] & base_geometry[layer_index];
+        PolygonList base_dense_geometry            = support_geometry[layer_index] & base_geometry[layer_index];
         base_dense_geometry -= interface_dense_geometry;
         PolygonList dense_geometry = interface_dense_geometry;
         dense_geometry |= base_dense_geometry;
@@ -854,9 +816,7 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
             sparse_geometry -= tube_wall_geometry;
             sparse_geometry -= dense_geometry;
         }
-        else {
-            sparse_geometry = support_geometry[layer_index] - dense_geometry;
-        }
+        else { sparse_geometry = support_geometry[layer_index] - dense_geometry; }
 
         for (const PolygonList& geometry : sparse_geometry.splitIntoParts(true)) {
             auto settings = QSharedPointer<SettingsBase>::create(*layers[layer_index]->getSb());
@@ -890,10 +850,9 @@ void PlanarSlicer::processSupport(QSharedPointer<Part> part, int layer_count, in
         }
 
         for (const PolygonList& geometry : interface_dense_geometry.splitIntoParts(true)) {
-            auto settings = QSharedPointer<SettingsBase>::create(*layers[layer_index]->getSb());
+            auto settings              = QSharedPointer<SettingsBase>::create(*layers[layer_index]->getSb());
             Distance interface_spacing = settings->setting<Distance>(PS::Support::kInterfaceLineSpacing);
-            if (interface_spacing <= 0)
-                interface_spacing = settings->setting<Distance>(PS::Layer::kBeadWidth);
+            if (interface_spacing <= 0) interface_spacing = settings->setting<Distance>(PS::Layer::kBeadWidth);
 
             settings->setSetting(PS::Support::kInterfaceRegion, true);
             settings->setSetting(PS::Support::kBaseRegion, false);
@@ -926,18 +885,16 @@ void PlanarSlicer::postProcess(nlohmann::json opt_data) {
         QVector<QSharedPointer<RegionBase>> previous_regions;
 
         for (int g_layer_num = 0, max_layers = m_global_layers.size(); g_layer_num < max_layers; ++g_layer_num) {
-            auto islands = m_global_layers[g_layer_num]->getIslands();
+            auto islands     = m_global_layers[g_layer_num]->getIslands();
             int region_count = 0;
-            int path_count = 0;
+            int path_count   = 0;
             for (const auto& island : islands) {
-                if (island.isNull())
-                    continue;
+                if (island.isNull()) continue;
 
                 const auto regions = island->getRegions();
                 region_count += regions.size();
                 for (const auto& region : regions) {
-                    if (!region.isNull())
-                        path_count += region->getPaths().size();
+                    if (!region.isNull()) path_count += region->getPaths().size();
                 }
             }
             Diagnostics::logLine(QString("Planar postprocess layer %1/%2 islands=%3 regions=%4 paths=%5")
@@ -963,7 +920,7 @@ void PlanarSlicer::postProcess(nlohmann::json opt_data) {
         }
     }
     else {
-        emit statusUpdate(StatusUpdateStepType::kPostProcess, 100); // Mark layerbar as done
+        emit statusUpdate(StatusUpdateStepType::kPostProcess, 100);  // Mark layerbar as done
     }
 
     Diagnostics::logLine(QStringLiteral("Planar postprocess finished"));
@@ -974,7 +931,7 @@ void PlanarSlicer::writeGCode() {
 
     // for updating status window
     double current_layer = 0;
-    double num_layers = m_global_layers.size();
+    double num_layers    = m_global_layers.size();
 
     // have each layer write its own gcode
     for (auto g_layer : m_global_layers) {
@@ -991,4 +948,4 @@ void PlanarSlicer::writeGCode() {
 
     stream << m_base->writeAfterPart();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/slicers/radial_slicer.cpp
+++ b/src/threading/slicers/radial_slicer.cpp
@@ -1,10 +1,10 @@
 #include "threading/slicers/radial_slicer.h"
 
+#include <QTextStream>
 #include <algorithm>
 #include <cmath>
 #include <limits>
 
-#include <QTextStream>
 #include <nlohmann/json_fwd.hpp>
 #include <qcontainerfwd.h>
 #include <qdebug.h>
@@ -45,7 +45,9 @@ const QString kRadialCenterX = "radial_center_x";
 const QString kRadialCenterY = "radial_center_y";
 
 //! @brief Returns a positive setting value or a safe fallback.
-Distance positiveOrFallback(Distance value, Distance fallback) { return value > 0 ? value : fallback; }
+Distance positiveOrFallback(Distance value, Distance fallback) {
+    return value > 0 ? value : fallback;
+}
 
 //! @brief Physical fallback used when the radial layer spacing setting is invalid.
 const Distance kDefaultRadialLayerHeight = 1.0 * mm;
@@ -60,23 +62,21 @@ const Distance kMinPathSegmentLength = 10.0 * micron;
 double totalPolylineLength(const QVector<Polyline>& polylines) {
     double total_length = 0.0;
     for (const Polyline& polyline : polylines) {
-        if (polyline.size() > 1) {
-            total_length += polyline.length()();
-        }
+        if (polyline.size() > 1) { total_length += polyline.length()(); }
     }
     return total_length;
 }
 
 //! @brief Clips a candidate radial ring against the model cross section.
-QVector<Polyline> clipCircleToSection(PolygonList& geometry, const Polyline& circle) { return geometry & circle; }
+QVector<Polyline> clipCircleToSection(PolygonList& geometry, const Polyline& circle) {
+    return geometry & circle;
+}
 
 //! @brief Returns whether model clipping removed any meaningful portion of the radial path.
 bool crossesModelBoundary(const Polyline& circle, const QVector<Polyline>& clipped_lines) {
-    if (clipped_lines.isEmpty() || circle.size() < 2) {
-        return false;
-    }
+    if (clipped_lines.isEmpty() || circle.size() < 2) { return false; }
 
-    const double circle_length = circle.length()();
+    const double circle_length  = circle.length()();
     const double clipped_length = totalPolylineLength(clipped_lines);
     return clipped_length < circle_length - kMinPathSegmentLength();
 }
@@ -84,9 +84,7 @@ bool crossesModelBoundary(const Polyline& circle, const QVector<Polyline>& clipp
 //! @brief Applies the configured radial boundary policy to a candidate radial path.
 QVector<Polyline> applyBoundaryPolicy(const Polyline& circle, const QVector<Polyline>& clipped_lines,
                                       RadialPathBoundaryPolicy handling) {
-    if (clipped_lines.isEmpty()) {
-        return {};
-    }
+    if (clipped_lines.isEmpty()) { return {}; }
 
     switch (handling) {
         case RadialPathBoundaryPolicy::kKeepBoundaryCrossingPath:
@@ -109,13 +107,11 @@ struct RadialCrossSection {
 bool meshBounds(const QVector<QSharedPointer<MeshBase>>& meshes, Point& mesh_min, Point& mesh_max) {
     bool has_bounds = false;
     for (const QSharedPointer<MeshBase>& mesh : meshes) {
-        if (mesh == nullptr || mesh->vertices().isEmpty()) {
-            continue;
-        }
+        if (mesh == nullptr || mesh->vertices().isEmpty()) { continue; }
 
         if (!has_bounds) {
-            mesh_min = mesh->min();
-            mesh_max = mesh->max();
+            mesh_min   = mesh->min();
+            mesh_max   = mesh->max();
             has_bounds = true;
             continue;
         }
@@ -135,9 +131,7 @@ bool meshBounds(const QVector<QSharedPointer<MeshBase>>& meshes, Point& mesh_min
 
 //! @brief Estimates progress loop iterations for an inclusive Distance range.
 int estimateInclusiveCount(Distance start, Distance end, Distance step) {
-    if (step <= 0 || start > end) {
-        return 1;
-    }
+    if (step <= 0 || start > end) { return 1; }
 
     return std::max(1, static_cast<int>(std::floor((end() - start()) / step())) + 1);
 }
@@ -145,18 +139,16 @@ int estimateInclusiveCount(Distance start, Distance end, Distance step) {
 //! @brief Returns the upper Z limit for generated cylindrical candidates.
 Distance cylindricalTopZ(const QSharedPointer<SettingsBase>& part_sb, Distance base_z, Distance mesh_top_z) {
     const Distance cylinder_height = part_sb->setting<Distance>(PS::Slicing::kCylinderHeight);
-    if (cylinder_height <= 0) {
-        return mesh_top_z;
-    }
+    if (cylinder_height <= 0) { return mesh_top_z; }
 
     const Distance capped_top_z(base_z + cylinder_height);
     return capped_top_z < mesh_top_z ? capped_top_z : mesh_top_z;
 }
-} // namespace
+}  // namespace
 
 RadialSlicer::RadialSlicer(QString gcodeLocation) : TraditionalAST(gcodeLocation) {
     m_syntax = GcodeSyntax::kArcSpecialties;
-    m_base = QSharedPointer<ArcSpecialtiesWriter>::create(GcodeMetaList::ArcSpecialtiesMeta, GSM->getGlobal());
+    m_base   = QSharedPointer<ArcSpecialtiesWriter>::create(GcodeMetaList::ArcSpecialtiesMeta, GSM->getGlobal());
 }
 
 void RadialSlicer::doSlice() {
@@ -170,16 +162,12 @@ void RadialSlicer::doSlice() {
     this->setMaxSteps(0);
     this->preProcess();
 
-    if (this->shouldCancel()) {
-        return;
-    }
+    if (this->shouldCancel()) { return; }
 
     this->postProcess();
     m_elapsed_time = m_timer.elapsed();
 
-    if (this->shouldCancel()) {
-        return;
-    }
+    if (this->shouldCancel()) { return; }
 
     if (!m_skip_gcode) {
         this->writeGCodeSetup();
@@ -187,9 +175,7 @@ void RadialSlicer::doSlice() {
         this->writeGCodeShutdown();
     }
 
-    if (this->shouldCancel()) {
-        return;
-    }
+    if (this->shouldCancel()) { return; }
 
     emit sliceComplete();
 }
@@ -206,10 +192,10 @@ void RadialSlicer::preProcess(nlohmann::json opt_data) {
         SlicingUtilities::GetMeshesByType(CSM->parts(), MeshType::kClipping);
 
     int last_preprocess_percent = -1;
-    int last_compute_percent = -1;
-    auto emitPartProgress = [this, &build_parts](StatusUpdateStepType type, int part_index, double part_fraction,
-                                                 int& last_percent) {
-        const double total_parts = std::max(1, static_cast<int>(build_parts.size()));
+    int last_compute_percent    = -1;
+    auto emitPartProgress       = [this, &build_parts](StatusUpdateStepType type, int part_index, double part_fraction,
+                                                       int& last_percent) {
+        const double total_parts           = std::max(1, static_cast<int>(build_parts.size()));
         const double bounded_part_fraction = std::clamp(part_fraction, 0.0, 1.0);
         const int percent =
             std::clamp(static_cast<int>(((part_index + bounded_part_fraction) / total_parts) * 100.0), 0, 100);
@@ -264,13 +250,11 @@ void RadialSlicer::preProcess(nlohmann::json opt_data) {
         const RadialPathBoundaryPolicy boundary_policy =
             static_cast<RadialPathBoundaryPolicy>(part_sb->setting<int>(PS::Slicing::kRadialPathBoundaryPolicy));
         Distance initial_radius = part_sb->setting<Distance>(PS::Slicing::kCylinderInnerRadius);
-        if (initial_radius < 0) {
-            initial_radius = 0.0 * micron;
-        }
+        if (initial_radius < 0) { initial_radius = 0.0 * micron; }
 
         const Distance base_z(mesh_min.z());
         const Distance top_z = cylindricalTopZ(part_sb, base_z, mesh_max.z());
-        Point center = radialCenterForPart(part_sb, part, base_z);
+        Point center         = radialCenterForPart(part_sb, part, base_z);
         const Distance max_radius(maxRadiusForMeshes(meshes, center));
 
         // Match planar slicing's centerline convention: the first layer sits
@@ -282,7 +266,7 @@ void RadialSlicer::preProcess(nlohmann::json opt_data) {
 
         QVector<RadialCrossSection> cross_sections;
         const int estimated_section_count = estimateInclusiveCount(first_bead_z, top_z, bead_width);
-        int sections_processed = 0;
+        int sections_processed            = 0;
         for (Distance z = first_bead_z; z <= top_z; z += bead_width) {
             Plane slicing_plane(Point(center.x(), center.y(), z()), QVector3D(0, 0, 1));
             PolygonList combined_geometry;
@@ -292,21 +276,13 @@ void RadialSlicer::preProcess(nlohmann::json opt_data) {
                 QVector3D average_normal;
                 PolygonList geometry =
                     CrossSection::doCrossSection(mesh, slicing_plane, shift, average_normal, part_sb);
-                if (geometry.isEmpty()) {
-                    continue;
-                }
+                if (geometry.isEmpty()) { continue; }
 
-                if (combined_geometry.isEmpty()) {
-                    combined_geometry = geometry;
-                }
-                else {
-                    combined_geometry += geometry;
-                }
+                if (combined_geometry.isEmpty()) { combined_geometry = geometry; }
+                else { combined_geometry += geometry; }
             }
 
-            if (!combined_geometry.isEmpty()) {
-                cross_sections.push_back(RadialCrossSection {z, combined_geometry});
-            }
+            if (!combined_geometry.isEmpty()) { cross_sections.push_back(RadialCrossSection {z, combined_geometry}); }
 
             ++sections_processed;
             emitPreProcessProgress(parts_processed, static_cast<double>(sections_processed) /
@@ -321,9 +297,9 @@ void RadialSlicer::preProcess(nlohmann::json opt_data) {
         }
 
         emitComputeProgress(parts_processed, 0.0);
-        int radial_layer_number = 0;
+        int radial_layer_number          = 0;
         const int estimated_radius_count = estimateInclusiveCount(first_radius, max_radius, layer_height);
-        int radii_processed = 0;
+        int radii_processed              = 0;
         for (Distance radius = first_radius; radius <= max_radius; radius += layer_height) {
             QSharedPointer<SettingsBase> layer_settings = QSharedPointer<SettingsBase>::create(*part_sb);
             layer_settings->makeLocalAdjustments(radial_layer_number);
@@ -338,22 +314,16 @@ void RadialSlicer::preProcess(nlohmann::json opt_data) {
                 // Intersect the horizontal model cross section with the
                 // current candidate path, then apply the radial boundary
                 // policy for paths intersected by the part boundary.
-                QVector<Polyline> clipped_lines = clipCircleToSection(section.geometry, circle);
+                QVector<Polyline> clipped_lines   = clipCircleToSection(section.geometry, circle);
                 QVector<Polyline> candidate_lines = applyBoundaryPolicy(circle, clipped_lines, boundary_policy);
 
                 for (Polyline line : candidate_lines) {
-                    if (line.size() < 2) {
-                        continue;
-                    }
+                    if (line.size() < 2) { continue; }
 
-                    for (Point& point : line) {
-                        point.z(section.z());
-                    }
+                    for (Point& point : line) { point.z(section.z()); }
 
                     Path path = createPath(line, layer_settings, center, radius, current_location);
-                    if (path.size() > 0) {
-                        radial_layer->addPath(path);
-                    }
+                    if (path.size() > 0) { radial_layer->addPath(path); }
                 }
             }
 
@@ -404,7 +374,7 @@ void RadialSlicer::writeGCode() {
     QTextStream stream(&m_temp_gcode_output_file);
 
     const double num_layers = std::max(1.0, static_cast<double>(m_radial_layers.size()));
-    int layer_number = 0;
+    int layer_number        = 0;
     for (const QSharedPointer<RadialLayer>& layer : m_radial_layers) {
         stream << m_base->writeLayerChange(layer_number);
         stream << m_base->writeBeforeLayer(layer->getMinZ(), layer->getSb());
@@ -420,9 +390,7 @@ void RadialSlicer::writeGCode() {
 }
 
 QSharedPointer<MeshBase> RadialSlicer::copyMesh(const QSharedPointer<MeshBase>& mesh) {
-    if (mesh == nullptr) {
-        return nullptr;
-    }
+    if (mesh == nullptr) { return nullptr; }
 
     if (ClosedMesh* closed_mesh = dynamic_cast<ClosedMesh*>(mesh.get())) {
         return QSharedPointer<ClosedMesh>::create(*closed_mesh);
@@ -453,14 +421,12 @@ Point RadialSlicer::radialCenterForPart(const QSharedPointer<SettingsBase>& part
 double RadialSlicer::maxRadiusForMeshes(const QVector<QSharedPointer<MeshBase>>& meshes, const Point& center) {
     double max_radius = 0.0;
     for (const QSharedPointer<MeshBase>& mesh : meshes) {
-        if (mesh == nullptr) {
-            continue;
-        }
+        if (mesh == nullptr) { continue; }
 
         for (const MeshVertex& vertex : mesh->vertices()) {
             const double dx = static_cast<double>(vertex.location.x() - center.x());
             const double dy = static_cast<double>(vertex.location.y() - center.y());
-            max_radius = std::max(max_radius, std::hypot(dx, dy));
+            max_radius      = std::max(max_radius, std::hypot(dx, dy));
         }
     }
     return max_radius;
@@ -505,35 +471,29 @@ QSharedPointer<SettingsBase> RadialSlicer::createSegmentSettings(const QSharedPo
 Path RadialSlicer::createPath(const Polyline& polyline, const QSharedPointer<SettingsBase>& layer_settings,
                               const Point& center, Distance radius, Point& current_location) {
     Path path;
-    if (polyline.size() < 2) {
-        return path;
-    }
+    if (polyline.size() < 2) { return path; }
 
-    const bool write_arcs = layer_settings->setting<bool>(PRS::MachineSetup::kSupportG3);
+    const bool write_arcs         = layer_settings->setting<bool>(PRS::MachineSetup::kSupportG3);
     const int arcs_per_revolution = std::max(1, layer_settings->setting<int>(PS::Slicing::kArcsPerRevolution));
     const QVector<Point> arc_points =
         write_arcs ? SlicingUtilities::GetCylindricalArcPoints(polyline, center, radius, arcs_per_revolution, true)
                    : QVector<Point>();
     const Point path_start = arc_points.size() > 1 ? arc_points.first() : polyline.first();
-    const Point path_end = arc_points.size() > 1 ? arc_points.last() : polyline.last();
+    const Point path_end   = arc_points.size() > 1 ? arc_points.last() : polyline.last();
 
     QSharedPointer<SettingsBase> region_start_settings = createSegmentSettings(layer_settings, center, true);
-    QSharedPointer<SettingsBase> print_settings = createSegmentSettings(layer_settings, center, false);
+    QSharedPointer<SettingsBase> print_settings        = createSegmentSettings(layer_settings, center, false);
     QSharedPointer<TravelSegment> travel = QSharedPointer<TravelSegment>::create(current_location, path_start);
     travel->setSb(region_start_settings);
 
     // Avoid tiny zero-length moves created when clipped arcs share endpoints.
-    if (current_location.distance(path_start) > kMinPathSegmentLength) {
-        path.add(travel);
-    }
+    if (current_location.distance(path_start) > kMinPathSegmentLength) { path.add(travel); }
 
     if (arc_points.size() > 1) {
         for (int i = 1, end = arc_points.size(); i < end; ++i) {
             const bool is_arc = SlicingUtilities::IsCylindricalArcSegment(arc_points[i - 1], arc_points[i], center,
                                                                           radius, arcs_per_revolution, true);
-            if (!is_arc && arc_points[i - 1].distance(arc_points[i]) <= kMinPathSegmentLength) {
-                continue;
-            }
+            if (!is_arc && arc_points[i - 1].distance(arc_points[i]) <= kMinPathSegmentLength) { continue; }
 
             QSharedPointer<SegmentBase> segment;
             if (is_arc) {
@@ -541,9 +501,7 @@ Path RadialSlicer::createPath(const Polyline& polyline, const QSharedPointer<Set
                     SlicingUtilities::GetCylindricalArcCenter(arc_points[i - 1], arc_points[i], center);
                 segment = QSharedPointer<ArcSegment>::create(arc_points[i - 1], arc_points[i], arc_center, true);
             }
-            else {
-                segment = QSharedPointer<LineSegment>::create(arc_points[i - 1], arc_points[i]);
-            }
+            else { segment = QSharedPointer<LineSegment>::create(arc_points[i - 1], arc_points[i]); }
 
             segment->setSb(i == 1 ? region_start_settings : print_settings);
             path.add(segment);
@@ -551,9 +509,7 @@ Path RadialSlicer::createPath(const Polyline& polyline, const QSharedPointer<Set
     }
     else {
         for (int i = 1, end = polyline.size(); i < end; ++i) {
-            if (polyline[i - 1].distance(polyline[i]) <= kMinPathSegmentLength) {
-                continue;
-            }
+            if (polyline[i - 1].distance(polyline[i]) <= kMinPathSegmentLength) { continue; }
 
             QSharedPointer<LineSegment> segment = QSharedPointer<LineSegment>::create(polyline[i - 1], polyline[i]);
             segment->setSb(i == 1 ? region_start_settings : print_settings);
@@ -561,10 +517,8 @@ Path RadialSlicer::createPath(const Polyline& polyline, const QSharedPointer<Set
         }
     }
 
-    if (path.size() > 0) {
-        current_location = path_end;
-    }
+    if (path.size() > 0) { current_location = path_end; }
 
     return path;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/step_thread.cpp
+++ b/src/threading/step_thread.cpp
@@ -1,6 +1,7 @@
 #include "threading/step_thread.h"
 
 #include <QMetaObject>
+
 #include <qsharedpointer.h>
 #include <qthread.h>
 #include <qtmetamacros.h>
@@ -17,11 +18,12 @@ StepThread::~StepThread() {
     stop();
 }
 
-void StepThread::setStep(const QSharedPointer<Step>& value) { m_step = value; }
+void StepThread::setStep(const QSharedPointer<Step>& value) {
+    m_step = value;
+}
 
 void StepThread::stop() {
-    if (!m_internal_thread.isRunning())
-        return;
+    if (!m_internal_thread.isRunning()) return;
 
     if (QThread::currentThread() == &m_internal_thread) {
         m_internal_thread.quit();
@@ -33,9 +35,7 @@ void StepThread::stop() {
 }
 
 void StepThread::doStep() {
-    if (!m_step.isNull()) {
-        m_step->compute();
-    }
+    if (!m_step.isNull()) { m_step->compute(); }
     emit completed();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/threading/traditional_ast.cpp
+++ b/src/threading/traditional_ast.cpp
@@ -44,9 +44,7 @@ void TraditionalAST::doSlice() {
     Diagnostics::logLine(QStringLiteral("Slicing preprocess complete"));
 
     int total_steps = 0;
-    for (QSharedPointer<Part> part : CSM->parts()) {
-        total_steps += part->countStepPairs();
-    }
+    for (QSharedPointer<Part> part : CSM->parts()) { total_steps += part->countStepPairs(); }
 
     // Instantiate the ideal thread amount.
     for (int i = 0, end = (total_steps > QThread::idealThreadCount() ? QThread::idealThreadCount() : total_steps);
@@ -60,14 +58,12 @@ void TraditionalAST::doSlice() {
 
     // For every selected step in every part, add the step to the queue.
     for (QSharedPointer<Part> part : CSM->parts()) {
-        if (part->rootMesh()->type() == MeshType::kClipping) // Skip parts that were used for clipping
+        if (part->rootMesh()->type() == MeshType::kClipping)  // Skip parts that were used for clipping
             continue;
 
         QList<QSharedPointer<Step>> allSteps = part->steps();
         for (QSharedPointer<Step> step : allSteps) {
-            if (step->isDirty() && !m_step_queue.contains(step)) {
-                m_step_queue.append(step);
-            }
+            if (step->isDirty() && !m_step_queue.contains(step)) { m_step_queue.append(step); }
         }
     }
 
@@ -75,8 +71,7 @@ void TraditionalAST::doSlice() {
 
     // For every thread available, give it a step to compute.
     for (StepThread* st : m_step_threads) {
-        if (m_step_queue.empty())
-            break;
+        if (m_step_queue.empty()) break;
 
         QSharedPointer<Step> step = m_step_queue.dequeue();
         st->setStep(step);
@@ -95,8 +90,7 @@ void TraditionalAST::doSlice() {
         this->postProcess();
         Diagnostics::logLine(QStringLiteral("Slicing postprocess complete"));
 
-        if (this->shouldCancel())
-            return;
+        if (this->shouldCancel()) return;
 
         if (!m_skip_gcode) {
             // Gcode output
@@ -106,8 +100,7 @@ void TraditionalAST::doSlice() {
             this->writeGCodeShutdown();
             Diagnostics::logLine(QStringLiteral("Slicing G-code generation complete"));
         }
-        if (this->shouldCancel())
-            return;
+        if (this->shouldCancel()) return;
 
         Diagnostics::logLine(QStringLiteral("Slicing sliceComplete emitted"));
         emit sliceComplete();
@@ -128,16 +121,15 @@ void TraditionalAST::cleanThread() {
         st->stop();
         delete st;
 
-        if (m_step_threads.isEmpty())
-            m_step_queue.clear();
+        if (m_step_threads.isEmpty()) m_step_queue.clear();
     }
     else {
-        if (m_queue_start_size == 0) // If there is nothing to compute then we are done
+        if (m_queue_start_size == 0)  // If there is nothing to compute then we are done
             emit statusUpdate(StatusUpdateStepType::kCompute, 100);
         else
-            emit statusUpdate(StatusUpdateStepType::kCompute,
-                              ((double)m_queue_start_size - (double)m_step_queue.size()) / (double)m_queue_start_size *
-                                  100);
+            emit statusUpdate(
+                StatusUpdateStepType::kCompute,
+                ((double)m_queue_start_size - (double)m_step_queue.size()) / (double)m_queue_start_size * 100);
 
         // If the queue is empty, then start destroying unused threads.
         if (m_step_queue.empty()) {
@@ -147,15 +139,13 @@ void TraditionalAST::cleanThread() {
 
             // If all threads have been destroyed, the slice is complete.
             if (m_step_threads.empty()) {
-
                 Diagnostics::logLine(QStringLiteral("Slicing compute complete; starting postprocess"));
                 this->postProcess();
                 Diagnostics::logLine(QStringLiteral("Slicing postprocess complete"));
 
                 m_elapsed_time = m_timer.elapsed();
 
-                if (this->shouldCancel())
-                    return;
+                if (this->shouldCancel()) return;
 
                 if (!m_skip_gcode) {
                     // Gcode output
@@ -165,8 +155,7 @@ void TraditionalAST::cleanThread() {
                     this->writeGCodeShutdown();
                     Diagnostics::logLine(QStringLiteral("Slicing G-code generation complete"));
                 }
-                if (this->shouldCancel())
-                    return;
+                if (this->shouldCancel()) return;
 
                 Diagnostics::logLine(QStringLiteral("Slicing sliceComplete emitted"));
                 emit sliceComplete();
@@ -185,4 +174,4 @@ void TraditionalAST::cleanThread() {
         QObject::disconnect(this, &TraditionalAST::stepStart, st, &StepThread::doStep);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/units/unit.cpp
+++ b/src/units/unit.cpp
@@ -9,115 +9,141 @@
 #include "utilities/enums.h"
 
 namespace ORNL {
-void to_json(json& j, const Distance& d) { j = d(); }
+void to_json(json& j, const Distance& d) {
+    j = d();
+}
 
-void from_json(const json& j, Distance& d) { d = j.get<NT>(); }
+void from_json(const json& j, Distance& d) {
+    d = j.get<NT>();
+}
 
-void to_json(json& j, const Time& t) { j = t(); }
+void to_json(json& j, const Time& t) {
+    j = t();
+}
 
-void from_json(const json& j, Time& t) { t = j.get<NT>(); }
+void from_json(const json& j, Time& t) {
+    t = j.get<NT>();
+}
 
-void to_json(json& j, const Mass& m) { j = m(); }
+void to_json(json& j, const Mass& m) {
+    j = m();
+}
 
-void from_json(const json& j, Mass& m) { m = j.get<NT>(); }
+void from_json(const json& j, Mass& m) {
+    m = j.get<NT>();
+}
 
-void to_json(json& j, const Velocity& v) { j = v(); }
+void to_json(json& j, const Velocity& v) {
+    j = v();
+}
 
-void from_json(const json& j, Velocity& v) { v = j.get<NT>(); }
+void from_json(const json& j, Velocity& v) {
+    v = j.get<NT>();
+}
 
-void to_json(json& j, const Acceleration& a) { j = a(); }
+void to_json(json& j, const Acceleration& a) {
+    j = a();
+}
 
-void from_json(const json& j, Acceleration& a) { a = j.get<NT>(); }
+void from_json(const json& j, Acceleration& a) {
+    a = j.get<NT>();
+}
 
-void to_json(json& j, const Density& a) { j = a(); }
+void to_json(json& j, const Density& a) {
+    j = a();
+}
 
-void from_json(const json& j, Density& a) { a = j.get<NT>(); }
+void from_json(const json& j, Density& a) {
+    a = j.get<NT>();
+}
 
-void to_json(json& j, const Angle& a) { j = a(); }
+void to_json(json& j, const Angle& a) {
+    j = a();
+}
 
-void from_json(const json& j, Angle& a) { a = j.get<NT>(); }
+void from_json(const json& j, Angle& a) {
+    a = j.get<NT>();
+}
 
-void to_json(json& j, const AngularVelocity& v) { j = v(); }
+void to_json(json& j, const AngularVelocity& v) {
+    j = v();
+}
 
-void from_json(const json& j, AngularVelocity& v) { v = j.get<NT>(); }
+void from_json(const json& j, AngularVelocity& v) {
+    v = j.get<NT>();
+}
 
-void to_json(json& j, const AngularAcceleration& a) { j = a(); }
+void to_json(json& j, const AngularAcceleration& a) {
+    j = a();
+}
 
-void from_json(const json& j, AngularAcceleration& a) { a = j.get<NT>(); }
+void from_json(const json& j, AngularAcceleration& a) {
+    a = j.get<NT>();
+}
 
-void to_json(json& j, const Area& a) { j = a(); }
+void to_json(json& j, const Area& a) {
+    j = a();
+}
 
-void from_json(const json& j, Area& a) { a = j.get<NT>(); }
+void from_json(const json& j, Area& a) {
+    a = j.get<NT>();
+}
 
-void to_json(json& j, const Volume& v) { j = v(); }
+void to_json(json& j, const Volume& v) {
+    j = v();
+}
 
-void from_json(const json& j, Volume& v) { v = j.get<NT>(); }
+void from_json(const json& j, Volume& v) {
+    v = j.get<NT>();
+}
 
-void to_json(json& j, const Temperature& t) { j = t(); }
+void to_json(json& j, const Temperature& t) {
+    j = t();
+}
 
-void from_json(const json& j, Temperature& t) { t = j.get<NT>(); }
+void from_json(const json& j, Temperature& t) {
+    t = j.get<NT>();
+}
 
-void to_json(json& j, const Voltage& v) { j = v(); }
+void to_json(json& j, const Voltage& v) {
+    j = v();
+}
 
-void from_json(const json& j, Voltage& v) { v = j.get<NT>(); }
+void from_json(const json& j, Voltage& v) {
+    v = j.get<NT>();
+}
 
-void to_json(json& j, const Power& p) { j = p(); }
+void to_json(json& j, const Power& p) {
+    j = p();
+}
 
-void from_json(const json& j, Power& p) { p = j.get<NT>(); }
+void from_json(const json& j, Power& p) {
+    p = j.get<NT>();
+}
 
 Distance::Distance(NT value) : Unit<1, 0, 0, 0, 0, 0>(value) {}
 
 Distance::Distance(const Unit<1, 0, 0, 0, 0, 0>& u) : Unit<1, 0, 0, 0, 0, 0>(u) {}
 
 QString Distance::toString() {
-    if (operator==(*this, in)) {
-        return Constants::Units::kInch;
-    }
-    else if (operator==(*this, ft)) {
-        return Constants::Units::kFeet;
-    }
-    else if (operator==(*this, mm)) {
-        return Constants::Units::kMm;
-    }
-    else if (operator==(*this, cm)) {
-        return Constants::Units::kCm;
-    }
-    else if (operator==(*this, m)) {
-        return Constants::Units::kM;
-    }
-    else if (operator==(*this, micron)) {
-        return Constants::Units::kMicron;
-    }
-    else if (operator==(*this, tensOfMicrons)) {
-        return Constants::Units::kTensOfMicrons;
-    }
-    else {
-        throw UnknownUnitException("Unknown distance unit");
-    }
+    if (operator==(*this, in)) { return Constants::Units::kInch; }
+    else if (operator==(*this, ft)) { return Constants::Units::kFeet; }
+    else if (operator==(*this, mm)) { return Constants::Units::kMm; }
+    else if (operator==(*this, cm)) { return Constants::Units::kCm; }
+    else if (operator==(*this, m)) { return Constants::Units::kM; }
+    else if (operator==(*this, micron)) { return Constants::Units::kMicron; }
+    else if (operator==(*this, tensOfMicrons)) { return Constants::Units::kTensOfMicrons; }
+    else { throw UnknownUnitException("Unknown distance unit"); }
 }
 
 Distance Distance::fromString(QString str) {
-    if (str == Constants::Units::kInch) {
-        return in;
-    }
-    else if (str == Constants::Units::kFeet) {
-        return ft;
-    }
-    else if (str == Constants::Units::kMm) {
-        return mm;
-    }
-    else if (str == Constants::Units::kCm) {
-        return cm;
-    }
-    else if (str == Constants::Units::kM) {
-        return m;
-    }
-    else if (str == Constants::Units::kMicron) {
-        return micron;
-    }
-    else {
-        throw UnknownUnitException("Unknown distance unit");
-    }
+    if (str == Constants::Units::kInch) { return in; }
+    else if (str == Constants::Units::kFeet) { return ft; }
+    else if (str == Constants::Units::kMm) { return mm; }
+    else if (str == Constants::Units::kCm) { return cm; }
+    else if (str == Constants::Units::kM) { return m; }
+    else if (str == Constants::Units::kMicron) { return micron; }
+    else { throw UnknownUnitException("Unknown distance unit"); }
 }
 
 Time::Time(NT value) : Unit<0, 1, 0, 0, 0, 0>(value) {}
@@ -125,33 +151,17 @@ Time::Time(NT value) : Unit<0, 1, 0, 0, 0, 0>(value) {}
 Time::Time(const Unit<0, 1, 0, 0, 0, 0>& u) : Unit<0, 1, 0, 0, 0, 0>(u) {}
 
 QString Time::toString() {
-    if (operator==(*this, s)) {
-        return Constants::Units::kSecond;
-    }
-    else if (operator==(*this, ms)) {
-        return Constants::Units::kMillisecond;
-    }
-    else if (operator==(*this, minute)) {
-        return Constants::Units::kMinute;
-    }
-    else {
-        throw UnknownUnitException("Unknown time unit");
-    }
+    if (operator==(*this, s)) { return Constants::Units::kSecond; }
+    else if (operator==(*this, ms)) { return Constants::Units::kMillisecond; }
+    else if (operator==(*this, minute)) { return Constants::Units::kMinute; }
+    else { throw UnknownUnitException("Unknown time unit"); }
 }
 
 Time Time::fromString(QString str) {
-    if (str == Constants::Units::kSecond) {
-        return s;
-    }
-    else if (str == Constants::Units::kMillisecond) {
-        return ms;
-    }
-    else if (str == Constants::Units::kMinute) {
-        return minute;
-    }
-    else {
-        throw UnknownUnitException("Unknown time unit");
-    }
+    if (str == Constants::Units::kSecond) { return s; }
+    else if (str == Constants::Units::kMillisecond) { return ms; }
+    else if (str == Constants::Units::kMinute) { return minute; }
+    else { throw UnknownUnitException("Unknown time unit"); }
 }
 
 Mass::Mass(NT value) : Unit<0, 0, 1, 0, 0, 0>(value) {}
@@ -159,39 +169,19 @@ Mass::Mass(NT value) : Unit<0, 0, 1, 0, 0, 0>(value) {}
 Mass::Mass(const Unit<0, 0, 1, 0, 0, 0>& u) : Unit<0, 0, 1, 0, 0, 0>(u) {}
 
 QString Mass::toString() {
-    if (operator==(*this, mg)) {
-        return Constants::Units::kMg;
-    }
-    else if (operator==(*this, g)) {
-        return Constants::Units::kG;
-    }
-    else if (operator==(*this, kg)) {
-        return Constants::Units::kKg;
-    }
-    else if (operator==(*this, lbm)) {
-        return Constants::Units::kLb;
-    }
-    else {
-        throw UnknownUnitException("Unknown mass unit");
-    }
+    if (operator==(*this, mg)) { return Constants::Units::kMg; }
+    else if (operator==(*this, g)) { return Constants::Units::kG; }
+    else if (operator==(*this, kg)) { return Constants::Units::kKg; }
+    else if (operator==(*this, lbm)) { return Constants::Units::kLb; }
+    else { throw UnknownUnitException("Unknown mass unit"); }
 }
 
 Mass Mass::fromString(QString str) {
-    if (str == Constants::Units::kMg) {
-        return mg;
-    }
-    else if (str == Constants::Units::kG) {
-        return g;
-    }
-    else if (str == Constants::Units::kKg) {
-        return kg;
-    }
-    else if (str == Constants::Units::kLb) {
-        return lbm;
-    }
-    else {
-        throw UnknownUnitException("Unknown mass unit");
-    }
+    if (str == Constants::Units::kMg) { return mg; }
+    else if (str == Constants::Units::kG) { return g; }
+    else if (str == Constants::Units::kKg) { return kg; }
+    else if (str == Constants::Units::kLb) { return lbm; }
+    else { throw UnknownUnitException("Unknown mass unit"); }
 }
 
 Velocity::Velocity(NT value) : Unit<1, -1, 0, 0, 0, 0>(value) {}
@@ -199,63 +189,27 @@ Velocity::Velocity(NT value) : Unit<1, -1, 0, 0, 0, 0>(value) {}
 Velocity::Velocity(const Unit<1, -1, 0, 0, 0, 0>& u) : Unit<1, -1, 0, 0, 0, 0>(u) {}
 
 QString Velocity::toString() {
-    if (operator==(*this, in / s)) {
-        return Constants::Units::kInchPerSec;
-    }
-    else if (operator==(*this, in / minute)) {
-        return Constants::Units::kInchPerMin;
-    }
-    else if (operator==(*this, ft / s)) {
-        return Constants::Units::kFeetPerSec;
-    }
-    else if (operator==(*this, mm / s)) {
-        return Constants::Units::kMmPerSec;
-    }
-    else if (operator==(*this, mm / minute)) {
-        return Constants::Units::kMmPerMin;
-    }
-    else if (operator==(*this, cm / s)) {
-        return Constants::Units::kCmPerSec;
-    }
-    else if (operator==(*this, m / s)) {
-        return Constants::Units::kMPerSec;
-    }
-    else if (operator==(*this, micron / s)) {
-        return Constants::Units::kMicronPerSec;
-    }
-    else {
-        throw UnknownUnitException("Unknown velocity unit");
-    }
+    if (operator==(*this, in / s)) { return Constants::Units::kInchPerSec; }
+    else if (operator==(*this, in / minute)) { return Constants::Units::kInchPerMin; }
+    else if (operator==(*this, ft / s)) { return Constants::Units::kFeetPerSec; }
+    else if (operator==(*this, mm / s)) { return Constants::Units::kMmPerSec; }
+    else if (operator==(*this, mm / minute)) { return Constants::Units::kMmPerMin; }
+    else if (operator==(*this, cm / s)) { return Constants::Units::kCmPerSec; }
+    else if (operator==(*this, m / s)) { return Constants::Units::kMPerSec; }
+    else if (operator==(*this, micron / s)) { return Constants::Units::kMicronPerSec; }
+    else { throw UnknownUnitException("Unknown velocity unit"); }
 }
 
 Velocity Velocity::fromString(QString str) {
-    if (str == Constants::Units::kInchPerSec) {
-        return in / s;
-    }
-    if (str == Constants::Units::kInchPerMin) {
-        return in / minute;
-    }
-    else if (str == Constants::Units::kFeetPerSec) {
-        return ft / s;
-    }
-    else if (str == Constants::Units::kMmPerSec) {
-        return mm / s;
-    }
-    else if (str == Constants::Units::kMmPerMin) {
-        return mm / minute;
-    }
-    else if (str == Constants::Units::kCmPerSec) {
-        return cm / s;
-    }
-    else if (str == Constants::Units::kMPerSec) {
-        return m / s;
-    }
-    else if (str == Constants::Units::kMicronPerSec) {
-        return micron / s;
-    }
-    else {
-        throw UnknownUnitException("Unknown velocity unit");
-    }
+    if (str == Constants::Units::kInchPerSec) { return in / s; }
+    if (str == Constants::Units::kInchPerMin) { return in / minute; }
+    else if (str == Constants::Units::kFeetPerSec) { return ft / s; }
+    else if (str == Constants::Units::kMmPerSec) { return mm / s; }
+    else if (str == Constants::Units::kMmPerMin) { return mm / minute; }
+    else if (str == Constants::Units::kCmPerSec) { return cm / s; }
+    else if (str == Constants::Units::kMPerSec) { return m / s; }
+    else if (str == Constants::Units::kMicronPerSec) { return micron / s; }
+    else { throw UnknownUnitException("Unknown velocity unit"); }
 }
 
 Acceleration::Acceleration(NT value) : Unit<1, -2, 0, 0, 0, 0>(value) {}
@@ -264,51 +218,23 @@ Acceleration::Acceleration(const Unit<1, -2, 0, 0, 0, 0>& u) : Unit<1, -2, 0, 0,
 
 QString Acceleration::toString() {
     Acceleration acc = mm / s / s;
-    if (operator==(*this, in / s / s)) {
-        return Constants::Units::kInchPerSec2;
-    }
-    else if (operator==(*this, ft / s / s)) {
-        return Constants::Units::kFeetPerSec2;
-    }
-    else if (operator==(*this, mm / s / s)) {
-        return Constants::Units::kMmPerSec2;
-    }
-    else if (operator==(*this, cm / s / s)) {
-        return Constants::Units::kCmPerSec2;
-    }
-    else if (operator==(*this, m / s / s)) {
-        return Constants::Units::kMPerSec2;
-    }
-    else if (operator==(*this, micron / s / s)) {
-        return Constants::Units::kMicronPerSec2;
-    }
-    else {
-        throw UnknownUnitException("Unknown acceleration unit");
-    }
+    if (operator==(*this, in / s / s)) { return Constants::Units::kInchPerSec2; }
+    else if (operator==(*this, ft / s / s)) { return Constants::Units::kFeetPerSec2; }
+    else if (operator==(*this, mm / s / s)) { return Constants::Units::kMmPerSec2; }
+    else if (operator==(*this, cm / s / s)) { return Constants::Units::kCmPerSec2; }
+    else if (operator==(*this, m / s / s)) { return Constants::Units::kMPerSec2; }
+    else if (operator==(*this, micron / s / s)) { return Constants::Units::kMicronPerSec2; }
+    else { throw UnknownUnitException("Unknown acceleration unit"); }
 }
 
 Acceleration Acceleration::fromString(QString str) {
-    if (str == Constants::Units::kInchPerSec2) {
-        return in / s / s;
-    }
-    else if (str == Constants::Units::kFeetPerSec2) {
-        return ft / s / s;
-    }
-    else if (str == Constants::Units::kMmPerSec2) {
-        return mm / s / s;
-    }
-    else if (str == Constants::Units::kCmPerSec2) {
-        return cm / s / s;
-    }
-    else if (str == Constants::Units::kMPerSec2) {
-        return m / s / s;
-    }
-    else if (str == Constants::Units::kMicronPerSec2) {
-        return micron / s / s;
-    }
-    else {
-        throw UnknownUnitException("Unknown acceleration unit");
-    }
+    if (str == Constants::Units::kInchPerSec2) { return in / s / s; }
+    else if (str == Constants::Units::kFeetPerSec2) { return ft / s / s; }
+    else if (str == Constants::Units::kMmPerSec2) { return mm / s / s; }
+    else if (str == Constants::Units::kCmPerSec2) { return cm / s / s; }
+    else if (str == Constants::Units::kMPerSec2) { return m / s / s; }
+    else if (str == Constants::Units::kMicronPerSec2) { return micron / s / s; }
+    else { throw UnknownUnitException("Unknown acceleration unit"); }
 }
 
 Density::Density(NT value) : Unit<-3, 0, 1, 0, 0, 0>(value) {}
@@ -316,77 +242,51 @@ Density::Density(NT value) : Unit<-3, 0, 1, 0, 0, 0>(value) {}
 Density::Density(const Unit<-3, 0, 1, 0, 0, 0>& u) : Unit<-3, 0, 1, 0, 0, 0>(u) {}
 
 QString Density::toString() {
-    if (operator==(*this, lbm / in / in / in)) {
-        return Constants::Units::kLbPerInch3;
-    }
-    else if (operator==(*this, g / cm / cm / cm)) {
-        return Constants::Units::kGPerCm3;
-    }
-    else {
-        throw UnknownUnitException("Unknown density unit");
-    }
+    if (operator==(*this, lbm / in / in / in)) { return Constants::Units::kLbPerInch3; }
+    else if (operator==(*this, g / cm / cm / cm)) { return Constants::Units::kGPerCm3; }
+    else { throw UnknownUnitException("Unknown density unit"); }
 }
 
 Density Density::fromString(QString str) {
-    if (str == Constants::Units::kLbPerInch3) {
-        return lbm / in / in / in;
-    }
-    else if (str == Constants::Units::kGPerCm3) {
-        return g / cm / cm / cm;
-    }
-    else {
-        throw UnknownUnitException("Unknown density unit");
-    }
+    if (str == Constants::Units::kLbPerInch3) { return lbm / in / in / in; }
+    else if (str == Constants::Units::kGPerCm3) { return g / cm / cm / cm; }
+    else { throw UnknownUnitException("Unknown density unit"); }
 }
 
 Angle::Angle(NT value) : Unit<0, 0, 0, 0, 0, 1>(value) {
     // Wrap value
-    while (m_value > Constants::Limits::Maximums::kMaxAngle) {
-        m_value -= 2.0f * static_cast<float>(M_PI);
-    }
+    while (m_value > Constants::Limits::Maximums::kMaxAngle) { m_value -= 2.0f * static_cast<float>(M_PI); }
 
-    while (m_value < Constants::Limits::Minimums::kMinAngle) {
-        m_value += 2.0f * static_cast<float>(M_PI);
-    }
+    while (m_value < Constants::Limits::Minimums::kMinAngle) { m_value += 2.0f * static_cast<float>(M_PI); }
 }
 
 Angle::Angle(const Unit<0, 0, 0, 0, 0, 1>& u) : Unit<0, 0, 0, 0, 0, 1>(u) {}
 
 QString Angle::toString() {
-    if (operator==(*this, deg)) {
-        return Constants::Units::kDegree;
-    }
-    else if (operator==(*this, rad)) {
-        return Constants::Units::kRadian;
-    }
-    else if (operator==(*this, rev)) {
-        return Constants::Units::kRevolution;
-    }
-    else {
-        throw UnknownUnitException("Unknown angle unit");
-    }
+    if (operator==(*this, deg)) { return Constants::Units::kDegree; }
+    else if (operator==(*this, rad)) { return Constants::Units::kRadian; }
+    else if (operator==(*this, rev)) { return Constants::Units::kRevolution; }
+    else { throw UnknownUnitException("Unknown angle unit"); }
 }
 
 Angle Angle::fromString(QString str) {
-    if (str == Constants::Units::kDegree) {
-        return deg;
-    }
-    else if (str == Constants::Units::kRadian) {
-        return rad;
-    }
-    else if (str == Constants::Units::kRevolution) {
-        return rev;
-    }
-    else {
-        throw UnknownUnitException("Unknown angle unit");
-    }
+    if (str == Constants::Units::kDegree) { return deg; }
+    else if (str == Constants::Units::kRadian) { return rad; }
+    else if (str == Constants::Units::kRevolution) { return rev; }
+    else { throw UnknownUnitException("Unknown angle unit"); }
 }
 
-double cos(const Angle& lhs) { return qCos(lhs()); }
+double cos(const Angle& lhs) {
+    return qCos(lhs());
+}
 
-double sin(const Angle& lhs) { return qSin(lhs()); }
+double sin(const Angle& lhs) {
+    return qSin(lhs());
+}
 
-double tan(const Angle& lhs) { return qTan(lhs()); }
+double tan(const Angle& lhs) {
+    return qTan(lhs());
+}
 
 Area::Area(NT value) : Unit<2, 0, 0, 0, 0, 0>(value) {}
 
@@ -404,7 +304,7 @@ NT Temperature::to(const Unit& u) const {
         offset = -459.67f;
 
     float retVal = (m_value / u()) + offset;
-    retVal = QString::number(retVal, 'f', 3).toFloat();
+    retVal       = QString::number(retVal, 'f', 3).toFloat();
     return retVal;
 }
 
@@ -428,33 +328,17 @@ NT Temperature::from(const NT& value, const Unit& u) {
 }
 
 QString Temperature::toString() {
-    if (operator==(*this, K)) {
-        return Constants::Units::kKelvin;
-    }
-    else if (operator==(*this, degC)) {
-        return Constants::Units::kCelsius;
-    }
-    else if (operator==(*this, degF)) {
-        return Constants::Units::kFahrenheit;
-    }
-    else {
-        throw UnknownUnitException("Unknown temperature unit");
-    }
+    if (operator==(*this, K)) { return Constants::Units::kKelvin; }
+    else if (operator==(*this, degC)) { return Constants::Units::kCelsius; }
+    else if (operator==(*this, degF)) { return Constants::Units::kFahrenheit; }
+    else { throw UnknownUnitException("Unknown temperature unit"); }
 }
 
 Temperature Temperature::fromString(QString str) {
-    if (str == Constants::Units::kKelvin) {
-        return K;
-    }
-    else if (str == Constants::Units::kCelsius) {
-        return degC;
-    }
-    else if (str == Constants::Units::kFahrenheit) {
-        return degF;
-    }
-    else {
-        throw UnknownUnitException("Unknown temperature unit");
-    }
+    if (str == Constants::Units::kKelvin) { return K; }
+    else if (str == Constants::Units::kCelsius) { return degC; }
+    else if (str == Constants::Units::kFahrenheit) { return degF; }
+    else { throw UnknownUnitException("Unknown temperature unit"); }
 }
 
 Voltage::Voltage(NT value) : Unit<2, -3, 1, -1, 0, 0>(value) {}
@@ -462,32 +346,16 @@ Voltage::Voltage(NT value) : Unit<2, -3, 1, -1, 0, 0>(value) {}
 Voltage::Voltage(const Unit<2, -3, 1, -1, 0, 0>& u) : Unit<2, -3, 1, -1, 0, 0>(u) {}
 
 QString Voltage::toString() {
-    if (operator==(*this, uV)) {
-        return Constants::Units::kmuV;
-    }
-    else if (operator==(*this, mV)) {
-        return Constants::Units::kmV;
-    }
-    else if (operator==(*this, V)) {
-        return Constants::Units::kV;
-    }
-    else {
-        throw UnknownUnitException("Unknown voltage unit");
-    }
+    if (operator==(*this, uV)) { return Constants::Units::kmuV; }
+    else if (operator==(*this, mV)) { return Constants::Units::kmV; }
+    else if (operator==(*this, V)) { return Constants::Units::kV; }
+    else { throw UnknownUnitException("Unknown voltage unit"); }
 }
 
 Voltage Voltage::fromString(QString str) {
-    if (str == Constants::Units::kmuV) {
-        return uV;
-    }
-    else if (str == Constants::Units::kmV) {
-        return mV;
-    }
-    else if (str == Constants::Units::kV) {
-        return V;
-    }
-    else {
-        throw UnknownUnitException("Unknown voltage unit");
-    }
+    if (str == Constants::Units::kmuV) { return uV; }
+    else if (str == Constants::Units::kmV) { return mV; }
+    else if (str == Constants::Units::kV) { return V; }
+    else { throw UnknownUnitException("Unknown voltage unit"); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -12,64 +12,64 @@ namespace ORNL {
 //================================================================================
 // Units
 //================================================================================
-const QString Constants::Units::kInch = "in";
-const QString Constants::Units::kInchPerSec = "in/sec";
-const QString Constants::Units::kInchPerMin = "in/min";
+const QString Constants::Units::kInch        = "in";
+const QString Constants::Units::kInchPerSec  = "in/sec";
+const QString Constants::Units::kInchPerMin  = "in/min";
 const QString Constants::Units::kInchPerSec2 = "in/sec²";
 const QString Constants::Units::kInchPerSec3 = "in/sec³";
 
-const QString Constants::Units::kFeet = "ft";
-const QString Constants::Units::kFeetPerSec = "ft/sec";
+const QString Constants::Units::kFeet        = "ft";
+const QString Constants::Units::kFeetPerSec  = "ft/sec";
 const QString Constants::Units::kFeetPerSec2 = "ft/sec²";
 const QString Constants::Units::kFeetPerSec3 = "ft/sec³";
 
-const QString Constants::Units::kMm = "mm";
-const QString Constants::Units::kMmPerSec = "mm/sec";
-const QString Constants::Units::kMmPerMin = "mm/min";
+const QString Constants::Units::kMm        = "mm";
+const QString Constants::Units::kMmPerSec  = "mm/sec";
+const QString Constants::Units::kMmPerMin  = "mm/min";
 const QString Constants::Units::kMmPerSec2 = "mm/sec²";
 const QString Constants::Units::kMmPerSec3 = "mm/sec³";
 
-const QString Constants::Units::kCm = "cm";
-const QString Constants::Units::kCmPerSec = "cm/sec";
+const QString Constants::Units::kCm        = "cm";
+const QString Constants::Units::kCmPerSec  = "cm/sec";
 const QString Constants::Units::kCmPerSec2 = "cm/sec²";
 const QString Constants::Units::kCmPerSec3 = "cm/sec³";
 
-const QString Constants::Units::kM = "m";
-const QString Constants::Units::kMPerSec = "m/sec";
+const QString Constants::Units::kM        = "m";
+const QString Constants::Units::kMPerSec  = "m/sec";
 const QString Constants::Units::kMPerSec2 = "m/sec²";
 const QString Constants::Units::kMPerSec3 = "m/sec³";
 
-const QString Constants::Units::kMicron = "μm";
+const QString Constants::Units::kMicron        = "μm";
 const QString Constants::Units::kTensOfMicrons = "μm * 10¹";
-const QString Constants::Units::kMicronPerSec = "μm/sec";
+const QString Constants::Units::kMicronPerSec  = "μm/sec";
 const QString Constants::Units::kMicronPerSec2 = "μm/sec²";
 const QString Constants::Units::kMicronPerSec3 = "μm/sec³";
 
-const QString Constants::Units::kDegree = "deg";
-const QString Constants::Units::kRadian = "rad";
+const QString Constants::Units::kDegree     = "deg";
+const QString Constants::Units::kRadian     = "rad";
 const QString Constants::Units::kRevolution = "rev";
 
-const QString Constants::Units::kSecond = "sec";
+const QString Constants::Units::kSecond      = "sec";
 const QString Constants::Units::kMillisecond = "ms";
-const QString Constants::Units::kMinute = "min";
+const QString Constants::Units::kMinute      = "min";
 
-const QString Constants::Units::kKg = "kg";
-const QString Constants::Units::kG = "g";
-const QString Constants::Units::kGPerCm3 = "g/cm³";
-const QString Constants::Units::kMg = "mg";
-const QString Constants::Units::kLb = "lbm";
+const QString Constants::Units::kKg         = "kg";
+const QString Constants::Units::kG          = "g";
+const QString Constants::Units::kGPerCm3    = "g/cm³";
+const QString Constants::Units::kMg         = "mg";
+const QString Constants::Units::kLb         = "lbm";
 const QString Constants::Units::kLbPerInch3 = "lbm/in³";
 
-const QString Constants::Units::kCelsius = "°C";
+const QString Constants::Units::kCelsius    = "°C";
 const QString Constants::Units::kFahrenheit = "°F";
-const QString Constants::Units::kKelvin = "°K";
+const QString Constants::Units::kKelvin     = "°K";
 
 const QString Constants::Units::kmuV = "µV";
-const QString Constants::Units::kmV = "mV";
-const QString Constants::Units::kV = "V";
+const QString Constants::Units::kmV  = "mV";
+const QString Constants::Units::kV   = "V";
 
 const QString Constants::Units::kPitchRollYaw = "Pitch/Roll/Yaw";
-const QString Constants::Units::kXYZ = "X/Y/Z";
+const QString Constants::Units::kXYZ          = "X/Y/Z";
 
 const QStringList Constants::Units::kDistanceUnits = {Constants::Units::kInch, Constants::Units::kFeet,
                                                       Constants::Units::kMm,   Constants::Units::kCm,
@@ -110,24 +110,24 @@ const QStringList Constants::Units::kRotationUnits = {Constants::Units::kPitchRo
 //================================================================================
 // Region Type Strings
 //================================================================================
-const QString Constants::RegionTypeStrings::kUnknown = "unknown";
-const QString Constants::RegionTypeStrings::kPerimeter = "PERIMETER";
-const QString Constants::RegionTypeStrings::kRadial = "RADIAL";
-const QString Constants::RegionTypeStrings::kHelical = "HELICAL";
-const QString Constants::RegionTypeStrings::kInset = "INSET";
-const QString Constants::RegionTypeStrings::kInfill = "INFILL";
-const QString Constants::RegionTypeStrings::kTopSkin = "TOP_SKIN";
-const QString Constants::RegionTypeStrings::kBottomSkin = "BOTTOM_SKIN";
-const QString Constants::RegionTypeStrings::kSkin = "SKIN";
-const QString Constants::RegionTypeStrings::kSupport = "SUPPORT";
+const QString Constants::RegionTypeStrings::kUnknown     = "unknown";
+const QString Constants::RegionTypeStrings::kPerimeter   = "PERIMETER";
+const QString Constants::RegionTypeStrings::kRadial      = "RADIAL";
+const QString Constants::RegionTypeStrings::kHelical     = "HELICAL";
+const QString Constants::RegionTypeStrings::kInset       = "INSET";
+const QString Constants::RegionTypeStrings::kInfill      = "INFILL";
+const QString Constants::RegionTypeStrings::kTopSkin     = "TOP_SKIN";
+const QString Constants::RegionTypeStrings::kBottomSkin  = "BOTTOM_SKIN";
+const QString Constants::RegionTypeStrings::kSkin        = "SKIN";
+const QString Constants::RegionTypeStrings::kSupport     = "SUPPORT";
 const QString Constants::RegionTypeStrings::kSupportRoof = "SUPPORT_ROOF";
-const QString Constants::RegionTypeStrings::kTravel = "TRAVEL";
-const QString Constants::RegionTypeStrings::kRaft = "RAFT";
-const QString Constants::RegionTypeStrings::kBrim = "BRIM";
-const QString Constants::RegionTypeStrings::kSkirt = "SKIRT";
-const QString Constants::RegionTypeStrings::kLaserScan = "LASER SCANNER";
+const QString Constants::RegionTypeStrings::kTravel      = "TRAVEL";
+const QString Constants::RegionTypeStrings::kRaft        = "RAFT";
+const QString Constants::RegionTypeStrings::kBrim        = "BRIM";
+const QString Constants::RegionTypeStrings::kSkirt       = "SKIRT";
+const QString Constants::RegionTypeStrings::kLaserScan   = "LASER SCANNER";
 const QString Constants::RegionTypeStrings::kThermalScan = "IR CAMERA";
-const QString Constants::RegionTypeStrings::kSkeleton = "SKELETON";
+const QString Constants::RegionTypeStrings::kSkeleton    = "SKELETON";
 
 //================================================================================
 // Legacy Region Type Strings
@@ -137,13 +137,13 @@ const QString Constants::LegacyRegionTypeStrings::kThing = "";
 //================================================================================
 // Infill Pattern Strings
 //================================================================================
-const QString Constants::InfillPatternTypeStrings::kLines = "Lines";
-const QString Constants::InfillPatternTypeStrings::kGrid = "Grid";
-const QString Constants::InfillPatternTypeStrings::kConcentric = "Concentric";
-const QString Constants::InfillPatternTypeStrings::kTriangles = "Triangles";
+const QString Constants::InfillPatternTypeStrings::kLines                = "Lines";
+const QString Constants::InfillPatternTypeStrings::kGrid                 = "Grid";
+const QString Constants::InfillPatternTypeStrings::kConcentric           = "Concentric";
+const QString Constants::InfillPatternTypeStrings::kTriangles            = "Triangles";
 const QString Constants::InfillPatternTypeStrings::kHexagonsAndTriangles = "Hexagons and Triangles";
-const QString Constants::InfillPatternTypeStrings::kHoneycomb = "Honeycomb";
-const QString Constants::InfillPatternTypeStrings::kRadialHatch = "Radial Hatch";
+const QString Constants::InfillPatternTypeStrings::kHoneycomb            = "Honeycomb";
+const QString Constants::InfillPatternTypeStrings::kRadialHatch          = "Radial Hatch";
 
 const QStringList Constants::InfillPatternTypeStrings::kInfillTypes = {
     Constants::InfillPatternTypeStrings::kLines,
@@ -157,52 +157,52 @@ const QStringList Constants::InfillPatternTypeStrings::kInfillTypes = {
 //================================================================================
 // Machine Syntax Strings
 //================================================================================
-QString Constants::PrinterSettings::SyntaxString::kAML3D = "AML3D";
-QString Constants::PrinterSettings::SyntaxString::kBeam = "Beam";
-QString Constants::PrinterSettings::SyntaxString::kCincinnati = "Cincinnati";
-QString Constants::PrinterSettings::SyntaxString::kCincinnatiLegacy = "Cincinnati-BERTHA";
-QString Constants::PrinterSettings::SyntaxString::kCommon = "Common";
-QString Constants::PrinterSettings::SyntaxString::kDmgDmu = "DMG DMU";
-QString Constants::PrinterSettings::SyntaxString::kGudel = "Gudel";
-QString Constants::PrinterSettings::SyntaxString::kHaasInch = "Haas-Inch";
-QString Constants::PrinterSettings::SyntaxString::kHaasMetric = "Haas-Metric";
+QString Constants::PrinterSettings::SyntaxString::kAML3D                = "AML3D";
+QString Constants::PrinterSettings::SyntaxString::kBeam                 = "Beam";
+QString Constants::PrinterSettings::SyntaxString::kCincinnati           = "Cincinnati";
+QString Constants::PrinterSettings::SyntaxString::kCincinnatiLegacy     = "Cincinnati-BERTHA";
+QString Constants::PrinterSettings::SyntaxString::kCommon               = "Common";
+QString Constants::PrinterSettings::SyntaxString::kDmgDmu               = "DMG DMU";
+QString Constants::PrinterSettings::SyntaxString::kGudel                = "Gudel";
+QString Constants::PrinterSettings::SyntaxString::kHaasInch             = "Haas-Inch";
+QString Constants::PrinterSettings::SyntaxString::kHaasMetric           = "Haas-Metric";
 QString Constants::PrinterSettings::SyntaxString::kHaasMetricNoComments = "Haas-Metric-No-Comments";
-QString Constants::PrinterSettings::SyntaxString::kHurco = "Hurco";
-QString Constants::PrinterSettings::SyntaxString::kIngersoll = "Ingersoll";
-QString Constants::PrinterSettings::SyntaxString::kKraussMaffei = "KraussMaffei";
-QString Constants::PrinterSettings::SyntaxString::kMarlin = "Marlin";
-QString Constants::PrinterSettings::SyntaxString::kJuggerBot = "JuggerBot";
-QString Constants::PrinterSettings::SyntaxString::kMazak = "Mazak";
-QString Constants::PrinterSettings::SyntaxString::kMeld = "Meld";
-QString Constants::PrinterSettings::SyntaxString::kMeltio = "Meltio";
-QString Constants::PrinterSettings::SyntaxString::kMVP = "MVP";
-QString Constants::PrinterSettings::SyntaxString::kOkuma = "Okuma";
-QString Constants::PrinterSettings::SyntaxString::kORNL = "ORNL";
-QString Constants::PrinterSettings::SyntaxString::kRomiFanuc = "ROMI Fanuc";
-QString Constants::PrinterSettings::SyntaxString::kSandia = "Sandia";
-QString Constants::PrinterSettings::SyntaxString::kSiemens = "Siemens";
-QString Constants::PrinterSettings::SyntaxString::kThermwood = "Thermwood";
-QString Constants::PrinterSettings::SyntaxString::kTormach = "Tormach";
-QString Constants::PrinterSettings::SyntaxString::kWolf = "Wolf";
-QString Constants::PrinterSettings::SyntaxString::kRepRap = "RepRap";
-QString Constants::PrinterSettings::SyntaxString::kMach4 = "Mach4";
-QString Constants::PrinterSettings::SyntaxString::kAeroBasic = "AeroBasic";
-QString Constants::PrinterSettings::SyntaxString::kAdamantine = "Adamantine";
-QString Constants::PrinterSettings::SyntaxString::kORNLMetric = "ORNL-Metric";
-QString Constants::PrinterSettings::SyntaxString::kArcSpecialties = "Arc Specialties";
+QString Constants::PrinterSettings::SyntaxString::kHurco                = "Hurco";
+QString Constants::PrinterSettings::SyntaxString::kIngersoll            = "Ingersoll";
+QString Constants::PrinterSettings::SyntaxString::kKraussMaffei         = "KraussMaffei";
+QString Constants::PrinterSettings::SyntaxString::kMarlin               = "Marlin";
+QString Constants::PrinterSettings::SyntaxString::kJuggerBot            = "JuggerBot";
+QString Constants::PrinterSettings::SyntaxString::kMazak                = "Mazak";
+QString Constants::PrinterSettings::SyntaxString::kMeld                 = "Meld";
+QString Constants::PrinterSettings::SyntaxString::kMeltio               = "Meltio";
+QString Constants::PrinterSettings::SyntaxString::kMVP                  = "MVP";
+QString Constants::PrinterSettings::SyntaxString::kOkuma                = "Okuma";
+QString Constants::PrinterSettings::SyntaxString::kORNL                 = "ORNL";
+QString Constants::PrinterSettings::SyntaxString::kRomiFanuc            = "ROMI Fanuc";
+QString Constants::PrinterSettings::SyntaxString::kSandia               = "Sandia";
+QString Constants::PrinterSettings::SyntaxString::kSiemens              = "Siemens";
+QString Constants::PrinterSettings::SyntaxString::kThermwood            = "Thermwood";
+QString Constants::PrinterSettings::SyntaxString::kTormach              = "Tormach";
+QString Constants::PrinterSettings::SyntaxString::kWolf                 = "Wolf";
+QString Constants::PrinterSettings::SyntaxString::kRepRap               = "RepRap";
+QString Constants::PrinterSettings::SyntaxString::kMach4                = "Mach4";
+QString Constants::PrinterSettings::SyntaxString::kAeroBasic            = "AeroBasic";
+QString Constants::PrinterSettings::SyntaxString::kAdamantine           = "Adamantine";
+QString Constants::PrinterSettings::SyntaxString::kORNLMetric           = "ORNL-Metric";
+QString Constants::PrinterSettings::SyntaxString::kArcSpecialties       = "Arc Specialties";
 
 //================================================================================
 // Optimizations
 //================================================================================
-const QString Constants::OrderOptimizationTypeStrings::kShortestTime = "shortest_time";
-const QString Constants::OrderOptimizationTypeStrings::kShortestDistance = "shortest_distance";
-const QString Constants::OrderOptimizationTypeStrings::kLargestDistance = "largest_distance";
+const QString Constants::OrderOptimizationTypeStrings::kShortestTime         = "shortest_time";
+const QString Constants::OrderOptimizationTypeStrings::kShortestDistance     = "shortest_distance";
+const QString Constants::OrderOptimizationTypeStrings::kLargestDistance      = "largest_distance";
 const QString Constants::OrderOptimizationTypeStrings::kLeastRecentlyVisited = "least_recently_visited";
-const QString Constants::OrderOptimizationTypeStrings::kNextClosest = "next_closest";
-const QString Constants::OrderOptimizationTypeStrings::kApproximateShortest = "approximate_shortest";
-const QString Constants::OrderOptimizationTypeStrings::kShortestDistance_DP = "shortest_distance_dp";
-const QString Constants::OrderOptimizationTypeStrings::kRandom = "random";
-const QString Constants::OrderOptimizationTypeStrings::kConsecutive = "consecutive";
+const QString Constants::OrderOptimizationTypeStrings::kNextClosest          = "next_closest";
+const QString Constants::OrderOptimizationTypeStrings::kApproximateShortest  = "approximate_shortest";
+const QString Constants::OrderOptimizationTypeStrings::kShortestDistance_DP  = "shortest_distance_dp";
+const QString Constants::OrderOptimizationTypeStrings::kRandom               = "random";
+const QString Constants::OrderOptimizationTypeStrings::kConsecutive          = "consecutive";
 
 const QStringList Constants::OrderOptimizationTypeStrings::kOrderOptimizationTypes = {
     Constants::OrderOptimizationTypeStrings::kShortestTime,
@@ -218,18 +218,18 @@ const QStringList Constants::OrderOptimizationTypeStrings::kOrderOptimizationTyp
 //================================================================================
 // Path Modifer Strings
 //================================================================================
-const QString Constants::PathModifierStrings::kPrestart = "PRESTART";
-const QString Constants::PathModifierStrings::kInitialStartup = "INITIAL STARTUP";
-const QString Constants::PathModifierStrings::kSlowDown = "SLOW DOWN";
-const QString Constants::PathModifierStrings::kForwardTipWipe = "FORWARD TIP WIPE";
-const QString Constants::PathModifierStrings::kReverseTipWipe = "REVERSE TIP WIPE";
-const QString Constants::PathModifierStrings::kAngledTipWipe = "ANGLED TIP WIPE";
-const QString Constants::PathModifierStrings::kCoasting = "COASTING";
-const QString Constants::PathModifierStrings::kSpiralLift = "SPIRAL LIFT";
-const QString Constants::PathModifierStrings::kRampingUp = "RAMPING UP";
-const QString Constants::PathModifierStrings::kRampingDown = "RAMPING DOWN";
-const QString Constants::PathModifierStrings::kLeadIn = "LEAD IN";
-const QString Constants::PathModifierStrings::kFlyingStart = "FLYING START";
+const QString Constants::PathModifierStrings::kPrestart         = "PRESTART";
+const QString Constants::PathModifierStrings::kInitialStartup   = "INITIAL STARTUP";
+const QString Constants::PathModifierStrings::kSlowDown         = "SLOW DOWN";
+const QString Constants::PathModifierStrings::kForwardTipWipe   = "FORWARD TIP WIPE";
+const QString Constants::PathModifierStrings::kReverseTipWipe   = "REVERSE TIP WIPE";
+const QString Constants::PathModifierStrings::kAngledTipWipe    = "ANGLED TIP WIPE";
+const QString Constants::PathModifierStrings::kCoasting         = "COASTING";
+const QString Constants::PathModifierStrings::kSpiralLift       = "SPIRAL LIFT";
+const QString Constants::PathModifierStrings::kRampingUp        = "RAMPING UP";
+const QString Constants::PathModifierStrings::kRampingDown      = "RAMPING DOWN";
+const QString Constants::PathModifierStrings::kLeadIn           = "LEAD IN";
+const QString Constants::PathModifierStrings::kFlyingStart      = "FLYING START";
 const QString Constants::PathModifierStrings::kPerimeterTipWipe = "PERIMETER TIP WIPE";
 
 //================================================================================
@@ -237,21 +237,21 @@ const QString Constants::PathModifierStrings::kPerimeterTipWipe = "PERIMETER TIP
 //================================================================================
 
 // Machine Setup
-const QString Constants::PrinterSettings::MachineSetup::kSyntax = "syntax";
+const QString Constants::PrinterSettings::MachineSetup::kSyntax      = "syntax";
 const QString Constants::PrinterSettings::MachineSetup::kMachineType = "machine_type";
-const QString Constants::PrinterSettings::MachineSetup::kForceG1 = "force_G1";
-const QString Constants::PrinterSettings::MachineSetup::kSupportG3 = "supports_G2_3";
+const QString Constants::PrinterSettings::MachineSetup::kForceG1     = "force_G1";
+const QString Constants::PrinterSettings::MachineSetup::kSupportG3   = "supports_G2_3";
 const QString Constants::PrinterSettings::MachineSetup::kEnableTrafo = "enable_trafo";
 const QString Constants::PrinterSettings::MachineSetup::kG2G3CenterPointInterpretation =
     "g2_g3_center_point_interpretation";
-const QString Constants::PrinterSettings::MachineSetup::kG2G3AbsoluteI = "g2_g3_absolute_i";
-const QString Constants::PrinterSettings::MachineSetup::kG2G3AbsoluteJ = "g2_g3_absolute_j";
-const QString Constants::PrinterSettings::MachineSetup::kToolNumber = "tool_number";
+const QString Constants::PrinterSettings::MachineSetup::kG2G3AbsoluteI  = "g2_g3_absolute_i";
+const QString Constants::PrinterSettings::MachineSetup::kG2G3AbsoluteJ  = "g2_g3_absolute_j";
+const QString Constants::PrinterSettings::MachineSetup::kToolNumber     = "tool_number";
 const QString Constants::PrinterSettings::MachineSetup::kToolCoordinate = "tool_coordinate";
 const QString Constants::PrinterSettings::MachineSetup::kBaseCoordinate = "base_coordinate";
-const QString Constants::PrinterSettings::MachineSetup::kAxisA = "axis_a";
-const QString Constants::PrinterSettings::MachineSetup::kAxisB = "axis_b";
-const QString Constants::PrinterSettings::MachineSetup::kAxisC = "axis_c";
+const QString Constants::PrinterSettings::MachineSetup::kAxisA          = "axis_a";
+const QString Constants::PrinterSettings::MachineSetup::kAxisB          = "axis_b";
+const QString Constants::PrinterSettings::MachineSetup::kAxisC          = "axis_c";
 const QString Constants::PrinterSettings::MachineSetup::kGCodeCoordinateFrameRotationX =
     "gcode_coordinate_frame_rotation_x";
 const QString Constants::PrinterSettings::MachineSetup::kGCodeCoordinateFrameRotationY =
@@ -261,69 +261,69 @@ const QString Constants::PrinterSettings::MachineSetup::kGCodeCoordinateFrameRot
 
 // Dimensions
 const QString Constants::PrinterSettings::Dimensions::kBuildVolumeType = "build_volume_type";
-const QString Constants::PrinterSettings::Dimensions::kXMin = "minimum_x";
-const QString Constants::PrinterSettings::Dimensions::kXMax = "maximum_x";
-const QString Constants::PrinterSettings::Dimensions::kYMin = "minimum_y";
-const QString Constants::PrinterSettings::Dimensions::kYMax = "maximum_y";
-const QString Constants::PrinterSettings::Dimensions::kZMin = "minimum_z";
-const QString Constants::PrinterSettings::Dimensions::kZMax = "maximum_z";
+const QString Constants::PrinterSettings::Dimensions::kXMin            = "minimum_x";
+const QString Constants::PrinterSettings::Dimensions::kXMax            = "maximum_x";
+const QString Constants::PrinterSettings::Dimensions::kYMin            = "minimum_y";
+const QString Constants::PrinterSettings::Dimensions::kYMax            = "maximum_y";
+const QString Constants::PrinterSettings::Dimensions::kZMin            = "minimum_z";
+const QString Constants::PrinterSettings::Dimensions::kZMax            = "maximum_z";
 const QString Constants::PrinterSettings::Dimensions::kUseVariableForZ = "variable_for_z";
-const QString Constants::PrinterSettings::Dimensions::kOuterRadius = "outer_radius";
-const QString Constants::PrinterSettings::Dimensions::kXOffset = "x_offset";
-const QString Constants::PrinterSettings::Dimensions::kYOffset = "y_offset";
-const QString Constants::PrinterSettings::Dimensions::kZOffset = "z_offset";
-const QString Constants::PrinterSettings::Dimensions::kEnableW = "enable_w_axis";
-const QString Constants::PrinterSettings::Dimensions::kWMin = "minimum_w";
-const QString Constants::PrinterSettings::Dimensions::kWMax = "maximum_w";
-const QString Constants::PrinterSettings::Dimensions::kInitialW = "initial_w";
+const QString Constants::PrinterSettings::Dimensions::kOuterRadius     = "outer_radius";
+const QString Constants::PrinterSettings::Dimensions::kXOffset         = "x_offset";
+const QString Constants::PrinterSettings::Dimensions::kYOffset         = "y_offset";
+const QString Constants::PrinterSettings::Dimensions::kZOffset         = "z_offset";
+const QString Constants::PrinterSettings::Dimensions::kEnableW         = "enable_w_axis";
+const QString Constants::PrinterSettings::Dimensions::kWMin            = "minimum_w";
+const QString Constants::PrinterSettings::Dimensions::kWMax            = "maximum_w";
+const QString Constants::PrinterSettings::Dimensions::kInitialW        = "initial_w";
 const QString Constants::PrinterSettings::Dimensions::kLayerChangeAxis = "layer_change";
-const QString Constants::PrinterSettings::Dimensions::kEnableDoffing = "doffing";
-const QString Constants::PrinterSettings::Dimensions::kDoffingHeight = "doffing_location";
-const QString Constants::PrinterSettings::Dimensions::kPurgeX = "purge_x";
-const QString Constants::PrinterSettings::Dimensions::kPurgeY = "purge_y";
-const QString Constants::PrinterSettings::Dimensions::kPurgeZ = "purge_z";
-const QString Constants::PrinterSettings::Dimensions::kEnableGridX = "enable_grid_x";
-const QString Constants::PrinterSettings::Dimensions::kGridXDistance = "grid_x_distance";
-const QString Constants::PrinterSettings::Dimensions::kGridXOffset = "grid_x_offset";
-const QString Constants::PrinterSettings::Dimensions::kEnableGridY = "enable_grid_y";
-const QString Constants::PrinterSettings::Dimensions::kGridYDistance = "grid_y_distance";
-const QString Constants::PrinterSettings::Dimensions::kGridYOffset = "grid_y_offset";
+const QString Constants::PrinterSettings::Dimensions::kEnableDoffing   = "doffing";
+const QString Constants::PrinterSettings::Dimensions::kDoffingHeight   = "doffing_location";
+const QString Constants::PrinterSettings::Dimensions::kPurgeX          = "purge_x";
+const QString Constants::PrinterSettings::Dimensions::kPurgeY          = "purge_y";
+const QString Constants::PrinterSettings::Dimensions::kPurgeZ          = "purge_z";
+const QString Constants::PrinterSettings::Dimensions::kEnableGridX     = "enable_grid_x";
+const QString Constants::PrinterSettings::Dimensions::kGridXDistance   = "grid_x_distance";
+const QString Constants::PrinterSettings::Dimensions::kGridXOffset     = "grid_x_offset";
+const QString Constants::PrinterSettings::Dimensions::kEnableGridY     = "enable_grid_y";
+const QString Constants::PrinterSettings::Dimensions::kGridYDistance   = "grid_y_distance";
+const QString Constants::PrinterSettings::Dimensions::kGridYOffset     = "grid_y_offset";
 
 // Auxiliary
-const QString Constants::PrinterSettings::Auxiliary::kEnableTamper = "enable_tamper";
+const QString Constants::PrinterSettings::Auxiliary::kEnableTamper  = "enable_tamper";
 const QString Constants::PrinterSettings::Auxiliary::kTamperVoltage = "tamper_voltage";
 
 // Machine Speed
-const QString Constants::PrinterSettings::MachineSpeed::kMinXYSpeed = "min_xy_speed";
-const QString Constants::PrinterSettings::MachineSpeed::kMaxXYSpeed = "max_xy_speed";
+const QString Constants::PrinterSettings::MachineSpeed::kMinXYSpeed       = "min_xy_speed";
+const QString Constants::PrinterSettings::MachineSpeed::kMaxXYSpeed       = "max_xy_speed";
 const QString Constants::PrinterSettings::MachineSpeed::kMinExtruderSpeed = "min_extruder_speed";
 const QString Constants::PrinterSettings::MachineSpeed::kMaxExtruderSpeed = "max_extruder_speed";
-const QString Constants::PrinterSettings::MachineSpeed::kWTableSpeed = "w_table_speed";
-const QString Constants::PrinterSettings::MachineSpeed::kZSpeed = "z_speed";
-const QString Constants::PrinterSettings::MachineSpeed::kGearRatio = "extruder_gear_ratio";
+const QString Constants::PrinterSettings::MachineSpeed::kWTableSpeed      = "w_table_speed";
+const QString Constants::PrinterSettings::MachineSpeed::kZSpeed           = "z_speed";
+const QString Constants::PrinterSettings::MachineSpeed::kGearRatio        = "extruder_gear_ratio";
 
 // Acceleration
 const QString Constants::PrinterSettings::Acceleration::kEnableDynamic = "enable_dynamic_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kDefault = "default_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kPerimeter = "perimeter_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kInset = "inset_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kSkin = "skin_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kInfill = "infill_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kSkeleton = "skeleton_acceleration";
-const QString Constants::PrinterSettings::Acceleration::kSupport = "support_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kDefault       = "default_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kPerimeter     = "perimeter_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kInset         = "inset_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kSkin          = "skin_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kInfill        = "infill_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kSkeleton      = "skeleton_acceleration";
+const QString Constants::PrinterSettings::Acceleration::kSupport       = "support_acceleration";
 
 // G-Code
-const QString Constants::PrinterSettings::GCode::kEnableStartupCode = "enable_default_startup_code";
-const QString Constants::PrinterSettings::GCode::kEnableMaterialLoad = "enable_material_load";
-const QString Constants::PrinterSettings::GCode::kEnableWaitForUser = "enable_wait_for_user";
-const QString Constants::PrinterSettings::GCode::kEnableBoundingBox = "enable_bounding_box";
+const QString Constants::PrinterSettings::GCode::kEnableStartupCode    = "enable_default_startup_code";
+const QString Constants::PrinterSettings::GCode::kEnableMaterialLoad   = "enable_material_load";
+const QString Constants::PrinterSettings::GCode::kEnableWaitForUser    = "enable_wait_for_user";
+const QString Constants::PrinterSettings::GCode::kEnableBoundingBox    = "enable_bounding_box";
 const QString Constants::PrinterSettings::GCode::kEnableSettingsFooter = "enable_settings_footer";
-const QString Constants::PrinterSettings::GCode::kLayerTimeComments = "enable_layer_time_comments";
+const QString Constants::PrinterSettings::GCode::kLayerTimeComments    = "enable_layer_time_comments";
 const QString Constants::PrinterSettings::GCode::kArcSpecialtiesG2G3OptionalStop =
     "arc_specialties_g2_g3_optional_stop";
-const QString Constants::PrinterSettings::GCode::kStartCode = "start_code";
+const QString Constants::PrinterSettings::GCode::kStartCode       = "start_code";
 const QString Constants::PrinterSettings::GCode::kLayerCodeChange = "layer_change_code";
-const QString Constants::PrinterSettings::GCode::kEndCode = "end_code";
+const QString Constants::PrinterSettings::GCode::kEndCode         = "end_code";
 
 //================================================================================
 // Material Settings
@@ -331,182 +331,182 @@ const QString Constants::PrinterSettings::GCode::kEndCode = "end_code";
 
 // Material Categories
 const QString Constants::MaterialSettings::Density::kMaterialType = "printing_material";
-const QString Constants::MaterialSettings::Density::kDensity = "other_density";
+const QString Constants::MaterialSettings::Density::kDensity      = "other_density";
 
 // Startup
-const QString Constants::MaterialSettings::Startup::kPerimeterEnable = "perimeter_start-up";
-const QString Constants::MaterialSettings::Startup::kPerimeterDistance = "perimeter_start-up_distance";
-const QString Constants::MaterialSettings::Startup::kPerimeterSpeed = "perimeter_start-up_speed";
+const QString Constants::MaterialSettings::Startup::kPerimeterEnable        = "perimeter_start-up";
+const QString Constants::MaterialSettings::Startup::kPerimeterDistance      = "perimeter_start-up_distance";
+const QString Constants::MaterialSettings::Startup::kPerimeterSpeed         = "perimeter_start-up_speed";
 const QString Constants::MaterialSettings::Startup::kPerimeterExtruderSpeed = "perimeter_start-up_extruder_speed";
-const QString Constants::MaterialSettings::Startup::kPerimeterRampUpEnable = "perimeter_start-up_ramp-up";
-const QString Constants::MaterialSettings::Startup::kPerimeterSteps = "perimeter_start-up_steps";
-const QString Constants::MaterialSettings::Startup::kInsetEnable = "inset_start-up";
-const QString Constants::MaterialSettings::Startup::kInsetDistance = "inset_start-up_distance";
-const QString Constants::MaterialSettings::Startup::kInsetSpeed = "inset_start-up_speed";
-const QString Constants::MaterialSettings::Startup::kInsetExtruderSpeed = "inset_start-up_extruder_speed";
-const QString Constants::MaterialSettings::Startup::kInsetRampUpEnable = "inset_start-up_ramp-up";
-const QString Constants::MaterialSettings::Startup::kInsetSteps = "inset_start-up_steps";
-const QString Constants::MaterialSettings::Startup::kSkinEnable = "skin_start-up";
-const QString Constants::MaterialSettings::Startup::kSkinDistance = "skin_start-up_distance";
-const QString Constants::MaterialSettings::Startup::kSkinSpeed = "skin_start-up_speed";
-const QString Constants::MaterialSettings::Startup::kSkinExtruderSpeed = "skin_start-up_extruder_speed";
-const QString Constants::MaterialSettings::Startup::kSkinRampUpEnable = "skin_start-up_ramp-up";
-const QString Constants::MaterialSettings::Startup::kSkinSteps = "skin_start-up_steps";
-const QString Constants::MaterialSettings::Startup::kInfillEnable = "infill_start-up";
-const QString Constants::MaterialSettings::Startup::kInfillDistance = "infill_start-up_distance";
-const QString Constants::MaterialSettings::Startup::kInfillSpeed = "infill_start-up_speed";
-const QString Constants::MaterialSettings::Startup::kInfillExtruderSpeed = "infill_start-up_extruder_speed";
-const QString Constants::MaterialSettings::Startup::kInfillRampUpEnable = "infill_start-up_ramp-up";
-const QString Constants::MaterialSettings::Startup::kInfillSteps = "infill_start-up_steps";
-const QString Constants::MaterialSettings::Startup::kSkeletonEnable = "skeleton_start-up";
-const QString Constants::MaterialSettings::Startup::kSkeletonDistance = "skeleton_start-up_distance";
-const QString Constants::MaterialSettings::Startup::kSkeletonSpeed = "skeleton_start-up_speed";
-const QString Constants::MaterialSettings::Startup::kSkeletonExtruderSpeed = "skeleton_start-up_extruder_speed";
-const QString Constants::MaterialSettings::Startup::kSkeletonRampUpEnable = "skeleton_start-up_ramp-up";
-const QString Constants::MaterialSettings::Startup::kSkeletonSteps = "skeleton_start-up_steps";
-const QString Constants::MaterialSettings::Startup::kStartUpAreaModifier = "start-up_area_modifier";
+const QString Constants::MaterialSettings::Startup::kPerimeterRampUpEnable  = "perimeter_start-up_ramp-up";
+const QString Constants::MaterialSettings::Startup::kPerimeterSteps         = "perimeter_start-up_steps";
+const QString Constants::MaterialSettings::Startup::kInsetEnable            = "inset_start-up";
+const QString Constants::MaterialSettings::Startup::kInsetDistance          = "inset_start-up_distance";
+const QString Constants::MaterialSettings::Startup::kInsetSpeed             = "inset_start-up_speed";
+const QString Constants::MaterialSettings::Startup::kInsetExtruderSpeed     = "inset_start-up_extruder_speed";
+const QString Constants::MaterialSettings::Startup::kInsetRampUpEnable      = "inset_start-up_ramp-up";
+const QString Constants::MaterialSettings::Startup::kInsetSteps             = "inset_start-up_steps";
+const QString Constants::MaterialSettings::Startup::kSkinEnable             = "skin_start-up";
+const QString Constants::MaterialSettings::Startup::kSkinDistance           = "skin_start-up_distance";
+const QString Constants::MaterialSettings::Startup::kSkinSpeed              = "skin_start-up_speed";
+const QString Constants::MaterialSettings::Startup::kSkinExtruderSpeed      = "skin_start-up_extruder_speed";
+const QString Constants::MaterialSettings::Startup::kSkinRampUpEnable       = "skin_start-up_ramp-up";
+const QString Constants::MaterialSettings::Startup::kSkinSteps              = "skin_start-up_steps";
+const QString Constants::MaterialSettings::Startup::kInfillEnable           = "infill_start-up";
+const QString Constants::MaterialSettings::Startup::kInfillDistance         = "infill_start-up_distance";
+const QString Constants::MaterialSettings::Startup::kInfillSpeed            = "infill_start-up_speed";
+const QString Constants::MaterialSettings::Startup::kInfillExtruderSpeed    = "infill_start-up_extruder_speed";
+const QString Constants::MaterialSettings::Startup::kInfillRampUpEnable     = "infill_start-up_ramp-up";
+const QString Constants::MaterialSettings::Startup::kInfillSteps            = "infill_start-up_steps";
+const QString Constants::MaterialSettings::Startup::kSkeletonEnable         = "skeleton_start-up";
+const QString Constants::MaterialSettings::Startup::kSkeletonDistance       = "skeleton_start-up_distance";
+const QString Constants::MaterialSettings::Startup::kSkeletonSpeed          = "skeleton_start-up_speed";
+const QString Constants::MaterialSettings::Startup::kSkeletonExtruderSpeed  = "skeleton_start-up_extruder_speed";
+const QString Constants::MaterialSettings::Startup::kSkeletonRampUpEnable   = "skeleton_start-up_ramp-up";
+const QString Constants::MaterialSettings::Startup::kSkeletonSteps          = "skeleton_start-up_steps";
+const QString Constants::MaterialSettings::Startup::kStartUpAreaModifier    = "start-up_area_modifier";
 const QString Constants::MaterialSettings::Startup::kDisableFeedrateScaling = "disable_start-up_feedrate_scaling";
 
 // Slowdown
-const QString Constants::MaterialSettings::Slowdown::kPerimeterEnable = "perimeter_slow_down";
-const QString Constants::MaterialSettings::Slowdown::kPerimeterDistance = "perimeter_slow_down_distance";
-const QString Constants::MaterialSettings::Slowdown::kPerimeterLiftDistance = "perimeter_slow_down_lift_distance";
-const QString Constants::MaterialSettings::Slowdown::kPerimeterSpeed = "perimeter_slow_down_speed";
+const QString Constants::MaterialSettings::Slowdown::kPerimeterEnable        = "perimeter_slow_down";
+const QString Constants::MaterialSettings::Slowdown::kPerimeterDistance      = "perimeter_slow_down_distance";
+const QString Constants::MaterialSettings::Slowdown::kPerimeterLiftDistance  = "perimeter_slow_down_lift_distance";
+const QString Constants::MaterialSettings::Slowdown::kPerimeterSpeed         = "perimeter_slow_down_speed";
 const QString Constants::MaterialSettings::Slowdown::kPerimeterExtruderSpeed = "perimeter_slow_down_extruder_speed";
 const QString Constants::MaterialSettings::Slowdown::kPerimeterCutoffDistance =
     "perimeter_slow_down_extruder_off_distance";
-const QString Constants::MaterialSettings::Slowdown::kInsetEnable = "inset_slow_down";
-const QString Constants::MaterialSettings::Slowdown::kInsetDistance = "inset_slow_down_distance";
-const QString Constants::MaterialSettings::Slowdown::kInsetLiftDistance = "inset_slow_down_lift_distance";
-const QString Constants::MaterialSettings::Slowdown::kInsetSpeed = "inset_slow_down_speed";
-const QString Constants::MaterialSettings::Slowdown::kInsetExtruderSpeed = "inset_slow_down_extruder_speed";
-const QString Constants::MaterialSettings::Slowdown::kInsetCutoffDistance = "inset_slow_down_extruder_off_distance";
-const QString Constants::MaterialSettings::Slowdown::kSkinEnable = "skin_slow_down";
-const QString Constants::MaterialSettings::Slowdown::kSkinDistance = "skin_slow_down_distance";
-const QString Constants::MaterialSettings::Slowdown::kSkinLiftDistance = "skin_slow_down_lift_distance";
-const QString Constants::MaterialSettings::Slowdown::kSkinSpeed = "skin_slow_down_speed";
-const QString Constants::MaterialSettings::Slowdown::kSkinExtruderSpeed = "skin_slow_down_extruder_speed";
-const QString Constants::MaterialSettings::Slowdown::kSkinCutoffDistance = "skin_slow_down_extruder_off_distance";
-const QString Constants::MaterialSettings::Slowdown::kInfillEnable = "infill_slow_down";
-const QString Constants::MaterialSettings::Slowdown::kInfillDistance = "infill_slow_down_distance";
-const QString Constants::MaterialSettings::Slowdown::kInfillLiftDistance = "infill_slow_down_lift_distance";
-const QString Constants::MaterialSettings::Slowdown::kInfillSpeed = "infill_slow_down_speed";
-const QString Constants::MaterialSettings::Slowdown::kInfillExtruderSpeed = "infill_slow_down_extruder_speed";
-const QString Constants::MaterialSettings::Slowdown::kInfillCutoffDistance = "infill_slow_down_extruder_off_distance";
-const QString Constants::MaterialSettings::Slowdown::kSkeletonEnable = "skeleton_slow_down";
-const QString Constants::MaterialSettings::Slowdown::kSkeletonDistance = "skeleton_slow_down_distance";
-const QString Constants::MaterialSettings::Slowdown::kSkeletonLiftDistance = "skeleton_slow_down_lift_distance";
-const QString Constants::MaterialSettings::Slowdown::kSkeletonSpeed = "skeleton_slow_down_speed";
+const QString Constants::MaterialSettings::Slowdown::kInsetEnable           = "inset_slow_down";
+const QString Constants::MaterialSettings::Slowdown::kInsetDistance         = "inset_slow_down_distance";
+const QString Constants::MaterialSettings::Slowdown::kInsetLiftDistance     = "inset_slow_down_lift_distance";
+const QString Constants::MaterialSettings::Slowdown::kInsetSpeed            = "inset_slow_down_speed";
+const QString Constants::MaterialSettings::Slowdown::kInsetExtruderSpeed    = "inset_slow_down_extruder_speed";
+const QString Constants::MaterialSettings::Slowdown::kInsetCutoffDistance   = "inset_slow_down_extruder_off_distance";
+const QString Constants::MaterialSettings::Slowdown::kSkinEnable            = "skin_slow_down";
+const QString Constants::MaterialSettings::Slowdown::kSkinDistance          = "skin_slow_down_distance";
+const QString Constants::MaterialSettings::Slowdown::kSkinLiftDistance      = "skin_slow_down_lift_distance";
+const QString Constants::MaterialSettings::Slowdown::kSkinSpeed             = "skin_slow_down_speed";
+const QString Constants::MaterialSettings::Slowdown::kSkinExtruderSpeed     = "skin_slow_down_extruder_speed";
+const QString Constants::MaterialSettings::Slowdown::kSkinCutoffDistance    = "skin_slow_down_extruder_off_distance";
+const QString Constants::MaterialSettings::Slowdown::kInfillEnable          = "infill_slow_down";
+const QString Constants::MaterialSettings::Slowdown::kInfillDistance        = "infill_slow_down_distance";
+const QString Constants::MaterialSettings::Slowdown::kInfillLiftDistance    = "infill_slow_down_lift_distance";
+const QString Constants::MaterialSettings::Slowdown::kInfillSpeed           = "infill_slow_down_speed";
+const QString Constants::MaterialSettings::Slowdown::kInfillExtruderSpeed   = "infill_slow_down_extruder_speed";
+const QString Constants::MaterialSettings::Slowdown::kInfillCutoffDistance  = "infill_slow_down_extruder_off_distance";
+const QString Constants::MaterialSettings::Slowdown::kSkeletonEnable        = "skeleton_slow_down";
+const QString Constants::MaterialSettings::Slowdown::kSkeletonDistance      = "skeleton_slow_down_distance";
+const QString Constants::MaterialSettings::Slowdown::kSkeletonLiftDistance  = "skeleton_slow_down_lift_distance";
+const QString Constants::MaterialSettings::Slowdown::kSkeletonSpeed         = "skeleton_slow_down_speed";
 const QString Constants::MaterialSettings::Slowdown::kSkeletonExtruderSpeed = "skeleton_slow_down_extruder_speed";
 const QString Constants::MaterialSettings::Slowdown::kSkeletonCutoffDistance =
     "skeleton_slow_down_extruder_off_distance";
-const QString Constants::MaterialSettings::Slowdown::kSlowDownAreaModifier = "slow_down_area_modifier";
+const QString Constants::MaterialSettings::Slowdown::kSlowDownAreaModifier   = "slow_down_area_modifier";
 const QString Constants::MaterialSettings::Slowdown::kDisableFeedrateScaling = "disable_slow_down_feedrate_scaling";
 
 // TipWipe
-const QString Constants::MaterialSettings::TipWipe::kPerimeterEnable = "perimeter_wipe";
-const QString Constants::MaterialSettings::TipWipe::kPerimeterDistance = "perimeter_wipe_distance";
-const QString Constants::MaterialSettings::TipWipe::kPerimeterSpeed = "perimeter_wipe_speed";
-const QString Constants::MaterialSettings::TipWipe::kPerimeterExtruderSpeed = "perimeter_wipe_extruder_speed";
-const QString Constants::MaterialSettings::TipWipe::kPerimeterDirection = "perimeter_wipe_direction";
-const QString Constants::MaterialSettings::TipWipe::kPerimeterAngle = "perimeter_wipe_angle";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterEnable         = "perimeter_wipe";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterDistance       = "perimeter_wipe_distance";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterSpeed          = "perimeter_wipe_speed";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterExtruderSpeed  = "perimeter_wipe_extruder_speed";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterDirection      = "perimeter_wipe_direction";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterAngle          = "perimeter_wipe_angle";
 const QString Constants::MaterialSettings::TipWipe::kPerimeterCutoffDistance = "perimeter_wipe_cutoff_distance";
-const QString Constants::MaterialSettings::TipWipe::kPerimeterLiftHeight = "perimeter_wipe_lift_height";
-const QString Constants::MaterialSettings::TipWipe::kInsetEnable = "inset_wipe";
-const QString Constants::MaterialSettings::TipWipe::kInsetDistance = "inset_wipe_distance";
-const QString Constants::MaterialSettings::TipWipe::kInsetSpeed = "inset_wipe_speed";
-const QString Constants::MaterialSettings::TipWipe::kInsetExtruderSpeed = "inset_wipe_extruder_speed";
-const QString Constants::MaterialSettings::TipWipe::kInsetDirection = "inset_wipe_direction";
-const QString Constants::MaterialSettings::TipWipe::kInsetAngle = "inset_wipe_angle";
-const QString Constants::MaterialSettings::TipWipe::kInsetCutoffDistance = "inset_wipe_cutoff_distance";
-const QString Constants::MaterialSettings::TipWipe::kInsetLiftHeight = "inset_wipe_lift_height";
-const QString Constants::MaterialSettings::TipWipe::kSkinEnable = "skin_wipe";
-const QString Constants::MaterialSettings::TipWipe::kSkinDistance = "skin_wipe_distance";
-const QString Constants::MaterialSettings::TipWipe::kSkinSpeed = "skin_wipe_speed";
-const QString Constants::MaterialSettings::TipWipe::kSkinExtruderSpeed = "skin_wipe_extruder_speed";
-const QString Constants::MaterialSettings::TipWipe::kSkinDirection = "skin_wipe_direction";
-const QString Constants::MaterialSettings::TipWipe::kSkinAngle = "skin_wipe_angle";
-const QString Constants::MaterialSettings::TipWipe::kSkinCutoffDistance = "skin_wipe_cutoff_distance";
-const QString Constants::MaterialSettings::TipWipe::kSkinLiftHeight = "skin_wipe_lift_height";
-const QString Constants::MaterialSettings::TipWipe::kInfillEnable = "infill_wipe";
-const QString Constants::MaterialSettings::TipWipe::kInfillDistance = "infill_wipe_distance";
-const QString Constants::MaterialSettings::TipWipe::kInfillSpeed = "infill_wipe_speed";
-const QString Constants::MaterialSettings::TipWipe::kInfillExtruderSpeed = "infill_wipe_extruder_speed";
-const QString Constants::MaterialSettings::TipWipe::kInfillDirection = "infill_wipe_direction";
-const QString Constants::MaterialSettings::TipWipe::kInfillAngle = "infill_wipe_angle";
-const QString Constants::MaterialSettings::TipWipe::kInfillCutoffDistance = "infill_wipe_cutoff_distance";
-const QString Constants::MaterialSettings::TipWipe::kInfillLiftHeight = "infill_wipe_lift_height";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonEnable = "skeleton_wipe";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonDistance = "skeleton_wipe_distance";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonSpeed = "skeleton_wipe_speed";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonExtruderSpeed = "skeleton_wipe_extruder_speed";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonDirection = "skeleton_wipe_direction";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonAngle = "skeleton_wipe_angle";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonCutoffDistance = "skeleton_wipe_cutoff_distance";
-const QString Constants::MaterialSettings::TipWipe::kSkeletonLiftHeight = "skeleton_wipe_lift_height";
-const QString Constants::MaterialSettings::TipWipe::kTipWipeVoltage = "tip_wipe_voltage";
-const QString Constants::MaterialSettings::TipWipe::kDisableFeedrateScaling = "disable_tip_wipe_feedrate_scaling";
+const QString Constants::MaterialSettings::TipWipe::kPerimeterLiftHeight     = "perimeter_wipe_lift_height";
+const QString Constants::MaterialSettings::TipWipe::kInsetEnable             = "inset_wipe";
+const QString Constants::MaterialSettings::TipWipe::kInsetDistance           = "inset_wipe_distance";
+const QString Constants::MaterialSettings::TipWipe::kInsetSpeed              = "inset_wipe_speed";
+const QString Constants::MaterialSettings::TipWipe::kInsetExtruderSpeed      = "inset_wipe_extruder_speed";
+const QString Constants::MaterialSettings::TipWipe::kInsetDirection          = "inset_wipe_direction";
+const QString Constants::MaterialSettings::TipWipe::kInsetAngle              = "inset_wipe_angle";
+const QString Constants::MaterialSettings::TipWipe::kInsetCutoffDistance     = "inset_wipe_cutoff_distance";
+const QString Constants::MaterialSettings::TipWipe::kInsetLiftHeight         = "inset_wipe_lift_height";
+const QString Constants::MaterialSettings::TipWipe::kSkinEnable              = "skin_wipe";
+const QString Constants::MaterialSettings::TipWipe::kSkinDistance            = "skin_wipe_distance";
+const QString Constants::MaterialSettings::TipWipe::kSkinSpeed               = "skin_wipe_speed";
+const QString Constants::MaterialSettings::TipWipe::kSkinExtruderSpeed       = "skin_wipe_extruder_speed";
+const QString Constants::MaterialSettings::TipWipe::kSkinDirection           = "skin_wipe_direction";
+const QString Constants::MaterialSettings::TipWipe::kSkinAngle               = "skin_wipe_angle";
+const QString Constants::MaterialSettings::TipWipe::kSkinCutoffDistance      = "skin_wipe_cutoff_distance";
+const QString Constants::MaterialSettings::TipWipe::kSkinLiftHeight          = "skin_wipe_lift_height";
+const QString Constants::MaterialSettings::TipWipe::kInfillEnable            = "infill_wipe";
+const QString Constants::MaterialSettings::TipWipe::kInfillDistance          = "infill_wipe_distance";
+const QString Constants::MaterialSettings::TipWipe::kInfillSpeed             = "infill_wipe_speed";
+const QString Constants::MaterialSettings::TipWipe::kInfillExtruderSpeed     = "infill_wipe_extruder_speed";
+const QString Constants::MaterialSettings::TipWipe::kInfillDirection         = "infill_wipe_direction";
+const QString Constants::MaterialSettings::TipWipe::kInfillAngle             = "infill_wipe_angle";
+const QString Constants::MaterialSettings::TipWipe::kInfillCutoffDistance    = "infill_wipe_cutoff_distance";
+const QString Constants::MaterialSettings::TipWipe::kInfillLiftHeight        = "infill_wipe_lift_height";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonEnable          = "skeleton_wipe";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonDistance        = "skeleton_wipe_distance";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonSpeed           = "skeleton_wipe_speed";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonExtruderSpeed   = "skeleton_wipe_extruder_speed";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonDirection       = "skeleton_wipe_direction";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonAngle           = "skeleton_wipe_angle";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonCutoffDistance  = "skeleton_wipe_cutoff_distance";
+const QString Constants::MaterialSettings::TipWipe::kSkeletonLiftHeight      = "skeleton_wipe_lift_height";
+const QString Constants::MaterialSettings::TipWipe::kTipWipeVoltage          = "tip_wipe_voltage";
+const QString Constants::MaterialSettings::TipWipe::kDisableFeedrateScaling  = "disable_tip_wipe_feedrate_scaling";
 
 // Spiral Lift
-const QString Constants::MaterialSettings::SpiralLift::kPerimeterEnable = "enable_spiral_perimeter";
-const QString Constants::MaterialSettings::SpiralLift::kInsetEnable = "enable_spiral_inset";
-const QString Constants::MaterialSettings::SpiralLift::kSkinEnable = "enable_spiral_skin";
-const QString Constants::MaterialSettings::SpiralLift::kInfillEnable = "enable_spiral_infill";
-const QString Constants::MaterialSettings::SpiralLift::kLayerEnable = "spiral_end_of_layer";
-const QString Constants::MaterialSettings::SpiralLift::kLiftHeight = "spiral_lift_height";
-const QString Constants::MaterialSettings::SpiralLift::kLiftRadius = "spiral_lift_radius";
-const QString Constants::MaterialSettings::SpiralLift::kLiftSpeed = "spiral_lift_speed";
-const QString Constants::MaterialSettings::SpiralLift::kLiftPoints = "spiral_lift_points";
+const QString Constants::MaterialSettings::SpiralLift::kPerimeterEnable        = "enable_spiral_perimeter";
+const QString Constants::MaterialSettings::SpiralLift::kInsetEnable            = "enable_spiral_inset";
+const QString Constants::MaterialSettings::SpiralLift::kSkinEnable             = "enable_spiral_skin";
+const QString Constants::MaterialSettings::SpiralLift::kInfillEnable           = "enable_spiral_infill";
+const QString Constants::MaterialSettings::SpiralLift::kLayerEnable            = "spiral_end_of_layer";
+const QString Constants::MaterialSettings::SpiralLift::kLiftHeight             = "spiral_lift_height";
+const QString Constants::MaterialSettings::SpiralLift::kLiftRadius             = "spiral_lift_radius";
+const QString Constants::MaterialSettings::SpiralLift::kLiftSpeed              = "spiral_lift_speed";
+const QString Constants::MaterialSettings::SpiralLift::kLiftPoints             = "spiral_lift_points";
 const QString Constants::MaterialSettings::SpiralLift::kDisableFeedrateScaling = "disable_spiral_lift_feedrate_scaling";
 
 // Purge
-const QString Constants::MaterialSettings::Purge::kInitialDuration = "initial_purge_duration";
-const QString Constants::MaterialSettings::Purge::kInitialScrewRPM = "initial_purge_dwell_screw_rpm";
-const QString Constants::MaterialSettings::Purge::kInitialTipWipeDelay = "initial_purge_tip_wipe_delay";
-const QString Constants::MaterialSettings::Purge::kEnablePurgeDwell = "purge_during_dwell";
-const QString Constants::MaterialSettings::Purge::kPurgeDwellDuration = "purge_dwell_duration";
-const QString Constants::MaterialSettings::Purge::kPurgeDwellRPM = "purge_dwell_screw_rpm";
+const QString Constants::MaterialSettings::Purge::kInitialDuration        = "initial_purge_duration";
+const QString Constants::MaterialSettings::Purge::kInitialScrewRPM        = "initial_purge_dwell_screw_rpm";
+const QString Constants::MaterialSettings::Purge::kInitialTipWipeDelay    = "initial_purge_tip_wipe_delay";
+const QString Constants::MaterialSettings::Purge::kEnablePurgeDwell       = "purge_during_dwell";
+const QString Constants::MaterialSettings::Purge::kPurgeDwellDuration     = "purge_dwell_duration";
+const QString Constants::MaterialSettings::Purge::kPurgeDwellRPM          = "purge_dwell_screw_rpm";
 const QString Constants::MaterialSettings::Purge::kPurgeDwellTipWipeDelay = "purge_tip_wipe_delay";
-const QString Constants::MaterialSettings::Purge::kPurgeLength = "purge_length";
-const QString Constants::MaterialSettings::Purge::kPurgeFeedrate = "purge_feedrate";
+const QString Constants::MaterialSettings::Purge::kPurgeLength            = "purge_length";
+const QString Constants::MaterialSettings::Purge::kPurgeFeedrate          = "purge_feedrate";
 
 // Extruder
-const QString Constants::MaterialSettings::Extruder::kInitialSpeed = "initial_extruder_speed";
+const QString Constants::MaterialSettings::Extruder::kInitialSpeed        = "initial_extruder_speed";
 const QString Constants::MaterialSettings::Extruder::kExtruderPrimeVolume = "extruder_prime_volume";
-const QString Constants::MaterialSettings::Extruder::kExtruderPrimeSpeed = "extruder_prime_speed";
-const QString Constants::MaterialSettings::Extruder::kOnDelayPerimeter = "extruder_on_delay_perimeter";
-const QString Constants::MaterialSettings::Extruder::kOnDelayInset = "extruder_on_delay_inset";
-const QString Constants::MaterialSettings::Extruder::kOnDelaySkin = "extruder_on_delay_skin";
-const QString Constants::MaterialSettings::Extruder::kOnDelayInfill = "extruder_on_delay_infill";
-const QString Constants::MaterialSettings::Extruder::kOnDelaySkeleton = "extruder_on_delay_skeleton";
-const QString Constants::MaterialSettings::Extruder::kOffDelay = "extruder_off_delay";
-const QString Constants::MaterialSettings::Extruder::kServoToTravelSpeed = "servo_extruder_to_travel_speed";
-const QString Constants::MaterialSettings::Extruder::kEnableM3S = "enable_m3s";
+const QString Constants::MaterialSettings::Extruder::kExtruderPrimeSpeed  = "extruder_prime_speed";
+const QString Constants::MaterialSettings::Extruder::kOnDelayPerimeter    = "extruder_on_delay_perimeter";
+const QString Constants::MaterialSettings::Extruder::kOnDelayInset        = "extruder_on_delay_inset";
+const QString Constants::MaterialSettings::Extruder::kOnDelaySkin         = "extruder_on_delay_skin";
+const QString Constants::MaterialSettings::Extruder::kOnDelayInfill       = "extruder_on_delay_infill";
+const QString Constants::MaterialSettings::Extruder::kOnDelaySkeleton     = "extruder_on_delay_skeleton";
+const QString Constants::MaterialSettings::Extruder::kOffDelay            = "extruder_off_delay";
+const QString Constants::MaterialSettings::Extruder::kServoToTravelSpeed  = "servo_extruder_to_travel_speed";
+const QString Constants::MaterialSettings::Extruder::kEnableM3S           = "enable_m3s";
 
 // Filament
-const QString Constants::MaterialSettings::Filament::kDiameter = "filament_diameter";
-const QString Constants::MaterialSettings::Filament::kRelative = "filament_relative_distance";
-const QString Constants::MaterialSettings::Filament::kDisableG92 = "disable_g92";
+const QString Constants::MaterialSettings::Filament::kDiameter      = "filament_diameter";
+const QString Constants::MaterialSettings::Filament::kRelative      = "filament_relative_distance";
+const QString Constants::MaterialSettings::Filament::kDisableG92    = "disable_g92";
 const QString Constants::MaterialSettings::Filament::kFilamentBAxis = "filament_b_axis";
 
 // Retraction
-const QString Constants::MaterialSettings::Retraction::kEnable = "retraction";
-const QString Constants::MaterialSettings::Retraction::kMinTravel = "retract_min_travel_length";
-const QString Constants::MaterialSettings::Retraction::kLength = "retraction_length";
-const QString Constants::MaterialSettings::Retraction::kSpeed = "retraction_speed";
-const QString Constants::MaterialSettings::Retraction::kOpenSpacesOnly = "retraction_open_spaces_only";
-const QString Constants::MaterialSettings::Retraction::kLayerChange = "retraction_layer_change";
-const QString Constants::MaterialSettings::Retraction::kPrimeSpeed = "filament_prime_speed";
+const QString Constants::MaterialSettings::Retraction::kEnable                = "retraction";
+const QString Constants::MaterialSettings::Retraction::kMinTravel             = "retract_min_travel_length";
+const QString Constants::MaterialSettings::Retraction::kLength                = "retraction_length";
+const QString Constants::MaterialSettings::Retraction::kSpeed                 = "retraction_speed";
+const QString Constants::MaterialSettings::Retraction::kOpenSpacesOnly        = "retraction_open_spaces_only";
+const QString Constants::MaterialSettings::Retraction::kLayerChange           = "retraction_layer_change";
+const QString Constants::MaterialSettings::Retraction::kPrimeSpeed            = "filament_prime_speed";
 const QString Constants::MaterialSettings::Retraction::kPrimeAdditionalLength = "filament_prime_length";
 
 // Temperatures
-const QString Constants::MaterialSettings::Temperatures::kBed = "bed_temperature";
-const QString Constants::MaterialSettings::Temperatures::kTwoZones = "two_zone_extruder";
-const QString Constants::MaterialSettings::Temperatures::kThreeZones = "three_zone_extruder";
-const QString Constants::MaterialSettings::Temperatures::kFourZones = "four_zone_extruder";
-const QString Constants::MaterialSettings::Temperatures::kFiveZones = "five_zone_extruder";
-const QString Constants::MaterialSettings::Temperatures::kExtruder = "extruder_temperature";
-const QString Constants::MaterialSettings::Temperatures::kStandBy = "standby_temperature";
+const QString Constants::MaterialSettings::Temperatures::kBed           = "bed_temperature";
+const QString Constants::MaterialSettings::Temperatures::kTwoZones      = "two_zone_extruder";
+const QString Constants::MaterialSettings::Temperatures::kThreeZones    = "three_zone_extruder";
+const QString Constants::MaterialSettings::Temperatures::kFourZones     = "four_zone_extruder";
+const QString Constants::MaterialSettings::Temperatures::kFiveZones     = "five_zone_extruder";
+const QString Constants::MaterialSettings::Temperatures::kExtruder      = "extruder_temperature";
+const QString Constants::MaterialSettings::Temperatures::kStandBy       = "standby_temperature";
 const QString Constants::MaterialSettings::Temperatures::kExtruderZone1 = "extruder_zone1";
 const QString Constants::MaterialSettings::Temperatures::kExtruderZone2 = "extruder_zone2";
 const QString Constants::MaterialSettings::Temperatures::kExtruderZone3 = "extruder_zone3";
@@ -514,269 +514,268 @@ const QString Constants::MaterialSettings::Temperatures::kExtruderZone4 = "extru
 const QString Constants::MaterialSettings::Temperatures::kExtruderZone5 = "extruder_zone5";
 
 // Cooling
-const QString Constants::MaterialSettings::Cooling::kEnable = "fan";
-const QString Constants::MaterialSettings::Cooling::kMinSpeed = "fan_min_speed";
-const QString Constants::MaterialSettings::Cooling::kMaxSpeed = "fan_max_speed";
-const QString Constants::MaterialSettings::Cooling::kForceMinLayerTime = "force_minimum_layer_time";
+const QString Constants::MaterialSettings::Cooling::kEnable                  = "fan";
+const QString Constants::MaterialSettings::Cooling::kMinSpeed                = "fan_min_speed";
+const QString Constants::MaterialSettings::Cooling::kMaxSpeed                = "fan_max_speed";
+const QString Constants::MaterialSettings::Cooling::kForceMinLayerTime       = "force_minimum_layer_time";
 const QString Constants::MaterialSettings::Cooling::kForceMinLayerTimeMethod = "minimum_layer_time_method";
-const QString Constants::MaterialSettings::Cooling::kMinLayerTime = "minimum_layer_time";
-const QString Constants::MaterialSettings::Cooling::kMaxLayerTime = "maximum_layer_time";
-const QString Constants::MaterialSettings::Cooling::kExtruderScaleFactor = "extruder_scale_factor";
-const QString Constants::MaterialSettings::Cooling::kPrePauseCode = "pre_pause_code";
-const QString Constants::MaterialSettings::Cooling::kPostPauseCode = "post_pause_code";
+const QString Constants::MaterialSettings::Cooling::kMinLayerTime            = "minimum_layer_time";
+const QString Constants::MaterialSettings::Cooling::kMaxLayerTime            = "maximum_layer_time";
+const QString Constants::MaterialSettings::Cooling::kExtruderScaleFactor     = "extruder_scale_factor";
+const QString Constants::MaterialSettings::Cooling::kPrePauseCode            = "pre_pause_code";
+const QString Constants::MaterialSettings::Cooling::kPostPauseCode           = "post_pause_code";
 
 // Platform Adhesion
-const QString Constants::MaterialSettings::PlatformAdhesion::kRaftEnable = "raft";
-const QString Constants::MaterialSettings::PlatformAdhesion::kRaftOffset = "raft_offset";
-const QString Constants::MaterialSettings::PlatformAdhesion::kRaftLayers = "raft_layer_count";
-const QString Constants::MaterialSettings::PlatformAdhesion::kRaftBeadWidth = "raft_bead_width";
-const QString Constants::MaterialSettings::PlatformAdhesion::kBrimEnable = "brim";
-const QString Constants::MaterialSettings::PlatformAdhesion::kBrimWidth = "brim_width";
-const QString Constants::MaterialSettings::PlatformAdhesion::kBrimLayers = "brim_layer_count";
-const QString Constants::MaterialSettings::PlatformAdhesion::kBrimBeadWidth = "brim_bead_width";
-const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtEnable = "skirt";
-const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtLoops = "skirt_loops";
+const QString Constants::MaterialSettings::PlatformAdhesion::kRaftEnable              = "raft";
+const QString Constants::MaterialSettings::PlatformAdhesion::kRaftOffset              = "raft_offset";
+const QString Constants::MaterialSettings::PlatformAdhesion::kRaftLayers              = "raft_layer_count";
+const QString Constants::MaterialSettings::PlatformAdhesion::kRaftBeadWidth           = "raft_bead_width";
+const QString Constants::MaterialSettings::PlatformAdhesion::kBrimEnable              = "brim";
+const QString Constants::MaterialSettings::PlatformAdhesion::kBrimWidth               = "brim_width";
+const QString Constants::MaterialSettings::PlatformAdhesion::kBrimLayers              = "brim_layer_count";
+const QString Constants::MaterialSettings::PlatformAdhesion::kBrimBeadWidth           = "brim_bead_width";
+const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtEnable             = "skirt";
+const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtLoops              = "skirt_loops";
 const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtDistanceFromObject = "skirt_distance_from_object";
-const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtLayers = "skirt_layer_count";
-const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtMinLength = "skirt_minimum_length";
-const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtBeadWidth = "skirt_bead_width";
+const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtLayers             = "skirt_layer_count";
+const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtMinLength          = "skirt_minimum_length";
+const QString Constants::MaterialSettings::PlatformAdhesion::kSkirtBeadWidth          = "skirt_bead_width";
 
 // MultiMaterial
-const QString Constants::MaterialSettings::MultiMaterial::kEnable = "enable_multi_material";
-const QString Constants::MaterialSettings::MultiMaterial::kPerimeterNum = "perimeter_material_num";
-const QString Constants::MaterialSettings::MultiMaterial::kInsetNum = "inset_material_num";
-const QString Constants::MaterialSettings::MultiMaterial::kSkinNum = "skin_material_num";
-const QString Constants::MaterialSettings::MultiMaterial::kSkeletonNum = "skeleton_material_num";
-const QString Constants::MaterialSettings::MultiMaterial::kInfillNum = "infill_material_num";
-const QString Constants::MaterialSettings::MultiMaterial::kTransitionDistance = "material_transition_distance";
+const QString Constants::MaterialSettings::MultiMaterial::kEnable               = "enable_multi_material";
+const QString Constants::MaterialSettings::MultiMaterial::kPerimeterNum         = "perimeter_material_num";
+const QString Constants::MaterialSettings::MultiMaterial::kInsetNum             = "inset_material_num";
+const QString Constants::MaterialSettings::MultiMaterial::kSkinNum              = "skin_material_num";
+const QString Constants::MaterialSettings::MultiMaterial::kSkeletonNum          = "skeleton_material_num";
+const QString Constants::MaterialSettings::MultiMaterial::kInfillNum            = "infill_material_num";
+const QString Constants::MaterialSettings::MultiMaterial::kTransitionDistance   = "material_transition_distance";
 const QString Constants::MaterialSettings::MultiMaterial::kEnableSecondDistance = "enable_second_transition_distance";
-const QString Constants::MaterialSettings::MultiMaterial::kSecondDistance = "second_transition_distance";
-const QString Constants::MaterialSettings::MultiMaterial::kUseM222 = "enable_m222";
+const QString Constants::MaterialSettings::MultiMaterial::kSecondDistance       = "second_transition_distance";
+const QString Constants::MaterialSettings::MultiMaterial::kUseM222              = "enable_m222";
 
 //================================================================================
 // Profile Settings
 //================================================================================
 
 // Layer
-const QString Constants::ProfileSettings::Layer::kLayerHeight = "layer_height";
-const QString Constants::ProfileSettings::Layer::kNozzleDiameter = "nozzle_diameter";
-const QString Constants::ProfileSettings::Layer::kBeadWidth = "default_width";
-const QString Constants::ProfileSettings::Layer::kSpeed = "default_speed";
-const QString Constants::ProfileSettings::Layer::kExtruderSpeed = "default_extruder_speed";
+const QString Constants::ProfileSettings::Layer::kLayerHeight      = "layer_height";
+const QString Constants::ProfileSettings::Layer::kNozzleDiameter   = "nozzle_diameter";
+const QString Constants::ProfileSettings::Layer::kBeadWidth        = "default_width";
+const QString Constants::ProfileSettings::Layer::kSpeed            = "default_speed";
+const QString Constants::ProfileSettings::Layer::kExtruderSpeed    = "default_extruder_speed";
 const QString Constants::ProfileSettings::Layer::kMinExtrudeLength = "minimum_extrude_length";
 
 // Perimeter
-const QString Constants::ProfileSettings::Perimeter::kEnable = "perimeter";
-const QString Constants::ProfileSettings::Perimeter::kCount = "perimeter_count";
-const QString Constants::ProfileSettings::Perimeter::kBoundarySelection = "perimeter_boundary_selection";
-const QString Constants::ProfileSettings::Perimeter::kBeadWidth = "perimeter_width";
-const QString Constants::ProfileSettings::Perimeter::kAdaptive = "perimeter_adapt";
-const QString Constants::ProfileSettings::Perimeter::kAdaptiveMinWidth = "perimeter_adapt_min_width";
-const QString Constants::ProfileSettings::Perimeter::kAdaptiveMaxWidth = "perimeter_adapt_max_width";
-const QString Constants::ProfileSettings::Perimeter::kSpeed = "perimeter_speed";
-const QString Constants::ProfileSettings::Perimeter::kExtruderSpeed = "perimeter_extruder_speed";
-const QString Constants::ProfileSettings::Perimeter::kExtrusionMultiplier = "perimeter_extrusion_multiplier";
-const QString Constants::ProfileSettings::Perimeter::kMinPathLength = "perimeter_minimum_path_length";
-const QString Constants::ProfileSettings::Perimeter::kMinSegmentLength = "perimeter_minimum_segment_length";
-const QString Constants::ProfileSettings::Perimeter::kEnableLeadIn = "perimeter_lead_in";
-const QString Constants::ProfileSettings::Perimeter::kLeadInFirstLayerOnly = "perimeter_lead_in_first_layer";
-const QString Constants::ProfileSettings::Perimeter::kEnableLeadInX = "perimeter_lead_in_x";
-const QString Constants::ProfileSettings::Perimeter::kEnableLeadInY = "perimeter_lead_in_y";
-const QString Constants::ProfileSettings::Perimeter::kEnableFlyingStart = "perimeter_flying_start";
-const QString Constants::ProfileSettings::Perimeter::kFlyingStartDistance = "perimeter_flying_start_distance";
-const QString Constants::ProfileSettings::Perimeter::kFlyingStartSpeed = "perimeter_flying_start_speed";
+const QString Constants::ProfileSettings::Perimeter::kEnable                = "perimeter";
+const QString Constants::ProfileSettings::Perimeter::kCount                 = "perimeter_count";
+const QString Constants::ProfileSettings::Perimeter::kBoundarySelection     = "perimeter_boundary_selection";
+const QString Constants::ProfileSettings::Perimeter::kBeadWidth             = "perimeter_width";
+const QString Constants::ProfileSettings::Perimeter::kAdaptive              = "perimeter_adapt";
+const QString Constants::ProfileSettings::Perimeter::kAdaptiveMinWidth      = "perimeter_adapt_min_width";
+const QString Constants::ProfileSettings::Perimeter::kAdaptiveMaxWidth      = "perimeter_adapt_max_width";
+const QString Constants::ProfileSettings::Perimeter::kSpeed                 = "perimeter_speed";
+const QString Constants::ProfileSettings::Perimeter::kExtruderSpeed         = "perimeter_extruder_speed";
+const QString Constants::ProfileSettings::Perimeter::kExtrusionMultiplier   = "perimeter_extrusion_multiplier";
+const QString Constants::ProfileSettings::Perimeter::kMinPathLength         = "perimeter_minimum_path_length";
+const QString Constants::ProfileSettings::Perimeter::kMinSegmentLength      = "perimeter_minimum_segment_length";
+const QString Constants::ProfileSettings::Perimeter::kEnableLeadIn          = "perimeter_lead_in";
+const QString Constants::ProfileSettings::Perimeter::kLeadInFirstLayerOnly  = "perimeter_lead_in_first_layer";
+const QString Constants::ProfileSettings::Perimeter::kEnableLeadInX         = "perimeter_lead_in_x";
+const QString Constants::ProfileSettings::Perimeter::kEnableLeadInY         = "perimeter_lead_in_y";
+const QString Constants::ProfileSettings::Perimeter::kEnableFlyingStart     = "perimeter_flying_start";
+const QString Constants::ProfileSettings::Perimeter::kFlyingStartDistance   = "perimeter_flying_start_distance";
+const QString Constants::ProfileSettings::Perimeter::kFlyingStartSpeed      = "perimeter_flying_start_speed";
 const QString Constants::ProfileSettings::Perimeter::kEnableSpiralPerimeter = "spiral_perimeter";
 
 // Inset
-const QString Constants::ProfileSettings::Inset::kEnable = "inset";
-const QString Constants::ProfileSettings::Inset::kCount = "inset_count";
-const QString Constants::ProfileSettings::Inset::kBeadWidth = "inset_width";
-const QString Constants::ProfileSettings::Inset::kAdaptive = "inset_adapt";
-const QString Constants::ProfileSettings::Inset::kAdaptiveMinWidth = "inset_adapt_min_width";
-const QString Constants::ProfileSettings::Inset::kAdaptiveMaxWidth = "inset_adapt_max_width";
-const QString Constants::ProfileSettings::Inset::kSpeed = "inset_speed";
-const QString Constants::ProfileSettings::Inset::kExtruderSpeed = "inset_extruder_speed";
+const QString Constants::ProfileSettings::Inset::kEnable              = "inset";
+const QString Constants::ProfileSettings::Inset::kCount               = "inset_count";
+const QString Constants::ProfileSettings::Inset::kBeadWidth           = "inset_width";
+const QString Constants::ProfileSettings::Inset::kAdaptive            = "inset_adapt";
+const QString Constants::ProfileSettings::Inset::kAdaptiveMinWidth    = "inset_adapt_min_width";
+const QString Constants::ProfileSettings::Inset::kAdaptiveMaxWidth    = "inset_adapt_max_width";
+const QString Constants::ProfileSettings::Inset::kSpeed               = "inset_speed";
+const QString Constants::ProfileSettings::Inset::kExtruderSpeed       = "inset_extruder_speed";
 const QString Constants::ProfileSettings::Inset::kExtrusionMultiplier = "inset_extrusion_multiplier";
-const QString Constants::ProfileSettings::Inset::kMinPathLength = "inset_minimum_path_length";
-const QString Constants::ProfileSettings::Inset::kMinSegmentLength = "inset_minimum_segment_length";
-const QString Constants::ProfileSettings::Inset::kOverlap = "inset_overlap_distance";
-const QString Constants::ProfileSettings::Inset::kEnableSpiralInset = "spiral_inset";
+const QString Constants::ProfileSettings::Inset::kMinPathLength       = "inset_minimum_path_length";
+const QString Constants::ProfileSettings::Inset::kMinSegmentLength    = "inset_minimum_segment_length";
+const QString Constants::ProfileSettings::Inset::kOverlap             = "inset_overlap_distance";
+const QString Constants::ProfileSettings::Inset::kEnableSpiralInset   = "spiral_inset";
 
 // Skeleton
-const QString Constants::ProfileSettings::Skeleton::kEnable = "skeleton";
-const QString Constants::ProfileSettings::Skeleton::kSkeletonInput = "skeleton_input";
+const QString Constants::ProfileSettings::Skeleton::kEnable                        = "skeleton";
+const QString Constants::ProfileSettings::Skeleton::kSkeletonInput                 = "skeleton_input";
 const QString Constants::ProfileSettings::Skeleton::kSkeletonInputCleaningDistance = "skeleton_input_cleaning_distance";
-const QString Constants::ProfileSettings::Skeleton::kSkeletonInputChamferingAngle = "skeleton_input_chamfering_angle";
+const QString Constants::ProfileSettings::Skeleton::kSkeletonInputChamferingAngle  = "skeleton_input_chamfering_angle";
 const QString Constants::ProfileSettings::Skeleton::kSkeletonOutputCleaningDistance =
     "skeleton_output_cleaning_distance";
-const QString Constants::ProfileSettings::Skeleton::kBeadWidth = "skeleton_width";
-const QString Constants::ProfileSettings::Skeleton::kSpeed = "skeleton_speed";
-const QString Constants::ProfileSettings::Skeleton::kExtruderSpeed = "skeleton_extruder_speed";
-const QString Constants::ProfileSettings::Skeleton::kExtrusionMultiplier = "skeleton_extrusion_multiplier";
-const QString Constants::ProfileSettings::Skeleton::kSkeletonAdapt = "skeleton_adapt";
-const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptStepSize = "skeleton_adapt_step_size";
-const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMinWidth = "skeleton_adapt_min_width";
+const QString Constants::ProfileSettings::Skeleton::kBeadWidth                   = "skeleton_width";
+const QString Constants::ProfileSettings::Skeleton::kSpeed                       = "skeleton_speed";
+const QString Constants::ProfileSettings::Skeleton::kExtruderSpeed               = "skeleton_extruder_speed";
+const QString Constants::ProfileSettings::Skeleton::kExtrusionMultiplier         = "skeleton_extrusion_multiplier";
+const QString Constants::ProfileSettings::Skeleton::kSkeletonAdapt               = "skeleton_adapt";
+const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptStepSize       = "skeleton_adapt_step_size";
+const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMinWidth       = "skeleton_adapt_min_width";
 const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMinWidthFilter = "skeleton_adapt_min_width_filter";
-const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMaxWidth = "skeleton_adapt_max_width";
+const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMaxWidth       = "skeleton_adapt_max_width";
 const QString Constants::ProfileSettings::Skeleton::kSkeletonAdaptMaxWidthFilter = "skeleton_adapt_max_width_filter";
-const QString Constants::ProfileSettings::Skeleton::kMinPathLength = "skeleton_minimum_path_length";
-const QString Constants::ProfileSettings::Skeleton::kMinSegmentLength = "skeleton_minimum_segment_length";
-const QString Constants::ProfileSettings::Skeleton::kPrestartEnable = "skeleton_prestart";
-const QString Constants::ProfileSettings::Skeleton::kPrestartDistance = "skeleton_prestart_distance";
-const QString Constants::ProfileSettings::Skeleton::kPrestartSpeed = "skeleton_prestart_speed";
-const QString Constants::ProfileSettings::Skeleton::kPrestartExtruderSpeed = "skeleton_prestart_extruder_speed";
-const QString Constants::ProfileSettings::Skeleton::kPrestartAreaModifier = "skeleton_prestart_area_modifier";
-const QString Constants::ProfileSettings::Skeleton::kLeadInEnable = "skeleton_lead_in";
-const QString Constants::ProfileSettings::Skeleton::kLeadInDistance = "skeleton_lead_in_distance";
-const QString Constants::ProfileSettings::Skeleton::kLeadInSpeed = "skeleton_lead_in_speed";
-const QString Constants::ProfileSettings::Skeleton::kLeadInExtruderSpeed = "skeleton_lead_in_extruder_speed";
-const QString Constants::ProfileSettings::Skeleton::kLeadInAreaModifier = "skeleton_lead_in_area_modifier";
-const QString Constants::ProfileSettings::Skeleton::kUseSkinMcode = "skeleton_skin_mcode";
+const QString Constants::ProfileSettings::Skeleton::kMinPathLength               = "skeleton_minimum_path_length";
+const QString Constants::ProfileSettings::Skeleton::kMinSegmentLength            = "skeleton_minimum_segment_length";
+const QString Constants::ProfileSettings::Skeleton::kPrestartEnable              = "skeleton_prestart";
+const QString Constants::ProfileSettings::Skeleton::kPrestartDistance            = "skeleton_prestart_distance";
+const QString Constants::ProfileSettings::Skeleton::kPrestartSpeed               = "skeleton_prestart_speed";
+const QString Constants::ProfileSettings::Skeleton::kPrestartExtruderSpeed       = "skeleton_prestart_extruder_speed";
+const QString Constants::ProfileSettings::Skeleton::kPrestartAreaModifier        = "skeleton_prestart_area_modifier";
+const QString Constants::ProfileSettings::Skeleton::kLeadInEnable                = "skeleton_lead_in";
+const QString Constants::ProfileSettings::Skeleton::kLeadInDistance              = "skeleton_lead_in_distance";
+const QString Constants::ProfileSettings::Skeleton::kLeadInSpeed                 = "skeleton_lead_in_speed";
+const QString Constants::ProfileSettings::Skeleton::kLeadInExtruderSpeed         = "skeleton_lead_in_extruder_speed";
+const QString Constants::ProfileSettings::Skeleton::kLeadInAreaModifier          = "skeleton_lead_in_area_modifier";
+const QString Constants::ProfileSettings::Skeleton::kUseSkinMcode                = "skeleton_skin_mcode";
 
 // Skin
-const QString Constants::ProfileSettings::Skin::kEnable = "skin";
-const QString Constants::ProfileSettings::Skin::kTopCount = "skin_top_count";
-const QString Constants::ProfileSettings::Skin::kBottomCount = "skin_bottom_count";
-const QString Constants::ProfileSettings::Skin::kPattern = "skin_pattern";
-const QString Constants::ProfileSettings::Skin::kAngle = "skin_angle";
-const QString Constants::ProfileSettings::Skin::kAngleRotation = "skin_angle_rotation";
-const QString Constants::ProfileSettings::Skin::kBeadWidth = "skin_width";
-const QString Constants::ProfileSettings::Skin::kSpeed = "skin_speed";
-const QString Constants::ProfileSettings::Skin::kExtruderSpeed = "skin_extruder_speed";
+const QString Constants::ProfileSettings::Skin::kEnable              = "skin";
+const QString Constants::ProfileSettings::Skin::kTopCount            = "skin_top_count";
+const QString Constants::ProfileSettings::Skin::kBottomCount         = "skin_bottom_count";
+const QString Constants::ProfileSettings::Skin::kPattern             = "skin_pattern";
+const QString Constants::ProfileSettings::Skin::kAngle               = "skin_angle";
+const QString Constants::ProfileSettings::Skin::kAngleRotation       = "skin_angle_rotation";
+const QString Constants::ProfileSettings::Skin::kBeadWidth           = "skin_width";
+const QString Constants::ProfileSettings::Skin::kSpeed               = "skin_speed";
+const QString Constants::ProfileSettings::Skin::kExtruderSpeed       = "skin_extruder_speed";
 const QString Constants::ProfileSettings::Skin::kExtrusionMultiplier = "skin_extrusion_multiplier";
-const QString Constants::ProfileSettings::Skin::kOverlap = "skin_exterior_overlap";
-const QString Constants::ProfileSettings::Skin::kMinPathLength = "skin_minimum_path_length";
-const QString Constants::ProfileSettings::Skin::kMinSegmentLength = "skin_minimum_segment_length";
-const QString Constants::ProfileSettings::Skin::kInfillEnable = "skin_gradual_infill";
-const QString Constants::ProfileSettings::Skin::kInfillSteps = "skin_gradual_infill_steps";
-const QString Constants::ProfileSettings::Skin::kInfillPattern = "skin_gradual_infill_pattern";
-const QString Constants::ProfileSettings::Skin::kInfillAngle = "skin_gradual_infill_angle";
-const QString Constants::ProfileSettings::Skin::kInfillRotation = "skin_gradual_infill_angle_rotation";
+const QString Constants::ProfileSettings::Skin::kOverlap             = "skin_exterior_overlap";
+const QString Constants::ProfileSettings::Skin::kMinPathLength       = "skin_minimum_path_length";
+const QString Constants::ProfileSettings::Skin::kMinSegmentLength    = "skin_minimum_segment_length";
+const QString Constants::ProfileSettings::Skin::kInfillEnable        = "skin_gradual_infill";
+const QString Constants::ProfileSettings::Skin::kInfillSteps         = "skin_gradual_infill_steps";
+const QString Constants::ProfileSettings::Skin::kInfillPattern       = "skin_gradual_infill_pattern";
+const QString Constants::ProfileSettings::Skin::kInfillAngle         = "skin_gradual_infill_angle";
+const QString Constants::ProfileSettings::Skin::kInfillRotation      = "skin_gradual_infill_angle_rotation";
 
 // Infill
-const QString Constants::ProfileSettings::Infill::kEnable = "infill";
-const QString Constants::ProfileSettings::Infill::kLineSpacing = "infill_line_spacing";
-const QString Constants::ProfileSettings::Infill::kDensity = "infill_density";
-const QString Constants::ProfileSettings::Infill::kManualLineSpacing = "infill_manual_spacing";
-const QString Constants::ProfileSettings::Infill::kPattern = "infill_pattern";
+const QString Constants::ProfileSettings::Infill::kEnable                  = "infill";
+const QString Constants::ProfileSettings::Infill::kLineSpacing             = "infill_line_spacing";
+const QString Constants::ProfileSettings::Infill::kDensity                 = "infill_density";
+const QString Constants::ProfileSettings::Infill::kManualLineSpacing       = "infill_manual_spacing";
+const QString Constants::ProfileSettings::Infill::kPattern                 = "infill_pattern";
 const QString Constants::ProfileSettings::Infill::kLinesPartitionedLinking = "infill_lines_partitioned_linking";
-const QString Constants::ProfileSettings::Infill::kAvoidLinkOverlap = "infill_avoid_link_overlap";
-const QString Constants::ProfileSettings::Infill::kBasedOnPrinter = "infill_based_on_printer";
-const QString Constants::ProfileSettings::Infill::kAngle = "infill_angle";
-const QString Constants::ProfileSettings::Infill::kAngleRotation = "infill_angle_rotation";
-const QString Constants::ProfileSettings::Infill::kOverlap = "infill_overlap_distance";
-const QString Constants::ProfileSettings::Infill::kBeadWidth = "infill_width";
-const QString Constants::ProfileSettings::Infill::kSpeed = "infill_speed";
-const QString Constants::ProfileSettings::Infill::kExtruderSpeed = "infill_extruder_speed";
-const QString Constants::ProfileSettings::Infill::kExtrusionMultiplier = "infill_extrusion_multiplier";
-const QString Constants::ProfileSettings::Infill::kCombineXLayers = "infill_combine_every_x_layers";
-const QString Constants::ProfileSettings::Infill::kCombineLayerShift = "infill_combine_layer_shift";
-const QString Constants::ProfileSettings::Infill::kMinPathLength = "infill_minimum_path_length";
-const QString Constants::ProfileSettings::Infill::kMinSegmentLength = "infill_minimum_segment_length";
+const QString Constants::ProfileSettings::Infill::kAvoidLinkOverlap        = "infill_avoid_link_overlap";
+const QString Constants::ProfileSettings::Infill::kBasedOnPrinter          = "infill_based_on_printer";
+const QString Constants::ProfileSettings::Infill::kAngle                   = "infill_angle";
+const QString Constants::ProfileSettings::Infill::kAngleRotation           = "infill_angle_rotation";
+const QString Constants::ProfileSettings::Infill::kOverlap                 = "infill_overlap_distance";
+const QString Constants::ProfileSettings::Infill::kBeadWidth               = "infill_width";
+const QString Constants::ProfileSettings::Infill::kSpeed                   = "infill_speed";
+const QString Constants::ProfileSettings::Infill::kExtruderSpeed           = "infill_extruder_speed";
+const QString Constants::ProfileSettings::Infill::kExtrusionMultiplier     = "infill_extrusion_multiplier";
+const QString Constants::ProfileSettings::Infill::kCombineXLayers          = "infill_combine_every_x_layers";
+const QString Constants::ProfileSettings::Infill::kCombineLayerShift       = "infill_combine_layer_shift";
+const QString Constants::ProfileSettings::Infill::kMinPathLength           = "infill_minimum_path_length";
+const QString Constants::ProfileSettings::Infill::kMinSegmentLength        = "infill_minimum_segment_length";
 
 // Support
-const QString Constants::ProfileSettings::Support::kEnable = "support";
-const QString Constants::ProfileSettings::Support::kPrintFirst = "support_print_first";
-const QString Constants::ProfileSettings::Support::kStructure = "support_structure";
-const QString Constants::ProfileSettings::Support::kPlacement = "support_placement";
-const QString Constants::ProfileSettings::Support::kTaper = "support_tapering";
-const QString Constants::ProfileSettings::Support::kTaperAngle = "support_taper_angle";
-const QString Constants::ProfileSettings::Support::kTaperWallContours = "support_taper_wall_contours";
-const QString Constants::ProfileSettings::Support::kTubeWallRegion = "support_tube_wall_region";
-const QString Constants::ProfileSettings::Support::kWallContours = "support_wall_contours";
-const QString Constants::ProfileSettings::Support::kThresholdAngle = "support_threshold_angle";
-const QString Constants::ProfileSettings::Support::kXYDistance = "support_xy_distance";
-const QString Constants::ProfileSettings::Support::kLayerOffset = "support_layer_offset";
-const QString Constants::ProfileSettings::Support::kMinInfillArea = "support_minimum_infill_area";
-const QString Constants::ProfileSettings::Support::kMinArea = "support_minimum_area";
-const QString Constants::ProfileSettings::Support::kPattern = "support_pattern";
-const QString Constants::ProfileSettings::Support::kLineSpacing = "support_line_spacing";
-const QString Constants::ProfileSettings::Support::kInterfaceLayers = "support_interface_layers";
-const QString Constants::ProfileSettings::Support::kInterfaceLineSpacing = "support_interface_line_spacing";
-const QString Constants::ProfileSettings::Support::kInterfaceExpansion = "support_interface_expansion";
-const QString Constants::ProfileSettings::Support::kInterfaceRegion = "support_interface_region";
-const QString Constants::ProfileSettings::Support::kBaseLayers = "support_base_layers";
-const QString Constants::ProfileSettings::Support::kBaseExpansion = "support_base_expansion";
-const QString Constants::ProfileSettings::Support::kMinSegmentLength = "support_minimum_segment_length";
-const QString Constants::ProfileSettings::Support::kBaseRegion = "support_base_region";
-const QString Constants::ProfileSettings::Support::kBridgeSuppression = "support_bridge_suppression";
-const QString Constants::ProfileSettings::Support::kBridgeMaxLength = "support_bridge_max_length";
-const QString Constants::ProfileSettings::Support::kValidation = "support_validation";
-const QString Constants::ProfileSettings::Support::kValidationMinOverlap = "support_validation_minimum_overlap";
+const QString Constants::ProfileSettings::Support::kEnable                = "support";
+const QString Constants::ProfileSettings::Support::kPrintFirst            = "support_print_first";
+const QString Constants::ProfileSettings::Support::kStructure             = "support_structure";
+const QString Constants::ProfileSettings::Support::kPlacement             = "support_placement";
+const QString Constants::ProfileSettings::Support::kTaper                 = "support_tapering";
+const QString Constants::ProfileSettings::Support::kTaperAngle            = "support_taper_angle";
+const QString Constants::ProfileSettings::Support::kTaperWallContours     = "support_taper_wall_contours";
+const QString Constants::ProfileSettings::Support::kTubeWallRegion        = "support_tube_wall_region";
+const QString Constants::ProfileSettings::Support::kWallContours          = "support_wall_contours";
+const QString Constants::ProfileSettings::Support::kThresholdAngle        = "support_threshold_angle";
+const QString Constants::ProfileSettings::Support::kXYDistance            = "support_xy_distance";
+const QString Constants::ProfileSettings::Support::kLayerOffset           = "support_layer_offset";
+const QString Constants::ProfileSettings::Support::kMinInfillArea         = "support_minimum_infill_area";
+const QString Constants::ProfileSettings::Support::kMinArea               = "support_minimum_area";
+const QString Constants::ProfileSettings::Support::kPattern               = "support_pattern";
+const QString Constants::ProfileSettings::Support::kLineSpacing           = "support_line_spacing";
+const QString Constants::ProfileSettings::Support::kInterfaceLayers       = "support_interface_layers";
+const QString Constants::ProfileSettings::Support::kInterfaceLineSpacing  = "support_interface_line_spacing";
+const QString Constants::ProfileSettings::Support::kInterfaceExpansion    = "support_interface_expansion";
+const QString Constants::ProfileSettings::Support::kInterfaceRegion       = "support_interface_region";
+const QString Constants::ProfileSettings::Support::kBaseLayers            = "support_base_layers";
+const QString Constants::ProfileSettings::Support::kBaseExpansion         = "support_base_expansion";
+const QString Constants::ProfileSettings::Support::kMinSegmentLength      = "support_minimum_segment_length";
+const QString Constants::ProfileSettings::Support::kBaseRegion            = "support_base_region";
+const QString Constants::ProfileSettings::Support::kBridgeSuppression     = "support_bridge_suppression";
+const QString Constants::ProfileSettings::Support::kBridgeMaxLength       = "support_bridge_max_length";
+const QString Constants::ProfileSettings::Support::kValidation            = "support_validation";
+const QString Constants::ProfileSettings::Support::kValidationMinOverlap  = "support_validation_minimum_overlap";
 const QString Constants::ProfileSettings::Support::kValidationMinBaseArea = "support_validation_minimum_base_area";
 const QString Constants::ProfileSettings::Support::kOrganicBranchDiameter = "support_organic_branch_diameter";
-const QString Constants::ProfileSettings::Support::kOrganicBranchSpacing = "support_organic_branch_spacing";
-const QString Constants::ProfileSettings::Support::kOrganicBranchAngle = "support_organic_branch_angle";
+const QString Constants::ProfileSettings::Support::kOrganicBranchSpacing  = "support_organic_branch_spacing";
+const QString Constants::ProfileSettings::Support::kOrganicBranchAngle    = "support_organic_branch_angle";
 
 // Travel
-const QString Constants::ProfileSettings::Travel::kSpeed = "travel_speed";
-const QString Constants::ProfileSettings::Travel::kInfillMinLength = "minimum_infill_travel_length";
-const QString Constants::ProfileSettings::Travel::kMinTravelLength = "min_travel_length";
-const QString Constants::ProfileSettings::Travel::kMinTravelForLift = "minimum_travel_for_lift";
-const QString Constants::ProfileSettings::Travel::kLiftHeight = "travel_lift_height";
-const QString Constants::ProfileSettings::Travel::kFinalLiftDistance = "final_lift_distance";
-const QString Constants::ProfileSettings::Travel::kEnableTravelPause = "enable_travel_pause";
+const QString Constants::ProfileSettings::Travel::kSpeed                    = "travel_speed";
+const QString Constants::ProfileSettings::Travel::kInfillMinLength          = "minimum_infill_travel_length";
+const QString Constants::ProfileSettings::Travel::kMinTravelLength          = "min_travel_length";
+const QString Constants::ProfileSettings::Travel::kMinTravelForLift         = "minimum_travel_for_lift";
+const QString Constants::ProfileSettings::Travel::kLiftHeight               = "travel_lift_height";
+const QString Constants::ProfileSettings::Travel::kFinalLiftDistance        = "final_lift_distance";
+const QString Constants::ProfileSettings::Travel::kEnableTravelPause        = "enable_travel_pause";
 const QString Constants::ProfileSettings::Travel::kEnableTravelCentroidMove = "travel_centroid_move";
-const QString Constants::ProfileSettings::Travel::kTravelPauseDuration = "travel_pause_duration";
+const QString Constants::ProfileSettings::Travel::kTravelPauseDuration      = "travel_pause_duration";
 
 // G-Code
 const QString Constants::ProfileSettings::GCode::kPerimeterStart = "perimeter_start_code";
-const QString Constants::ProfileSettings::GCode::kPerimeterEnd = "perimeter_end_code";
-const QString Constants::ProfileSettings::GCode::kInsetStart = "inset_start_code";
-const QString Constants::ProfileSettings::GCode::kInsetEnd = "inset_end_code";
-const QString Constants::ProfileSettings::GCode::kSkeletonStart = "skeleton_start_code";
-const QString Constants::ProfileSettings::GCode::kSkeletonEnd = "skeleton_end_code";
-const QString Constants::ProfileSettings::GCode::kSkinStart = "skin_start_code";
-const QString Constants::ProfileSettings::GCode::kSkinEnd = "skin_end_code";
-const QString Constants::ProfileSettings::GCode::kInfillStart = "infill_start_code";
-const QString Constants::ProfileSettings::GCode::kInfillEnd = "infill_end_code";
-const QString Constants::ProfileSettings::GCode::kSupportStart = "support_start_code";
-const QString Constants::ProfileSettings::GCode::kSupportEnd = "support_end_code";
+const QString Constants::ProfileSettings::GCode::kPerimeterEnd   = "perimeter_end_code";
+const QString Constants::ProfileSettings::GCode::kInsetStart     = "inset_start_code";
+const QString Constants::ProfileSettings::GCode::kInsetEnd       = "inset_end_code";
+const QString Constants::ProfileSettings::GCode::kSkeletonStart  = "skeleton_start_code";
+const QString Constants::ProfileSettings::GCode::kSkeletonEnd    = "skeleton_end_code";
+const QString Constants::ProfileSettings::GCode::kSkinStart      = "skin_start_code";
+const QString Constants::ProfileSettings::GCode::kSkinEnd        = "skin_end_code";
+const QString Constants::ProfileSettings::GCode::kInfillStart    = "infill_start_code";
+const QString Constants::ProfileSettings::GCode::kInfillEnd      = "infill_end_code";
+const QString Constants::ProfileSettings::GCode::kSupportStart   = "support_start_code";
+const QString Constants::ProfileSettings::GCode::kSupportEnd     = "support_end_code";
 
 // Special Modes
-const QString Constants::ProfileSettings::SpecialModes::kSmoothing = "smoothing";
-const QString Constants::ProfileSettings::SpecialModes::kSmoothingType = "smoothing_type";
-const QString Constants::ProfileSettings::SpecialModes::kSmoothingTolerance = "smoothing_tolerance";
+const QString Constants::ProfileSettings::SpecialModes::kSmoothing                  = "smoothing";
+const QString Constants::ProfileSettings::SpecialModes::kSmoothingType              = "smoothing_type";
+const QString Constants::ProfileSettings::SpecialModes::kSmoothingTolerance         = "smoothing_tolerance";
 const QString Constants::ProfileSettings::SpecialModes::kEnableSharpCornerExtension = "sharp_corner_extension";
-const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionAngle = "sharp_corner_extension_angle";
+const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionAngle  = "sharp_corner_extension_angle";
 const QString Constants::ProfileSettings::SpecialModes::kSharpCornerExtensionDistance =
     "sharp_corner_extension_distance";
 const QString Constants::ProfileSettings::SpecialModes::kSharpCornerClosePointsThreshold =
     "sharp_corner_close_points_threshold";
 const QString Constants::ProfileSettings::SpecialModes::kSharpCornerSharpeningLegLength =
     "sharp_corner_sharpening_leg_length";
-const QString Constants::ProfileSettings::SpecialModes::kEnableSpiralize = "enable_spiralize_mode";
-const QString Constants::ProfileSettings::SpecialModes::kEnableFixModel = "enable_fix_model";
-const QString Constants::ProfileSettings::SpecialModes::kEnableOversize = "oversize";
-const QString Constants::ProfileSettings::SpecialModes::kOversizeDistance = "oversize_distance";
-const QString Constants::ProfileSettings::SpecialModes::kEnableWidthHeight = "enable_width_height";
-const QString Constants::ProfileSettings::SpecialModes::kEnableArcFitting = "arc_fitting";
+const QString Constants::ProfileSettings::SpecialModes::kEnableSpiralize     = "enable_spiralize_mode";
+const QString Constants::ProfileSettings::SpecialModes::kEnableFixModel      = "enable_fix_model";
+const QString Constants::ProfileSettings::SpecialModes::kEnableOversize      = "oversize";
+const QString Constants::ProfileSettings::SpecialModes::kOversizeDistance    = "oversize_distance";
+const QString Constants::ProfileSettings::SpecialModes::kEnableWidthHeight   = "enable_width_height";
+const QString Constants::ProfileSettings::SpecialModes::kEnableArcFitting    = "arc_fitting";
 const QString Constants::ProfileSettings::SpecialModes::kArcFittingTolerance = "arc_fitting_tolerance";
 const QString Constants::ProfileSettings::SpecialModes::kArcFittingMinimumSegmentCount =
     "arc_fitting_minimum_segment_count";
 
 // Optimizations
-const QString Constants::ProfileSettings::Optimizations::kLayerOrdering = "layer_ordering";
+const QString Constants::ProfileSettings::Optimizations::kLayerOrdering          = "layer_ordering";
 const QString Constants::ProfileSettings::Optimizations::kLayerGroupingTolerance = "layer_grouping_tolerance";
-const QString Constants::ProfileSettings::Optimizations::kIslandOrder = "island_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPathOrder = "path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder =
-    "perimeter_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder = "inset_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder = "skin_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kCustomIslandXLocation = "custom_island_order_x_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomIslandYLocation = "custom_island_order_y_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomIslandZLocation = "custom_island_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathXLocation = "custom_path_order_x_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathYLocation = "custom_path_order_y_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathZLocation = "custom_path_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kPointOrder = "point_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kIslandOrder            = "island_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPathOrder              = "path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder     = "perimeter_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder         = "inset_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder          = "skin_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kCustomIslandXLocation  = "custom_island_order_x_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomIslandYLocation  = "custom_island_order_y_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomIslandZLocation  = "custom_island_order_z_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathXLocation    = "custom_path_order_x_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathYLocation    = "custom_path_order_y_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathZLocation    = "custom_path_order_z_location";
+const QString Constants::ProfileSettings::Optimizations::kPointOrder             = "point_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kEnablePointOrderSegmentBreaking =
     "enable_point_order_segment_breaking";
 const QString Constants::ProfileSettings::Optimizations::kLocalRandomnessEnable = "local_randomness_enable";
 const QString Constants::ProfileSettings::Optimizations::kLocalRandomnessRadius = "local_randomness_radius";
-const QString Constants::ProfileSettings::Optimizations::kMinDistanceEnabled = "enable_min_distance";
-const QString Constants::ProfileSettings::Optimizations::kMinDistanceThreshold = "min_distance_threshold";
+const QString Constants::ProfileSettings::Optimizations::kMinDistanceEnabled    = "enable_min_distance";
+const QString Constants::ProfileSettings::Optimizations::kMinDistanceThreshold  = "min_distance_threshold";
 const QString Constants::ProfileSettings::Optimizations::kConsecutiveDistanceThreshold =
     "consecutive_path_distance_threshold";
 const QString Constants::ProfileSettings::Optimizations::kCustomPointXLocation = "custom_point_order_x_location";
@@ -792,41 +791,41 @@ const QString Constants::ProfileSettings::Optimizations::kCustomPointSecondYLoca
     "custom_second_point_order_y_location";
 const QString Constants::ProfileSettings::Optimizations::kCustomPointSecondZLocation =
     "custom_second_point_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kSeamAttractorVectorX = "seam_attractor_vector_x";
-const QString Constants::ProfileSettings::Optimizations::kSeamAttractorVectorY = "seam_attractor_vector_y";
-const QString Constants::ProfileSettings::Optimizations::kSeamAttractorVectorZ = "seam_attractor_vector_z";
+const QString Constants::ProfileSettings::Optimizations::kSeamAttractorVectorX  = "seam_attractor_vector_x";
+const QString Constants::ProfileSettings::Optimizations::kSeamAttractorVectorY  = "seam_attractor_vector_y";
+const QString Constants::ProfileSettings::Optimizations::kSeamAttractorVectorZ  = "seam_attractor_vector_z";
 const QString Constants::ProfileSettings::Optimizations::kCustomPointXIncrement = "custom_point_order_x_increment";
 const QString Constants::ProfileSettings::Optimizations::kCustomPointYIncrement = "custom_point_order_y_increment";
 
 // Ordering
-const QString Constants::ProfileSettings::Ordering::kRegionOrder = "region_order";
+const QString Constants::ProfileSettings::Ordering::kRegionOrder               = "region_order";
 const QString Constants::ProfileSettings::Ordering::kPerimeterReverseDirection = "perimeter_reverse_direction";
-const QString Constants::ProfileSettings::Ordering::kInsetReverseDirection = "inset_reverse_direction";
+const QString Constants::ProfileSettings::Ordering::kInsetReverseDirection     = "inset_reverse_direction";
 
 // Laser Scanner
-const QString Constants::ProfileSettings::LaserScanner::kLaserScanner = "laser_scanner";
-const QString Constants::ProfileSettings::LaserScanner::kSpeed = "laser_speed";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerHeightOffset = "laser_scanner_height_offset";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerXOffset = "laser_scanner_x_offset";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerYOffset = "laser_scanner_y_offset";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerHeight = "laser_scanner_height";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerWidth = "laser_scanner_width";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerStepDistance = "laser_scanner_step_distance";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScanLineResolution = "laser_scan_line_resolution";
-const QString Constants::ProfileSettings::LaserScanner::kLaserScannerAxis = "laser_scanner_axis";
-const QString Constants::ProfileSettings::LaserScanner::kInvertLaserScannerHead = "invert_laser_scanner_head";
-const QString Constants::ProfileSettings::LaserScanner::kEnableBedScan = "enable_bed_scan";
-const QString Constants::ProfileSettings::LaserScanner::kScanLayerSkip = "scan_layer_skip";
-const QString Constants::ProfileSettings::LaserScanner::kEnableScannerBuffer = "enable_scanner_buffer";
-const QString Constants::ProfileSettings::LaserScanner::kBufferDistance = "buffer_distance";
-const QString Constants::ProfileSettings::LaserScanner::kTransmitHeightMap = "transmit_height_map";
-const QString Constants::ProfileSettings::LaserScanner::kGlobalScan = "global_scan";
-const QString Constants::ProfileSettings::LaserScanner::kOrientationAxis = "orientation_axis";
-const QString Constants::ProfileSettings::LaserScanner::kOrientationAngle = "orientation_angle";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScanner                = "laser_scanner";
+const QString Constants::ProfileSettings::LaserScanner::kSpeed                       = "laser_speed";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerHeightOffset    = "laser_scanner_height_offset";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerXOffset         = "laser_scanner_x_offset";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerYOffset         = "laser_scanner_y_offset";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerHeight          = "laser_scanner_height";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerWidth           = "laser_scanner_width";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerStepDistance    = "laser_scanner_step_distance";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScanLineResolution     = "laser_scan_line_resolution";
+const QString Constants::ProfileSettings::LaserScanner::kLaserScannerAxis            = "laser_scanner_axis";
+const QString Constants::ProfileSettings::LaserScanner::kInvertLaserScannerHead      = "invert_laser_scanner_head";
+const QString Constants::ProfileSettings::LaserScanner::kEnableBedScan               = "enable_bed_scan";
+const QString Constants::ProfileSettings::LaserScanner::kScanLayerSkip               = "scan_layer_skip";
+const QString Constants::ProfileSettings::LaserScanner::kEnableScannerBuffer         = "enable_scanner_buffer";
+const QString Constants::ProfileSettings::LaserScanner::kBufferDistance              = "buffer_distance";
+const QString Constants::ProfileSettings::LaserScanner::kTransmitHeightMap           = "transmit_height_map";
+const QString Constants::ProfileSettings::LaserScanner::kGlobalScan                  = "global_scan";
+const QString Constants::ProfileSettings::LaserScanner::kOrientationAxis             = "orientation_axis";
+const QString Constants::ProfileSettings::LaserScanner::kOrientationAngle            = "orientation_angle";
 const QString Constants::ProfileSettings::LaserScanner::kEnableOrientationDefinition = "enable_orientation_definition";
-const QString Constants::ProfileSettings::LaserScanner::kOrientationA = "orientation_a";
-const QString Constants::ProfileSettings::LaserScanner::kOrientationB = "orientation_b";
-const QString Constants::ProfileSettings::LaserScanner::kOrientationC = "orientation_c";
+const QString Constants::ProfileSettings::LaserScanner::kOrientationA                = "orientation_a";
+const QString Constants::ProfileSettings::LaserScanner::kOrientationB                = "orientation_b";
+const QString Constants::ProfileSettings::LaserScanner::kOrientationC                = "orientation_c";
 
 // Thermal Scanner
 const QString Constants::ProfileSettings::ThermalScanner::kThermalScanner = "thermal_scanner";
@@ -836,25 +835,25 @@ const QString Constants::ProfileSettings::ThermalScanner::kThermalScannerXOffset
 const QString Constants::ProfileSettings::ThermalScanner::kThermalScannerYOffset = "thermal_scanner_y_offset";
 
 // Slicing
-const QString Constants::ProfileSettings::Slicing::kSlicingMode = "slicing_mode";
-const QString Constants::ProfileSettings::Slicing::kCylindricalPathPattern = "cylindrical_path_pattern";
-const QString Constants::ProfileSettings::Slicing::kSlicePlaneNormalX = "slice_plane_normal_x";
-const QString Constants::ProfileSettings::Slicing::kSlicePlaneNormalY = "slice_plane_normal_y";
-const QString Constants::ProfileSettings::Slicing::kSlicePlaneNormalZ = "slice_plane_normal_z";
-const QString Constants::ProfileSettings::Slicing::kCylinderInnerRadius = "cylinder_inner_radius";
-const QString Constants::ProfileSettings::Slicing::kCylinderHeight = "cylinder_height";
-const QString Constants::ProfileSettings::Slicing::kCylinderAxisSource = "cylinder_axis_source";
-const QString Constants::ProfileSettings::Slicing::kCylinderAxisX = "cylinder_axis_x";
-const QString Constants::ProfileSettings::Slicing::kCylinderAxisY = "cylinder_axis_y";
-const QString Constants::ProfileSettings::Slicing::kRadialPathBoundaryPolicy = "radial_path_boundary_policy";
-const QString Constants::ProfileSettings::Slicing::kRadialPathStartAngle = "radial_path_start_angle";
+const QString Constants::ProfileSettings::Slicing::kSlicingMode               = "slicing_mode";
+const QString Constants::ProfileSettings::Slicing::kCylindricalPathPattern    = "cylindrical_path_pattern";
+const QString Constants::ProfileSettings::Slicing::kSlicePlaneNormalX         = "slice_plane_normal_x";
+const QString Constants::ProfileSettings::Slicing::kSlicePlaneNormalY         = "slice_plane_normal_y";
+const QString Constants::ProfileSettings::Slicing::kSlicePlaneNormalZ         = "slice_plane_normal_z";
+const QString Constants::ProfileSettings::Slicing::kCylinderInnerRadius       = "cylinder_inner_radius";
+const QString Constants::ProfileSettings::Slicing::kCylinderHeight            = "cylinder_height";
+const QString Constants::ProfileSettings::Slicing::kCylinderAxisSource        = "cylinder_axis_source";
+const QString Constants::ProfileSettings::Slicing::kCylinderAxisX             = "cylinder_axis_x";
+const QString Constants::ProfileSettings::Slicing::kCylinderAxisY             = "cylinder_axis_y";
+const QString Constants::ProfileSettings::Slicing::kRadialPathBoundaryPolicy  = "radial_path_boundary_policy";
+const QString Constants::ProfileSettings::Slicing::kRadialPathStartAngle      = "radial_path_start_angle";
 const QString Constants::ProfileSettings::Slicing::kHelicalPathBoundaryPolicy = "helical_path_boundary_policy";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathHandedness = "helical_path_handedness";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathStartAngle = "helical_path_start_angle";
-const QString Constants::ProfileSettings::Slicing::kMaxHelicalPathLength = "max_helical_path_length";
-const QString Constants::ProfileSettings::Slicing::kArcsPerRevolution = "arcs_per_revolution";
-const QString Constants::ProfileSettings::Slicing::kImagePixelSizeX = "image_pixel_size_x";
-const QString Constants::ProfileSettings::Slicing::kImagePixelSizeY = "image_pixel_size_y";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathHandedness     = "helical_path_handedness";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathStartAngle     = "helical_path_start_angle";
+const QString Constants::ProfileSettings::Slicing::kMaxHelicalPathLength      = "max_helical_path_length";
+const QString Constants::ProfileSettings::Slicing::kArcsPerRevolution         = "arcs_per_revolution";
+const QString Constants::ProfileSettings::Slicing::kImagePixelSizeX           = "image_pixel_size_x";
+const QString Constants::ProfileSettings::Slicing::kImagePixelSizeY           = "image_pixel_size_y";
 
 //================================================================================
 // Experimental Settings
@@ -878,208 +877,208 @@ const QString Constants::ExperimentalSettings::Ramping::kTrajectoryAngleExtruder
 
 // File Output
 const QString Constants::ExperimentalSettings::FileOutput::kMeldCompanionOutput = "additional_meld_output";
-const QString Constants::ExperimentalSettings::FileOutput::kMeldDiscrete = "meld_discrete_feed_commands";
-const QString Constants::ExperimentalSettings::FileOutput::kTormachOutput = "tormach_file_output";
-const QString Constants::ExperimentalSettings::FileOutput::kTormachMode = "tormach_mode";
-const QString Constants::ExperimentalSettings::FileOutput::kAML3DOutput = "aml3d_file_output";
-const QString Constants::ExperimentalSettings::FileOutput::kAML3DWeaveLength = "aml3d_weave_length";
-const QString Constants::ExperimentalSettings::FileOutput::kAML3DWeaveWidth = "aml3d_weave_width";
-const QString Constants::ExperimentalSettings::FileOutput::kSandiaOutput = "sandia_file_output";
-const QString Constants::ExperimentalSettings::FileOutput::kSandiaMetalFile = "sandia_metal_file";
-const QString Constants::ExperimentalSettings::FileOutput::kSandiaCVEL = "sandia_cvel";
-const QString Constants::ExperimentalSettings::FileOutput::kMarlinOutput = "marlin_file_output";
-const QString Constants::ExperimentalSettings::FileOutput::kMarlinTravels = "marlin_include_travels";
-const QString Constants::ExperimentalSettings::FileOutput::kSimulationOutput = "simulation_file_output";
-const QString Constants::ExperimentalSettings::FileOutput::kAMCMOutput = "amcm_file_output";
-const QString Constants::ExperimentalSettings::FileOutput::kAMCMDataLogging = "amcm_data_logging";
+const QString Constants::ExperimentalSettings::FileOutput::kMeldDiscrete        = "meld_discrete_feed_commands";
+const QString Constants::ExperimentalSettings::FileOutput::kTormachOutput       = "tormach_file_output";
+const QString Constants::ExperimentalSettings::FileOutput::kTormachMode         = "tormach_mode";
+const QString Constants::ExperimentalSettings::FileOutput::kAML3DOutput         = "aml3d_file_output";
+const QString Constants::ExperimentalSettings::FileOutput::kAML3DWeaveLength    = "aml3d_weave_length";
+const QString Constants::ExperimentalSettings::FileOutput::kAML3DWeaveWidth     = "aml3d_weave_width";
+const QString Constants::ExperimentalSettings::FileOutput::kSandiaOutput        = "sandia_file_output";
+const QString Constants::ExperimentalSettings::FileOutput::kSandiaMetalFile     = "sandia_metal_file";
+const QString Constants::ExperimentalSettings::FileOutput::kSandiaCVEL          = "sandia_cvel";
+const QString Constants::ExperimentalSettings::FileOutput::kMarlinOutput        = "marlin_file_output";
+const QString Constants::ExperimentalSettings::FileOutput::kMarlinTravels       = "marlin_include_travels";
+const QString Constants::ExperimentalSettings::FileOutput::kSimulationOutput    = "simulation_file_output";
+const QString Constants::ExperimentalSettings::FileOutput::kAMCMOutput          = "amcm_file_output";
+const QString Constants::ExperimentalSettings::FileOutput::kAMCMDataLogging     = "amcm_data_logging";
 
 // Cross-Section
 const QString Constants::ExperimentalSettings::CrossSection::kLargestGap = "cross_section_largest_gap";
-const QString Constants::ExperimentalSettings::CrossSection::kMaxStitch = "cross_section_max_stitch_distance";
+const QString Constants::ExperimentalSettings::CrossSection::kMaxStitch  = "cross_section_max_stitch_distance";
 
 //================================================================================
 // Settings
 //================================================================================
 // Master
-const std::string Constants::Settings::Master::kDisplay = "display";
-const std::string Constants::Settings::Master::kType = "type";
-const std::string Constants::Settings::Master::kToolTip = "tooltip";
-const std::string Constants::Settings::Master::kMinor = "minor";
-const std::string Constants::Settings::Master::kMajor = "major";
-const std::string Constants::Settings::Master::kOptions = "options";
-const std::string Constants::Settings::Master::kDepends = "depends";
-const std::string Constants::Settings::Master::kDefault = "default";
+const std::string Constants::Settings::Master::kDisplay         = "display";
+const std::string Constants::Settings::Master::kType            = "type";
+const std::string Constants::Settings::Master::kToolTip         = "tooltip";
+const std::string Constants::Settings::Master::kMinor           = "minor";
+const std::string Constants::Settings::Master::kMajor           = "major";
+const std::string Constants::Settings::Master::kOptions         = "options";
+const std::string Constants::Settings::Master::kDepends         = "depends";
+const std::string Constants::Settings::Master::kDefault         = "default";
 const std::string Constants::Settings::Master::kDependencyGroup = "dependency_group";
-const std::string Constants::Settings::Master::kLocal = "local";
+const std::string Constants::Settings::Master::kLocal           = "local";
 
 // Input
-const std::string Constants::Settings::Input::kName = "name";
-const std::string Constants::Settings::Input::kDisplay = "display";
-const std::string Constants::Settings::Input::kWidget = "widget";
-const std::string Constants::Settings::Input::kToolTip = "tooltip";
-const std::string Constants::Settings::Input::kDepends = "depends";
-const std::string Constants::Settings::Input::kMinor = "minor";
-const std::string Constants::Settings::Input::kMajor = "major";
-const std::string Constants::Settings::Input::kLocal = "local";
+const std::string Constants::Settings::Input::kName       = "name";
+const std::string Constants::Settings::Input::kDisplay    = "display";
+const std::string Constants::Settings::Input::kWidget     = "widget";
+const std::string Constants::Settings::Input::kToolTip    = "tooltip";
+const std::string Constants::Settings::Input::kDepends    = "depends";
+const std::string Constants::Settings::Input::kMinor      = "minor";
+const std::string Constants::Settings::Input::kMajor      = "major";
+const std::string Constants::Settings::Input::kLocal      = "local";
 const std::string Constants::Settings::Input::kComponents = "components";
-const std::string Constants::Settings::Input::kSetting = "setting";
-const std::string Constants::Settings::Input::kLabel = "label";
-const std::string Constants::Settings::Input::kType = "type";
-const std::string Constants::Settings::Input::kDefault = "default";
-const std::string Constants::Settings::Input::kVector2 = "vector2";
-const std::string Constants::Settings::Input::kVector3 = "vector3";
+const std::string Constants::Settings::Input::kSetting    = "setting";
+const std::string Constants::Settings::Input::kLabel      = "label";
+const std::string Constants::Settings::Input::kType       = "type";
+const std::string Constants::Settings::Input::kDefault    = "default";
+const std::string Constants::Settings::Input::kVector2    = "vector2";
+const std::string Constants::Settings::Input::kVector3    = "vector3";
 
 // Session
-const std::string Constants::Settings::Session::kParts = "parts";
-const std::string Constants::Settings::Session::kName = "name";
-const std::string Constants::Settings::Session::kTransform = "transform";
-const std::string Constants::Settings::Session::kTransforms = "transforms";
-const std::string Constants::Settings::Session::kMeshType = "mesh_type";
-const std::string Constants::Settings::Session::kGenType = "gen_type";
-const std::string Constants::Settings::Session::kOrgDims = "org_dim";
-const std::string Constants::Settings::Session::kFile = "file";
-const std::string Constants::Settings::Session::kDir = "#SESSION#";
-const std::string Constants::Settings::Session::LocalFile::kName = "name";
+const std::string Constants::Settings::Session::kParts               = "parts";
+const std::string Constants::Settings::Session::kName                = "name";
+const std::string Constants::Settings::Session::kTransform           = "transform";
+const std::string Constants::Settings::Session::kTransforms          = "transforms";
+const std::string Constants::Settings::Session::kMeshType            = "mesh_type";
+const std::string Constants::Settings::Session::kGenType             = "gen_type";
+const std::string Constants::Settings::Session::kOrgDims             = "org_dim";
+const std::string Constants::Settings::Session::kFile                = "file";
+const std::string Constants::Settings::Session::kDir                 = "#SESSION#";
+const std::string Constants::Settings::Session::LocalFile::kName     = "name";
 const std::string Constants::Settings::Session::LocalFile::kSettings = "settings";
-const std::string Constants::Settings::Session::LocalFile::kRanges = "ranges";
-const std::string Constants::Settings::Session::Files::kSession = "session.s2c";
-const std::string Constants::Settings::Session::Files::kGlobal = "global.s2c";
-const std::string Constants::Settings::Session::Files::kLocal = "local.s2c";
-const std::string Constants::Settings::Session::Files::kPref = "pref.s2c";
-const std::string Constants::Settings::Session::Files::kModel = "model";
-const std::string Constants::Settings::Session::Range::kLow = "low";
-const std::string Constants::Settings::Session::Range::kHigh = "high";
-const std::string Constants::Settings::Session::Range::kName = "name";
-const std::string Constants::Settings::Session::Range::kSettings = "settings";
+const std::string Constants::Settings::Session::LocalFile::kRanges   = "ranges";
+const std::string Constants::Settings::Session::Files::kSession      = "session.s2c";
+const std::string Constants::Settings::Session::Files::kGlobal       = "global.s2c";
+const std::string Constants::Settings::Session::Files::kLocal        = "local.s2c";
+const std::string Constants::Settings::Session::Files::kPref         = "pref.s2c";
+const std::string Constants::Settings::Session::Files::kModel        = "model";
+const std::string Constants::Settings::Session::Range::kLow          = "low";
+const std::string Constants::Settings::Session::Range::kHigh         = "high";
+const std::string Constants::Settings::Session::Range::kName         = "name";
+const std::string Constants::Settings::Session::Range::kSettings     = "settings";
 
 // Current Tabs
-const QString Constants::Settings::SettingTab::kPrinter = "Printer";
-const QString Constants::Settings::SettingTab::kMaterial = "Material";
-const QString Constants::Settings::SettingTab::kProfile = "Profile";
+const QString Constants::Settings::SettingTab::kPrinter      = "Printer";
+const QString Constants::Settings::SettingTab::kMaterial     = "Material";
+const QString Constants::Settings::SettingTab::kProfile      = "Profile";
 const QString Constants::Settings::SettingTab::kExperimental = "Experimental";
 
 //================================================================================
 // Segment Settings(G-Code Output)
 //================================================================================
-const QString Constants::SegmentSettings::kHeight = "height";
-const QString Constants::SegmentSettings::kWidth = "width";
-const QString Constants::SegmentSettings::kSpeed = "speed";
-const QString Constants::SegmentSettings::kAccel = "accel";
-const QString Constants::SegmentSettings::kExtruderSpeed = "extruder_speed";
-const QString Constants::SegmentSettings::kWaitTime = "wait_time";
-const QString Constants::SegmentSettings::kRegionType = "region_type";
-const QString Constants::SegmentSettings::kPathModifiers = "path_modifiers";
-const QString Constants::SegmentSettings::kMaterialNumber = "material_number";
-const QString Constants::SegmentSettings::kRecipe = "recipe_index";
-const QString Constants::SegmentSettings::kESP = "esp";
+const QString Constants::SegmentSettings::kHeight               = "height";
+const QString Constants::SegmentSettings::kWidth                = "width";
+const QString Constants::SegmentSettings::kSpeed                = "speed";
+const QString Constants::SegmentSettings::kAccel                = "accel";
+const QString Constants::SegmentSettings::kExtruderSpeed        = "extruder_speed";
+const QString Constants::SegmentSettings::kWaitTime             = "wait_time";
+const QString Constants::SegmentSettings::kRegionType           = "region_type";
+const QString Constants::SegmentSettings::kPathModifiers        = "path_modifiers";
+const QString Constants::SegmentSettings::kMaterialNumber       = "material_number";
+const QString Constants::SegmentSettings::kRecipe               = "recipe_index";
+const QString Constants::SegmentSettings::kESP                  = "esp";
 const QString Constants::SegmentSettings::kIsRegionStartSegment = "is_region_start_segment";
-const QString Constants::SegmentSettings::kAdapted = "adapted";
+const QString Constants::SegmentSettings::kAdapted              = "adapted";
 
 //================================================================================
 // Limits
 //================================================================================
 // Maximums
-const Distance Constants::Limits::Maximums::kMaxDistance = std::numeric_limits<float>::max();
-const Velocity Constants::Limits::Maximums::kMaxSpeed = std::numeric_limits<float>::max();
-const Acceleration Constants::Limits::Maximums::kMaxAccel = std::numeric_limits<float>::max();
-const AngularVelocity Constants::Limits::Maximums::kMaxAngVel = std::numeric_limits<float>::max();
-const Time Constants::Limits::Maximums::kMaxTime = std::numeric_limits<float>::max();
+const Distance Constants::Limits::Maximums::kMaxDistance       = std::numeric_limits<float>::max();
+const Velocity Constants::Limits::Maximums::kMaxSpeed          = std::numeric_limits<float>::max();
+const Acceleration Constants::Limits::Maximums::kMaxAccel      = std::numeric_limits<float>::max();
+const AngularVelocity Constants::Limits::Maximums::kMaxAngVel  = std::numeric_limits<float>::max();
+const Time Constants::Limits::Maximums::kMaxTime               = std::numeric_limits<float>::max();
 const Temperature Constants::Limits::Maximums::kMaxTemperature = std::numeric_limits<float>::max();
-const Angle Constants::Limits::Maximums::kMaxAngle = 2 * pi;
-const Area Constants::Limits::Maximums::kMaxArea = std::numeric_limits<float>::max();
-const Voltage Constants::Limits::Maximums::kMaxVoltage = std::numeric_limits<float>::max();
-const double Constants::Limits::Maximums::kMaxUnitlessFloat = 9999.99;
-const float Constants::Limits::Maximums::kMaxFloat = std::numeric_limits<float>::max();
-const float Constants::Limits::Maximums::kInfFloat = std::numeric_limits<float>::infinity();
+const Angle Constants::Limits::Maximums::kMaxAngle             = 2 * pi;
+const Area Constants::Limits::Maximums::kMaxArea               = std::numeric_limits<float>::max();
+const Voltage Constants::Limits::Maximums::kMaxVoltage         = std::numeric_limits<float>::max();
+const double Constants::Limits::Maximums::kMaxUnitlessFloat    = 9999.99;
+const float Constants::Limits::Maximums::kMaxFloat             = std::numeric_limits<float>::max();
+const float Constants::Limits::Maximums::kInfFloat             = std::numeric_limits<float>::infinity();
 
 // Minimums
-const Distance Constants::Limits::Minimums::kMinDistance = 0.0;
-const Distance Constants::Limits::Minimums::kMinLocation = std::numeric_limits<float>::lowest();
-const Velocity Constants::Limits::Minimums::kMinSpeed = std::numeric_limits<float>::lowest();
-const Acceleration Constants::Limits::Minimums::kMinAccel = std::numeric_limits<float>::lowest();
-const AngularVelocity Constants::Limits::Minimums::kMinAngVel = std::numeric_limits<float>::lowest();
-const Time Constants::Limits::Minimums::kMinTime = std::numeric_limits<float>::lowest();
+const Distance Constants::Limits::Minimums::kMinDistance       = 0.0;
+const Distance Constants::Limits::Minimums::kMinLocation       = std::numeric_limits<float>::lowest();
+const Velocity Constants::Limits::Minimums::kMinSpeed          = std::numeric_limits<float>::lowest();
+const Acceleration Constants::Limits::Minimums::kMinAccel      = std::numeric_limits<float>::lowest();
+const AngularVelocity Constants::Limits::Minimums::kMinAngVel  = std::numeric_limits<float>::lowest();
+const Time Constants::Limits::Minimums::kMinTime               = std::numeric_limits<float>::lowest();
 const Temperature Constants::Limits::Minimums::kMinTemperature = std::numeric_limits<float>::lowest();
-const Angle Constants::Limits::Minimums::kMinAngle = -2 * pi;
-const Area Constants::Limits::Minimums::kMinArea = std::numeric_limits<float>::lowest();
-const double Constants::Limits::Minimums::kMinUnitlessFloat = -9999.99;
-const float Constants::Limits::Minimums::kMinFloat = std::numeric_limits<float>::lowest();
+const Angle Constants::Limits::Minimums::kMinAngle             = -2 * pi;
+const Area Constants::Limits::Minimums::kMinArea               = std::numeric_limits<float>::lowest();
+const double Constants::Limits::Minimums::kMinUnitlessFloat    = -9999.99;
+const float Constants::Limits::Minimums::kMinFloat             = std::numeric_limits<float>::lowest();
 
 //================================================================================
 // Colors
 //================================================================================
-const QColor Constants::Colors::kYellow = QColor(255, 255, 0, 255);
-const QColor Constants::Colors::kRed = QColor(255, 0, 0, 255);
-const QColor Constants::Colors::kBlue = QColor(0, 0, 255, 255);
-const QColor Constants::Colors::kLightBlue = QColor(0, 255, 255, 255);
-const QColor Constants::Colors::kGreen = QColor(0, 255, 0, 255);
-const QColor Constants::Colors::kPurple = QColor(127, 0, 255, 255);
-const QColor Constants::Colors::kOrange = QColor(255, 128, 0, 255);
-const QColor Constants::Colors::kWhite = QColor(255, 255, 255, 255);
-const QColor Constants::Colors::kBlack = QColor(0, 0, 0, 255);
+const QColor Constants::Colors::kYellow               = QColor(255, 255, 0, 255);
+const QColor Constants::Colors::kRed                  = QColor(255, 0, 0, 255);
+const QColor Constants::Colors::kBlue                 = QColor(0, 0, 255, 255);
+const QColor Constants::Colors::kLightBlue            = QColor(0, 255, 255, 255);
+const QColor Constants::Colors::kGreen                = QColor(0, 255, 0, 255);
+const QColor Constants::Colors::kPurple               = QColor(127, 0, 255, 255);
+const QColor Constants::Colors::kOrange               = QColor(255, 128, 0, 255);
+const QColor Constants::Colors::kWhite                = QColor(255, 255, 255, 255);
+const QColor Constants::Colors::kBlack                = QColor(0, 0, 0, 255);
 const QVector<QColor> Constants::Colors::kModelColors = {kBlue, kPurple, kRed, kOrange, kGreen};
 
 //================================================================================
 // UI
 //================================================================================
 // Shadow
-const int Constants::UI::Common::DropShadow::kXOffset = 2;
-const int Constants::UI::Common::DropShadow::kYOffset = 2;
+const int Constants::UI::Common::DropShadow::kXOffset    = 2;
+const int Constants::UI::Common::DropShadow::kYOffset    = 2;
 const int Constants::UI::Common::DropShadow::kBlurRadius = 4;
-const QColor Constants::UI::Common::DropShadow::kColor = QColor(10, 10, 10, 60);
+const QColor Constants::UI::Common::DropShadow::kColor   = QColor(10, 10, 10, 60);
 
 // MainWindow
-const QSize Constants::UI::MainWindow::kWindowSize = QSize(1280, 820);
-const QSize Constants::UI::MainWindow::kViewWidgetSize = QSize(745, 750);
-const QSize Constants::UI::MainWindow::kLayerbarMinSize = QSize(40, 0);
-const int Constants::UI::MainWindow::kProgressBarWidth = 200;
+const QSize Constants::UI::MainWindow::kWindowSize       = QSize(1280, 820);
+const QSize Constants::UI::MainWindow::kViewWidgetSize   = QSize(745, 750);
+const QSize Constants::UI::MainWindow::kLayerbarMinSize  = QSize(40, 0);
+const int Constants::UI::MainWindow::kProgressBarWidth   = 200;
 const int Constants::UI::MainWindow::kStatusBarMaxHeight = 200;
 
 // MainWindow: SideDock
-const int Constants::UI::MainWindow::SideDock::kSettingsWidth = 500;
-const int Constants::UI::MainWindow::SideDock::kGCodeWidth = 500;
+const int Constants::UI::MainWindow::SideDock::kSettingsWidth   = 500;
+const int Constants::UI::MainWindow::SideDock::kGCodeWidth      = 500;
 const int Constants::UI::MainWindow::SideDock::kLayerTimesWidth = 500;
 
 // MainWindow: Margins
-const int Constants::UI::MainWindow::Margins::kMainLayoutSpacing = 6;
+const int Constants::UI::MainWindow::Margins::kMainLayoutSpacing    = 6;
 const int Constants::UI::MainWindow::Margins::kMainContainerSpacing = 0;
-const int Constants::UI::MainWindow::Margins::kMainLayout = 11;
-const int Constants::UI::MainWindow::Margins::kMainContainer = 0;
+const int Constants::UI::MainWindow::Margins::kMainLayout           = 11;
+const int Constants::UI::MainWindow::Margins::kMainContainer        = 0;
 
 // Main Toolbar
-const int Constants::UI::MainToolbar::kMaxWidth = 1250;
-const int Constants::UI::MainToolbar::kStartOffset = 20;
-const int Constants::UI::MainToolbar::kEndOffset = 10;
+const int Constants::UI::MainToolbar::kMaxWidth       = 1250;
+const int Constants::UI::MainToolbar::kStartOffset    = 20;
+const int Constants::UI::MainToolbar::kEndOffset      = 10;
 const int Constants::UI::MainToolbar::kVerticalOffset = 10;
 
 // View Controls Toolbars
-const int Constants::UI::ViewControlsToolbar::kHeight = 80;
-const int Constants::UI::ViewControlsToolbar::kWidth = 290;
+const int Constants::UI::ViewControlsToolbar::kHeight       = 80;
+const int Constants::UI::ViewControlsToolbar::kWidth        = 290;
 const int Constants::UI::ViewControlsToolbar::kBottomOffset = 10;
-const int Constants::UI::ViewControlsToolbar::kRightOffset = 10;
+const int Constants::UI::ViewControlsToolbar::kRightOffset  = 10;
 
 // Part Toolbar
-const int Constants::UI::PartToolbar::kWidth = 40;
-const int Constants::UI::PartToolbar::kHeight = 550;
-const int Constants::UI::PartToolbar::kLeftOffset = 10;
+const int Constants::UI::PartToolbar::kWidth        = 40;
+const int Constants::UI::PartToolbar::kHeight       = 550;
+const int Constants::UI::PartToolbar::kLeftOffset   = 10;
 const int Constants::UI::PartToolbar::kMinTopOffset = 60;
 
 // Part Toolbar: Input
-const int Constants::UI::PartToolbar::Input::kBoxWidth = 700;
-const int Constants::UI::PartToolbar::Input::kBoxHeight = 70;
+const int Constants::UI::PartToolbar::Input::kBoxWidth         = 700;
+const int Constants::UI::PartToolbar::Input::kBoxHeight        = 70;
 const int Constants::UI::PartToolbar::Input::kExtraButtonWidth = 50;
-const int Constants::UI::PartToolbar::Input::kPrecision = 4;
-const int Constants::UI::PartToolbar::Input::kAnimationInTime = 400;
+const int Constants::UI::PartToolbar::Input::kPrecision        = 4;
+const int Constants::UI::PartToolbar::Input::kAnimationInTime  = 400;
 const int Constants::UI::PartToolbar::Input::kAnimationOutTime = 400;
 
 // Part Control
-const QSize Constants::UI::PartControl::kSize = QSize(275, 150);
-const int Constants::UI::PartControl::kLeftOffset = 10;
+const QSize Constants::UI::PartControl::kSize       = QSize(275, 150);
+const int Constants::UI::PartControl::kLeftOffset   = 10;
 const int Constants::UI::PartControl::kBottomOffset = 10;
 
 // Themes
 const QString Constants::UI::Themes::kSystemMode = "System (default)";
-const QString Constants::UI::Themes::kDarkMode = "Dark Mode";
+const QString Constants::UI::Themes::kDarkMode   = "Dark Mode";
 
 const QStringList Constants::UI::Themes::kThemes = {Constants::UI::Themes::kSystemMode,
                                                     Constants::UI::Themes::kDarkMode};
@@ -1088,13 +1087,13 @@ const QStringList Constants::UI::Themes::kThemes = {Constants::UI::Themes::kSyst
 // OpenGL
 //================================================================================
 const double Constants::OpenGL::kZoomDefault = -75;
-const double Constants::OpenGL::kZoomMin = -125;
-const double Constants::OpenGL::kZoomMax = -0.01;
-const double Constants::OpenGL::kTrackball = 90.0f;
+const double Constants::OpenGL::kZoomMin     = -125;
+const double Constants::OpenGL::kZoomMax     = -0.01;
+const double Constants::OpenGL::kTrackball   = 90.0f;
 
-const double Constants::OpenGL::kFov = 60.0;
+const double Constants::OpenGL::kFov       = 60.0;
 const double Constants::OpenGL::kNearPlane = 0.1;
-const double Constants::OpenGL::kFarPlane = 1000.0;
+const double Constants::OpenGL::kFarPlane  = 1000.0;
 
 const float Constants::OpenGL::kObjectToView = 0.00001f;
 const float Constants::OpenGL::kViewToObject = 100000.0f;
@@ -1103,44 +1102,44 @@ const float Constants::OpenGL::kViewToObject = 100000.0f;
 const char* Constants::OpenGL::Shader::kVertShaderFile = ":/shaders/vert";
 const char* Constants::OpenGL::Shader::kFragShaderFile = ":/shaders/frag";
 
-const char* Constants::OpenGL::Shader::kLightingColorName = "lightColor";
-const char* Constants::OpenGL::Shader::kLightingPositionName = "lightPos";
-const char* Constants::OpenGL::Shader::kCameraPositionName = "viewPos";
-const char* Constants::OpenGL::Shader::kAmbientStrengthName = "ambientStrength";
+const char* Constants::OpenGL::Shader::kLightingColorName           = "lightColor";
+const char* Constants::OpenGL::Shader::kLightingPositionName        = "lightPos";
+const char* Constants::OpenGL::Shader::kCameraPositionName          = "viewPos";
+const char* Constants::OpenGL::Shader::kAmbientStrengthName         = "ambientStrength";
 const char* Constants::OpenGL::Shader::kUsingSolidWireframeModeName = "usingSolidWireframeMode";
 
 const char* Constants::OpenGL::Shader::kPositionName = "position";
-const char* Constants::OpenGL::Shader::kColorName = "color";
-const char* Constants::OpenGL::Shader::kNormalName = "normal";
-const char* Constants::OpenGL::Shader::kUVName = "uv";
+const char* Constants::OpenGL::Shader::kColorName    = "color";
+const char* Constants::OpenGL::Shader::kNormalName   = "normal";
+const char* Constants::OpenGL::Shader::kUVName       = "uv";
 
-const char* Constants::OpenGL::Shader::kProjectionName = "projection";
-const char* Constants::OpenGL::Shader::kViewName = "view";
-const char* Constants::OpenGL::Shader::kModelName = "model";
-const char* Constants::OpenGL::Shader::kStackingAxisName = "stackingAxis";
-const char* Constants::OpenGL::Shader::kOverhangAngleName = "overhangAngle";
-const char* Constants::OpenGL::Shader::kOverhangModeName = "usingOverhangMode";
+const char* Constants::OpenGL::Shader::kProjectionName          = "projection";
+const char* Constants::OpenGL::Shader::kViewName                = "view";
+const char* Constants::OpenGL::Shader::kModelName               = "model";
+const char* Constants::OpenGL::Shader::kStackingAxisName        = "stackingAxis";
+const char* Constants::OpenGL::Shader::kOverhangAngleName       = "overhangAngle";
+const char* Constants::OpenGL::Shader::kOverhangModeName        = "usingOverhangMode";
 const char* Constants::OpenGL::Shader::kRenderingPartObjectName = "renderingPartObject";
 //================================================================================
 // Slicer 1 Keys - used for gcode processing (all caps)
 //================================================================================
-const QString Constants::GcodeFileVariables::kPrinterBaseOffset = "PRINTERBASEOFFSET";
-const QString Constants::GcodeFileVariables::kExtrusionWidth = "EXTRUSIONWIDTH";
-const QString Constants::GcodeFileVariables::kXOffset = "XOFFSET";
-const QString Constants::GcodeFileVariables::kYOffset = "YOFFSET";
-const QString Constants::GcodeFileVariables::kLiftSpeed = "LIFTSPEED";
-const QString Constants::GcodeFileVariables::kTravelSpeedMin = "TRAVELSPEEDMIN";
-const QString Constants::GcodeFileVariables::kTravelSpeed = "TRAVELSPEED";
-const QString Constants::GcodeFileVariables::kWTableSpeed = "WTABLESPEED";
-const QString Constants::GcodeFileVariables::kInitialLayerThickness = "INITIALLAYERTHICKNESS";
-const QString Constants::GcodeFileVariables::kLayerThickness = "LAYERTHICKNESS";
-const QString Constants::GcodeFileVariables::kFirstLayerDefaultWidth = "LAYER0EXTRUSIONWIDTH";
-const QString Constants::GcodeFileVariables::kForceMinLayerTime = "FORCEMINIMUMLAYERTIME";
+const QString Constants::GcodeFileVariables::kPrinterBaseOffset       = "PRINTERBASEOFFSET";
+const QString Constants::GcodeFileVariables::kExtrusionWidth          = "EXTRUSIONWIDTH";
+const QString Constants::GcodeFileVariables::kXOffset                 = "XOFFSET";
+const QString Constants::GcodeFileVariables::kYOffset                 = "YOFFSET";
+const QString Constants::GcodeFileVariables::kLiftSpeed               = "LIFTSPEED";
+const QString Constants::GcodeFileVariables::kTravelSpeedMin          = "TRAVELSPEEDMIN";
+const QString Constants::GcodeFileVariables::kTravelSpeed             = "TRAVELSPEED";
+const QString Constants::GcodeFileVariables::kWTableSpeed             = "WTABLESPEED";
+const QString Constants::GcodeFileVariables::kInitialLayerThickness   = "INITIALLAYERTHICKNESS";
+const QString Constants::GcodeFileVariables::kLayerThickness          = "LAYERTHICKNESS";
+const QString Constants::GcodeFileVariables::kFirstLayerDefaultWidth  = "LAYER0EXTRUSIONWIDTH";
+const QString Constants::GcodeFileVariables::kForceMinLayerTime       = "FORCEMINIMUMLAYERTIME";
 const QString Constants::GcodeFileVariables::kForceMinLayerTimeMethod = "MINIMUMLAYERTIMEMETHOD";
-const QString Constants::GcodeFileVariables::kMinimalLayerTime = "MINIMALLAYERTIME";
-const QString Constants::GcodeFileVariables::kMaximalLayerTime = "MAXIMALLAYERTIME";
-const QString Constants::GcodeFileVariables::kPlasticType = "PLASTICTYPE";
-const QString Constants::GcodeFileVariables::kManualDensity = "MANUALDENSITY";
+const QString Constants::GcodeFileVariables::kMinimalLayerTime        = "MINIMALLAYERTIME";
+const QString Constants::GcodeFileVariables::kMaximalLayerTime        = "MAXIMALLAYERTIME";
+const QString Constants::GcodeFileVariables::kPlasticType             = "PLASTICTYPE";
+const QString Constants::GcodeFileVariables::kManualDensity           = "MANUALDENSITY";
 // actualdensity?
 
 // Slicer 1 and ORNLSlicer keys that are necessary for gcode parsing
@@ -1224,41 +1223,41 @@ const QHash<QString, QString> Constants::GcodeFileVariables::kRequiredConversion
      {Constants::GcodeFileVariables::kTravelSpeed, Constants::PrinterSettings::MachineSpeed::kMaxXYSpeed},
      {Constants::GcodeFileVariables::kWTableSpeed, Constants::PrinterSettings::MachineSpeed::kWTableSpeed}});
 
-const std::string Constants::SettingFileStrings::kHeader = "header";
-const std::string Constants::SettingFileStrings::kCreatedBy = "created_by";
-const std::string Constants::SettingFileStrings::kCreatedOn = "created_on";
+const std::string Constants::SettingFileStrings::kHeader       = "header";
+const std::string Constants::SettingFileStrings::kCreatedBy    = "created_by";
+const std::string Constants::SettingFileStrings::kCreatedOn    = "created_on";
 const std::string Constants::SettingFileStrings::kLastModified = "last_modified";
-const std::string Constants::SettingFileStrings::kVersion = "version";
-const std::string Constants::SettingFileStrings::kLock = "lock";
-const std::string Constants::SettingFileStrings::kSettings = "settings";
+const std::string Constants::SettingFileStrings::kVersion      = "version";
+const std::string Constants::SettingFileStrings::kLock         = "lock";
+const std::string Constants::SettingFileStrings::kSettings     = "settings";
 
-const QString Constants::ConsoleOptionStrings::kInputProjectFile = "input_project_file";
-const QString Constants::ConsoleOptionStrings::kInputStlFiles = "input_stl_files";
-const QString Constants::ConsoleOptionStrings::kInputStlFilesDirectory = "input_stl_files_directory";
-const QString Constants::ConsoleOptionStrings::kInputSupportStlFiles = "input_support_stl_files";
+const QString Constants::ConsoleOptionStrings::kInputProjectFile              = "input_project_file";
+const QString Constants::ConsoleOptionStrings::kInputStlFiles                 = "input_stl_files";
+const QString Constants::ConsoleOptionStrings::kInputStlFilesDirectory        = "input_stl_files_directory";
+const QString Constants::ConsoleOptionStrings::kInputSupportStlFiles          = "input_support_stl_files";
 const QString Constants::ConsoleOptionStrings::kInputSupportStlFilesDirectory = "input_support_stl_files_directory";
-const QString Constants::ConsoleOptionStrings::kInputStlCount = "input_stl_count";
-const QString Constants::ConsoleOptionStrings::kInputSupportStlCount = "input_support_stl_count";
-const QString Constants::ConsoleOptionStrings::kInputGlobalSettings = "input_global_settings";
-const QString Constants::ConsoleOptionStrings::kInputLocalSettings = "input_local_settings";
-const QString Constants::ConsoleOptionStrings::kInputSTLTransform = "input_stl_transform";
-const QString Constants::ConsoleOptionStrings::kOutputLocation = "output_location";
+const QString Constants::ConsoleOptionStrings::kInputStlCount                 = "input_stl_count";
+const QString Constants::ConsoleOptionStrings::kInputSupportStlCount          = "input_support_stl_count";
+const QString Constants::ConsoleOptionStrings::kInputGlobalSettings           = "input_global_settings";
+const QString Constants::ConsoleOptionStrings::kInputLocalSettings            = "input_local_settings";
+const QString Constants::ConsoleOptionStrings::kInputSTLTransform             = "input_stl_transform";
+const QString Constants::ConsoleOptionStrings::kOutputLocation                = "output_location";
 
-const QString Constants::ConsoleOptionStrings::kShiftPartsOnLoad = "shift_parts_on_load";
-const QString Constants::ConsoleOptionStrings::kAlignParts = "align_parts";
+const QString Constants::ConsoleOptionStrings::kShiftPartsOnLoad      = "shift_parts_on_load";
+const QString Constants::ConsoleOptionStrings::kAlignParts            = "align_parts";
 const QString Constants::ConsoleOptionStrings::kUseImplicitTransforms = "use_implicit_transforms";
 
-const QString Constants::ConsoleOptionStrings::kOverwriteOutputFile = "overwrite_output_file";
+const QString Constants::ConsoleOptionStrings::kOverwriteOutputFile   = "overwrite_output_file";
 const QString Constants::ConsoleOptionStrings::kIncludeAuxiliaryFiles = "include_auxiliary_files";
-const QString Constants::ConsoleOptionStrings::kIncludeProjectFile = "include_project_file";
-const QString Constants::ConsoleOptionStrings::kBundleOutput = "bundle_output";
-const QString Constants::ConsoleOptionStrings::kHeaderSlicedBy = "header_sliced_by";
-const QString Constants::ConsoleOptionStrings::kHeaderDescription = "header_description";
+const QString Constants::ConsoleOptionStrings::kIncludeProjectFile    = "include_project_file";
+const QString Constants::ConsoleOptionStrings::kBundleOutput          = "bundle_output";
+const QString Constants::ConsoleOptionStrings::kHeaderSlicedBy        = "header_sliced_by";
+const QString Constants::ConsoleOptionStrings::kHeaderDescription     = "header_description";
 
-const QString Constants::ConsoleOptionStrings::kSliceBounds = "slice_bounds";
-const QString Constants::ConsoleOptionStrings::kSingleSliceHeight = "single_slice_height";
+const QString Constants::ConsoleOptionStrings::kSliceBounds            = "slice_bounds";
+const QString Constants::ConsoleOptionStrings::kSingleSliceHeight      = "single_slice_height";
 const QString Constants::ConsoleOptionStrings::kSingleSliceLayerNumber = "single_slice_layer_number";
 
 const QString Constants::ConsoleOptionStrings::kVersion = "version";
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/utilities/enums.cpp
+++ b/src/utilities/enums.cpp
@@ -1,13 +1,21 @@
 #include "utilities/enums.h"
 
 namespace ORNL {
-void to_json(json& j, const InfillPatterns& i) { j = json {{"infill_pattern", static_cast<int>(i)}}; }
+void to_json(json& j, const InfillPatterns& i) {
+    j = json {{"infill_pattern", static_cast<int>(i)}};
+}
 
-void from_json(const json& j, InfillPatterns& i) { i = static_cast<InfillPatterns>(j["infill_pattern"].get<int>()); }
+void from_json(const json& j, InfillPatterns& i) {
+    i = static_cast<InfillPatterns>(j["infill_pattern"].get<int>());
+}
 
-void to_json(json& j, const SkeletonInput& i) { j = json {{"skeleton_input", static_cast<int>(i)}}; }
+void to_json(json& j, const SkeletonInput& i) {
+    j = json {{"skeleton_input", static_cast<int>(i)}};
+}
 
-void from_json(const json& j, SkeletonInput& i) { i = static_cast<SkeletonInput>(j["skeleton_input"].get<int>()); }
+void from_json(const json& j, SkeletonInput& i) {
+    i = static_cast<SkeletonInput>(j["skeleton_input"].get<int>());
+}
 
 void to_json(json& j, const IslandOrderOptimization& o) {
     j = json {{"island_order_optimization", static_cast<int>(o)}};
@@ -17,23 +25,29 @@ void from_json(const json& j, IslandOrderOptimization& o) {
     o = static_cast<IslandOrderOptimization>(j["island_order_optimization"].get<int>());
 }
 
-void to_json(json& j, const PathOrderOptimization& o) { j = json {{"path_order_optimization", static_cast<int>(o)}}; }
+void to_json(json& j, const PathOrderOptimization& o) {
+    j = json {{"path_order_optimization", static_cast<int>(o)}};
+}
 
 void from_json(const json& j, PathOrderOptimization& o) {
     o = static_cast<PathOrderOptimization>(j["path_order_optimization"].get<int>());
 }
 
-void to_json(json& j, const PointOrderOptimization& o) { j = json {{"point_order_optimization", static_cast<int>(o)}}; }
+void to_json(json& j, const PointOrderOptimization& o) {
+    j = json {{"point_order_optimization", static_cast<int>(o)}};
+}
 
 void from_json(const json& j, PointOrderOptimization& o) {
     o = static_cast<PointOrderOptimization>(j["point_order_optimization"].get<int>());
 }
 
-void to_json(json& j, const SlicingMode& i) { j = json {{"slicing_mode", static_cast<int>(i)}}; }
+void to_json(json& j, const SlicingMode& i) {
+    j = json {{"slicing_mode", static_cast<int>(i)}};
+}
 
 void from_json(const json& j, SlicingMode& i) {
     const char* key = j.contains("slicing_mode") ? "slicing_mode" : "slicer_type";
-    i = static_cast<SlicingMode>(j[key].get<int>());
+    i               = static_cast<SlicingMode>(j[key].get<int>());
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/utilities/mathutils.cpp
+++ b/src/utilities/mathutils.cpp
@@ -31,9 +31,13 @@ bool equals(double a, double b) {
     return (a == b) || (std::abs(a - b) < std::abs(std::min(a, b)) * std::numeric_limits<double>::epsilon());
 }
 
-bool equals(double a, double b, double eps) { return (a == b) || (std::abs(a - b) < eps); }
+bool equals(double a, double b, double eps) {
+    return (a == b) || (std::abs(a - b) < eps);
+}
 
-bool notEquals(double a, double b) { return !equals(a, b); }
+bool notEquals(double a, double b) {
+    return !equals(a, b);
+}
 
 Point center(QVector<Point> points) {
     float x = 0, y = 0, z = 0;
@@ -99,17 +103,12 @@ bool intersect(Point p1, Point q1, Point p2, Point q2) {
     short o3 = orientation(p2, q2, p1);
     short o4 = orientation(p2, q2, q1);
 
-    if (o1 != o2 && o3 != o4)
-        return true;
+    if (o1 != o2 && o3 != o4) return true;
 
-    if (o1 == 0 && onSegment(p1, p2, q1))
-        return true;
-    if (o2 == 0 && onSegment(p1, q2, q1))
-        return true;
-    if (o3 == 0 && onSegment(p2, p1, q2))
-        return true;
-    if (o4 == 0 && onSegment(p2, q1, q2))
-        return true;
+    if (o1 == 0 && onSegment(p1, p2, q1)) return true;
+    if (o2 == 0 && onSegment(p1, q2, q1)) return true;
+    if (o3 == 0 && onSegment(p2, p1, q2)) return true;
+    if (o4 == 0 && onSegment(p2, q1, q2)) return true;
 
     return false;
 }
@@ -123,12 +122,10 @@ short orientation(Point A, Point B, Point C) {
     float val = (C.x() - A.x()) * (B.y() - A.y()) - (C.y() - A.y()) * (B.x() - A.x());
 
     //! Point C is colinear to line AB
-    if (qFuzzyIsNull(val))
-        return 0;
+    if (qFuzzyIsNull(val)) return 0;
 
     //! Point C lies to the left of line AB -> orientation of ABC is ccw
-    if (val < 0)
-        return -1;
+    if (val < 0) return -1;
 
     //! Point C lies to the right of line AB -> orientation of ABC is cw
     return 1;
@@ -154,7 +151,7 @@ Point lineIntersection(Point A, Point B, Point C, Point D) {
 }
 
 Point linePlaneIntersection(Point line_pt, QVector3D line_direction, Plane plane) {
-    QVector3D N = plane.normal();
+    QVector3D N    = plane.normal();
     Point plane_pt = plane.point();
 
     double t =
@@ -171,16 +168,14 @@ bool nearCollinear(Point A, Point B, Point C, Angle threshold) {
     Distance a = B.distance(C);
 
     // if any of the two points are the same
-    if (a == 0 || b == 0 || c == 0)
-        return true;
+    if (a == 0 || b == 0 || c == 0) return true;
 
     // Or if any of the two points are close enough, 1.0e-6 is hardcoded for now
     Distance d_max = qMax(a, b);
-    d_max = qMax(d_max, c);
+    d_max          = qMax(d_max, c);
     Distance d_min = qMin(a, b);
-    d_min = qMin(d_min, c);
-    if (d_min / d_max < 1.0e-6)
-        return true;
+    d_min          = qMin(d_min, c);
+    if (d_min / d_max < 1.0e-6) return true;
 
     // checking two of three angles is enough. If B is the mid point of collinear ABC
     //   Angle ABC = PI, not 0. But the other two angles are 0
@@ -192,26 +187,14 @@ bool nearCollinear(Point A, Point B, Point C, Angle threshold) {
 
 bool slopesNearCollinear(Point pt1, Point pt2, Point pt3, Distance distSqrd) {
     if (std::abs(pt1.x() - pt2.x()) > std::abs(pt1.y() - pt2.y())) {
-        if ((pt1.x() > pt2.x()) == (pt1.x() < pt3.x())) {
-            return distanceFromLineSqrd(pt1, pt2, pt3) < distSqrd;
-        }
-        else if ((pt2.x() > pt1.x()) == (pt2.x() < pt3.x())) {
-            return distanceFromLineSqrd(pt2, pt1, pt3) < distSqrd;
-        }
-        else {
-            return distanceFromLineSqrd(pt3, pt1, pt2) < distSqrd;
-        }
+        if ((pt1.x() > pt2.x()) == (pt1.x() < pt3.x())) { return distanceFromLineSqrd(pt1, pt2, pt3) < distSqrd; }
+        else if ((pt2.x() > pt1.x()) == (pt2.x() < pt3.x())) { return distanceFromLineSqrd(pt2, pt1, pt3) < distSqrd; }
+        else { return distanceFromLineSqrd(pt3, pt1, pt2) < distSqrd; }
     }
     else {
-        if ((pt1.y() > pt2.y()) == (pt1.y() < pt3.y())) {
-            return distanceFromLineSqrd(pt1, pt2, pt3) < distSqrd;
-        }
-        else if ((pt2.y() > pt1.y()) == (pt2.y() < pt3.y())) {
-            return distanceFromLineSqrd(pt2, pt1, pt3) < distSqrd;
-        }
-        else {
-            return distanceFromLineSqrd(pt3, pt1, pt2) < distSqrd;
-        }
+        if ((pt1.y() > pt2.y()) == (pt1.y() < pt3.y())) { return distanceFromLineSqrd(pt1, pt2, pt3) < distSqrd; }
+        else if ((pt2.y() > pt1.y()) == (pt2.y() < pt3.y())) { return distanceFromLineSqrd(pt2, pt1, pt3) < distSqrd; }
+        else { return distanceFromLineSqrd(pt3, pt1, pt2) < distSqrd; }
     }
 }
 
@@ -219,13 +202,13 @@ Distance distanceFromLineSqrd(Point pt, Point ln1, Point ln2) {
     float A = ln1.y() - ln2.y();
     float B = ln2.x() - ln1.x();
     float C = A * ln1.x() + B * ln1.y();
-    C = A * pt.x() + B * pt.y() - C;
+    C       = A * pt.x() + B * pt.y() - C;
     return (C * C) / (A * A + B * B);
 }
 
 float distanceFromLineSegSqrd(Point pt, Point ln1, Point ln2) {
-    float x = ln1.x();
-    float y = ln1.y();
+    float x  = ln1.x();
+    float y  = ln1.y();
     float dx = ln2.x() - x;
     float dy = ln2.y() - y;
 
@@ -248,19 +231,19 @@ float distanceFromLineSegSqrd(Point pt, Point ln1, Point ln2) {
     return dx * dx + dy * dy;
 }
 
-bool pointsAreClose(Point pt1, Point pt2, Distance distSqrd) { return std::pow(pt1.distance(pt2)(), 2) <= distSqrd(); }
+bool pointsAreClose(Point pt1, Point pt2, Distance distSqrd) {
+    return std::pow(pt1.distance(pt2)(), 2) <= distSqrd();
+}
 
-uint32_t cantorPair(uint32_t a, uint32_t b) { return (a + b) * (a + b + 1) / 2 + a; }
+uint32_t cantorPair(uint32_t a, uint32_t b) {
+    return (a + b) * (a + b + 1) / 2 + a;
+}
 
 std::pair<Point, double> nearestPointOnSegment(const Point& a, const Point& b, const Point& p) {
     double t = (b - a).dot(p - a) / (b - a).dot(b - a);
 
-    if (t < 0) {
-        return std::make_pair(a, p.distance(a)());
-    }
-    else if (t > 1) {
-        return std::make_pair(b, p.distance(b)());
-    }
+    if (t < 0) { return std::make_pair(a, p.distance(a)()); }
+    else if (t > 1) { return std::make_pair(b, p.distance(b)()); }
     else {
         Point nearest = a * (1.0 - t) + b * t;
         return std::make_pair(nearest, p.distance(nearest)());
@@ -282,11 +265,11 @@ QVector<Point> chamferCorner(const Point& A, const Point& B, const Point& C, Dis
 // 1000.51  ->  0:16:41
 // 59.45    --> 0:00:59
 QString formattedTimeSpanHHMMSS(double sec) {
-    int seconds = int(sec);
-    int hours = (seconds / 60 / 60);
-    int minutes = (seconds / 60) % 60;
+    int seconds          = int(sec);
+    int hours            = (seconds / 60 / 60);
+    int minutes          = (seconds / 60) % 60;
     int remainingSeconds = seconds % 60;
-    int milliseconds = round((sec - seconds) * 1000);
+    int milliseconds     = round((sec - seconds) * 1000);
     return QString::number(hours) + ":" + QString::number(minutes).rightJustified(2, '0') + ":" +
            QString::number(remainingSeconds).rightJustified(2, '0') + "." +
            QString::number(milliseconds).leftJustified(3, '0');
@@ -302,43 +285,35 @@ QString formattedTimeSpanHHMMSS(Time time) {
 // 1000.5 -> 16 min 41 sec
 // 43.23  -> 43 sec
 QString formattedTimeSpan(double sec) {
-    int seconds = int(sec);
-    int hours = (seconds / 60 / 60);
-    int minutes = (seconds / 60) % 60;
+    int seconds          = int(sec);
+    int hours            = (seconds / 60 / 60);
+    int minutes          = (seconds / 60) % 60;
     int remainingSeconds = seconds % 60;
     if (hours > 0) {
         return QString::number(hours) + " hr " + QString::number(minutes) + " min " +
                QString::number(remainingSeconds) + " sec";
     }
-    else if (minutes > 0) {
-        return QString::number(minutes) + " min " + QString::number(remainingSeconds) + " sec";
-    }
-    else {
-        return QString::number(remainingSeconds) + " sec";
-    }
+    else if (minutes > 0) { return QString::number(minutes) + " min " + QString::number(remainingSeconds) + " sec"; }
+    else { return QString::number(remainingSeconds) + " sec"; }
 }
 
 QString formattedTimeSpan(Time sec) {
-    int seconds = int(sec());
-    int hours = (seconds / 60 / 60);
-    int minutes = (seconds / 60) % 60;
+    int seconds          = int(sec());
+    int hours            = (seconds / 60 / 60);
+    int minutes          = (seconds / 60) % 60;
     int remainingSeconds = seconds % 60;
     if (hours > 0) {
         return QString::number(hours) + " hr " + QString::number(minutes) + " min " +
                QString::number(remainingSeconds) + " sec";
     }
-    else if (minutes > 0) {
-        return QString::number(minutes) + " min " + QString::number(remainingSeconds) + " sec";
-    }
-    else {
-        return QString::number(remainingSeconds) + " sec";
-    }
+    else if (minutes > 0) { return QString::number(minutes) + " min " + QString::number(remainingSeconds) + " sec"; }
+    else { return QString::number(remainingSeconds) + " sec"; }
 }
 
 QQuaternion CreateQuaternion(double x, double y, double z, QuaternionOrder order) {
     double pitch = qDegreesToRadians(x);
-    double yaw = qDegreesToRadians(y);
-    double roll = qDegreesToRadians(z);
+    double yaw   = qDegreesToRadians(y);
+    double roll  = qDegreesToRadians(z);
 
     QQuaternion result;
     QVector3D vx(1, 0, 0), vy(0, 1, 0), vz(0, 0, 1);
@@ -347,11 +322,11 @@ QQuaternion CreateQuaternion(double x, double y, double z, QuaternionOrder order
     qy = AxisAngleToQuat(vy, yaw);
     qz = AxisAngleToQuat(vz, roll);
     if (order == QuaternionOrder::kXYZ) {
-        qt = QuatMult(qx, qy);
+        qt     = QuatMult(qx, qy);
         result = QuatMult(qt, qz);
     }
     else if (order == QuaternionOrder::kZYX) {
-        qt = QuatMult(qz, qy);
+        qt     = QuatMult(qz, qy);
         result = QuatMult(qt, qx);
     }
 
@@ -366,11 +341,11 @@ QQuaternion CreateQuaternion(Angle x, Angle y, Angle z, QuaternionOrder order) {
     qy = AxisAngleToQuat(vy, y());
     qz = AxisAngleToQuat(vz, z());
     if (order == QuaternionOrder::kXYZ) {
-        qt = QuatMult(qx, qy);
+        qt     = QuatMult(qx, qy);
         result = QuatMult(qt, qz);
     }
     else if (order == QuaternionOrder::kZYX) {
-        qt = QuatMult(qz, qy);
+        qt     = QuatMult(qz, qy);
         result = QuatMult(qt, qx);
     }
 
@@ -426,17 +401,17 @@ QQuaternion CreateQuaternion(QVector3D vector_start, QVector3D vector_end) {
     // if they're opposite, create some non-zero quaternion to give 180 degree rotation. This quanternion is not unique
     if (qFuzzyCompare(cross_product.lengthSquared(), 0.0f) && vector_start != vector_end) {
         // hard code the axis-aligned cases for now
-        if (vector_start == QVector3D(0, 0, 1) || vector_end == QVector3D(0, 0, 1)) // input vectors are z-axis aligned
+        if (vector_start == QVector3D(0, 0, 1) || vector_end == QVector3D(0, 0, 1))  // input vectors are z-axis aligned
         {
             cross_product = QVector3D(1, 0, 0);
         }
         else if (vector_start == QVector3D(0, 1, 0) ||
-                 vector_end == QVector3D(0, 1, 0)) // input vectors are y-axis aligned
+                 vector_end == QVector3D(0, 1, 0))  // input vectors are y-axis aligned
         {
             cross_product = QVector3D(1, 0, 0);
         }
         else if (vector_start == QVector3D(1, 0, 0) ||
-                 vector_end == QVector3D(1, 0, 0)) // input vectors are x-axis aligned
+                 vector_end == QVector3D(1, 0, 0))  // input vectors are x-axis aligned
         {
             cross_product = QVector3D(0, 1, 0);
         }
@@ -459,27 +434,25 @@ QQuaternion CreateQuaternion(QVector3D vector_start, QVector3D vector_end) {
 void EulerAngles(QQuaternion q, double* pitch, double* roll, double* yaw) {
     double sinr_cosp = 2 * (q.scalar() * q.x() + q.y() * q.z());
     double cosr_cosp = 1 - 2 * (q.x() * q.x() + q.y() * q.y());
-    *pitch = std::atan2(sinr_cosp, cosr_cosp);
+    *pitch           = std::atan2(sinr_cosp, cosr_cosp);
 
     double sinp = 2 * (q.scalar() * q.y() - q.z() * q.x());
     if (std::abs(sinp) >= 1)
-        *roll = std::copysign(M_PI / 2, sinp); // use 90 degrees if out of range
+        *roll = std::copysign(M_PI / 2, sinp);  // use 90 degrees if out of range
     else
         *roll = std::asin(sinp);
 
     double siny_cosp = 2 * (q.scalar() * q.z() + q.x() * q.y());
     double cosy_cosp = 1 - 2 * (q.y() * q.y() + q.z() * q.z());
-    *yaw = std::atan2(siny_cosp, cosy_cosp);
+    *yaw             = std::atan2(siny_cosp, cosy_cosp);
 }
 
 double findBinomialCoefficients(int n, int k) {
     double coefficient = 1;
 
-    for (int i = n - k + 1; i <= n; i++)
-        coefficient *= i;
+    for (int i = n - k + 1; i <= n; i++) coefficient *= i;
 
-    for (int i = 1; i <= k; i++)
-        coefficient /= i;
+    for (int i = 1; i <= k; i++) coefficient /= i;
 
     return coefficient;
 }
@@ -494,9 +467,9 @@ std::tuple<QVector3D, QQuaternion, QVector3D> decomposeTransformMatrix(QMatrix4x
     mtrx(2, 3) = 0.0f;
 
     // Extract scale
-    float scale_x = mtrx.column(0).length();
-    float scale_y = mtrx.column(1).length();
-    float scale_z = mtrx.column(2).length();
+    float scale_x   = mtrx.column(0).length();
+    float scale_y   = mtrx.column(1).length();
+    float scale_z   = mtrx.column(2).length();
     QVector3D scale = QVector3D(scale_x, scale_y, scale_z);
 
     // Divide out the scales
@@ -522,19 +495,15 @@ QMatrix4x4 composeTransformMatrix(QVector3D t, QQuaternion r, QVector3D s) {
 }
 
 double clamp(double min, double val, double max) {
-    if (val < min)
-        return min;
-    if (val > max)
-        return max;
+    if (val < min) return min;
+    if (val > max) return max;
 
     return val;
 }
 
 double snap(double val, double interval) {
     double half_interval = interval / 2;
-    if (val < 0) {
-        half_interval = -half_interval;
-    }
+    if (val < 0) { half_interval = -half_interval; }
 
     return (((int)(val + half_interval)) / (int)interval) * interval;
 }
@@ -553,6 +522,8 @@ QVector3D sphericalToCartesian(float rho, float theta, float phi) {
     return ret;
 }
 
-bool glEquals(double a, double b) { return (std::abs(a - b) < 1e-5); }
-} // namespace MathUtils
-} // namespace ORNL
+bool glEquals(double a, double b) {
+    return (std::abs(a - b) < 1e-5);
+}
+}  // namespace MathUtils
+}  // namespace ORNL

--- a/src/utilities/qt_json_conversion.cpp
+++ b/src/utilities/qt_json_conversion.cpp
@@ -7,13 +7,17 @@
 #include <qquaternion.h>
 #include <qvectornd.h>
 
-void to_json(fifojson& j, const QString& s) { j = s.toStdString(); }
+void to_json(fifojson& j, const QString& s) {
+    j = s.toStdString();
+}
 
-void from_json(const fifojson& j, QString& s) { s = j.get<std::string>().c_str(); }
+void from_json(const fifojson& j, QString& s) {
+    s = j.get<std::string>().c_str();
+}
 
 void to_json(fifojson& j, const QQuaternion& q) {
     QVector4D v = q.toVector4D();
-    j = fifojson {{"w", v.w()}, {"x", v.x()}, {"y", v.y()}, {"z", v.z()}};
+    j           = fifojson {{"w", v.w()}, {"x", v.x()}, {"y", v.y()}, {"z", v.z()}};
 }
 
 void from_json(const fifojson& j, QQuaternion& q) {
@@ -23,7 +27,9 @@ void from_json(const fifojson& j, QQuaternion& q) {
     q.setZ(j["z"]);
 }
 
-void to_json(fifojson& j, const QVector3D& v) { j = fifojson {{"x", v.x()}, {"y", v.y()}, {"z", v.z()}}; }
+void to_json(fifojson& j, const QVector3D& v) {
+    j = fifojson {{"x", v.x()}, {"y", v.y()}, {"z", v.z()}};
+}
 
 void from_json(const fifojson& j, QVector3D& v) {
     v.setX(j["x"]);
@@ -32,16 +38,12 @@ void from_json(const fifojson& j, QVector3D& v) {
 }
 
 void to_json(fifojson& j, const QMatrix4x4& m) {
-    j = fifojson::array();
+    j                 = fifojson::array();
     const float* data = m.data();
 
-    for (int i = 0; i < 16; i++) {
-        j[i] = data[i];
-    }
+    for (int i = 0; i < 16; i++) { j[i] = data[i]; }
 }
 
 void from_json(const fifojson& j, QMatrix4x4& m) {
-    for (int i = 0; i < 16; i++) {
-        m.data()[i] = j[i];
-    }
+    for (int i = 0; i < 16; i++) { m.data()[i] = j[i]; }
 }

--- a/src/utilities/runtime_diagnostics.cpp
+++ b/src/utilities/runtime_diagnostics.cpp
@@ -22,5 +22,7 @@ void logLine(const QString& message) {
     std::cerr << "[ornlslicer] " << message.toStdString() << std::endl;
 }
 
-void logRuntimeSummary(const QString& mode) { logLine(runtimeSummary(mode)); }
-} // namespace ORNL::Diagnostics
+void logRuntimeSummary(const QString& mode) {
+    logLine(runtimeSummary(mode));
+}
+}  // namespace ORNL::Diagnostics

--- a/src/utilities/theme_tool.cpp
+++ b/src/utilities/theme_tool.cpp
@@ -49,58 +49,102 @@ void Theme::chooseTheme(int themeNum) {
 // Folder Path
 // -----------------------------------------------------------------------------
 
-void Theme::setPath(QString path) { m_folder_path = path; }
+void Theme::setPath(QString path) {
+    m_folder_path = path;
+}
 
-QString Theme::getFolderPath() { return m_folder_path; }
+QString Theme::getFolderPath() {
+    return m_folder_path;
+}
 
 // -----------------------------------------------------------------------------
 // Dot Colors
 // -----------------------------------------------------------------------------
 // Base color
-void Theme::setDotColor(int r, int g, int b, int a) { m_dotColors[0] = QColor(r, g, b, a); }
-void Theme::setDotColor(QColor color) { m_dotColors[0] = color; }
+void Theme::setDotColor(int r, int g, int b, int a) {
+    m_dotColors[0] = QColor(r, g, b, a);
+}
+void Theme::setDotColor(QColor color) {
+    m_dotColors[0] = color;
+}
 
 // Hover color
-void Theme::setDotHoverColor(int r, int g, int b, int a) { m_dotColors[1] = QColor(r, g, b, a); }
-void Theme::setDotHoverColor(QColor color) { m_dotColors[1] = color; }
+void Theme::setDotHoverColor(int r, int g, int b, int a) {
+    m_dotColors[1] = QColor(r, g, b, a);
+}
+void Theme::setDotHoverColor(QColor color) {
+    m_dotColors[1] = color;
+}
 
 // Selected color
-void Theme::setDotSelectedColor(int r, int g, int b, int a) { m_dotColors[2] = QColor(r, g, b, a); }
-void Theme::setDotSelectedColor(QColor color) { m_dotColors[2] = color; }
+void Theme::setDotSelectedColor(int r, int g, int b, int a) {
+    m_dotColors[2] = QColor(r, g, b, a);
+}
+void Theme::setDotSelectedColor(QColor color) {
+    m_dotColors[2] = color;
+}
 
 // Grouped color
-void Theme::setDotGroupedColor(int r, int g, int b, int a) { m_dotColors[3] = QColor(r, g, b, a); }
-void Theme::setDotGroupedColor(QColor color) { m_dotColors[3] = color; }
+void Theme::setDotGroupedColor(int r, int g, int b, int a) {
+    m_dotColors[3] = QColor(r, g, b, a);
+}
+void Theme::setDotGroupedColor(QColor color) {
+    m_dotColors[3] = color;
+}
 
 // Label color
-void Theme::setDotLabelColor(int r, int g, int b, int a) { m_dotColors[4] = QColor(r, g, b, a); }
-void Theme::setDotLabelColor(QColor color) { m_dotColors[4] = color; }
+void Theme::setDotLabelColor(int r, int g, int b, int a) {
+    m_dotColors[4] = QColor(r, g, b, a);
+}
+void Theme::setDotLabelColor(QColor color) {
+    m_dotColors[4] = color;
+}
 
-QVector<QColor> Theme::getDotColors() { return m_dotColors; }
+QVector<QColor> Theme::getDotColors() {
+    return m_dotColors;
+}
 
 // -----------------------------------------------------------------------------
 // Paired Dot Color (line drawn between dots on layer bar)
 // -----------------------------------------------------------------------------
-void Theme::setDotPairedColor(int r, int g, int b, int a) { m_dotColor_paired = QColor(r, g, b, a); }
-void Theme::setDotPairedColor(QColor color) { m_dotColor_paired = color; }
+void Theme::setDotPairedColor(int r, int g, int b, int a) {
+    m_dotColor_paired = QColor(r, g, b, a);
+}
+void Theme::setDotPairedColor(QColor color) {
+    m_dotColor_paired = color;
+}
 
-QColor Theme::getDotPairedColor() { return m_dotColor_paired; }
+QColor Theme::getDotPairedColor() {
+    return m_dotColor_paired;
+}
 
 // -----------------------------------------------------------------------------
 // Layerbar Major Line Color
 // -----------------------------------------------------------------------------
-void Theme::setLayerbarMajorColor(int r, int g, int b, int a) { m_lineColor_major = QColor(r, g, b, a); }
-void Theme::setLayerbarMajorColor(QColor color) { m_lineColor_major = color; }
+void Theme::setLayerbarMajorColor(int r, int g, int b, int a) {
+    m_lineColor_major = QColor(r, g, b, a);
+}
+void Theme::setLayerbarMajorColor(QColor color) {
+    m_lineColor_major = color;
+}
 
-QColor Theme::getLayerbarMajorColor() { return m_lineColor_major; }
+QColor Theme::getLayerbarMajorColor() {
+    return m_lineColor_major;
+}
 
 // -----------------------------------------------------------------------------
 // Layerbar Minor Line Color
 // -----------------------------------------------------------------------------
-void Theme::setLayerbarMinorColor(int r, int g, int b, int a) { m_lineColor_minor = QColor(r, g, b, a); }
-void Theme::setLayerbarMinorColor(QColor color) { m_lineColor_minor = color; }
+void Theme::setLayerbarMinorColor(int r, int g, int b, int a) {
+    m_lineColor_minor = QColor(r, g, b, a);
+}
+void Theme::setLayerbarMinorColor(QColor color) {
+    m_lineColor_minor = color;
+}
 
-QColor Theme::getLayerbarMinorColor() { return m_lineColor_minor; }
+QColor Theme::getLayerbarMinorColor() {
+    return m_lineColor_minor;
+}
 
 // -----------------------------------------------------------------------------
 // View Background Color
@@ -112,22 +156,28 @@ void Theme::setBgColor(double r, double g, double b, double a) {
     m_bgColor[3] = a;
 }
 
-QVector<double> Theme::getBgColor() { return m_bgColor; }
+QVector<double> Theme::getBgColor() {
+    return m_bgColor;
+}
 
 // -----------------------------------------------------------------------------
 // G-code Text Editor Colors
 // -----------------------------------------------------------------------------
 void Theme::setGcodeTextboxLineColors(QList<int> base, QList<int> highlight) {
-    m_gcodeLineColor_base = QColor(base[0], base[1], base[2]);
+    m_gcodeLineColor_base      = QColor(base[0], base[1], base[2]);
     m_gcodeLineColor_highlight = QColor(highlight[0], highlight[1], highlight[2]);
 }
 void Theme::setGcodeTextboxLineColors(QColor base_color, QColor highlight_color) {
-    m_gcodeLineColor_base = base_color;
+    m_gcodeLineColor_base      = base_color;
     m_gcodeLineColor_highlight = highlight_color;
 }
 
-QColor Theme::getGcodeTextboxBaseLineColor() { return m_gcodeLineColor_base; }
+QColor Theme::getGcodeTextboxBaseLineColor() {
+    return m_gcodeLineColor_base;
+}
 
-QColor Theme::getGcodeTextboxHighlightLineColor() { return m_gcodeLineColor_highlight; }
+QColor Theme::getGcodeTextboxHighlightLineColor() {
+    return m_gcodeLineColor_highlight;
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/cmd_widget.cpp
+++ b/src/widgets/cmd_widget.cpp
@@ -9,15 +9,20 @@
 
 namespace ORNL {
 
-CmdWidget::CmdWidget(QWidget* parent) : QWidget(parent) { this->setupWidget(); }
+CmdWidget::CmdWidget(QWidget* parent) : QWidget(parent) {
+    this->setupWidget();
+}
 
-void CmdWidget::operator<<(QString str) { this->append(str); }
+void CmdWidget::operator<<(QString str) {
+    this->append(str);
+}
 
-void CmdWidget::print(QString str) { this->append(str); }
+void CmdWidget::print(QString str) {
+    this->append(str);
+}
 
 void CmdWidget::runCmd(QString cmd) {
-    if (cmd.isEmpty())
-        return;
+    if (cmd.isEmpty()) return;
     this->append(cmd);
 }
 
@@ -52,7 +57,9 @@ void CmdWidget::setupSubWidgets() {
     // m_accept->setToolTip("Submit");
 }
 
-void CmdWidget::setupLayout() { m_layout = new QGridLayout(this); }
+void CmdWidget::setupLayout() {
+    m_layout = new QGridLayout(this);
+}
 
 void CmdWidget::setupInsert() {
     m_layout->addWidget(m_output, 0, 0, 1, 2);
@@ -65,4 +72,4 @@ void CmdWidget::setupEvents() {
     // connect(m_accept, &QToolButton::pressed, this, &CmdWidget::fetchFromCmdEdit);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/gcode_info_control.cpp
+++ b/src/widgets/gcode_info_control.cpp
@@ -1,10 +1,10 @@
 #include "widgets/gcode_info_control.h"
 
+#include <QtMath>
 #include <algorithm>
 #include <cmath>
 #include <limits>
 
-#include <QtMath>
 #include <qboxlayout.h>
 #include <qcombobox.h>
 #include <qcontainerfwd.h>
@@ -31,46 +31,46 @@
 
 namespace ORNL {
 namespace {
-constexpr double kTwoPi = 6.28318530717958647692;
+constexpr double kTwoPi                    = 6.28318530717958647692;
 constexpr double kCenterlineArcSampleAngle = kTwoPi / 48.0;
 constexpr int kCenterlineBezierSampleCount = 48;
-constexpr double kDistanceEpsilon = 1.0e-9;
+constexpr double kDistanceEpsilon          = 1.0e-9;
 
-double clamp01(double value) { return std::max(0.0, std::min(1.0, value)); }
+double clamp01(double value) {
+    return std::max(0.0, std::min(1.0, value));
+}
 
-QVector3D viewPointToMicrons(const Point& point) { return point.toQVector3D() * Constants::OpenGL::kViewToObject; }
+QVector3D viewPointToMicrons(const Point& point) {
+    return point.toQVector3D() * Constants::OpenGL::kViewToObject;
+}
 
 QVector<QVector3D> linearCenterlineSamples(const QSharedPointer<SegmentBase>& segment) {
     return {viewPointToMicrons(segment->start()), viewPointToMicrons(segment->end())};
 }
 
 QVector<QVector3D> arcCenterlineSamples(const ArcSegment& arc) {
-    const Point start = arc.start();
-    const Point center = arc.center();
-    const Point end = arc.end();
+    const Point start   = arc.start();
+    const Point center  = arc.center();
+    const Point end     = arc.end();
     const double radius = std::hypot(start.x() - center.x(), start.y() - center.y());
-    const double sweep = arc.angle()();
+    const double sweep  = arc.angle()();
 
     if (!std::isfinite(radius) || !std::isfinite(sweep) || radius <= kDistanceEpsilon || sweep <= kDistanceEpsilon) {
         return {viewPointToMicrons(start), viewPointToMicrons(end)};
     }
 
-    const int sample_count = std::max(1, static_cast<int>(std::ceil(std::abs(sweep) / kCenterlineArcSampleAngle)));
-    const double start_angle = std::atan2(start.y() - center.y(), start.x() - center.x());
+    const int sample_count    = std::max(1, static_cast<int>(std::ceil(std::abs(sweep) / kCenterlineArcSampleAngle)));
+    const double start_angle  = std::atan2(start.y() - center.y(), start.x() - center.x());
     const double signed_sweep = arc.counterclockwise() ? sweep : -sweep;
-    const double z_delta = end.z() - start.z();
+    const double z_delta      = end.z() - start.z();
 
     QVector<QVector3D> samples;
     samples.reserve(sample_count + 1);
     for (int i = 0; i <= sample_count; ++i) {
-        if (i == 0) {
-            samples.push_back(viewPointToMicrons(start));
-        }
-        else if (i == sample_count) {
-            samples.push_back(viewPointToMicrons(end));
-        }
+        if (i == 0) { samples.push_back(viewPointToMicrons(start)); }
+        else if (i == sample_count) { samples.push_back(viewPointToMicrons(end)); }
         else {
-            const double t = static_cast<double>(i) / static_cast<double>(sample_count);
+            const double t     = static_cast<double>(i) / static_cast<double>(sample_count);
             const double angle = start_angle + (signed_sweep * t);
             samples.push_back(QVector3D(center.x() + (radius * std::cos(angle)),
                                         center.y() + (radius * std::sin(angle)), start.z() + (z_delta * t)) *
@@ -92,45 +92,35 @@ QVector<QVector3D> bezierCenterlineSamples(BezierSegment& bezier) {
 }
 
 QVector<QVector3D> centerlineSamples(const QSharedPointer<SegmentBase>& segment) {
-    if (segment.isNull()) {
-        return {};
-    }
+    if (segment.isNull()) { return {}; }
 
-    if (const auto* arc = dynamic_cast<ArcSegment*>(segment.data())) {
-        return arcCenterlineSamples(*arc);
-    }
-    if (auto* bezier = dynamic_cast<BezierSegment*>(segment.data())) {
-        return bezierCenterlineSamples(*bezier);
-    }
+    if (const auto* arc = dynamic_cast<ArcSegment*>(segment.data())) { return arcCenterlineSamples(*arc); }
+    if (auto* bezier = dynamic_cast<BezierSegment*>(segment.data())) { return bezierCenterlineSamples(*bezier); }
 
     return linearCenterlineSamples(segment);
 }
 
 double lineSegmentDistance(const QVector3D& first_start, const QVector3D& first_end, const QVector3D& second_start,
                            const QVector3D& second_end) {
-    const QVector3D first_direction = first_end - first_start;
+    const QVector3D first_direction  = first_end - first_start;
     const QVector3D second_direction = second_end - second_start;
-    const QVector3D start_delta = first_start - second_start;
+    const QVector3D start_delta      = first_start - second_start;
 
-    const double first_length_squared = QVector3D::dotProduct(first_direction, first_direction);
+    const double first_length_squared  = QVector3D::dotProduct(first_direction, first_direction);
     const double second_length_squared = QVector3D::dotProduct(second_direction, second_direction);
-    const double second_projection = QVector3D::dotProduct(second_direction, start_delta);
+    const double second_projection     = QVector3D::dotProduct(second_direction, start_delta);
 
-    double first_t = 0.0;
+    double first_t  = 0.0;
     double second_t = 0.0;
 
     if (first_length_squared <= kDistanceEpsilon && second_length_squared <= kDistanceEpsilon) {
         return first_start.distanceToPoint(second_start);
     }
 
-    if (first_length_squared <= kDistanceEpsilon) {
-        second_t = clamp01(second_projection / second_length_squared);
-    }
+    if (first_length_squared <= kDistanceEpsilon) { second_t = clamp01(second_projection / second_length_squared); }
     else {
         const double first_projection = QVector3D::dotProduct(first_direction, start_delta);
-        if (second_length_squared <= kDistanceEpsilon) {
-            first_t = clamp01(-first_projection / first_length_squared);
-        }
+        if (second_length_squared <= kDistanceEpsilon) { first_t = clamp01(-first_projection / first_length_squared); }
         else {
             const double direction_projection = QVector3D::dotProduct(first_direction, second_direction);
             const double denominator =
@@ -145,24 +135,22 @@ double lineSegmentDistance(const QVector3D& first_start, const QVector3D& first_
             second_t = (direction_projection * first_t + second_projection) / second_length_squared;
             if (second_t < 0.0) {
                 second_t = 0.0;
-                first_t = clamp01(-first_projection / first_length_squared);
+                first_t  = clamp01(-first_projection / first_length_squared);
             }
             else if (second_t > 1.0) {
                 second_t = 1.0;
-                first_t = clamp01((direction_projection - first_projection) / first_length_squared);
+                first_t  = clamp01((direction_projection - first_projection) / first_length_squared);
             }
         }
     }
 
-    const QVector3D first_closest = first_start + (first_direction * static_cast<float>(first_t));
+    const QVector3D first_closest  = first_start + (first_direction * static_cast<float>(first_t));
     const QVector3D second_closest = second_start + (second_direction * static_cast<float>(second_t));
     return first_closest.distanceToPoint(second_closest);
 }
 
 int centerlineSegmentCount(const QVector<QVector3D>& samples) {
-    if (samples.isEmpty()) {
-        return 0;
-    }
+    if (samples.isEmpty()) { return 0; }
     return std::max(1, static_cast<int>(samples.size()) - 1);
 }
 
@@ -175,13 +163,11 @@ QVector3D centerlineSegmentEnd(const QVector<QVector3D>& samples, int index) {
 }
 
 double centerlineDistance(const QSharedPointer<SegmentBase>& first, const QSharedPointer<SegmentBase>& second) {
-    const QVector<QVector3D> first_samples = centerlineSamples(first);
+    const QVector<QVector3D> first_samples  = centerlineSamples(first);
     const QVector<QVector3D> second_samples = centerlineSamples(second);
-    const int first_segment_count = centerlineSegmentCount(first_samples);
-    const int second_segment_count = centerlineSegmentCount(second_samples);
-    if (first_segment_count == 0 || second_segment_count == 0) {
-        return std::numeric_limits<double>::infinity();
-    }
+    const int first_segment_count           = centerlineSegmentCount(first_samples);
+    const int second_segment_count          = centerlineSegmentCount(second_samples);
+    if (first_segment_count == 0 || second_segment_count == 0) { return std::numeric_limits<double>::infinity(); }
 
     double min_distance = std::numeric_limits<double>::infinity();
     for (int first_index = 0; first_index < first_segment_count; ++first_index) {
@@ -196,9 +182,11 @@ double centerlineDistance(const QSharedPointer<SegmentBase>& first, const QShare
 
     return min_distance;
 }
-} // namespace
+}  // namespace
 
-GCodeInfoControl::GCodeInfoControl(QWidget* parent) : QWidget(parent) { setupWidget(); }
+GCodeInfoControl::GCodeInfoControl(QWidget* parent) : QWidget(parent) {
+    setupWidget();
+}
 
 void GCodeInfoControl::setGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
     m_gcode = gcode;
@@ -247,8 +235,7 @@ void GCodeInfoControl::addSegmentInfo(int selectedLineNumber) {
     if (index < 0) {
         index = 0;
         for (; index < m_line_no_list.length(); ++index) {
-            if (m_line_no_list[index] > selectedLineNumber)
-                break;
+            if (m_line_no_list[index] > selectedLineNumber) break;
         }
 
         m_line_no_list.insert(index, selectedLineNumber);
@@ -268,22 +255,16 @@ void GCodeInfoControl::removeSegmentInfo(int selectedLineNumber) {
     m_line_no_list.removeAt(index);
     m_headercb_lines->removeItem(index);
 
-    if (m_line_no_list.isEmpty() || m_headercb_lines->currentIndex() < 0) {
-        fillSegmentInfo(0);
-    }
-    else {
-        fillSegmentInfo(m_line_no_list[m_headercb_lines->currentIndex()]);
-    }
+    if (m_line_no_list.isEmpty() || m_headercb_lines->currentIndex() < 0) { fillSegmentInfo(0); }
+    else { fillSegmentInfo(m_line_no_list[m_headercb_lines->currentIndex()]); }
 }
 
 QSharedPointer<SegmentBase> GCodeInfoControl::segmentForLine(uint lineNo) {
     for (auto& layer : m_gcode) {
-        if (layer.isEmpty() || layer.back()->lineNumber() < lineNo)
-            continue;
+        if (layer.isEmpty() || layer.back()->lineNumber() < lineNo) continue;
 
         for (auto& seg : layer) {
-            if (seg->lineNumber() == lineNo)
-                return seg;
+            if (seg->lineNumber() == lineNo) return seg;
         }
     }
 
@@ -292,21 +273,18 @@ QSharedPointer<SegmentBase> GCodeInfoControl::segmentForLine(uint lineNo) {
 
 void GCodeInfoControl::updateCenterDistanceInfo(uint lineNo) {
     m_infolbl_center_distance->setText("");
-    if (m_line_no_list.size() != 2)
-        return;
+    if (m_line_no_list.size() != 2) return;
 
-    const int first_line = m_line_no_list.first();
+    const int first_line  = m_line_no_list.first();
     const int second_line = m_line_no_list.last();
-    const int other_line = first_line == static_cast<int>(lineNo) ? second_line : first_line;
+    const int other_line  = first_line == static_cast<int>(lineNo) ? second_line : first_line;
 
     QSharedPointer<SegmentBase> current_segment = segmentForLine(lineNo);
-    QSharedPointer<SegmentBase> other_segment = segmentForLine(other_line);
-    if (current_segment.isNull() || other_segment.isNull())
-        return;
+    QSharedPointer<SegmentBase> other_segment   = segmentForLine(other_line);
+    if (current_segment.isNull() || other_segment.isNull()) return;
 
     const double distance = centerlineDistance(current_segment, other_segment);
-    if (!std::isfinite(distance))
-        return;
+    if (!std::isfinite(distance)) return;
 
     m_infolbl_center_distance->setText(QString("Line %1: %2").arg(other_line).arg(formatDistance(distance)));
 }
@@ -336,17 +314,11 @@ void GCodeInfoControl::updateDirectionForSegment(const QSharedPointer<SegmentBas
     auto& meta = segment->m_segment_info_meta;
     QVector3D direction(meta.end.x() - meta.start.x(), meta.end.y() - meta.start.y(), meta.end.z() - meta.start.z());
 
-    if (meta.isXYmove()) {
-        updateDirection(viewAngleForDirection(direction, 360 - meta.getCCWXAngle()));
-    }
+    if (meta.isXYmove()) { updateDirection(viewAngleForDirection(direction, 360 - meta.getCCWXAngle())); }
     else {
         float diff = meta.getZChange();
-        if (diff == 0) {
-            m_infolbl_direction->setVisible(false);
-        }
-        else {
-            updateZDirection(viewAngleForDirection(direction, diff > 0 ? 180 : 0));
-        }
+        if (diff == 0) { m_infolbl_direction->setVisible(false); }
+        else { updateZDirection(viewAngleForDirection(direction, diff > 0 ? 180 : 0)); }
     }
 }
 
@@ -360,8 +332,7 @@ double GCodeInfoControl::viewAngleForDirection(const QVector3D& direction, doubl
     }
 
     double angle = qRadiansToDegrees(std::atan2(view_direction.y(), view_direction.x()));
-    if (angle < 0.0)
-        angle += 360.0;
+    if (angle < 0.0) angle += 360.0;
 
     return 360.0 - angle;
 }
@@ -374,19 +345,19 @@ void GCodeInfoControl::setViewMatrix(const QMatrix4x4& viewMatrix) {
 void GCodeInfoControl::setupWidget() {
     QLabel* lbl2DAxis = new QLabel;
 
-    m_infolbl_type = new QLabel;
-    m_infolbl_speed = new QLabel;
-    m_infolbl_extruder_speed = new QLabel;
-    m_infolbl_length = new QLabel;
+    m_infolbl_type            = new QLabel;
+    m_infolbl_speed           = new QLabel;
+    m_infolbl_extruder_speed  = new QLabel;
+    m_infolbl_length          = new QLabel;
     m_infolbl_center_distance = new QLabel;
-    m_infolbl_layer_no = new QLabel;
-    m_infolbl_line_no = new QLabel;
-    m_infolbl_direction = new QLabel;
-    m_infopm_direction = new QPixmap(":/icons/right_flat.png");
-    m_infopm_direction_z = new QPixmap(":/icons/down_black.png");
+    m_infolbl_layer_no        = new QLabel;
+    m_infolbl_line_no         = new QLabel;
+    m_infolbl_direction       = new QLabel;
+    m_infopm_direction        = new QPixmap(":/icons/right_flat.png");
+    m_infopm_direction_z      = new QPixmap(":/icons/down_black.png");
     lbl2DAxis->setPixmap(QPixmap(":/icons/2d_axis.png"));
 
-    m_info_display = new QFrame;
+    m_info_display           = new QFrame;
     m_info_display_indicator = new QLabel;
     m_info_display_indicator->setPixmap(QPixmap(":/icons/down_black.png"));
 
@@ -482,4 +453,4 @@ void GCodeInfoControl::setupHeaderWidget() {
     hlayout->addWidget(line);
     hlayout->addWidget(m_headercb_lines);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/gcode_widget.cpp
+++ b/src/widgets/gcode_widget.cpp
@@ -1,6 +1,7 @@
 #include "widgets/gcode_widget.h"
 
 #include <QResizeEvent>
+
 #include <qboxlayout.h>
 #include <qcontainerfwd.h>
 #include <qobject.h>
@@ -21,37 +22,49 @@
 #include "widgets/view_controls_toolbar.h"
 
 namespace ORNL {
-GCodeWidget::GCodeWidget(QWidget* parent) : QWidget(parent) { this->setupWidget(); }
+GCodeWidget::GCodeWidget(QWidget* parent) : QWidget(parent) {
+    this->setupWidget();
+}
 
 GCodeView* GCodeWidget::view() {
-    m_view_controls->raise(); // If the gcode view is changed, the controls need to be raised as well
+    m_view_controls->raise();  // If the gcode view is changed, the controls need to be raised as well
     return m_gcode_view;
 }
 
-void GCodeWidget::setPartMeta(QSharedPointer<PartMetaModel> meta) { m_gcode_view->setMeta(meta); }
+void GCodeWidget::setPartMeta(QSharedPointer<PartMetaModel> meta) {
+    m_gcode_view->setMeta(meta);
+}
 
-void GCodeWidget::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) { m_gcode_view->addGCode(gcode); }
+void GCodeWidget::addGCode(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
+    m_gcode_view->addGCode(gcode);
+}
 
-void GCodeWidget::clear() { m_gcode_view->clear(); }
+void GCodeWidget::clear() {
+    m_gcode_view->clear();
+}
 
 void GCodeWidget::setOrthoView(bool status) {
     const bool changed = m_ortho_enabled != status;
-    m_ortho_enabled = status;
+    m_ortho_enabled    = status;
 
     m_view_controls->setProjectionControlsEnabled(!status);
     m_view_controls->setOrthographicViewChecked(status);
     m_gcode_view->useOrthographic(status);
 
-    if (changed) {
-        emit orthographicViewChanged(status);
-    }
+    if (changed) { emit orthographicViewChanged(status); }
 }
 
-void GCodeWidget::showSegmentInfo(bool show) { m_segment_info_control->setVisible(show); }
+void GCodeWidget::showSegmentInfo(bool show) {
+    m_segment_info_control->setVisible(show);
+}
 
-void GCodeWidget::showGhosts(bool status) { m_gcode_view->showGhosts(status); }
+void GCodeWidget::showGhosts(bool status) {
+    m_gcode_view->showGhosts(status);
+}
 
-void GCodeWidget::showSeams(bool show) { m_gcode_view->showSeams(show); }
+void GCodeWidget::showSeams(bool show) {
+    m_gcode_view->showSeams(show);
+}
 
 void GCodeWidget::handleModifiedSetting(QString key) {
     static const auto printer_settings = QSet<QString> {PRS::Dimensions::kXMin,
@@ -102,21 +115,25 @@ void GCodeWidget::handleModifiedSetting(QString key) {
                                                              PRS::Dimensions::kXOffset,
                                                              PRS::Dimensions::kYOffset};
 
-    if (printer_settings.contains(key)) {
-        m_gcode_view->updatePrinterSettings(GSM->getGlobal());
-    }
-    else if (optimization_settings.contains(key)) {
-        m_gcode_view->updateOptimizationSettings(GSM->getGlobal());
-    }
+    if (printer_settings.contains(key)) { m_gcode_view->updatePrinterSettings(GSM->getGlobal()); }
+    else if (optimization_settings.contains(key)) { m_gcode_view->updateOptimizationSettings(GSM->getGlobal()); }
 }
 
-void GCodeWidget::zoomIn() { m_gcode_view->zoomIn(); }
+void GCodeWidget::zoomIn() {
+    m_gcode_view->zoomIn();
+}
 
-void GCodeWidget::zoomOut() { m_gcode_view->zoomOut(); }
+void GCodeWidget::zoomOut() {
+    m_gcode_view->zoomOut();
+}
 
-void GCodeWidget::resetZoom() { m_gcode_view->resetZoom(); }
+void GCodeWidget::resetZoom() {
+    m_gcode_view->resetZoom();
+}
 
-void GCodeWidget::resetCamera() { m_gcode_view->resetCamera(); }
+void GCodeWidget::resetCamera() {
+    m_gcode_view->resetCamera();
+}
 
 void GCodeWidget::setupWidget() {
     this->setupSubWidgets();
@@ -142,12 +159,8 @@ void GCodeWidget::setupSubWidgets() {
     m_gcode_view->resize(this->width(), this->height());
     m_gcode_view->setFormat(format);
     SegmentDisplayType types = SegmentDisplayType::kNone;
-    if (PreferencesManager::getInstance()->getHideTravelPreference()) {
-        types |= SegmentDisplayType::kTravel;
-    }
-    if (PreferencesManager::getInstance()->getHideSupportPreference()) {
-        types |= SegmentDisplayType::kSupport;
-    }
+    if (PreferencesManager::getInstance()->getHideTravelPreference()) { types |= SegmentDisplayType::kTravel; }
+    if (PreferencesManager::getInstance()->getHideSupportPreference()) { types |= SegmentDisplayType::kSupport; }
     m_gcode_view->hideSegmentType(types, true);
 
     // View Controls
@@ -184,4 +197,4 @@ void GCodeWidget::resizeEvent(QResizeEvent* event) {
 
     emit resized(event->size());
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/gcodebar.cpp
+++ b/src/widgets/gcodebar.cpp
@@ -4,6 +4,7 @@
 #include <QPushButton>
 #include <QStandardPaths>
 #include <QTextDocumentWriter>
+
 #include <qcheckbox.h>
 #include <qcombobox.h>
 #include <qframe.h>
@@ -48,9 +49,7 @@ void GcodeBar::updateGcodeText(QString text, QHash<QString, QTextCharFormat> fon
 
     // Preserve the last search without running an empty-document search over large G-code files.
     m_search_count = 0;
-    if (!m_search_bar->text().trimmed().isEmpty()) {
-        search();
-    }
+    if (!m_search_bar->text().trimmed().isEmpty()) { search(); }
 }
 
 void GcodeBar::clear() {
@@ -98,8 +97,7 @@ void GcodeBar::updateLowerSlider(int new_value) {
 }
 
 void GcodeBar::forwardLowerLayerUpdate(int new_value) {
-    if (m_lock_layer->isChecked())
-        m_layer_upper->setValue(new_value + m_lock_distance);
+    if (m_lock_layer->isChecked()) m_layer_upper->setValue(new_value + m_lock_distance);
     // Before we forward, we should check if the new upper layer value is less than the lower layer,
     // and if so, set the lower layer to the upper layer.
     else if (new_value > m_layer_upper->value()) {
@@ -140,8 +138,7 @@ void GcodeBar::updateUpperSlider(int new_value) {
 }
 
 void GcodeBar::forwardUpperLayerUpdate(int new_value) {
-    if (m_lock_layer->isChecked())
-        m_layer_lower->setValue(new_value - m_lock_distance);
+    if (m_lock_layer->isChecked()) m_layer_lower->setValue(new_value - m_lock_distance);
     // Before we forward, we should check if the new upper layer value is less than the lower layer,
     // and if so, set the lower layer to the upper layer.
     else if (new_value < m_layer_lower->value()) {
@@ -202,8 +199,7 @@ void GcodeBar::forwardLineChange(QList<int> linesToAdd, QList<int> linesToRemove
     if (linesToAdd.count() == 1 && linesToAdd[0] > 0) {
         int layerNumber = 0;
         for (int layerStartLine : m_layer_first_line_numbers) {
-            if (layerStartLine > linesToAdd[0] + 1)
-                break;
+            if (layerStartLine > linesToAdd[0] + 1) break;
             ++layerNumber;
         }
         --layerNumber;
@@ -236,8 +232,7 @@ void GcodeBar::setMaxLayer(int max_value) {
 void GcodeBar::setMaxSegment(int max_value) {
     // If layer has no geometry, max_value will be negative one
     // Make max_value zero to show no geometry exists
-    if (max_value < 0)
-        max_value = 0;
+    if (max_value < 0) max_value = 0;
 
     m_segment_lower->setMaximum(max_value);
     m_segment_lower_slider->setMaximum(max_value);
@@ -263,7 +258,6 @@ void GcodeBar::setupWidget() {
 }
 
 void GcodeBar::setupSubWidgets() {
-
     // Search Separator
     m_search_separator = new QFrame(this);
     m_search_separator->setFrameShape(QFrame::HLine);
@@ -443,8 +437,7 @@ void GcodeBar::setupEvents() {
     });
 
     connect(m_lock_layer, &QCheckBox::clicked, [this] {
-        if (m_lock_layer->isChecked())
-            m_lock_distance = m_layer_upper->value() - m_layer_lower->value();
+        if (m_lock_layer->isChecked()) m_lock_distance = m_layer_upper->value() - m_layer_lower->value();
     });
 
     // Timeout occurs when the timer is up, and the next layer or segment is drawn
@@ -479,12 +472,10 @@ void GcodeBar::search() {
 }
 
 void GcodeBar::updateRefreshButton(bool change) {
-
     // Don't enable the refresh button if the change is for formatting resulted from a search
     // QPlainTextEdit::modificationChanged is for all types of modifications. No signal available for content change
     // only
-    if (!m_search_only_change)
-        m_refresh_btn->setEnabled(change);
+    if (!m_search_only_change) m_refresh_btn->setEnabled(change);
 }
 
 void GcodeBar::updatePlayButton() {
@@ -517,10 +508,8 @@ void GcodeBar::updateSegmentPlayButton() {
         m_segment_play_btn->setToolTip("Start playing segments");
     }
     else {
-        if (m_hide_travel->isChecked())
-            m_hide_travel->click();
-        if (m_hide_support->isChecked())
-            m_hide_support->click();
+        if (m_hide_travel->isChecked()) m_hide_travel->click();
+        if (m_hide_support->isChecked()) m_hide_support->click();
 
         // Delay between drawing segments in milliseconds
         int draw_time = PreferencesManager::getInstance()->getSegmentLag();
@@ -561,4 +550,4 @@ void GcodeBar::drawNextSegment() {
         m_segment_play_btn->setToolTip("Start playing segments");
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/gcodehighlighter.cpp
+++ b/src/widgets/gcodehighlighter.cpp
@@ -8,13 +8,13 @@
 namespace ORNL {
 GcodeHighlighter::GcodeHighlighter(QTextDocument* parent) : QSyntaxHighlighter(parent) {}
 
-void GcodeHighlighter::setColorRules(QHash<QString, QTextCharFormat> colorHash) { m_color_hash = colorHash; }
+void GcodeHighlighter::setColorRules(QHash<QString, QTextCharFormat> colorHash) {
+    m_color_hash = colorHash;
+}
 
 void GcodeHighlighter::highlightBlock(const QString& text) {
     const auto color = m_color_hash.constFind(text);
-    if (color != m_color_hash.constEnd()) {
-        setFormat(0, text.length(), color.value());
-    }
+    if (color != m_color_hash.constEnd()) { setFormat(0, text.length(), color.value()); }
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/gcodetextboxwidget.cpp
+++ b/src/widgets/gcodetextboxwidget.cpp
@@ -23,7 +23,10 @@
 
 namespace ORNL {
 GcodeTextBoxWidget::GcodeTextBoxWidget(QWidget* parent)
-    : QPlainTextEdit(parent), m_highlighter(this->document()), m_previous_line(0), m_last_block_count(0),
+    : QPlainTextEdit(parent),
+      m_highlighter(this->document()),
+      m_previous_line(0),
+      m_last_block_count(0),
       m_last_block_clicked_on(0) {
     setLineWrapMode(QPlainTextEdit::NoWrap);
 
@@ -45,9 +48,9 @@ void GcodeTextBoxWidget::lineNumbersPaintEvent(QPaintEvent* event) {
     painter.fillRect(event->rect(), QColor(255, 255, 255, 100));
 
     QTextBlock block = firstVisibleBlock();
-    int blockNumber = block.blockNumber();
-    int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
-    int bottom = top + static_cast<int>(blockBoundingRect(block).height());
+    int blockNumber  = block.blockNumber();
+    int top          = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
+    int bottom       = top + static_cast<int>(blockBoundingRect(block).height());
 
     while (block.isValid() && top <= event->rect().bottom()) {
         if (block.isVisible() && bottom >= event->rect().top()) {
@@ -57,8 +60,8 @@ void GcodeTextBoxWidget::lineNumbersPaintEvent(QPaintEvent* event) {
                              number);
         }
 
-        block = block.next();
-        top = bottom;
+        block  = block.next();
+        top    = bottom;
         bottom = top + static_cast<int>(blockBoundingRect(block).height());
         ++blockNumber;
     }
@@ -68,7 +71,9 @@ int GcodeTextBoxWidget::calculateLineNumbersDisplayWidth() {
     return 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * ceil(log10(std::max<int>(2, blockCount())) + 1);
 }
 
-int GcodeTextBoxWidget::getCursorBlockNumber() { return textCursor().block().blockNumber(); }
+int GcodeTextBoxWidget::getCursorBlockNumber() {
+    return textCursor().block().blockNumber();
+}
 
 void GcodeTextBoxWidget::highlightLine(QList<int> linesToAdd, QList<int> linesToRemove, bool shouldCenter) {
     QTextCursor manipulate_cursor(textCursor());
@@ -85,8 +90,7 @@ void GcodeTextBoxWidget::highlightLine(QList<int> linesToAdd, QList<int> linesTo
         format.setBackground(QBrush(PreferencesManager::getInstance()->getTheme().getGcodeTextboxHighlightLineColor()));
         manipulate_cursor.setBlockFormat(format);
         setTextCursor(manipulate_cursor);
-        if (shouldCenter)
-            this->centerCursor();
+        if (shouldCenter) this->centerCursor();
 
         m_selected_blocks.insert(line_num);
     }
@@ -114,17 +118,17 @@ bool GcodeTextBoxWidget::getCursorManualMove() {
     return m_manual_cursor_move;
 }
 
-void GcodeTextBoxWidget::setCursorManualMoveFalse() { m_manual_cursor_move = false; }
+void GcodeTextBoxWidget::setCursorManualMoveFalse() {
+    m_manual_cursor_move = false;
+}
 
 void GcodeTextBoxWidget::moveCursorToLine(int line_num) {
     if (!m_manual_cursor_move) {
         // move further down and move back to the line to ensure that the GCode editor will place the line on top
-        int visible_lines = this->height() / this->fontMetrics().height();
+        int visible_lines    = this->height() / this->fontMetrics().height();
         int move_ahead_lines = std::min(document()->blockCount() - line_num, visible_lines);
-        QTextBlock block = document()->findBlockByLineNumber(line_num + move_ahead_lines);
-        if (block.isValid()) {
-            setTextCursor(QTextCursor(block));
-        }
+        QTextBlock block     = document()->findBlockByLineNumber(line_num + move_ahead_lines);
+        if (block.isValid()) { setTextCursor(QTextCursor(block)); }
     }
 
     setTextCursor(QTextCursor(document()->findBlockByLineNumber(line_num - 1)));
@@ -132,7 +136,7 @@ void GcodeTextBoxWidget::moveCursorToLine(int line_num) {
 }
 
 void GcodeTextBoxWidget::resetHighlight() {
-    m_previous_line = -1;
+    m_previous_line     = -1;
     m_highlighted_block = QTextBlock();
 }
 
@@ -167,16 +171,10 @@ void GcodeTextBoxWidget::updateLineNumberDisplayAreaWidth(int blockCount) {
 }
 
 void GcodeTextBoxWidget::updateLineNumberDisplayArea(const QRect& rect, int height) {
-    if (height) {
-        m_line_number_display_area->scroll(0, height);
-    }
-    else {
-        m_line_number_display_area->update(0, rect.y(), m_line_number_display_area->width(), rect.height());
-    }
+    if (height) { m_line_number_display_area->scroll(0, height); }
+    else { m_line_number_display_area->update(0, rect.y(), m_line_number_display_area->width(), rect.height()); }
 
-    if (rect.contains(viewport()->rect())) {
-        setViewportMargins(calculateLineNumbersDisplayWidth(), 0, 0, 0);
-    }
+    if (rect.contains(viewport()->rect())) { setViewportMargins(calculateLineNumbersDisplayWidth(), 0, 0, 0); }
 }
 
 void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
@@ -184,8 +182,7 @@ void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
 
     QPlainTextEdit::mouseReleaseEvent(event);
 
-    if (event->button() != Qt::LeftButton)
-        return;
+    if (event->button() != Qt::LeftButton) return;
 
     m_manual_cursor_move = true;
 
@@ -195,9 +192,7 @@ void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
         return;
     }
 
-    if (m_previous_line == textCursor().blockNumber()) {
-        return;
-    }
+    if (m_previous_line == textCursor().blockNumber()) { return; }
 
     QList<int> linesToAdd, linesToRemove;
     if (modifier == Qt::ControlModifier) {
@@ -213,27 +208,24 @@ void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
         std::sort(minMaxVec.begin(), minMaxVec.end());
 
         for (int i = minMaxVec[0]; i < minMaxVec[1]; ++i) {
-            if (!m_selected_blocks.contains(i))
-                linesToAdd.push_back(i);
+            if (!m_selected_blocks.contains(i)) linesToAdd.push_back(i);
         }
         for (int key : m_selected_blocks.values()) {
-            if (key < minMaxVec[0] || key > minMaxVec[1])
-                linesToRemove.push_back(key);
+            if (key < minMaxVec[0] || key > minMaxVec[1]) linesToRemove.push_back(key);
         }
     }
     else {
         if (!textCursor().selection().isEmpty()) {
             QTextCursor cursor_copy(textCursor());
             int start = textCursor().selectionStart();
-            int end = textCursor().selectionEnd();
+            int end   = textCursor().selectionEnd();
             cursor_copy.setPosition(start);
             int firstLine = cursor_copy.blockNumber();
             cursor_copy.setPosition(end);
             int lastLine = cursor_copy.blockNumber();
 
             for (int i = firstLine; i <= lastLine; ++i) {
-                if (!m_selected_blocks.contains(i))
-                    linesToAdd.push_back(i);
+                if (!m_selected_blocks.contains(i)) linesToAdd.push_back(i);
             }
         }
         else {
@@ -247,8 +239,7 @@ void GcodeTextBoxWidget::mouseReleaseEvent(QMouseEvent* event) {
 
     verticalScrollBar()->setValue(scrollPos);
     QTextBlock clicked_block = document()->findBlockByLineNumber(m_last_block_clicked_on);
-    if (clicked_block.isValid())
-        setTextCursor(QTextCursor(clicked_block));
+    if (clicked_block.isValid()) setTextCursor(QTextCursor(clicked_block));
 }
 
 void GcodeTextBoxWidget::keyPressEvent(QKeyEvent* event) {
@@ -257,14 +248,10 @@ void GcodeTextBoxWidget::keyPressEvent(QKeyEvent* event) {
         linesToRemove = m_selected_blocks.values();
 
         m_manual_cursor_move = true;
-        int lineId = textCursor().blockNumber();
+        int lineId           = textCursor().blockNumber();
 
-        if (event->key() == Qt::Key_Up) {
-            --lineId;
-        }
-        else if (event->key() == Qt::Key_Down) {
-            ++lineId;
-        }
+        if (event->key() == Qt::Key_Up) { --lineId; }
+        else if (event->key() == Qt::Key_Down) { ++lineId; }
 
         linesToAdd.push_back(lineId);
         emit lineChange(linesToAdd, linesToRemove);
@@ -297,7 +284,7 @@ void GcodeTextBoxWidget::search(QString searchString, int searchCount) {
             // move the cursor there
             //   if the next match is currently visible on the current page, the page stays
             //   else jump to the page for the next match and set that line on top
-            int blockNumber = firstVisibleBlock().blockNumber();
+            int blockNumber   = firstVisibleBlock().blockNumber();
             int visible_lines = this->height() / this->fontMetrics().height();
             if (lineNum - blockNumber > visible_lines - 1 || lineNum < blockNumber)
                 m_manual_cursor_move = false;
@@ -306,9 +293,7 @@ void GcodeTextBoxWidget::search(QString searchString, int searchCount) {
 
             moveCursorToLine(lineNum + 1);
         }
-        else {
-            m_cursor_index = 0;
-        }
+        else { m_cursor_index = 0; }
     }
     else {
         // reset highlight cursor for a new search. GCode reload automatically resets the search
@@ -341,19 +326,17 @@ void GcodeTextBoxWidget::search(QString searchString, int searchCount) {
     QTextCharFormat focusedColorFormat = plainFormat;
     focusedColorFormat.setBackground(QColor(255, 100, 0));
 
-    bool found = false;
-    int lineNum = -1;
+    bool found    = false;
+    int lineNum   = -1;
     int matchedId = 0;
     while (!highlightCursor.isNull() && !highlightCursor.atEnd()) {
         highlightCursor = document->find(searchString, highlightCursor);
         if (!highlightCursor.isNull()) {
             m_matched_lines.append(highlightCursor.blockNumber());
-            if (lineNum < 0)
-                lineNum = highlightCursor.blockNumber();
+            if (lineNum < 0) lineNum = highlightCursor.blockNumber();
             found = true;
             highlightCursor.mergeCharFormat(matchedColorFormat);
-            if (matchedId == m_cursor_index)
-                highlightCursor.mergeCharFormat(focusedColorFormat);
+            if (matchedId == m_cursor_index) highlightCursor.mergeCharFormat(focusedColorFormat);
             ++matchedId;
         }
     }
@@ -361,10 +344,9 @@ void GcodeTextBoxWidget::search(QString searchString, int searchCount) {
     // leap to the first match for a fresh search
     if (found && m_cursor_index == 0) {
         // if the first match is not currently visible, move the cursor there
-        int blockNumber = firstVisibleBlock().blockNumber();
+        int blockNumber   = firstVisibleBlock().blockNumber();
         int visible_lines = this->height() / this->fontMetrics().height();
-        if (lineNum - blockNumber > visible_lines - 1 || lineNum < blockNumber)
-            moveCursorToLine(lineNum + 1);
+        if (lineNum - blockNumber > visible_lines - 1 || lineNum < blockNumber) moveCursorToLine(lineNum + 1);
     }
 
     cursor.endEditBlock();
@@ -372,4 +354,4 @@ void GcodeTextBoxWidget::search(QString searchString, int searchCount) {
     // this is necessary to make the PlainTextEdit emit modification signal again for content editing
     document->setModified(false);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/graphics_view/grid_scene.cpp
+++ b/src/widgets/graphics_view/grid_scene.cpp
@@ -2,6 +2,7 @@
 
 #include <QDebug>
 #include <QPainter>
+
 #include <qcolor.h>
 #include <qgraphicsscene.h>
 #include <qnamespace.h>
@@ -10,9 +11,13 @@
 #include "utilities/mathutils.h"
 
 namespace ORNL {
-GridScene::GridScene(QObject* parent) : QGraphicsScene(parent) { m_grid_step = 20; }
+GridScene::GridScene(QObject* parent) : QGraphicsScene(parent) {
+    m_grid_step = 20;
+}
 
-void GridScene::setGridStep(int step) { m_grid_step = step; }
+void GridScene::setGridStep(int step) {
+    m_grid_step = step;
+}
 
 void GridScene::drawBackground(QPainter* painter, const QRectF& rect) {
     // Draw grid lines.
@@ -25,10 +30,10 @@ void GridScene::drawBackground(QPainter* painter, const QRectF& rect) {
     painter->setPen(p);
 
     QRectF scene_rect = this->sceneRect();
-    int scene_left = MathUtils::snap(scene_rect.left(), m_grid_step);
-    int scene_right = MathUtils::snap(scene_rect.right(), m_grid_step);
-    int scene_top = MathUtils::snap(scene_rect.top(), m_grid_step);
-    int scene_bottom = MathUtils::snap(scene_rect.bottom(), m_grid_step);
+    int scene_left    = MathUtils::snap(scene_rect.left(), m_grid_step);
+    int scene_right   = MathUtils::snap(scene_rect.right(), m_grid_step);
+    int scene_top     = MathUtils::snap(scene_rect.top(), m_grid_step);
+    int scene_bottom  = MathUtils::snap(scene_rect.bottom(), m_grid_step);
 
     for (int i = scene_left; i < scene_right; i += m_grid_step * 100) {
         painter->drawLine(i, scene_top, i, scene_bottom);
@@ -46,15 +51,13 @@ void GridScene::drawForeground(QPainter* painter, const QRectF& rect) {
 
         painter->setPen(dot_color);
 
-        int left = MathUtils::snap(rect.left(), m_grid_step) - m_grid_step;
-        int right = MathUtils::snap(rect.right(), m_grid_step) + m_grid_step;
-        int top = MathUtils::snap(rect.top(), m_grid_step) - m_grid_step;
+        int left   = MathUtils::snap(rect.left(), m_grid_step) - m_grid_step;
+        int right  = MathUtils::snap(rect.right(), m_grid_step) + m_grid_step;
+        int top    = MathUtils::snap(rect.top(), m_grid_step) - m_grid_step;
         int bottom = MathUtils::snap(rect.bottom(), m_grid_step) + m_grid_step;
 
         for (int i = left; i < right; i += m_grid_step) {
-            for (int j = top; j < bottom; j += m_grid_step) {
-                painter->drawPoint(i, j);
-            }
+            for (int j = top; j < bottom; j += m_grid_step) { painter->drawPoint(i, j); }
         }
     }
 
@@ -70,4 +73,4 @@ void GridScene::drawForeground(QPainter* painter, const QRectF& rect) {
     painter->drawLine(-5, 0, 5, 0);
     painter->drawLine(0, 5, 0, -5);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/graphics_view/polyline_item.cpp
+++ b/src/widgets/graphics_view/polyline_item.cpp
@@ -1,8 +1,8 @@
 #include "widgets/graphics_view/polyline_item.h"
 
+#include <QPainter>
 #include <cstdint>
 
-#include <QPainter>
 #include <qgraphicsitem.h>
 #include <qnamespace.h>
 #include <qobject.h>
@@ -11,7 +11,9 @@
 #include "geometry/polyline.h"
 
 namespace ORNL {
-PolylineGraphicsItem::PolylineGraphicsItem(QGraphicsItem* parent) : QGraphicsItem(parent) { m_color = Qt::green; }
+PolylineGraphicsItem::PolylineGraphicsItem(QGraphicsItem* parent) : QGraphicsItem(parent) {
+    m_color = Qt::green;
+}
 
 PolylineGraphicsItem::PolylineGraphicsItem(const Polyline& polyline, QGraphicsItem* parent) : QGraphicsItem(parent) {
     this->setPolyline(polyline);
@@ -19,23 +21,30 @@ PolylineGraphicsItem::PolylineGraphicsItem(const Polyline& polyline, QGraphicsIt
 }
 
 void PolylineGraphicsItem::setPolyline(const Polyline& polyline) {
-    m_polyline = polyline;
+    m_polyline      = polyline;
     m_bounding_rect = QRect(m_polyline.min().toQPoint() + QPoint(2, 2), m_polyline.max().toQPoint() + QPoint(2, 2));
 
     m_draw_to = polyline.size();
 }
 
-void PolylineGraphicsItem::setSegmentDraw(uint32_t segment_no) { m_draw_to = segment_no; }
+void PolylineGraphicsItem::setSegmentDraw(uint32_t segment_no) {
+    m_draw_to = segment_no;
+}
 
-Polyline PolylineGraphicsItem::getPolyline() const { return m_polyline; }
+Polyline PolylineGraphicsItem::getPolyline() const {
+    return m_polyline;
+}
 
-void PolylineGraphicsItem::setColor(QColor color) { m_color = color; }
+void PolylineGraphicsItem::setColor(QColor color) {
+    m_color = color;
+}
 
-QRectF PolylineGraphicsItem::boundingRect() const { return m_bounding_rect; }
+QRectF PolylineGraphicsItem::boundingRect() const {
+    return m_bounding_rect;
+}
 
 void PolylineGraphicsItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) {
-    if (m_polyline.count() <= 1)
-        return;
+    if (m_polyline.count() <= 1) return;
 
     QPen line_pen;
     line_pen.setColor(m_color);
@@ -56,8 +65,6 @@ void PolylineGraphicsItem::paint(QPainter* painter, const QStyleOptionGraphicsIt
     }
 
     painter->setPen(vertex_pen);
-    for (int i = 0; i < m_draw_to; i++) {
-        painter->drawPoint(m_polyline[i].toQPoint());
-    }
+    for (int i = 0; i < m_draw_to; i++) { painter->drawPoint(m_polyline[i].toQPoint()); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/layerbar.cpp
+++ b/src/widgets/layerbar.cpp
@@ -57,14 +57,14 @@
 
 namespace ORNL {
 LayerBar::LayerBar(QSharedPointer<PartMetaModel> pm, QWidget* parent) : QWidget(parent) {
-    m_model = pm;
+    m_model  = pm;
     m_layers = 0;
     m_position.resize(m_layers);
-    m_part = nullptr;
-    m_skip = 1;
+    m_part             = nullptr;
+    m_skip             = 1;
     m_last_clicked_dot = nullptr;
-    m_track_change = false;
-    m_original_y = 0;
+    m_track_change     = false;
+    m_original_y       = 0;
 
     setupActions();
 
@@ -76,17 +76,19 @@ LayerBar::LayerBar(QSharedPointer<PartMetaModel> pm, QWidget* parent) : QWidget(
     connect(m_model.get(), &PartMetaModel::itemRemovedUpdate, this, &LayerBar::removalUpdate);
 }
 
-LayerBar::~LayerBar() { qDeleteAll(m_position); }
+LayerBar::~LayerBar() {
+    qDeleteAll(m_position);
+}
 
-QSize LayerBar::sizeHint() const { return QSize(40, 200); }
+QSize LayerBar::sizeHint() const {
+    return QSize(40, 200);
+}
 
 void LayerBar::addSingle(int layer) {
-    if (layer < 0) {
-        return;
-    }
+    if (layer < 0) { return; }
 
-    LayerDot* new_dot = addDot(layer, false);  // visually add dot. Not from template
-    m_part->createSettingsRange(layer, layer); // add range to part
+    LayerDot* new_dot = addDot(layer, false);   // visually add dot. Not from template
+    m_part->createSettingsRange(layer, layer);  // add range to part
     updateLayerSettingsRangeAvailability();
     selectDot(new_dot);
     m_last_clicked_dot = new_dot;
@@ -95,8 +97,8 @@ void LayerBar::addSingle(int layer) {
 }
 
 void LayerBar::addSingleFromTemplate(int layer, QSharedPointer<SettingsBase> sb) {
-    LayerDot* new_dot = addDot(layer, true);       // visually add dot. From template
-    m_part->createSettingsRange(layer, layer, sb); // add range to part with settings base
+    LayerDot* new_dot = addDot(layer, true);        // visually add dot. From template
+    m_part->createSettingsRange(layer, layer, sb);  // add range to part with settings base
     updateLayerSettingsRangeAvailability();
     new_dot->isFromTemplate();
     selectDot(new_dot);
@@ -107,7 +109,7 @@ void LayerBar::addSingleFromTemplate(int layer, QSharedPointer<SettingsBase> sb)
 
 void LayerBar::addRange(int lower, int upper) {
     if (layerValid(lower) && layerValid(upper)) {
-        LayerDot* a = addDot(lower, false); // Not from template
+        LayerDot* a = addDot(lower, false);  // Not from template
         LayerDot* b = addDot(upper, false);
 
         dot_range* range = new dot_range;
@@ -126,7 +128,7 @@ void LayerBar::addRange(int lower, int upper) {
 
 void LayerBar::addRangeFromTemplate(int lower, int upper, QSharedPointer<SettingsBase> sb) {
     if (layerValid(lower) && layerValid(upper)) {
-        LayerDot* a = addDot(lower, true); // From template
+        LayerDot* a = addDot(lower, true);  // From template
         LayerDot* b = addDot(upper, true);
 
         a->isFromTemplate();
@@ -149,8 +151,7 @@ void LayerBar::addRangeFromTemplate(int lower, int upper, QSharedPointer<Setting
 void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
     // delete all the old dots / positions
     qDeleteAll(m_position);
-    for (auto& dot : m_position)
-        dot = nullptr;
+    for (auto& dot : m_position) dot = nullptr;
 
     m_selection.clear();
 
@@ -169,18 +170,18 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
         resizeEvent(nullptr);
 
         // reconstruct the dots, ranges and groups
-        QVector<dot_group*> dot_group_list; // keep a list of groups we've made so we don't make the same one twice
+        QVector<dot_group*> dot_group_list;  // keep a list of groups we've made so we don't make the same one twice
 
-        auto ranges = m_part->getSettingsRanges();
+        auto ranges              = m_part->getSettingsRanges();
         auto range_from_template = m_part->getRangesFromTemplate();
         for (auto range : ranges) {
-            int low = range->low();
-            int high = range->high();
-            QString group_name = range->groupName(); // only single dots can be in groups
-            int min = qMin(low, high);
-            int max = qMax(low, high);
+            int low            = range->low();
+            int high           = range->high();
+            QString group_name = range->groupName();  // only single dots can be in groups
+            int min            = qMin(low, high);
+            int max            = qMax(low, high);
 
-            if (low == high) // add Single
+            if (low == high)  // add Single
             {
                 LayerDot* new_dot;
 
@@ -188,19 +189,18 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
                     new_dot = addDot(low, false);
                 else
                     new_dot = addDot(low, true);
-                if (group_name.length() > 0) // dot is in a group
+                if (group_name.length() > 0)  // dot is in a group
                 {
                     dot_group* group = nullptr;
 
                     // look for the group in existing groups
                     for (int i = 0, end = dot_group_list.size(); i < end && group == nullptr; ++i) {
-                        if (dot_group_list[i]->group_name == group_name)
-                            group = dot_group_list[i];
+                        if (dot_group_list[i]->group_name == group_name) group = dot_group_list[i];
                     }
 
                     // if we didn't find the group in the list, make it & add to list
                     if (group == nullptr) {
-                        group = new dot_group;
+                        group             = new dot_group;
                         group->group_name = group_name;
                         dot_group_list.push_back(group);
                     }
@@ -210,7 +210,7 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
                     new_dot->setGroup(group);
                 }
             }
-            else // add range
+            else  // add range
             {
                 LayerDot* a;
                 LayerDot* b;
@@ -219,22 +219,22 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
                     a = addDot(low, false);
                     b = addDot(high, false);
                 }
-                else { // From template
+                else {  // From template
                     a = addDot(low, true);
                     b = addDot(high, true);
                 }
                 dot_range* range = new dot_range;
-                range->a = a;
-                range->b = b;
+                range->a         = a;
+                range->b         = b;
 
                 a->setRange(range);
                 b->setRange(range);
             }
         }
     }
-    else // Disable on settings/ clipping mesh or no part
+    else  // Disable on settings/ clipping mesh or no part
     {
-        m_part = nullptr;
+        m_part   = nullptr;
         m_layers = 0;
         m_position.resize(m_layers);
         m_selection.clear();
@@ -266,7 +266,7 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
         updateLayers();
         resizeEvent(nullptr);
         for (LayerDot* dot : m_position) {
-            if (dot != nullptr) // Delete current layer dots and load new ones from selected template
+            if (dot != nullptr)  // Delete current layer dots and load new ones from selected template
                 deleteSingle(dot);
         }
         loadTemplateLayers();
@@ -279,13 +279,11 @@ void LayerBar::changePart(QSharedPointer<PartMetaItem> item) {
     update();
 }
 
-void LayerBar::reselectPart() { // If no part selected
-    if (m_part == nullptr)
-        return;
+void LayerBar::reselectPart() {  // If no part selected
+    if (m_part == nullptr) return;
     // delete all the old dots / positions
     qDeleteAll(m_position);
-    for (auto& dot : m_position)
-        dot = nullptr;
+    for (auto& dot : m_position) dot = nullptr;
 
     m_selection.clear();
     // Clear dots if no template selected.
@@ -304,18 +302,18 @@ void LayerBar::reselectPart() { // If no part selected
         resizeEvent(nullptr);
 
         // reconstruct the dots, ranges and groups
-        QVector<dot_group*> dot_group_list; // keep a list of groups we've made so we don't make the same one twice
+        QVector<dot_group*> dot_group_list;  // keep a list of groups we've made so we don't make the same one twice
 
-        auto ranges = m_part->getSettingsRanges();
+        auto ranges              = m_part->getSettingsRanges();
         auto range_from_template = m_part->getRangesFromTemplate();
         for (auto range : ranges) {
-            int low = range->low();
-            int high = range->high();
-            QString group_name = range->groupName(); // only single dots can be in groups
-            int min = qMin(low, high);
-            int max = qMax(low, high);
+            int low            = range->low();
+            int high           = range->high();
+            QString group_name = range->groupName();  // only single dots can be in groups
+            int min            = qMin(low, high);
+            int max            = qMax(low, high);
 
-            if (low == high) // add Single
+            if (low == high)  // add Single
             {
                 LayerDot* new_dot;
 
@@ -323,19 +321,18 @@ void LayerBar::reselectPart() { // If no part selected
                     new_dot = addDot(low, false);
                 else
                     new_dot = addDot(low, true);
-                if (group_name.length() > 0) // dot is in a group
+                if (group_name.length() > 0)  // dot is in a group
                 {
                     dot_group* group = nullptr;
 
                     // look for the group in existing groups
                     for (int i = 0, end = dot_group_list.size(); i < end && group == nullptr; ++i) {
-                        if (dot_group_list[i]->group_name == group_name)
-                            group = dot_group_list[i];
+                        if (dot_group_list[i]->group_name == group_name) group = dot_group_list[i];
                     }
 
                     // if we didn't find the group in the list, make it & add to list
                     if (group == nullptr) {
-                        group = new dot_group;
+                        group             = new dot_group;
                         group->group_name = group_name;
                         dot_group_list.push_back(group);
                     }
@@ -345,7 +342,7 @@ void LayerBar::reselectPart() { // If no part selected
                     new_dot->setGroup(group);
                 }
             }
-            else // add range
+            else  // add range
             {
                 LayerDot* a;
                 LayerDot* b;
@@ -354,13 +351,13 @@ void LayerBar::reselectPart() { // If no part selected
                     a = addDot(low, false);
                     b = addDot(high, false);
                 }
-                else { // From template
+                else {  // From template
                     a = addDot(low, true);
                     b = addDot(high, true);
                 }
                 dot_range* range = new dot_range;
-                range->a = a;
-                range->b = b;
+                range->a         = a;
+                range->b         = b;
 
                 a->setRange(range);
                 b->setRange(range);
@@ -388,7 +385,7 @@ void LayerBar::reselectPart() { // If no part selected
         updateLayers();
         resizeEvent(nullptr);
         for (LayerDot* dot : m_position) {
-            if (dot != nullptr) // Delete current layer dots and load new ones from selected template
+            if (dot != nullptr)  // Delete current layer dots and load new ones from selected template
                 deleteSingle(dot);
         }
         loadTemplateLayers();
@@ -404,15 +401,15 @@ void LayerBar::reselectPart() { // If no part selected
 void LayerBar::loadTemplateLayers() {
     QVector<SettingsRange> sr = GSM->getLayerSettings();
     for (int i = 0, end = sr.size(); i < end; ++i) {
-        if (sr[i].high() <= m_layers) {        // Don't load layers that are higher than part height
-            if (sr[i].low() == sr[i].high()) { // If single layer
+        if (sr[i].high() <= m_layers) {         // Don't load layers that are higher than part height
+            if (sr[i].low() == sr[i].high()) {  // If single layer
                 addSingleFromTemplate(sr[i].low(), sr[i].getSb());
             }
-            else { // If range
+            else {  // If range
                 addRangeFromTemplate(sr[i].low(), sr[i].high(), sr[i].getSb());
             }
         }
-        else { // If not in range, add to deleted layers in case they need to be brought back if layerbar grows.
+        else {  // If not in range, add to deleted layers in case they need to be brought back if layerbar grows.
             m_deleted_ranges.push_back(sr[i]);
         }
     }
@@ -426,8 +423,7 @@ void LayerBar::removePart(QSharedPointer<Part> part) {
 }
 
 void LayerBar::deleteSelection() {
-    for (LayerDot* dot : m_selection)
-        deleteSingle(dot);
+    for (LayerDot* dot : m_selection) deleteSingle(dot);
 
     m_selection.clear();
     clearSelection();
@@ -436,11 +432,11 @@ void LayerBar::deleteSelection() {
 
 void LayerBar::setLayer() {
     bool ok;
-    bool moved = false;
-    LayerDot* dot = m_selection.back();
+    bool moved        = false;
+    LayerDot* dot     = m_selection.back();
     int orginal_layer = dot->getLayer();
-    int new_layer = QInputDialog::getInt(this, "Layer Entry", "Enter new layer number:", dot->getLayer() + 1, 1,
-                                         m_layers + 1, 1, &ok);
+    int new_layer     = QInputDialog::getInt(this, "Layer Entry", "Enter new layer number:", dot->getLayer() + 1, 1,
+                                             m_layers + 1, 1, &ok);
     new_layer--;
 
     moved = moveDotToLayer(dot, new_layer);
@@ -463,10 +459,9 @@ void LayerBar::setLayer() {
 }
 
 void LayerBar::setPairLayers() {
-    LayerDot* first_layer = m_selection.back();
+    LayerDot* first_layer  = m_selection.back();
     LayerDot* second_layer = m_selection.front();
-    if (first_layer->getLayer() > second_layer->getLayer())
-        std::swap(first_layer, second_layer);
+    if (first_layer->getLayer() > second_layer->getLayer()) std::swap(first_layer, second_layer);
 
     // Dialog prompt to get user input for range start and end
     QDialog dialog(this);
@@ -474,8 +469,8 @@ void LayerBar::setPairLayers() {
     dialog.setWindowTitle("Move existing layer range");
 
     // Input for first and last in range
-    QSpinBox* spinbox_first = new QSpinBox(&dialog);  // start of range
-    QSpinBox* spinbox_second = new QSpinBox(&dialog); // end of range
+    QSpinBox* spinbox_first  = new QSpinBox(&dialog);  // start of range
+    QSpinBox* spinbox_second = new QSpinBox(&dialog);  // end of range
     spinbox_first->setRange(1, m_layers - 1);
     spinbox_second->setRange(1, m_layers);
 
@@ -484,7 +479,7 @@ void LayerBar::setPairLayers() {
 
     // Add inputs into a layout and the form
     QGroupBox* groupBox = new QGroupBox(tr("Alter the layer numbers to the desired location."));
-    QGridLayout* grid = new QGridLayout;
+    QGridLayout* grid   = new QGridLayout;
     grid->addWidget(new QLabel("First layer"), 1, 1);
     grid->addWidget(new QLabel("Last layer"), 2, 1);
     grid->addWidget(spinbox_first, 1, 2);
@@ -503,12 +498,10 @@ void LayerBar::setPairLayers() {
     bool result = dialog.exec();
 
     while (result == QDialog::Accepted) {
-        int first_val = spinbox_first->value() - 1;
+        int first_val  = spinbox_first->value() - 1;
         int second_val = spinbox_second->value() - 1;
 
-        if (first_val == first_layer->getLayer() && second_val == second_layer->getLayer()) {
-            break;
-        }
+        if (first_val == first_layer->getLayer() && second_val == second_layer->getLayer()) { break; }
 
         if (first_val < second_val &&
             !m_part->getSettingsRange(first_layer->getLayer(), second_layer->getLayer()).isNull() &&
@@ -516,11 +509,9 @@ void LayerBar::setPairLayers() {
             (this->layerValid(second_val) || m_position[second_val] == second_layer)) {
             m_part->updateSettingsRangeLimits(first_layer->getLayer(), second_layer->getLayer(), first_val, second_val);
 
-            if (first_layer->getLayer() != first_val)
-                this->moveDotToLayer(first_layer, first_val);
+            if (first_layer->getLayer() != first_val) this->moveDotToLayer(first_layer, first_val);
 
-            if (second_layer->getLayer() != second_val)
-                this->moveDotToLayer(second_layer, second_val);
+            if (second_layer->getLayer() != second_val) this->moveDotToLayer(second_layer, second_val);
 
             updateLayers();
             removeInvalidSelections();
@@ -552,8 +543,7 @@ void LayerBar::addSelection() {
         new_layer--;
     }
 
-    if (ok)
-        addSingle(new_layer);
+    if (ok) addSingle(new_layer);
 }
 
 void LayerBar::addPair() {
@@ -563,20 +553,19 @@ void LayerBar::addPair() {
     dialog.setWindowTitle("Add New Range of Layer Settings");
 
     // Input for first and last in range
-    QDoubleSpinBox* pairFirst = new QDoubleSpinBox(&dialog); // start of range
-    QDoubleSpinBox* pairLast = new QDoubleSpinBox(&dialog);  // end of range
+    QDoubleSpinBox* pairFirst = new QDoubleSpinBox(&dialog);  // start of range
+    QDoubleSpinBox* pairLast  = new QDoubleSpinBox(&dialog);  // end of range
     pairFirst->setRange(1, m_layers - 1);
     pairLast->setRange(1, m_layers);
     pairFirst->setDecimals(0);
     pairLast->setDecimals(0);
 
     // If a dot is selected, use that dot as the start
-    if (m_selection.size() == 1)
-        pairFirst->setValue(m_selection[0]->getLayer() + 1);
+    if (m_selection.size() == 1) pairFirst->setValue(m_selection[0]->getLayer() + 1);
 
     // Add inputs into a layout and the form
     QGroupBox* groupBox = new QGroupBox(tr("Indicate which layers to pair"));
-    QGridLayout* grid = new QGridLayout;
+    QGridLayout* grid   = new QGridLayout;
     grid->addWidget(new QLabel("First layer"), 1, 1);
     grid->addWidget(new QLabel("Second layer"), 2, 1);
     grid->addWidget(pairFirst, 1, 2);
@@ -596,7 +585,7 @@ void LayerBar::addPair() {
     if (dialog.exec() == QDialog::Accepted) {
         // Initiate values and dots
         int first = pairFirst->value() - 1;
-        int last = pairLast->value() - 1;
+        int last  = pairLast->value() - 1;
         LayerDot* a;
         LayerDot* b;
         bool ok = true;
@@ -606,8 +595,9 @@ void LayerBar::addPair() {
         options.setOptions(QInputDialog::UseListViewForComboBoxItems);
         options.setComboBoxItems(choose);
         options.setWindowTitle("Could not add the settings range");
-        options.setLabelText("One of the specified layers already has settings associated with it. \n"
-                             "What would you like to do?");
+        options.setLabelText(
+            "One of the specified layers already has settings associated with it. \n"
+            "What would you like to do?");
 
         if (m_selection.size() == 0) {
             while (!layerValid(first) && ok) {
@@ -619,9 +609,7 @@ void LayerBar::addPair() {
                         &ok);
                     first--;
                 }
-                else if (options.textValue().contains("Delete") && ok) {
-                    deleteSingle(m_position[first]);
-                }
+                else if (options.textValue().contains("Delete") && ok) { deleteSingle(m_position[first]); }
             }
             while (!layerValid(last) && ok) {
                 options.exec();
@@ -631,9 +619,7 @@ void LayerBar::addPair() {
                         "Layer " + QString::number(last + 1) + " was invalid. New last layer:", 1, 1, m_layers, 1, &ok);
                     last--;
                 }
-                else if (options.textValue().contains("Delete") && ok) {
-                    deleteSingle(m_position[last]);
-                }
+                else if (options.textValue().contains("Delete") && ok) { deleteSingle(m_position[last]); }
             }
             while (first == last && ok) {
                 last = QInputDialog::getInt(
@@ -642,9 +628,7 @@ void LayerBar::addPair() {
                     &ok);
                 last--;
             }
-            if (ok) {
-                this->addRange(first, last);
-            }
+            if (ok) { this->addRange(first, last); }
         }
         else if (m_selection.size() == 1) {
             while (!layerValid(last) && ok) {
@@ -655,9 +639,7 @@ void LayerBar::addPair() {
                         "Layer " + QString::number(last + 1) + " was invalid. New last layer:", 1, 1, m_layers, 1, &ok);
                     last--;
                 }
-                else if (options.textValue().contains("Delete") && ok) {
-                    deleteSingle(m_position[last]);
-                }
+                else if (options.textValue().contains("Delete") && ok) { deleteSingle(m_position[last]); }
             }
             while (first == last && ok) {
                 last = QInputDialog::getInt(
@@ -699,8 +681,8 @@ void LayerBar::addGroup() {
     dialog.setWindowTitle("Add a Selection Group");
 
     // Radiobuttons for selecting odds/evens or making a custom selection group
-    QRadioButton* selectOdds = new QRadioButton("Select all odd layers.", &dialog);
-    QRadioButton* selectEvens = new QRadioButton("Select all even layers.", &dialog);
+    QRadioButton* selectOdds   = new QRadioButton("Select all odd layers.", &dialog);
+    QRadioButton* selectEvens  = new QRadioButton("Select all even layers.", &dialog);
     QRadioButton* selectCustom = new QRadioButton("Make a custom group.", &dialog);
 
     // ButtonGroup to make the buttons exclusive
@@ -710,22 +692,22 @@ void LayerBar::addGroup() {
     chooseSelection->addButton(selectCustom, 3);
 
     // Inputs for a custom selection group
-    QDoubleSpinBox* grpStart = new QDoubleSpinBox(&dialog); // first layer in the group
-    grpStart->setRange(1, m_layers - 2);                    // minimum of 1, maximum of 2nd to last layer of the part
-    grpStart->setDecimals(0);                               // no decimals
-    QDoubleSpinBox* grpEnd = new QDoubleSpinBox(&dialog);   // last layer in the group
-    grpEnd->setRange(3, m_layers);                          // minimum of 3, maximum of last layer
-    grpEnd->setValue(m_layers);                             // default is last layer
-    grpEnd->setDecimals(0);                                 // no decimals
-    QDoubleSpinBox* interval = new QDoubleSpinBox(&dialog); // number of layers to skip between selections
-    interval->setRange(1, m_layers / 2);                    // minimum of 0, maximum of 1/2 total number of layers
-    interval->setDecimals(0);                               // no decimals
+    QDoubleSpinBox* grpStart = new QDoubleSpinBox(&dialog);  // first layer in the group
+    grpStart->setRange(1, m_layers - 2);                     // minimum of 1, maximum of 2nd to last layer of the part
+    grpStart->setDecimals(0);                                // no decimals
+    QDoubleSpinBox* grpEnd = new QDoubleSpinBox(&dialog);    // last layer in the group
+    grpEnd->setRange(3, m_layers);                           // minimum of 3, maximum of last layer
+    grpEnd->setValue(m_layers);                              // default is last layer
+    grpEnd->setDecimals(0);                                  // no decimals
+    QDoubleSpinBox* interval = new QDoubleSpinBox(&dialog);  // number of layers to skip between selections
+    interval->setRange(1, m_layers / 2);                     // minimum of 0, maximum of 1/2 total number of layers
+    interval->setDecimals(0);                                // no decimals
     QLineEdit* name = new QLineEdit(&dialog);
     name->setText("New Group");
 
     // Groupbox to group the inputs together and enable/disable them based on radiobutton selection
     QGroupBox* groupBox = new QGroupBox(tr("Custom Group"));
-    QGridLayout* grid = new QGridLayout;
+    QGridLayout* grid   = new QGridLayout;
     grid->addWidget(new QLabel("Start at layer"), 1, 1);
     grid->addWidget(new QLabel("Stop at layer"), 2, 1);
     grid->addWidget(new QLabel("Interval*"), 3, 1);
@@ -768,25 +750,25 @@ void LayerBar::addGroup() {
     if (dialog.exec() == QDialog::Accepted) {
         // If the user didn't dismiss the dialog, add dots at the appropriate layers
         // Default values: select all odd layers (checkedId == 1)
-        int start = 0;
-        int end = m_layers;
-        int skip = 2;
+        int start          = 0;
+        int end            = m_layers;
+        int skip           = 2;
         QString group_name = "Odd Layers";
         if (chooseSelection->checkedId() == 2) {
             // If user wants to select even layers
             group_name = "Even Layers";
-            start = 1;
+            start      = 1;
         }
         else if (chooseSelection->checkedId() == 3) {
             // If user wants to make a custom selection group
-            start = grpStart->value() - 1;
-            end = grpEnd->value();
-            skip = interval->value() + 1;
+            start      = grpStart->value() - 1;
+            end        = grpEnd->value();
+            skip       = interval->value() + 1;
             group_name = name->text();
         }
 
         // Make the dot group
-        dot_group* group = new dot_group;
+        dot_group* group  = new dot_group;
         group->group_name = group_name;
 
         for (int i = start; i < end; i = i + skip) {
@@ -810,7 +792,7 @@ void LayerBar::groupDots() {
     QString group_name = QInputDialog::getText(this, "Create Group", "Enter a name for the new group:");
 
     // Make a new group
-    dot_group* group = new dot_group;
+    dot_group* group  = new dot_group;
     group->group_name = group_name;
 
     for (LayerDot* dot : m_selection) {
@@ -867,13 +849,12 @@ void LayerBar::transformUpdate(QSharedPointer<PartMetaItem> item) {
         MathUtils::decomposeTransformMatrix(part->rootMesh()->transformation());
 
     QVector3D gop_translation = item->translation();
-    QQuaternion gop_rotation = item->rotation();
-    QVector3D gop_scale = item->scale();
+    QQuaternion gop_rotation  = item->rotation();
+    QVector3D gop_scale       = item->scale();
     gop_translation *= Constants::OpenGL::kViewToObject;
 
-    if (gop_rotation != part_rotation || gop_scale != part_scale) // Only need to recalculate on scale/ rotation events
+    if (gop_rotation != part_rotation || gop_scale != part_scale)  // Only need to recalculate on scale/ rotation events
     {
-
         QMatrix4x4 object_transformation = MathUtils::composeTransformMatrix(gop_translation, gop_rotation, gop_scale);
         part->setTransformation(object_transformation);
 
@@ -881,11 +862,12 @@ void LayerBar::transformUpdate(QSharedPointer<PartMetaItem> item) {
     }
 }
 
-void LayerBar::visualUpdate(QSharedPointer<PartMetaItem> item) { changePart(item); }
+void LayerBar::visualUpdate(QSharedPointer<PartMetaItem> item) {
+    changePart(item);
+}
 
 void LayerBar::removalUpdate(QSharedPointer<PartMetaItem> item) {
-    if (item->isSelected())
-        changePart(nullptr);
+    if (item->isSelected()) changePart(nullptr);
 }
 
 void LayerBar::makePair() {
@@ -922,7 +904,6 @@ void LayerBar::splitPair() {
 }
 
 void LayerBar::paintEvent(QPaintEvent* event) {
-
     QPainter painter(this);
 
     painter.setRenderHint(QPainter::Antialiasing);
@@ -932,13 +913,12 @@ void LayerBar::paintEvent(QPaintEvent* event) {
 
 void LayerBar::mousePressEvent(QMouseEvent* event) {
     // if there's no part or no layers, do nothing
-    if (m_part == nullptr || m_layers <= 0)
-        return;
+    if (m_part == nullptr || m_layers <= 0) return;
 
     // Get the dot underneath the cursor.
     LayerDot* dot = qobject_cast<LayerDot*>(this->childAt(event->pos()));
 
-    if (dot == nullptr) // there is not a dot under the cursor
+    if (dot == nullptr)  // there is not a dot under the cursor
     {
         // If the left button was clicked, make a new dot if possible.
         if (event->button() == Qt::LeftButton) {
@@ -950,7 +930,7 @@ void LayerBar::mousePressEvent(QMouseEvent* event) {
                 clearSelection();
         }
     }
-    else // there is a dot under the cursor
+    else  // there is a dot under the cursor
     {
         if (event->button() == Qt::LeftButton) {
             // If SHIFT is held and there's a dot already selected,
@@ -977,7 +957,7 @@ void LayerBar::mousePressEvent(QMouseEvent* event) {
                     m_should_deselect = false;
                 }
             }
-            else // no key modifiers
+            else  // no key modifiers
             {
                 if (!dot->isSelected()) {
                     clearSelection();
@@ -985,9 +965,7 @@ void LayerBar::mousePressEvent(QMouseEvent* event) {
                     changeSelectedSettings();
                     m_should_deselect = false;
                 }
-                else {
-                    m_should_deselect = true;
-                }
+                else { m_should_deselect = true; }
             }
             m_last_clicked_dot = dot;
         }
@@ -995,8 +973,7 @@ void LayerBar::mousePressEvent(QMouseEvent* event) {
 }
 
 void LayerBar::mouseReleaseEvent(QMouseEvent* event) {
-    if (m_part == nullptr || m_layers <= 0)
-        return;
+    if (m_part == nullptr || m_layers <= 0) return;
 
     // this function needs to update part's ranges if the dots were moved by user
     if (!m_selection.isEmpty() && event->button() == Qt::LeftButton && m_track_change) {
@@ -1005,26 +982,24 @@ void LayerBar::mouseReleaseEvent(QMouseEvent* event) {
 
         QVector<LayerDot*> selection_copy = m_selection;
         std::sort(selection_copy.begin(), selection_copy.end(),
-                  [](LayerDot* a, LayerDot* b) { return a->getLayer() < b->getLayer(); }); // sort low to high
+                  [](LayerDot* a, LayerDot* b) { return a->getLayer() < b->getLayer(); });  // sort low to high
 
         // Upon release, calculate each dot's new position.
         for (int i = 0; i < selection_copy.size();
-             ++i) // initentionally re-evaluating array size on every iteration bc it can change
+             ++i)  // initentionally re-evaluating array size on every iteration bc it can change
         {
             LayerDot* dot = selection_copy[i];
             // if the range has been visually moved, but not moved on the part, update the part
             if (dot->getLayer() != dot->getDisplayLayer()) {
-                int old_low = dot->getLayer();
+                int old_low  = dot->getLayer();
                 int old_high = dot->getLayer();
-                if (dot->getRange() != nullptr)
-                    old_high = dot->getPair()->getLayer();
+                if (dot->getRange() != nullptr) old_high = dot->getPair()->getLayer();
 
-                int new_low = dot->getDisplayLayer();
+                int new_low  = dot->getDisplayLayer();
                 int new_high = dot->getDisplayLayer();
-                if (dot->getRange() != nullptr)
-                    new_high = dot->getPair()->getDisplayLayer();
+                if (dot->getRange() != nullptr) new_high = dot->getPair()->getDisplayLayer();
 
-                if (moveDotToLayer(dot, new_low)) // successfully moved the layer
+                if (moveDotToLayer(dot, new_low))  // successfully moved the layer
                 {
                     // need to update the ranges on the part to reflect the click/drag movement
                     m_part->updateSettingsRangeLimits(old_low, old_high, new_low, new_high);
@@ -1061,32 +1036,32 @@ void LayerBar::mouseReleaseEvent(QMouseEvent* event) {
 void LayerBar::mouseMoveEvent(QMouseEvent* event) {
     if (!m_selection.isEmpty() && event->buttons() & Qt::LeftButton &&
         QGuiApplication::keyboardModifiers() == Qt::NoModifier) {
-        m_should_deselect = false;
+        m_should_deselect   = false;
         int relative_origin = m_last_clicked_dot->y();
         if (!m_track_change) {
-            m_original_y = relative_origin;
+            m_original_y   = relative_origin;
             m_track_change = true;
         }
 
         // ensure that none of the selected dots are moved out of bounds when clicking & dragging dots
         LayerDot* highest_dot = m_selection[0];
-        LayerDot* lowest_dot = m_selection[0];
-        int min = lowest_dot->getLayer();
-        int max = highest_dot->getLayer();
+        LayerDot* lowest_dot  = m_selection[0];
+        int min               = lowest_dot->getLayer();
+        int max               = highest_dot->getLayer();
         for (auto d : m_selection) {
             if (d->getLayer() > max) {
-                max = d->getLayer();
+                max         = d->getLayer();
                 highest_dot = d;
             }
             else if (d->getLayer() < min) {
-                min = d->getLayer();
+                min        = d->getLayer();
                 lowest_dot = d;
             }
         }
 
-        int new_low_coord = event->y() + (lowest_dot->y() - relative_origin) - 10;
+        int new_low_coord  = event->y() + (lowest_dot->y() - relative_origin) - 10;
         int new_high_coord = event->y() + (highest_dot->y() - relative_origin) - 10;
-        int adjusted_y = event->y();
+        int adjusted_y     = event->y();
 
         // if the move will put a dot out-of-bounds, adjust the move amount
         if (new_low_coord > getPositionFromLayer(0))
@@ -1097,7 +1072,7 @@ void LayerBar::mouseMoveEvent(QMouseEvent* event) {
         // For each selected dot, try to move them to the appropriate location.
         for (LayerDot* dot : m_selection) {
             int y_coord = adjusted_y + (dot->y() - relative_origin) - 10;
-            int layer = getLayerFromPosition(y_coord);
+            int layer   = getLayerFromPosition(y_coord);
 
             // move
             dot->move(dot->x(), y_coord);
@@ -1137,26 +1112,22 @@ void LayerBar::contextMenuEvent(QContextMenuEvent* event) {
         // if any selected dot is in a group or pair, then the dots CAN'T be group
         // if all selected dots are in the same group, then the dots CAN be ungrouped
         dot_group* check_group = m_selection[0]->getGroup();
-        bool can_group = (check_group == nullptr);   // assume we can group, until we find a dot in a pair or group
-        bool can_ungroup = (check_group != nullptr); // assume we can ungroup if the first dot is in a group, until
-                                                     //   we find a dot that isn't in that group
+        bool can_group   = (check_group == nullptr);  // assume we can group, until we find a dot in a pair or group
+        bool can_ungroup = (check_group != nullptr);  // assume we can ungroup if the first dot is in a group, until
+                                                      //   we find a dot that isn't in that group
         for (LayerDot* dot : m_selection) {
             if (dot->getGroup() != nullptr) {
                 can_group = false;
-                if (check_group != dot->getGroup())
-                    can_ungroup = false;
+                if (check_group != dot->getGroup()) can_ungroup = false;
             }
             else if (dot->getPair() != nullptr)
                 can_group = true;
         }
 
         // add the corresponding actions to the menu
-        if (can_group)
-            menu.addAction(m_group_dots);
+        if (can_group) menu.addAction(m_group_dots);
 
-        if (can_ungroup) {
-            menu.addAction(m_ungroup_dots);
-        }
+        if (can_ungroup) { menu.addAction(m_ungroup_dots); }
 
         menu.addSeparator();
     }
@@ -1182,11 +1153,10 @@ void LayerBar::contextMenuEvent(QContextMenuEvent* event) {
 
 void LayerBar::resizeEvent(QResizeEvent* event) {
     // Recalculate the following to use in movement.
-    m_px_divs = ((float)(this->height() - (m_layers * 3) - 6) / (m_layers + 1)) + 1;
+    m_px_divs     = ((float)(this->height() - (m_layers * 3) - 6) / (m_layers + 1)) + 1;
     m_px_divs_inc = m_px_divs + 2;
 
-    if (m_px_divs < 30)
-        m_skip = static_cast<int>(30 / m_px_divs);
+    if (m_px_divs < 30) m_skip = static_cast<int>(30 / m_px_divs);
 
     // Update all dots to their correct position.
     for (LayerDot* dot : m_position) {
@@ -1202,20 +1172,18 @@ void LayerBar::resizeEvent(QResizeEvent* event) {
 void LayerBar::paintDivisions(QPainter* painter) {
     const int maj_hz_pad = 3;
     const int min_hz_pad = 7;
-    const int bar_size = 3;
+    const int bar_size   = 3;
 
     painter->setPen(PreferencesManager::getInstance()->getTheme().getLayerbarMajorColor());
 
     // m_px_divs = size BETWEEN divisions, m_px_divs_inc = size INCLUDING divisions
-    m_px_divs = ((float)(this->height() - (m_layers * bar_size) - (bar_size * 2)) / (m_layers + 1)) + 1;
+    m_px_divs     = ((float)(this->height() - (m_layers * bar_size) - (bar_size * 2)) / (m_layers + 1)) + 1;
     m_px_divs_inc = m_px_divs + 2;
 
     // Adjust the skip value based on the available room.
     int minor_skip = 1;
     if (m_px_divs < 60) {
-        if (m_px_divs < 5) {
-            minor_skip = static_cast<int>(5 / m_px_divs);
-        }
+        if (m_px_divs < 5) { minor_skip = static_cast<int>(5 / m_px_divs); }
 
         m_skip = static_cast<int>(60 / m_px_divs);
     }
@@ -1226,9 +1194,7 @@ void LayerBar::paintDivisions(QPainter* painter) {
     float loc = 2;
     for (int i = 0; i < m_layers; ++i) {
         if (i % m_skip) {
-            if (i % minor_skip) {
-                loc += m_px_divs + 2;
-            }
+            if (i % minor_skip) { loc += m_px_divs + 2; }
             else {
                 // Draw the minor line.
                 painter->setPen(PreferencesManager::getInstance()->getTheme().getLayerbarMinorColor());
@@ -1274,7 +1240,7 @@ void LayerBar::paintRanges(QPainter* painter) {
         for (auto settings_range : m_part->getSettingsRanges()) {
             if (!settings_range->isSingle()) {
                 LayerDot* low_dot = m_position[settings_range->low()];
-                dot_range* range = low_dot->getRange();
+                dot_range* range  = low_dot->getRange();
 
                 // Determine edges of ranges.
                 QPoint a_point, b_point;
@@ -1298,7 +1264,7 @@ LayerDot* LayerBar::addDot(int layer, bool from_template) {
         new LayerDot(this, layer, PreferencesManager::getInstance()->getTheme().getDotColors(), from_template);
     dot->move((this->width() / 2) - (dot->width() / 2), -20);
 
-    if (this->moveDotToLayer(dot, layer)) // successfully moved to layer
+    if (this->moveDotToLayer(dot, layer))  // successfully moved to layer
     {
         this->clearSelection();
 
@@ -1306,7 +1272,7 @@ LayerDot* LayerBar::addDot(int layer, bool from_template) {
         m_position[dot->getLayer()] = dot;
         dot->show();
     }
-    else // couldn't move to layer, so backtrack
+    else  // couldn't move to layer, so backtrack
     {
         delete dot;
         dot = nullptr;
@@ -1316,7 +1282,7 @@ LayerDot* LayerBar::addDot(int layer, bool from_template) {
 
 void LayerBar::deleteSingle(LayerDot* dot) {
     // Remove the dot from internal containers.
-    int layer = dot->getLayer();
+    int layer         = dot->getLayer();
     m_position[layer] = nullptr;
 
     // When the animation finishes, delete the dot.
@@ -1324,7 +1290,7 @@ void LayerBar::deleteSingle(LayerDot* dot) {
 
     dot->smoothMove(dot->x(), this->height());
 
-    if (dot->getRange() != nullptr) // If this dot is in a range, delete the range.
+    if (dot->getRange() != nullptr)  // If this dot is in a range, delete the range.
     {
         dot_range* range = dot->getRange();
 
@@ -1338,16 +1304,15 @@ void LayerBar::deleteSingle(LayerDot* dot) {
         dot->getPair()->setRange(nullptr);
         delete range;
     }
-    else if (dot->getGroup() != nullptr) // dot is in group, remove it from group before deleting dot
+    else if (dot->getGroup() != nullptr)  // dot is in group, remove it from group before deleting dot
     {
         dot_group* group = dot->getGroup();
         group->grouped.removeAt(group->grouped.indexOf(dot));
         m_part->removeSettingsRange(dot->getLayer(), dot->getLayer());
 
-        if (group->grouped.size() < 0)
-            delete group;
+        if (group->grouped.size() < 0) delete group;
     }
-    else // just a single dot, delete it
+    else  // just a single dot, delete it
     {
         m_part->removeSettingsRange(dot->getLayer(), dot->getLayer());
     }
@@ -1401,9 +1366,7 @@ void LayerBar::updateLayers() {
     if (m_part->getSb()->contains(PS::Layer::kLayerHeight)) {
         global_layer_height = m_part->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
     }
-    else {
-        global_layer_height = GSM->getGlobal()->setting<Distance>(PS::Layer::kLayerHeight);
-    }
+    else { global_layer_height = GSM->getGlobal()->setting<Distance>(PS::Layer::kLayerHeight); }
 
     int layer_count = 0;
     // if valid config ( normal and axis not perpendicular)
@@ -1417,13 +1380,14 @@ void LayerBar::updateLayers() {
         Distance part_height = slicing_plane.distanceToPoint(part_max);
 
         Point g_direction = part_min + (slicing_vector * global_layer_height());
-        global_layer_height = slicing_plane.distanceToPoint(g_direction); // height in direction normal to slicing plane
+        global_layer_height =
+            slicing_plane.distanceToPoint(g_direction);  // height in direction normal to slicing plane
 
         // count the layers
         Distance current_height = 0;
-        layer_count = 0;
-        auto ranges = m_part->getSettingsRanges();
-        bool is_in_range = false;
+        layer_count             = 0;
+        auto ranges             = m_part->getSettingsRanges();
+        bool is_in_range        = false;
         uint range_id;
 
         while (current_height < part_height) {
@@ -1435,7 +1399,7 @@ void LayerBar::updateLayers() {
                     if (!is_in_range) {
                         // this is the first range we've found that contains the layer
                         is_in_range = true;
-                        range_id = i.key();
+                        range_id    = i.key();
                     }
                     else {
                         // The current layer is in multiple ranges
@@ -1445,10 +1409,10 @@ void LayerBar::updateLayers() {
                         //    - for multi-layer ranges with same low-index, the range with
                         //      the lower high index will be selected
                         auto old_range = ranges[range_id];
-                        if (range->isSingle() ||               // new range is single, top priority
-                            range->low() > old_range->low() || // new range has higher low than old
+                        if (range->isSingle() ||                // new range is single, top priority
+                            range->low() > old_range->low() ||  // new range has higher low than old
                             old_range->low() == range->low() &&
-                                range->high() < old_range->high()) // new range is narrower
+                                range->high() < old_range->high())  // new range is narrower
                         {
                             range_id = i.key();
                         }
@@ -1461,14 +1425,12 @@ void LayerBar::updateLayers() {
             // height
             if (is_in_range && ranges[range_id]->getSb()->contains(PS::Layer::kLayerHeight)) {
                 Distance range_height = ranges[range_id]->getSb()->setting<Distance>(PS::Layer::kLayerHeight);
-                Point p = slicing_plane.point() + (slicing_vector * range_height());
-                range_height = slicing_plane.distanceToPoint(p); // height in direction normal to slicing plane
+                Point p               = slicing_plane.point() + (slicing_vector * range_height());
+                range_height = slicing_plane.distanceToPoint(p);  // height in direction normal to slicing plane
 
                 current_height += range_height;
             }
-            else {
-                current_height += global_layer_height;
-            }
+            else { current_height += global_layer_height; }
 
             ++layer_count;
         }
@@ -1481,32 +1443,22 @@ void LayerBar::updateLayers() {
                       (slicing_vector * ranges[range_id]->getSb()->setting<Distance>(PS::Layer::kLayerHeight)());
             last_layer_height = slicing_plane.distanceToPoint(p);
         }
-        else {
-            last_layer_height = global_layer_height;
-        }
+        else { last_layer_height = global_layer_height; }
 
-        if ((current_height - part_height) >= (last_layer_height / 2.0)) {
-            --layer_count;
-        }
+        if ((current_height - part_height) >= (last_layer_height / 2.0)) { --layer_count; }
         m_layers = layer_count;
     }
-    else {
-        m_layers = 0;
-    }
+    else { m_layers = 0; }
     // if the number of layers decreased, remove any dots from
     // layers that don't exist anymore
     if (layer_count < m_position.size()) {
         for (int i = m_position.size() - 1; i >= layer_count; --i) {
             if (m_position[i] != nullptr) {
-                if (clampRangeToLayerCount(m_position[i], layer_count)) {
-                    continue;
-                }
+                if (clampRangeToLayerCount(m_position[i], layer_count)) { continue; }
 
                 int layer_num = m_position[i]->getLayer();
                 LayerDot* dot = m_position[i]->getPair();
-                if (dot == nullptr) {
-                    storeDeletedLayers(layer_num, layer_num);
-                }
+                if (dot == nullptr) { storeDeletedLayers(layer_num, layer_num); }
                 else {
                     int pair = dot->getLayer();
                     storeDeletedLayers(layer_num, pair);
@@ -1518,21 +1470,23 @@ void LayerBar::updateLayers() {
     int old_size = m_position.size();
     m_position.resize(m_layers);
     if (old_size < m_position.size()) {
-        if (m_deleted_ranges.size() > 0) {
-            returnDeletedLayers();
-        }
+        if (m_deleted_ranges.size() > 0) { returnDeletedLayers(); }
     }
 
     double layers = (m_layers <= 30) ? m_layers : 30;
-    m_px_divs = height() / layers;
+    m_px_divs     = height() / layers;
 
     resizeEvent(nullptr);
     update();
 }
 
-bool LayerBar::sortByTop(SettingsRange a, SettingsRange b) { return a.high() > b.high(); }
+bool LayerBar::sortByTop(SettingsRange a, SettingsRange b) {
+    return a.high() > b.high();
+}
 
-QVector<SettingsRange> LayerBar::getDeletedRanges() { return m_deleted_ranges; }
+QVector<SettingsRange> LayerBar::getDeletedRanges() {
+    return m_deleted_ranges;
+}
 
 void LayerBar::storeDeletedLayers(int layer_number, int pair) {
     QVector<SettingsRange> sr = GSM->getLayerSettings();
@@ -1550,12 +1504,12 @@ void LayerBar::storeDeletedLayers(int layer_number, int pair) {
 void LayerBar::returnDeletedLayers() {
     while (m_deleted_ranges.size() > 0 && m_deleted_ranges[m_deleted_ranges.size() - 1].high() < m_layers) {
         if (m_deleted_ranges[m_deleted_ranges.size() - 1].low() ==
-            m_deleted_ranges[m_deleted_ranges.size() - 1].high()) { // Bring back single
+            m_deleted_ranges[m_deleted_ranges.size() - 1].high()) {  // Bring back single
             addSingleFromTemplate(m_deleted_ranges[m_deleted_ranges.size() - 1].low(),
                                   m_deleted_ranges[m_deleted_ranges.size() - 1].getSb());
             m_deleted_ranges.pop_back();
         }
-        else { // Bring back range
+        else {  // Bring back range
             addRangeFromTemplate(m_deleted_ranges[m_deleted_ranges.size() - 1].low(),
                                  m_deleted_ranges[m_deleted_ranges.size() - 1].high(),
                                  m_deleted_ranges[m_deleted_ranges.size() - 1].getSb());
@@ -1632,10 +1586,10 @@ int LayerBar::getPositionFromLayer(int layer) {
 bool LayerBar::moveDotToLayer(LayerDot* dot, int layer) {
     bool moved_dot = false;
 
-    if (layerValid(layer)) // a valid layer is in bounds and has no dot on it
+    if (layerValid(layer))  // a valid layer is in bounds and has no dot on it
     {
         m_position[dot->getLayer()] = nullptr;
-        m_position[layer] = dot;
+        m_position[layer]           = dot;
 
         int x = (this->width() / 2) - (dot->width() / 2);
         int y = getPositionFromLayer(layer);
@@ -1651,7 +1605,9 @@ bool LayerBar::moveDotToLayer(LayerDot* dot, int layer) {
     return moved_dot;
 }
 
-bool LayerBar::moveDotToNextLayer(LayerDot* dot) { return moveDotToNextLayer(dot, getLayerFromPosition(dot->y())); }
+bool LayerBar::moveDotToNextLayer(LayerDot* dot) {
+    return moveDotToNextLayer(dot, getLayerFromPosition(dot->y()));
+}
 
 void LayerBar::removeInvalidSelections() {
     for (int i = m_selection.size() - 1; i >= 0; --i) {
@@ -1664,24 +1620,20 @@ void LayerBar::removeInvalidSelections() {
 }
 
 bool LayerBar::clampRangeToLayerCount(LayerDot* dot, int layer_count) {
-    if (dot == nullptr || dot->getRange() == nullptr || layer_count <= 0)
-        return false;
+    if (dot == nullptr || dot->getRange() == nullptr || layer_count <= 0) return false;
 
     LayerDot* pair = dot->getPair();
-    if (pair == nullptr || pair->getLayer() >= layer_count)
-        return false;
+    if (pair == nullptr || pair->getLayer() >= layer_count) return false;
 
     const int last_layer = layer_count - 1;
-    const int old_low = qMin(dot->getLayer(), pair->getLayer());
-    const int old_high = qMax(dot->getLayer(), pair->getLayer());
-    const int new_low = qMin(pair->getLayer(), last_layer);
-    const int new_high = last_layer;
+    const int old_low    = qMin(dot->getLayer(), pair->getLayer());
+    const int old_high   = qMax(dot->getLayer(), pair->getLayer());
+    const int new_low    = qMin(pair->getLayer(), last_layer);
+    const int new_high   = last_layer;
 
-    if (new_low >= new_high || m_position[new_high] != nullptr)
-        return false;
+    if (new_low >= new_high || m_position[new_high] != nullptr) return false;
 
-    if (!moveDotToLayer(dot, new_high))
-        return false;
+    if (!moveDotToLayer(dot, new_high)) return false;
 
     m_part->updateSettingsRangeLimits(old_low, old_high, new_low, new_high);
     return true;
@@ -1693,11 +1645,9 @@ bool LayerBar::moveDotToNextLayer(LayerDot* dot, int layer) {
 
     while (true) {
         // Check up then down for each check distance.
-        if (moveDotToLayer(dot, layer + check_dist))
-            break;
+        if (moveDotToLayer(dot, layer + check_dist)) break;
 
-        if (moveDotToLayer(dot, layer - check_dist))
-            break;
+        if (moveDotToLayer(dot, layer - check_dist)) break;
 
         check_dist++;
     }
@@ -1737,20 +1687,20 @@ void LayerBar::changeSelectedSettings() {
     QVector<LayerDot*> selected_copy = m_selection;
     // sort from low to high, so that low value is always found first
     std::sort(selected_copy.begin(), selected_copy.end(),
-              [](LayerDot* a, LayerDot* b) { return a->getLayer() < b->getLayer(); }); // sort low to high
+              [](LayerDot* a, LayerDot* b) { return a->getLayer() < b->getLayer(); });  // sort low to high
 
-    for (int i = 0; i < selected_copy.size(); ++i) // intentionally re-evaluating array size bc it will change
+    for (int i = 0; i < selected_copy.size(); ++i)  // intentionally re-evaluating array size bc it will change
     {
         LayerDot* dot = selected_copy[i];
 
         if (dot->getRange() != nullptr) {
-            int low = qMin(dot->getLayer(), dot->getPair()->getLayer());
+            int low  = qMin(dot->getLayer(), dot->getPair()->getLayer());
             int high = qMax(dot->getLayer(), dot->getPair()->getLayer());
             include_visual_layer_range(low, high);
 
             selected_copy.removeAt(selected_copy.indexOf(dot->getPair()));
 
-            auto range = m_part->getSettingsRange(low, high);
+            auto range   = m_part->getSettingsRange(low, high);
             QString name = "Layers " + QString::number(low + 1) + " - " + QString::number(high + 1);
             names.append(name);
             settings_bases.append(range->getSb());
@@ -1760,7 +1710,7 @@ void LayerBar::changeSelectedSettings() {
             // get the dot group & its name
             // add the group name to the list
             auto dot_group = dot->getGroup();
-            QString name = dot_group->group_name;
+            QString name   = dot_group->group_name;
             names.append(name);
 
             for (LayerDot* grouped_dot : dot_group->grouped) {
@@ -1782,7 +1732,7 @@ void LayerBar::changeSelectedSettings() {
         else {
             int layer_num = dot->getLayer();
             include_visual_layer_range(layer_num, layer_num);
-            auto range = m_part->getSettingsRange(layer_num, layer_num);
+            auto range   = m_part->getSettingsRange(layer_num, layer_num);
             QString name = "Layer " + QString::number(layer_num + 1);
             names.append(name);
             settings_bases.append(range->getSb());
@@ -1792,8 +1742,7 @@ void LayerBar::changeSelectedSettings() {
 
     std::sort(selected_layer_ranges.begin(), selected_layer_ranges.end(),
               [](const QPair<int, int>& a, const QPair<int, int>& b) {
-                  if (a.first == b.first)
-                      return a.second < b.second;
+                  if (a.first == b.first) return a.second < b.second;
 
                   return a.first < b.first;
               });
@@ -1809,27 +1758,26 @@ void LayerBar::changeSelectedSettings() {
     }
 
     QString final;
-    if (names.size() == 0) // no selected ranges, change back to part settings
+    if (names.size() == 0)  // no selected ranges, change back to part settings
     {
         final = m_part->name();
         settings_bases.append(m_part->getSb());
         inherited_bases.append(QSharedPointer<SettingsBase>());
     }
-    else if (names.size() == 1) // just one selected range, display it
+    else if (names.size() == 1)  // just one selected range, display it
     {
         final = names[0];
         final += " of " + m_part->name();
     }
-    else if (names.size() <= 3) // several selected ranges, display their names concatenated
+    else if (names.size() <= 3)  // several selected ranges, display their names concatenated
     {
         for (int i = 0, end = names.size(); i < end; ++i) {
-            if (i > 0)
-                final += ", ";
+            if (i > 0) final += ", ";
             final += names[i];
         }
         final += " of " + m_part->name();
     }
-    else // too many ranges to display all the names
+    else  // too many ranges to display all the names
     {
         final = "Multiple ranges";
         final += " of " + m_part->name();
@@ -1842,8 +1790,7 @@ void LayerBar::changeSelectedSettings() {
 }
 
 void LayerBar::clearSelection() {
-    for (LayerDot* curr_dot : m_selection)
-        curr_dot->setSelected(false);
+    for (LayerDot* curr_dot : m_selection) curr_dot->setSelected(false);
 
     m_selection.clear();
     changeSelectedSettings();
@@ -1851,8 +1798,7 @@ void LayerBar::clearSelection() {
 
 void LayerBar::selectAll() {
     for (LayerDot* dot : m_position) {
-        if (dot != nullptr)
-            selectDot(dot);
+        if (dot != nullptr) selectDot(dot);
     }
     changeSelectedSettings();
 }
@@ -1860,14 +1806,13 @@ void LayerBar::selectAll() {
 void LayerBar::selectOnInterval(int min, int max) {
     for (int i = min; i <= max; i++) {
         LayerDot* dot = m_position[i];
-        if (dot != nullptr)
-            selectDot(dot);
+        if (dot != nullptr) selectDot(dot);
     }
     changeSelectedSettings();
 }
 
 void LayerBar::selectDot(LayerDot* dot) {
-    if (dot->getGroup() != nullptr) // dot it group, select all dots in group
+    if (dot->getGroup() != nullptr)  // dot it group, select all dots in group
     {
         QVector<LayerDot*> grouped_dots = dot->getGroup()->grouped;
         for (auto d : grouped_dots) {
@@ -1877,7 +1822,7 @@ void LayerBar::selectDot(LayerDot* dot) {
             }
         }
     }
-    else if (dot->getRange() != nullptr) // dot in range, select its pair too
+    else if (dot->getRange() != nullptr)  // dot in range, select its pair too
     {
         if (!dot->isSelected()) {
             dot->setSelected(true);
@@ -1890,7 +1835,7 @@ void LayerBar::selectDot(LayerDot* dot) {
             m_selection.append(paired_dot);
         }
     }
-    else // just a single dot
+    else  // just a single dot
     {
         if (!dot->isSelected()) {
             dot->setSelected(true);
@@ -1900,7 +1845,7 @@ void LayerBar::selectDot(LayerDot* dot) {
 }
 
 void LayerBar::deselectDot(LayerDot* dot) {
-    if (dot->getGroup() != nullptr) // dot in group, deselect all dots in group
+    if (dot->getGroup() != nullptr)  // dot in group, deselect all dots in group
     {
         QVector<LayerDot*> grouped_dots = dot->getGroup()->grouped;
         for (auto d : grouped_dots) {
@@ -1910,7 +1855,7 @@ void LayerBar::deselectDot(LayerDot* dot) {
             }
         }
     }
-    else if (dot->getRange() != nullptr) // dot in range, deselect its pair too
+    else if (dot->getRange() != nullptr)  // dot in range, deselect its pair too
     {
         if (dot->isSelected()) {
             dot->setSelected(false);
@@ -1923,7 +1868,7 @@ void LayerBar::deselectDot(LayerDot* dot) {
             m_selection.removeAt(m_selection.indexOf(paired_dot));
         }
     }
-    else // just a single dot
+    else  // just a single dot
     {
         if (dot->isSelected()) {
             dot->setSelected(false);
@@ -1934,19 +1879,19 @@ void LayerBar::deselectDot(LayerDot* dot) {
 
 void LayerBar::setupActions() {
     // Setup actions.
-    m_set_layer_act = new QAction("Set Layer Number", this);
+    m_set_layer_act        = new QAction("Set Layer Number", this);
     m_set_range_layers_act = new QAction("Set Range Layer Numbers", this);
-    m_delete_act = new QAction("Delete Selected Layer Settings", this);
-    m_add_act = new QAction("Add Layer Settings", this);
-    m_add_group = new QAction("Add a Group of Layer Settings", this);
-    m_join_act = new QAction("Pair Selected Layers", this);
-    m_split_act = new QAction("Split Pair", this);
-    m_add_pair = new QAction("Add a Range of Layer Settings", this);
-    m_pair_from_one = new QAction("Select a Range from This Layer", this);
-    m_clear_act = new QAction("Clear Selection", this);
-    m_group_dots = new QAction("Group Selected Layer Settings", this);
-    m_ungroup_dots = new QAction("Ungroup Selected Layer Settings", this);
-    m_select_all = new QAction("Select All", this);
+    m_delete_act           = new QAction("Delete Selected Layer Settings", this);
+    m_add_act              = new QAction("Add Layer Settings", this);
+    m_add_group            = new QAction("Add a Group of Layer Settings", this);
+    m_join_act             = new QAction("Pair Selected Layers", this);
+    m_split_act            = new QAction("Split Pair", this);
+    m_add_pair             = new QAction("Add a Range of Layer Settings", this);
+    m_pair_from_one        = new QAction("Select a Range from This Layer", this);
+    m_clear_act            = new QAction("Clear Selection", this);
+    m_group_dots           = new QAction("Group Selected Layer Settings", this);
+    m_ungroup_dots         = new QAction("Ungroup Selected Layer Settings", this);
+    m_select_all           = new QAction("Select All", this);
 
     // Connect our actions to our signals.
     connect(m_set_layer_act, &QAction::triggered, this, &LayerBar::setLayer);
@@ -1964,4 +1909,4 @@ void LayerBar::setupActions() {
     connect(m_select_all, &QAction::triggered, this, &LayerBar::selectAll);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/layerdot.cpp
+++ b/src/widgets/layerdot.cpp
@@ -27,18 +27,20 @@ LayerDot::LayerDot(QWidget* parent, int new_layer, QVector<QColor> m_colors, boo
     m_move_ani->setDuration(0);
 
     m_dot_colors = m_colors;
-    if (!from_template) // Default color orange if dot from template. Green if dot entered by user.
+    if (!from_template)  // Default color orange if dot from template. Green if dot entered by user.
         m_default_color = m_dot_colors.at(
-            0); // dot colors = [0]base_color, [1]hover_color, [2]selected_color, [3]group_color, [4]label_color
+            0);  // dot colors = [0]base_color, [1]hover_color, [2]selected_color, [3]group_color, [4]label_color
     else
         m_default_color = m_dot_colors.at(2);
-    m_color = m_default_color;
-    m_shrink = 0;
-    m_selected = false;
+    m_color         = m_default_color;
+    m_shrink        = 0;
+    m_selected      = false;
     m_from_template = false;
 }
 
-LayerDot::~LayerDot() { delete m_move_ani; }
+LayerDot::~LayerDot() {
+    delete m_move_ani;
+}
 
 void LayerDot::setSelected(bool status) {
     m_selected = status;
@@ -87,37 +89,43 @@ void LayerDot::smoothMove(int x, int y) {
 }
 
 void LayerDot::setShrink(int shrink) {
-    if (shrink > 17 || shrink < 0)
-        shrink = 17;
+    if (shrink > 17 || shrink < 0) shrink = 17;
     m_shrink = shrink;
 }
 
-int LayerDot::getLayer() { return m_layer; }
+int LayerDot::getLayer() {
+    return m_layer;
+}
 
-int LayerDot::getDisplayLayer() { return m_display_layer; }
+int LayerDot::getDisplayLayer() {
+    return m_display_layer;
+}
 
-LayerBar::dot_range* LayerDot::getRange() { return m_range; }
+LayerBar::dot_range* LayerDot::getRange() {
+    return m_range;
+}
 
 LayerDot* LayerDot::getPair() {
-    if (m_range == nullptr)
-        return nullptr;
+    if (m_range == nullptr) return nullptr;
     return (m_range->a == this) ? m_range->b : m_range->a;
 }
 
 QString LayerDot::getGroupName() {
-    if (m_group != nullptr) {
-        return m_group->group_name;
-    }
+    if (m_group != nullptr) { return m_group->group_name; }
     return "";
 }
 
-LayerBar::dot_group* LayerDot::getGroup() { return m_group; }
+LayerBar::dot_group* LayerDot::getGroup() {
+    return m_group;
+}
 
-bool LayerDot::isSelected() { return m_selected; }
+bool LayerDot::isSelected() {
+    return m_selected;
+}
 
 void LayerDot::isFromTemplate() {
     m_from_template = true;
-    m_color = m_dot_colors.at(2);
+    m_color         = m_dot_colors.at(2);
 }
 
 void LayerDot::paintEvent(QPaintEvent* event) {
@@ -148,7 +156,7 @@ void LayerDot::paintLayerDot(QPainter* painter) {
     const QPoint upper_corner(0, m_shrink), lower_corner(19, 19 - m_shrink);
 
     // Setup the fill and the circle dimensions.
-    QBrush filler((m_selected) ? m_dot_colors.at(3) : m_color, Qt::SolidPattern); // blue if selected
+    QBrush filler((m_selected) ? m_dot_colors.at(3) : m_color, Qt::SolidPattern);  // blue if selected
     QRect circle_bounds(upper_corner, lower_corner);
 
     // Draw the circle.
@@ -170,4 +178,4 @@ void LayerDot::updateTooltip() {
         this->setToolTip("Range Selection Layer " + QString::number(m_layer + 1) + " to " +
                          QString::number(this->getPair()->getLayer() + 1));
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/linenumberdisplay.cpp
+++ b/src/widgets/linenumberdisplay.cpp
@@ -7,8 +7,12 @@
 namespace ORNL {
 LineNumberDisplay::LineNumberDisplay(GcodeTextBoxWidget* textbox) : QWidget(textbox), textBox(textbox) {}
 
-QSize LineNumberDisplay::sizeHint() const { return QSize(textBox->calculateLineNumbersDisplayWidth(), 0); }
+QSize LineNumberDisplay::sizeHint() const {
+    return QSize(textBox->calculateLineNumbersDisplayWidth(), 0);
+}
 
-void LineNumberDisplay::paintEvent(QPaintEvent* event) { textBox->lineNumbersPaintEvent(event); }
+void LineNumberDisplay::paintEvent(QPaintEvent* event) {
+    textBox->lineNumbersPaintEvent(event);
+}
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/main_toolbar.cpp
+++ b/src/widgets/main_toolbar.cpp
@@ -1,7 +1,5 @@
 #include "widgets/main_toolbar.h"
 
-#include <algorithm>
-
 #include <QComboBox>
 #include <QFile>
 #include <QGraphicsDropShadowEffect>
@@ -9,6 +7,8 @@
 #include <QLayout>
 #include <QMenu>
 #include <QSignalBlocker>
+#include <algorithm>
+
 #include <qaction.h>
 #include <qfiledevice.h>
 #include <qicon.h>
@@ -43,7 +43,7 @@ bool usesCustomPathOrderLocation(const QSharedPointer<SettingsBase>& sb) {
            optionalPathOrderUsesCustomLocation(sb->setting<int>(PS::Optimizations::kInsetPathOrder)) ||
            optionalPathOrderUsesCustomLocation(sb->setting<int>(PS::Optimizations::kSkinPathOrder));
 }
-} // namespace
+}  // namespace
 
 MainToolbar::MainToolbar(QWidget* parent) : m_parent(parent), QToolBar(parent) {
     setup();
@@ -193,7 +193,7 @@ QToolButton* MainToolbar::buildIconButton(const QString& icon_loc, const QString
 }
 
 QMenu* MainToolbar::buildAddMenu() {
-    auto* add_menu = new QMenu(this);
+    auto* add_menu          = new QMenu(this);
     auto* build_part_action = new QAction("Load Build Model", this);
     build_part_action->setIcon(QIcon(":/icons/print_head.png"));
     connect(build_part_action, &QAction::triggered, this, [this]() { emit loadModel(MeshType::kBuild); });
@@ -257,22 +257,16 @@ QMenu* MainToolbar::buildShapeMenu() {
 
         double length = promptForSize("Enter length", PreferencesManager::getInstance()->getDistanceUnitText(),
                                       PreferencesManager::getInstance()->getDistanceUnit()(), len_ok);
-        if (!len_ok) {
-            return;
-        }
+        if (!len_ok) { return; }
         double width = promptForSize("Enter width", PreferencesManager::getInstance()->getDistanceUnitText(),
                                      PreferencesManager::getInstance()->getDistanceUnit()(), width_ok);
-        if (!width_ok) {
-            return;
-        }
+        if (!width_ok) { return; }
         double height = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
                                       PreferencesManager::getInstance()->getDistanceUnit()(), height_ok);
-        if (!height_ok) {
-            return;
-        }
+        if (!height_ok) { return; }
 
         auto new_mesh = QSharedPointer<ClosedMesh>::create(MeshFactory::CreateBoxMesh(length, width, height));
-        QString name = promptForName();
+        QString name  = promptForName();
         if (name != "") {
             new_mesh->setName(name);
             auto new_part = QSharedPointer<Part>::create(new_mesh);
@@ -288,17 +282,13 @@ QMenu* MainToolbar::buildShapeMenu() {
         double side_length =
             promptForSize("Enter side length", PreferencesManager::getInstance()->getDistanceUnitText(),
                           PreferencesManager::getInstance()->getDistanceUnit()(), side_length_ok);
-        if (!side_length_ok) {
-            return;
-        }
+        if (!side_length_ok) { return; }
         double height = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
                                       PreferencesManager::getInstance()->getDistanceUnit()(), height_ok);
-        if (!height_ok) {
-            return;
-        }
+        if (!height_ok) { return; }
 
         auto new_mesh = QSharedPointer<ClosedMesh>::create(MeshFactory::CreateHexagonalPrismMesh(side_length, height));
-        QString name = promptForName();
+        QString name  = promptForName();
         if (name != "") {
             new_mesh->setName(name);
             auto new_part = QSharedPointer<Part>::create(new_mesh);
@@ -313,22 +303,16 @@ QMenu* MainToolbar::buildShapeMenu() {
 
         double length = promptForSize("Enter length", PreferencesManager::getInstance()->getDistanceUnitText(),
                                       PreferencesManager::getInstance()->getDistanceUnit()(), len_ok);
-        if (!len_ok) {
-            return;
-        }
+        if (!len_ok) { return; }
         double width = promptForSize("Enter width", PreferencesManager::getInstance()->getDistanceUnitText(),
                                      PreferencesManager::getInstance()->getDistanceUnit()(), width_ok);
-        if (!width_ok) {
-            return;
-        }
+        if (!width_ok) { return; }
         double height = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
                                       PreferencesManager::getInstance()->getDistanceUnit()(), height_ok);
-        if (!height_ok) {
-            return;
-        }
+        if (!height_ok) { return; }
 
         auto new_mesh = QSharedPointer<OpenMesh>::create(MeshFactory::CreateOpenTopBoxMesh(length, width, height));
-        QString name = promptForName();
+        QString name  = promptForName();
         if (name != "") {
             new_mesh->setName(name);
             auto new_part = QSharedPointer<Part>::create(new_mesh);
@@ -345,7 +329,7 @@ QMenu* MainToolbar::buildShapeMenu() {
 
         if (ok) {
             auto new_mesh = QSharedPointer<ClosedMesh>::create(MeshFactory::CreateTriaglePyramidMesh(length));
-            QString name = promptForName();
+            QString name  = promptForName();
             if (name != "") {
                 new_mesh->setName(name);
                 auto new_part = QSharedPointer<Part>::create(new_mesh);
@@ -358,10 +342,10 @@ QMenu* MainToolbar::buildShapeMenu() {
     auto* cylinder_action = new QAction("Create Cylinder", this);
     connect(cylinder_action, &QAction::triggered, this, [this, PM = PreferencesManager::getInstance()]() {
         bool ok;
-        double radius = promptForSize("Enter radius", PreferencesManager::getInstance()->getDistanceUnitText(),
-                                      PreferencesManager::getInstance()->getDistanceUnit()(), ok);
-        double height = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
-                                      PreferencesManager::getInstance()->getDistanceUnit()(), ok);
+        double radius  = promptForSize("Enter radius", PreferencesManager::getInstance()->getDistanceUnitText(),
+                                       PreferencesManager::getInstance()->getDistanceUnit()(), ok);
+        double height  = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
+                                       PreferencesManager::getInstance()->getDistanceUnit()(), ok);
         int resolution = int(promptForSize("Enter resolution", "segments", 1.0, ok));
 
         if (ok) {
@@ -380,15 +364,15 @@ QMenu* MainToolbar::buildShapeMenu() {
     auto* cone_action = new QAction("Create Cone", this);
     connect(cone_action, &QAction::triggered, this, [this, PM = PreferencesManager::getInstance()]() {
         bool ok;
-        double radius = promptForSize("Enter radius", PreferencesManager::getInstance()->getDistanceUnitText(),
-                                      PreferencesManager::getInstance()->getDistanceUnit()(), ok);
-        double height = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
-                                      PreferencesManager::getInstance()->getDistanceUnit()(), ok);
+        double radius  = promptForSize("Enter radius", PreferencesManager::getInstance()->getDistanceUnitText(),
+                                       PreferencesManager::getInstance()->getDistanceUnit()(), ok);
+        double height  = promptForSize("Enter height", PreferencesManager::getInstance()->getDistanceUnitText(),
+                                       PreferencesManager::getInstance()->getDistanceUnit()(), ok);
         int resolution = int(promptForSize("Enter resolution", "segments", 1.0, ok));
 
         if (ok) {
             auto new_mesh = QSharedPointer<ClosedMesh>::create(MeshFactory::CreateConeMesh(radius, height, resolution));
-            QString name = promptForName();
+            QString name  = promptForName();
             if (name != "") {
                 new_mesh->setName(name);
                 auto new_part = QSharedPointer<Part>::create(new_mesh);
@@ -426,7 +410,7 @@ void MainToolbar::enableCorrectOptions() {
         m_2d_gcode_btn->setEnabled(false);
         m_show_ghosts_btn->setEnabled(false);
         m_export_gcode_btn->setEnabled(false);
-        handleModifiedSetting(""); // Checks and sets seam button
+        handleModifiedSetting("");  // Checks and sets seam button
     }
 }
 
@@ -439,12 +423,11 @@ QString MainToolbar::promptForName() {
     while (name.isEmpty()) {
         name = QInputDialog::getText(this, tr("New Mesh Name"), label, QLineEdit::Normal, "", &ok);
 
-        if (!ok)
-            break;
+        if (!ok) break;
 
         if (CSM->getPart(name) != nullptr) {
             label = "Name already in use. Please enter another:";
-            name = "";
+            name  = "";
         }
     }
 
@@ -455,20 +438,19 @@ double MainToolbar::promptForSize(const QString& label_text, const QString& unit
                                   bool& ok) {
     QString str_value;
     QString label = label_text + "(" + unit_text + "):";
-    double value = 0.0;
-    ok = true;
+    double value  = 0.0;
+    ok            = true;
 
     while (str_value.isEmpty()) {
         str_value = QInputDialog::getText(this, tr("Input"), label, QLineEdit::Normal, "", &ok);
 
-        if (!ok)
-            break;
+        if (!ok) break;
 
         bool conv_ok = false;
-        value = str_value.toDouble(&conv_ok);
+        value        = str_value.toDouble(&conv_ok);
 
         if (!conv_ok) {
-            label = "Error with number. " + label_text + "(" + unit_text + "):";
+            label     = "Error with number. " + label_text + "(" + unit_text + "):";
             str_value = "";
         }
     }
@@ -512,9 +494,13 @@ void MainToolbar::resize(QSize new_size) {
     this->raise();
 }
 
-void MainToolbar::setSliceAbility(bool status) { m_slice_btn->setEnabled(status); }
+void MainToolbar::setSliceAbility(bool status) {
+    m_slice_btn->setEnabled(status);
+}
 
-void MainToolbar::setExportAbility(bool status) { m_export_gcode_btn->setEnabled(status); }
+void MainToolbar::setExportAbility(bool status) {
+    m_export_gcode_btn->setEnabled(status);
+}
 
 void MainToolbar::setLayerSettingsRangeAbility(bool status) {
     m_layer_settings_range_available = status;
@@ -523,9 +509,7 @@ void MainToolbar::setLayerSettingsRangeAbility(bool status) {
         m_layer_settings_range_btn->setToolTip("No layer-specific settings to show");
         m_layer_settings_range_btn->setChecked(false);
     }
-    else {
-        m_layer_settings_range_btn->setToolTip("Show selected layer settings height");
-    }
+    else { m_layer_settings_range_btn->setToolTip("Show selected layer settings height"); }
 
     enableCorrectOptions();
 }
@@ -554,4 +538,4 @@ void MainToolbar::handleModifiedSetting(const QString& setting_key) {
         m_seam_btn->setToolTip("Show optimization points");
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/input/tool_bar_align_input.cpp
+++ b/src/widgets/part_widget/input/tool_bar_align_input.cpp
@@ -2,6 +2,7 @@
 
 #include <QFile>
 #include <QGraphicsDropShadowEffect>
+
 #include <qboxlayout.h>
 #include <qeasingcurve.h>
 #include <qfiledevice.h>
@@ -19,7 +20,9 @@
 #include "utilities/constants.h"
 
 namespace ORNL {
-ToolbarAlignInput::ToolbarAlignInput(QWidget* parent) : QFrame(parent) { this->setupWidget(); }
+ToolbarAlignInput::ToolbarAlignInput(QWidget* parent) : QFrame(parent) {
+    this->setupWidget();
+}
 
 void ToolbarAlignInput::setPos(QPoint pos) {
     m_pos = pos;
@@ -179,4 +182,4 @@ QFrame* ToolbarAlignInput::buildSeparator() {
     return line;
 }
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/part_widget/input/tool_bar_input.cpp
+++ b/src/widgets/part_widget/input/tool_bar_input.cpp
@@ -2,6 +2,7 @@
 
 #include <QFile>
 #include <QGraphicsDropShadowEffect>
+
 #include <qboxlayout.h>
 #include <qcheckbox.h>
 #include <qcombobox.h>
@@ -46,7 +47,7 @@ void ToolbarInput::setWrapping(bool w) {
 
 void ToolbarInput::setModel(QSharedPointer<PartMetaModel> m, ModelTrackingType type) {
     m_model = m;
-    m_type = type;
+    m_type  = type;
 
     switch (type) {
         case ModelTrackingType::kTranslation: {
@@ -101,8 +102,7 @@ void ToolbarInput::setValue(Axis axis, double val) {
 }
 
 void ToolbarInput::setIndex(int index) {
-    if (m_combo != nullptr)
-        m_combo->setCurrentIndex(index);
+    if (m_combo != nullptr) m_combo->setCurrentIndex(index);
 }
 
 double ToolbarInput::getValue(Axis axis) {
@@ -126,11 +126,17 @@ void ToolbarInput::setMaximumValue(double val) {
     m_input_z->setMaximum(val);
 }
 
-void ToolbarInput::setMaximumXValue(double val) { m_input_x->setMaximum(val); }
+void ToolbarInput::setMaximumXValue(double val) {
+    m_input_x->setMaximum(val);
+}
 
-void ToolbarInput::setMaximumYValue(double val) { m_input_y->setMaximum(val); }
+void ToolbarInput::setMaximumYValue(double val) {
+    m_input_y->setMaximum(val);
+}
 
-void ToolbarInput::setMaximumZValue(double val) { m_input_z->setMaximum(val); }
+void ToolbarInput::setMaximumZValue(double val) {
+    m_input_z->setMaximum(val);
+}
 
 void ToolbarInput::setMinimumValue(double val) {
     m_input_x->setMinimum(val);
@@ -138,23 +144,36 @@ void ToolbarInput::setMinimumValue(double val) {
     m_input_z->setMinimum(val);
 }
 
-void ToolbarInput::setMinimumXValue(double val) { m_input_x->setMinimum(val); }
+void ToolbarInput::setMinimumXValue(double val) {
+    m_input_x->setMinimum(val);
+}
 
-void ToolbarInput::setMinimumYValue(double val) { m_input_y->setMinimum(val); }
+void ToolbarInput::setMinimumYValue(double val) {
+    m_input_y->setMinimum(val);
+}
 
-void ToolbarInput::setMinimumZValue(double val) { m_input_z->setMinimum(val); }
+void ToolbarInput::setMinimumZValue(double val) {
+    m_input_z->setMinimum(val);
+}
 
-void ToolbarInput::setUnitText(QString unit) { m_label_unit->setText(unit); }
+void ToolbarInput::setUnitText(QString unit) {
+    m_label_unit->setText(unit);
+}
 
-void ToolbarInput::setXText(QString x) { m_label_x->setText(x); }
+void ToolbarInput::setXText(QString x) {
+    m_label_x->setText(x);
+}
 
-void ToolbarInput::setYText(QString y) { m_label_y->setText(y); }
+void ToolbarInput::setYText(QString y) {
+    m_label_y->setText(y);
+}
 
-void ToolbarInput::setZText(QString z) { m_label_z->setText(z); }
+void ToolbarInput::setZText(QString z) {
+    m_label_z->setText(z);
+}
 
 void ToolbarInput::readValue(double val) {
-    if (m_model.isNull() || m_selected_item.isNull())
-        return;
+    if (m_model.isNull() || m_selected_item.isNull()) return;
 
     QVector3D new_val;
 
@@ -178,8 +197,8 @@ void ToolbarInput::readValue(double val) {
         }
 
         case ModelTrackingType::kRotation: {
-            Angle conv = deg;
-            Angle pm_ang = PreferencesManager::getInstance()->getAngleUnit();
+            Angle conv    = deg;
+            Angle pm_ang  = PreferencesManager::getInstance()->getAngleUnit();
             double conv_d = conv.to(pm_ang);
 
             QObject::disconnect(m_model.get(), &PartMetaModel::transformUpdate, this,
@@ -204,8 +223,7 @@ void ToolbarInput::readValue(double val) {
 }
 
 void ToolbarInput::readUnit(int index) {
-    if (m_model.isNull() || m_selected_item.isNull())
-        return;
+    if (m_model.isNull() || m_selected_item.isNull()) return;
 
     Distance conversion;
     switch (index) {
@@ -308,8 +326,7 @@ void ToolbarInput::modelSelectionUpdate(QSharedPointer<PartMetaItem> item) {
 }
 
 void ToolbarInput::modelTranslationUpdate(QSharedPointer<PartMetaItem> item) {
-    if (m_selected_item != item)
-        return;
+    if (m_selected_item != item) return;
 
     Distance conv;
     Distance pm_dist = PreferencesManager::getInstance()->getDistanceUnit();
@@ -333,11 +350,10 @@ void ToolbarInput::modelTranslationUpdate(QSharedPointer<PartMetaItem> item) {
 }
 
 void ToolbarInput::modelRotationUpdate(QSharedPointer<PartMetaItem> item) {
-    if (m_selected_item != item)
-        return;
+    if (m_selected_item != item) return;
 
-    Angle conv = deg;
-    Angle pm_ang = PreferencesManager::getInstance()->getAngleUnit();
+    Angle conv    = deg;
+    Angle pm_ang  = PreferencesManager::getInstance()->getAngleUnit();
     double conv_d = conv.to(pm_ang);
 
     QVector3D r = m_selected_item->rotation().toEulerAngles();
@@ -356,8 +372,7 @@ void ToolbarInput::modelRotationUpdate(QSharedPointer<PartMetaItem> item) {
 }
 
 void ToolbarInput::modelScaleUpdate(QSharedPointer<PartMetaItem> item) {
-    if (item != m_selected_item)
-        return;
+    if (item != m_selected_item) return;
 
     Distance conversion;
     switch (item->scaleUnitIndex()) {
@@ -403,8 +418,7 @@ void ToolbarInput::modelScaleUpdate(QSharedPointer<PartMetaItem> item) {
 }
 
 void ToolbarInput::modelRemovalUpdate(QSharedPointer<PartMetaItem> item) {
-    if (item == m_selected_item)
-        m_selected_item = nullptr;
+    if (item == m_selected_item) m_selected_item = nullptr;
 }
 
 void ToolbarInput::setupWidget() {
@@ -486,7 +500,9 @@ void ToolbarInput::setupStyle() {
     style->close();
 }
 
-void ToolbarInput::setupLayouts() { m_layout = new QHBoxLayout(this); }
+void ToolbarInput::setupLayouts() {
+    m_layout = new QHBoxLayout(this);
+}
 
 void ToolbarInput::setupInsert() {
     this->setLayout(m_layout);
@@ -556,11 +572,17 @@ QFrame* ToolbarInput::buildSeparator() {
     return line;
 }
 
-void ToolbarInput::disableX(bool has_settings_part) { m_input_x->setDisabled(has_settings_part); }
+void ToolbarInput::disableX(bool has_settings_part) {
+    m_input_x->setDisabled(has_settings_part);
+}
 
-void ToolbarInput::disableY(bool has_settings_part) { m_input_y->setDisabled(has_settings_part); }
+void ToolbarInput::disableY(bool has_settings_part) {
+    m_input_y->setDisabled(has_settings_part);
+}
 
-void ToolbarInput::disableZ(bool has_settings_part) { m_input_z->setDisabled(has_settings_part); }
+void ToolbarInput::disableZ(bool has_settings_part) {
+    m_input_z->setDisabled(has_settings_part);
+}
 
 void ToolbarInput::disableCombo(bool has_settings_part) {
     m_combo->setDisabled(has_settings_part);
@@ -572,4 +594,4 @@ void ToolbarInput::setPrecision(uint decimals) {
     m_input_y->setDecimals(decimals);
     m_input_z->setDecimals(decimals);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/model/part_meta_item.cpp
+++ b/src/widgets/part_widget/model/part_meta_item.cpp
@@ -22,7 +22,7 @@ namespace ORNL {
 PartMetaItem::PartMetaItem(QSharedPointer<Part> p) {
     m_part = p;
 
-    m_selected = false;
+    m_selected     = false;
     m_transparency = 255;
 
     m_type = m_part->rootMesh()->type();
@@ -38,7 +38,7 @@ PartMetaItem::PartMetaItem(QSharedPointer<Part> p) {
         m_scale_unit_index = 3;
     else if (unit == Constants::Units::kFeet)
         m_scale_unit_index = 4;
-    else // If it is any other unit default to mm
+    else  // If it is any other unit default to mm
         m_scale_unit_index = 0;
 
     m_transformation = m_part->rootMesh()->transformation();
@@ -57,18 +57,26 @@ PartMetaItem::PartMetaItem(QSharedPointer<Part> p) {
     emit modified(PartMetaUpdateType::kAddUpdate);
 }
 
-void PartMetaItem::replaceInModel(QString filename) { m_model->replaceItem(this->sharedFromThis(), filename); }
+void PartMetaItem::replaceInModel(QString filename) {
+    m_model->replaceItem(this->sharedFromThis(), filename);
+}
 
-void PartMetaItem::reloadInModel() { m_model->reloadItem(this->sharedFromThis()); }
+void PartMetaItem::reloadInModel() {
+    m_model->reloadItem(this->sharedFromThis());
+}
 
-void PartMetaItem::removeFromModel() { m_model->removeItem(this->sharedFromThis()); }
+void PartMetaItem::removeFromModel() {
+    m_model->removeItem(this->sharedFromThis());
+}
 
 void PartMetaItem::setSelected(bool toggle) {
     m_selected = toggle;
     emit modified(PartMetaUpdateType::kSelectionUpdate);
 }
 
-bool PartMetaItem::isSelected() { return m_selected; }
+bool PartMetaItem::isSelected() {
+    return m_selected;
+}
 
 void PartMetaItem::setMeshType(MeshType mt) {
     m_part->setMeshType(mt);
@@ -77,17 +85,21 @@ void PartMetaItem::setMeshType(MeshType mt) {
     emit modified(PartMetaUpdateType::kVisualUpdate);
 }
 
-MeshType PartMetaItem::meshType() { return m_type; }
+MeshType PartMetaItem::meshType() {
+    return m_type;
+}
 
 void PartMetaItem::setTransparency(uint val) {
     m_transparency = val;
     emit modified(PartMetaUpdateType::kVisualUpdate);
 }
 
-uint PartMetaItem::transparency() { return m_transparency; }
+uint PartMetaItem::transparency() {
+    return m_transparency;
+}
 
 void PartMetaItem::setWireframe(bool show) {
-    m_render_mode = (show) ? GL_LINES : GL_TRIANGLES;
+    m_render_mode    = (show) ? GL_LINES : GL_TRIANGLES;
     m_wireframe_mode = show;
     emit modified(PartMetaUpdateType::kVisualUpdate);
 }
@@ -98,24 +110,31 @@ void PartMetaItem::setSolidWireframe(bool show) {
     emit modified(PartMetaUpdateType::kVisualUpdate);
 }
 
-bool PartMetaItem::wireframeMode() { return m_wireframe_mode; }
+bool PartMetaItem::wireframeMode() {
+    return m_wireframe_mode;
+}
 
-ushort PartMetaItem::renderMode() { return m_render_mode; }
+ushort PartMetaItem::renderMode() {
+    return m_render_mode;
+}
 
-bool PartMetaItem::solidWireframeMode() { return m_solid_wireframe_mode; }
+bool PartMetaItem::solidWireframeMode() {
+    return m_solid_wireframe_mode;
+}
 
 void PartMetaItem::setTranslation(QVector3D t) {
-    m_translation = t;
+    m_translation    = t;
     m_transformation = MathUtils::composeTransformMatrix(m_translation, m_rotation, m_scale);
 
     emit modified(PartMetaUpdateType::kTransformUpdate);
 }
 
-QVector3D PartMetaItem::translation() { return m_translation; }
+QVector3D PartMetaItem::translation() {
+    return m_translation;
+}
 
 void PartMetaItem::setRotation(QQuaternion r, bool current_rotation) {
-    if (m_rotation == r)
-        return;
+    if (m_rotation == r) return;
 
     const bool has_parenting = !m_parent.isNull() || !m_children.isEmpty();
 
@@ -123,7 +142,7 @@ void PartMetaItem::setRotation(QQuaternion r, bool current_rotation) {
     // can inherit the motion correctly. Baking rotation into the mesh resets the parent transform
     // and breaks the hierarchy relationship for settings meshes.
     if (current_rotation || has_parenting) {
-        m_rotation = r;
+        m_rotation       = r;
         m_transformation = MathUtils::composeTransformMatrix(m_translation, m_rotation, m_scale);
         emit modified(PartMetaUpdateType::kTransformUpdate);
         return;
@@ -132,13 +151,13 @@ void PartMetaItem::setRotation(QQuaternion r, bool current_rotation) {
     QVector3D translation = m_translation;
     setTranslation(QVector3D(0, 0, 0));
 
-    m_rotation = r;
+    m_rotation       = r;
     m_transformation = MathUtils::composeTransformMatrix(m_translation, m_rotation, m_scale);
     emit modified(PartMetaUpdateType::kTransformUpdate);
 
-    m_scale = QVector3D(1, 1, 1);
-    m_rotation = QQuaternion(1, 0, 0, 0);
-    m_translation = translation;
+    m_scale          = QVector3D(1, 1, 1);
+    m_rotation       = QQuaternion(1, 0, 0, 0);
+    m_translation    = translation;
     m_transformation = MathUtils::composeTransformMatrix(m_translation, m_rotation, m_scale);
     m_part->rootMesh()->alignAxis(m_transformation);
 
@@ -146,28 +165,34 @@ void PartMetaItem::setRotation(QQuaternion r, bool current_rotation) {
     emit modified(PartMetaUpdateType::kReloadUpdate);
 }
 
-QQuaternion PartMetaItem::rotation() { return m_rotation; }
+QQuaternion PartMetaItem::rotation() {
+    return m_rotation;
+}
 
 void PartMetaItem::setScale(QVector3D s) {
-    m_scale = s;
+    m_scale          = s;
     m_transformation = MathUtils::composeTransformMatrix(m_translation, m_rotation, m_scale);
 
     emit modified(PartMetaUpdateType::kTransformUpdate);
 }
 
-QVector3D PartMetaItem::scale() { return m_scale; }
+QVector3D PartMetaItem::scale() {
+    return m_scale;
+}
 
 void PartMetaItem::setTransformation(QMatrix4x4 m) {
-    m_transformation = m;
+    m_transformation                             = m;
     std::tie(m_translation, m_rotation, m_scale) = MathUtils::decomposeTransformMatrix(m_transformation);
 
     emit modified(PartMetaUpdateType::kTransformUpdate);
 }
 
-QMatrix4x4 PartMetaItem::transformation() { return m_transformation; }
+QMatrix4x4 PartMetaItem::transformation() {
+    return m_transformation;
+}
 
 void PartMetaItem::resetTransformation() {
-    m_transformation = m_original_transformation;
+    m_transformation                             = m_original_transformation;
     std::tie(m_translation, m_rotation, m_scale) = MathUtils::decomposeTransformMatrix(m_transformation);
 
     m_part->rootMesh()->resetAlignedAxis(m_transformation);
@@ -176,7 +201,9 @@ void PartMetaItem::resetTransformation() {
     emit modified(PartMetaUpdateType::kReloadUpdate);
 }
 
-void PartMetaItem::setOriginalTransformation(QMatrix4x4 m) { m_aligned_transformation = m; }
+void PartMetaItem::setOriginalTransformation(QMatrix4x4 m) {
+    m_aligned_transformation = m;
+}
 
 void PartMetaItem::adoptChild(QSharedPointer<PartMetaItem> c) {
     m_children.append(c);
@@ -185,7 +212,9 @@ void PartMetaItem::adoptChild(QSharedPointer<PartMetaItem> c) {
     emit modified(PartMetaUpdateType::kParentingUpdate);
 }
 
-QList<QSharedPointer<PartMetaItem>> PartMetaItem::children() { return m_children; }
+QList<QSharedPointer<PartMetaItem>> PartMetaItem::children() {
+    return m_children;
+}
 
 void PartMetaItem::orphanChild(QSharedPointer<PartMetaItem> c) {
     m_children.removeOne(c);
@@ -200,11 +229,17 @@ void PartMetaItem::setParent(QSharedPointer<PartMetaItem> p) {
     emit modified(PartMetaUpdateType::kParentingUpdate);
 }
 
-QSharedPointer<PartMetaItem> PartMetaItem::parent() { return m_parent; }
+QSharedPointer<PartMetaItem> PartMetaItem::parent() {
+    return m_parent;
+}
 
-void PartMetaItem::setGraphicsPart(QSharedPointer<PartObject> gop) { m_graphics_part = gop; }
+void PartMetaItem::setGraphicsPart(QSharedPointer<PartObject> gop) {
+    m_graphics_part = gop;
+}
 
-QSharedPointer<PartObject> PartMetaItem::graphicsPart() { return m_graphics_part; }
+QSharedPointer<PartObject> PartMetaItem::graphicsPart() {
+    return m_graphics_part;
+}
 
 void PartMetaItem::setScaleUnitIndex(uint idx) {
     m_scale_unit_index = idx;
@@ -212,23 +247,27 @@ void PartMetaItem::setScaleUnitIndex(uint idx) {
     emit modified(PartMetaUpdateType::kTransformUpdate);
 }
 
-uint PartMetaItem::scaleUnitIndex() { return m_scale_unit_index; }
+uint PartMetaItem::scaleUnitIndex() {
+    return m_scale_unit_index;
+}
 
-QSharedPointer<Part> PartMetaItem::part() { return m_part; }
+QSharedPointer<Part> PartMetaItem::part() {
+    return m_part;
+}
 
 int PartMetaItem::instanceCount() {
-    if (m_model.isNull())
-        return 1;
+    if (m_model.isNull()) return 1;
 
     return m_model->instanceCount(this->sharedFromThis());
 }
 
 void PartMetaItem::setInstanceCount(int count) {
-    if (m_model.isNull())
-        return;
+    if (m_model.isNull()) return;
 
     m_model->setInstanceCount(this->sharedFromThis(), count);
 }
 
-void PartMetaItem::setModel(QSharedPointer<PartMetaModel> m) { m_model = m; }
-} // namespace ORNL
+void PartMetaItem::setModel(QSharedPointer<PartMetaModel> m) {
+    m_model = m;
+}
+}  // namespace ORNL

--- a/src/widgets/part_widget/model/part_meta_model.cpp
+++ b/src/widgets/part_widget/model/part_meta_model.cpp
@@ -1,10 +1,10 @@
 #include "widgets/part_widget/model/part_meta_model.h"
 
+#include <QStack>
+#include <QStringList>
 #include <algorithm>
 #include <limits>
 
-#include <QStack>
-#include <QStringList>
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qmap.h>
@@ -25,34 +25,28 @@ const QString kCopySuffix = "_copy";
 
 QString instanceBaseName(const QString& name) {
     const int copy_index = name.lastIndexOf(kCopySuffix);
-    if (copy_index < 0)
-        return name;
+    if (copy_index < 0) return name;
 
     const QString suffix = name.mid(copy_index + kCopySuffix.size());
-    if (suffix.isEmpty())
-        return name.left(copy_index);
+    if (suffix.isEmpty()) return name.left(copy_index);
 
     if (suffix.startsWith("_")) {
         bool suffix_is_number = false;
         suffix.mid(1).toUInt(&suffix_is_number);
-        if (suffix_is_number)
-            return name.left(copy_index);
+        if (suffix_is_number) return name.left(copy_index);
     }
 
     return name;
 }
 
 bool isInstanceName(const QString& name, const QString& base_name) {
-    if (name == base_name)
-        return true;
+    if (name == base_name) return true;
 
     const QString copy_name = base_name + kCopySuffix;
-    if (name == copy_name)
-        return true;
+    if (name == copy_name) return true;
 
     const QString numbered_copy_prefix = copy_name + "_";
-    if (!name.startsWith(numbered_copy_prefix))
-        return false;
+    if (!name.startsWith(numbered_copy_prefix)) return false;
 
     bool suffix_is_number = false;
     name.mid(numbered_copy_prefix.size()).toUInt(&suffix_is_number);
@@ -60,31 +54,26 @@ bool isInstanceName(const QString& name, const QString& base_name) {
 }
 
 uint instanceSortIndex(const QString& name, const QString& base_name) {
-    if (name == base_name)
-        return 0;
+    if (name == base_name) return 0;
 
     const QString copy_name = base_name + kCopySuffix;
-    if (name == copy_name)
-        return 1;
+    if (name == copy_name) return 1;
 
     const QString numbered_copy_prefix = copy_name + "_";
     if (name.startsWith(numbered_copy_prefix)) {
         bool suffix_is_number = false;
-        const uint suffix = name.mid(numbered_copy_prefix.size()).toUInt(&suffix_is_number);
-        if (suffix_is_number)
-            return suffix + 2;
+        const uint suffix     = name.mid(numbered_copy_prefix.size()).toUInt(&suffix_is_number);
+        if (suffix_is_number) return suffix + 2;
     }
 
     return std::numeric_limits<uint>::max();
 }
 
 QString uniqueInstanceName(const QString& base_name, const QStringList& names) {
-    if (!names.contains(base_name))
-        return base_name;
+    if (!names.contains(base_name)) return base_name;
 
     const QString first_copy_name = base_name + kCopySuffix;
-    if (!names.contains(first_copy_name))
-        return first_copy_name;
+    if (!names.contains(first_copy_name)) return first_copy_name;
 
     uint count = 1;
     QString name;
@@ -97,12 +86,10 @@ QString uniqueInstanceName(const QString& base_name, const QStringList& names) {
 }
 
 void setPartInstanceName(QSharedPointer<Part> part, const QString& name) {
-    if (part.isNull())
-        return;
+    if (part.isNull()) return;
 
     part->setName(name);
-    if (!part->rootMesh().isNull())
-        part->rootMesh()->setName(name);
+    if (!part->rootMesh().isNull()) part->rootMesh()->setName(name);
 }
 
 QSharedPointer<Part> copyPartInstance(QSharedPointer<Part> source, const QString& name) {
@@ -112,39 +99,37 @@ QSharedPointer<Part> copyPartInstance(QSharedPointer<Part> source, const QString
 
     return copy;
 }
-} // namespace
+}  // namespace
 
 PartMetaModel::PartMetaModel() {
     // NOP
 }
 
-QList<QSharedPointer<PartMetaItem>> PartMetaModel::items() { return m_pointer_lookup.values(); }
+QList<QSharedPointer<PartMetaItem>> PartMetaModel::items() {
+    return m_pointer_lookup.values();
+}
 
 QList<QSharedPointer<PartMetaItem>> PartMetaModel::selectedItems() {
     QList<QSharedPointer<PartMetaItem>> ret;
     for (auto& pm : m_pointer_lookup.values()) {
-        if (pm->isSelected())
-            ret.append(pm);
+        if (pm->isSelected()) ret.append(pm);
     }
 
     return ret;
 }
 
 QSharedPointer<PartMetaItem> PartMetaModel::lookupByGraphic(QSharedPointer<PartObject> gop) {
-    if (gop.isNull())
-        return nullptr;
+    if (gop.isNull()) return nullptr;
     return this->lookupByPointer(gop->part());
 }
 
 QSharedPointer<PartMetaItem> PartMetaModel::lookupByTreeItem(PartControlTreeItem* item) {
-    if (!item)
-        return nullptr;
+    if (!item) return nullptr;
     return this->lookupByPointer(item->getPart());
 }
 
 QSharedPointer<PartMetaItem> PartMetaModel::lookupByPointer(QSharedPointer<Part> p) {
-    if (!m_pointer_lookup.contains(p))
-        return nullptr;
+    if (!m_pointer_lookup.contains(p)) return nullptr;
     return m_pointer_lookup[p];
 }
 
@@ -166,16 +151,12 @@ void PartMetaModel::addItem(QSharedPointer<PartMetaItem> pm) {
     QMap<QSharedPointer<Part>, QSharedPointer<PartMetaItem>> item_lookup;
 
     item_lookup[pm->part()] = pm;
-    for (auto& c : pm->part()->children()) {
-        queue.push(c);
-    }
+    for (auto& c : pm->part()->children()) { queue.push(c); }
 
     while (!queue.empty()) {
         QSharedPointer<Part> curr_part = queue.pop();
 
-        for (auto& c : curr_part->children()) {
-            queue.push(c);
-        }
+        for (auto& c : curr_part->children()) { queue.push(c); }
 
         QSharedPointer<PartMetaItem> cpm = QSharedPointer<PartMetaItem>::create(curr_part);
         QObject::connect(cpm.get(), &PartMetaItem::modified, this, &PartMetaModel::itemUpdated);
@@ -184,7 +165,7 @@ void PartMetaModel::addItem(QSharedPointer<PartMetaItem> pm) {
         item_lookup[curr_part->parent()]->blockSignals(true);
         item_lookup[curr_part->parent()]->adoptChild(cpm);
         item_lookup[curr_part->parent()]->blockSignals(false);
-        item_lookup[curr_part] = cpm;
+        item_lookup[curr_part]      = cpm;
         m_pointer_lookup[curr_part] = cpm;
 
         cpm->setModel(this->sharedFromThis());
@@ -192,31 +173,26 @@ void PartMetaModel::addItem(QSharedPointer<PartMetaItem> pm) {
 }
 
 void PartMetaModel::replaceItem(QSharedPointer<PartMetaItem> pm, QString filename) {
-    if (pm.isNull())
-        return;
+    if (pm.isNull()) return;
 
     CSM->replacePart(pm, filename);
 }
 
 void PartMetaModel::reloadItem(QSharedPointer<PartMetaItem> pm) {
-    if (pm.isNull())
-        return;
+    if (pm.isNull()) return;
 
     CSM->reloadPart(pm);
 }
 
 void PartMetaModel::removeItem(QSharedPointer<PartMetaItem> pm) {
-    if (pm.isNull())
-        return;
+    if (pm.isNull()) return;
 
     m_pointer_lookup.remove(pm->part());
 
     // Children of this item need to find new parents. This item's parent can adopt.
     auto pm_par = pm->parent();
     if (pm_par.isNull()) {
-        for (auto pm_child : pm->children()) {
-            pm->orphanChild(pm_child);
-        }
+        for (auto pm_child : pm->children()) { pm->orphanChild(pm_child); }
     }
     else {
         pm_par->orphanChild(pm);
@@ -231,32 +207,26 @@ void PartMetaModel::removeItem(QSharedPointer<PartMetaItem> pm) {
 }
 
 void PartMetaModel::clearItems() {
-    for (auto& pm : m_pointer_lookup.values()) {
-        this->removeItem(pm);
-    }
+    for (auto& pm : m_pointer_lookup.values()) { this->removeItem(pm); }
 }
 
-void PartMetaModel::setSelectionCopied() { m_copied_list = this->selectedItems(); }
+void PartMetaModel::setSelectionCopied() {
+    m_copied_list = this->selectedItems();
+}
 
 void PartMetaModel::copySelection() {
     QStack<QSharedPointer<PartMetaItem>> queue;
-    for (auto& pm : m_copied_list) {
-        queue.push(pm);
-    }
+    for (auto& pm : m_copied_list) { queue.push(pm); }
 
     QStringList namelist;
-    for (auto& p : m_pointer_lookup.keys()) {
-        namelist.append(p->name());
-    }
+    for (auto& p : m_pointer_lookup.keys()) { namelist.append(p->name()); }
 
     QMap<QSharedPointer<PartMetaItem>, QSharedPointer<Part>> result;
 
     while (!queue.empty()) {
         QSharedPointer<PartMetaItem> pm = queue.pop();
 
-        for (auto& cpm : pm->children()) {
-            queue.push(cpm);
-        }
+        for (auto& cpm : pm->children()) { queue.push(cpm); }
 
         // Copy part.
         QSharedPointer<Part> p = QSharedPointer<Part>::create(pm->part());
@@ -264,7 +234,7 @@ void PartMetaModel::copySelection() {
         p->setName(p->name() + "_copy");
 
         QString org_name = p->name();
-        uint count = 1;
+        uint count       = 1;
 
         // Find a new name.
         while (namelist.contains(p->name())) {
@@ -276,27 +246,25 @@ void PartMetaModel::copySelection() {
         result[pm] = p;
 
         // If this item has a parent, link it up.
-        if (result.contains(pm->parent())) {
-            result[pm->parent()]->adoptChild(p);
-        }
+        if (result.contains(pm->parent())) { result[pm->parent()]->adoptChild(p); }
     }
 
     // Add to model.
     for (auto& p : result.values()) {
-        if (!p->parent().isNull())
-            continue;
+        if (!p->parent().isNull()) continue;
         this->newItem(p);
     }
 }
 
-int PartMetaModel::instanceCount(QSharedPointer<PartMetaItem> pm) { return this->instanceItems(pm).size(); }
+int PartMetaModel::instanceCount(QSharedPointer<PartMetaItem> pm) {
+    return this->instanceItems(pm).size();
+}
 
 void PartMetaModel::setInstanceCount(QSharedPointer<PartMetaItem> pm, int count) {
-    if (pm.isNull() || count < 1)
-        return;
+    if (pm.isNull() || count < 1) return;
 
     QList<QSharedPointer<PartMetaItem>> instances = this->instanceItems(pm);
-    const QString base_name = instanceBaseName(pm->part()->name());
+    const QString base_name                       = instanceBaseName(pm->part()->name());
 
     while (instances.size() > count) {
         int remove_index = -1;
@@ -307,23 +275,19 @@ void PartMetaModel::setInstanceCount(QSharedPointer<PartMetaItem> pm, int count)
             }
         }
 
-        if (remove_index < 0)
-            break;
+        if (remove_index < 0) break;
 
         QSharedPointer<PartMetaItem> item = instances.takeAt(remove_index);
         this->removeItem(item);
     }
 
-    if (instances.size() >= count)
-        return;
+    if (instances.size() >= count) return;
 
     QStringList namelist;
-    for (auto& p : m_pointer_lookup.keys()) {
-        namelist.append(p->name());
-    }
+    for (auto& p : m_pointer_lookup.keys()) { namelist.append(p->name()); }
 
     while (instances.size() < count) {
-        const QString name = uniqueInstanceName(base_name, namelist);
+        const QString name        = uniqueInstanceName(base_name, namelist);
         QSharedPointer<Part> copy = copyPartInstance(pm->part(), name);
 
         CSM->addPart(copy, false);
@@ -335,13 +299,11 @@ void PartMetaModel::setInstanceCount(QSharedPointer<PartMetaItem> pm, int count)
 
 QList<QSharedPointer<PartMetaItem>> PartMetaModel::instanceItems(QSharedPointer<PartMetaItem> pm) {
     QList<QSharedPointer<PartMetaItem>> instances;
-    if (pm.isNull())
-        return instances;
+    if (pm.isNull()) return instances;
 
     const QString base_name = instanceBaseName(pm->part()->name());
     for (auto& item : m_pointer_lookup.values()) {
-        if (isInstanceName(item->part()->name(), base_name))
-            instances.append(item);
+        if (isInstanceName(item->part()->name(), base_name)) instances.append(item);
     }
 
     std::sort(instances.begin(), instances.end(),
@@ -382,4 +344,4 @@ void PartMetaModel::itemUpdated(PartMetaItem::PartMetaUpdateType type) {
 
     emit modelUpdated(sender);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/part_control/part_control.cpp
+++ b/src/widgets/part_widget/part_control/part_control.cpp
@@ -5,6 +5,7 @@
 #include <QListWidget>
 #include <QMenu>
 #include <QStack>
+
 #include <QtWidgets/QInputDialog>
 #include <qabstractitemview.h>
 #include <qboxlayout.h>
@@ -34,7 +35,9 @@ PartControl::PartControl(QWidget* parent) : QWidget(parent) {
     this->setupEvents();
 }
 
-int PartControl::count() { return m_tree_widget->topLevelItemCount(); }
+int PartControl::count() {
+    return m_tree_widget->topLevelItemCount();
+}
 
 QString PartControl::nameOfFirstPart() {
     return ((PartControlTreeItem*)m_tree_widget->topLevelItem(0))->getPart()->name();
@@ -66,7 +69,7 @@ void PartControl::modelAdditionUpdate(QSharedPointer<PartMetaItem> pm) {
 void PartControl::modelRemovalUpdate(QSharedPointer<PartMetaItem> pm) {
     QList<QTreeWidgetItem*> tl = m_tree_widget->findItems(pm->part()->name(), Qt::MatchExactly | Qt::MatchRecursive);
     PartControlTreeItem* tree_item = tree_item = (PartControlTreeItem*)tl.at(0);
-    PartControlTreeItem* tree_item_parent = (PartControlTreeItem*)tree_item->parent();
+    PartControlTreeItem* tree_item_parent      = (PartControlTreeItem*)tree_item->parent();
 
     // Move children to parent.
     QList<QTreeWidgetItem*> child_list = tree_item->takeChildren();
@@ -93,9 +96,7 @@ void PartControl::modelSelectionUpdate(QSharedPointer<PartMetaItem> pm) {
             p = (PartControlTreeItem*)p->parent();
         }
     }
-    else {
-        tree_item->setSelected(false);
-    }
+    else { tree_item->setSelected(false); }
     connect(m_tree_widget, &PartControlTreeWidget::itemSelectionChanged, this, &PartControl::handleSelectionChange);
 }
 
@@ -142,8 +143,7 @@ void PartControl::handleSelectionChange() {
     QList<QTreeWidgetItem*> tl = m_tree_widget->findItems("*", Qt::MatchWildcard | Qt::MatchRecursive);
     for (auto curr_item : tl) {
         QSharedPointer<PartMetaItem> meta = m_model->lookupByTreeItem((PartControlTreeItem*)curr_item);
-        if (meta.isNull())
-            continue;
+        if (meta.isNull()) continue;
 
         if (meta->graphicsPart()->locked()) {
             curr_item->setSelected(false);
@@ -151,12 +151,8 @@ void PartControl::handleSelectionChange() {
         }
 
         // Note: this extra checking here is to prevent unnecessary calls to views.
-        if (curr_item->isSelected() && !meta->isSelected()) {
-            meta->setSelected(true);
-        }
-        else if (!curr_item->isSelected() && meta->isSelected()) {
-            meta->setSelected(false);
-        }
+        if (curr_item->isSelected() && !meta->isSelected()) { meta->setSelected(true); }
+        else if (!curr_item->isSelected() && meta->isSelected()) { meta->setSelected(false); }
     }
 
     QObject::connect(m_model.get(), &PartMetaModel::selectionUpdate, this, &PartControl::modelSelectionUpdate);
@@ -167,18 +163,16 @@ void PartControl::handleParentingChange() {
 
     QList<QTreeWidgetItem*> tl = m_tree_widget->findItems("*", Qt::MatchWildcard | Qt::MatchRecursive);
     for (auto curr_item : tl) {
-        QSharedPointer<PartMetaItem> meta = m_model->lookupByTreeItem((PartControlTreeItem*)curr_item);
+        QSharedPointer<PartMetaItem> meta        = m_model->lookupByTreeItem((PartControlTreeItem*)curr_item);
         QSharedPointer<PartMetaItem> item_parent = m_model->lookupByTreeItem((PartControlTreeItem*)curr_item->parent());
 
         // If the model's parent does not match the item's parent, then we need to update the model.
         if (meta->parent() != item_parent) {
             // Parent orphans the child.
-            if (!meta->parent().isNull())
-                meta->parent()->orphanChild(meta);
+            if (!meta->parent().isNull()) meta->parent()->orphanChild(meta);
 
             // New parent adopts the child.
-            if (!item_parent.isNull())
-                item_parent->adoptChild(meta);
+            if (!item_parent.isNull()) item_parent->adoptChild(meta);
 
             QList<QTreeWidgetItem*> tl =
                 m_tree_widget->findItems(meta->part()->name(), Qt::MatchExactly | Qt::MatchRecursive);
@@ -197,9 +191,7 @@ void PartControl::setFloatingStatus(const QString& name, bool status) {
 
     for (auto result : search) {
         auto tree_item = dynamic_cast<PartControlTreeItem*>(result);
-        if (tree_item != nullptr) {
-            tree_item->setFloating(status);
-        }
+        if (tree_item != nullptr) { tree_item->setFloating(status); }
     }
 }
 
@@ -208,9 +200,7 @@ void PartControl::setOutsideStatus(const QString& name, bool status) {
 
     for (auto result : search) {
         auto tree_item = dynamic_cast<PartControlTreeItem*>(result);
-        if (tree_item != nullptr) {
-            tree_item->setOutsideVolume(status);
-        }
+        if (tree_item != nullptr) { tree_item->setOutsideVolume(status); }
     }
 }
 
@@ -264,4 +254,4 @@ void PartControl::setupStyle() {
     effect->setColor(Constants::UI::Common::DropShadow::kColor);
     this->setGraphicsEffect(effect);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/part_control/part_control_tree_item.cpp
+++ b/src/widgets/part_widget/part_control/part_control_tree_item.cpp
@@ -22,7 +22,9 @@ PartControlTreeItem::PartControlTreeItem(QSharedPointer<PartMetaItem> pm) {
     this->updateMeshType(m_part->rootMesh()->type());
 }
 
-QSharedPointer<Part> PartControlTreeItem::getPart() { return m_part; }
+QSharedPointer<Part> PartControlTreeItem::getPart() {
+    return m_part;
+}
 
 void PartControlTreeItem::updateMeshType(MeshType type) {
     m_mesh_type = type;
@@ -83,11 +85,9 @@ void PartControlTreeItem::updateToolTip() {
         tooltip.append(
             "\nThis model contains errors and is not a closed volume. Some ORNLSlicer features may be unavailable.");
 
-    if (!m_is_mesh_inside_volume)
-        tooltip.append("\nThis model is outside the print volume.");
+    if (!m_is_mesh_inside_volume) tooltip.append("\nThis model is outside the print volume.");
 
-    if (m_is_mesh_floating)
-        tooltip.append("\nThis model is floating.");
+    if (m_is_mesh_floating) tooltip.append("\nThis model is floating.");
 
     this->setToolTip(0, tooltip);
 }
@@ -113,8 +113,7 @@ PartControlTreeItem::Container::Container(QString name, bool closed, QWidget* pa
     error_label->setPixmap(error_icon.pixmap(QSize(20, 20)));
     layout->addWidget(error_label);
 
-    if (closed)
-        error_label->setVisible(false);
+    if (closed) error_label->setVisible(false);
 
     QIcon align_icon(":/icons/alert_outline_orange.png");
     m_alignment_badge = new QLabel(this);
@@ -126,12 +125,10 @@ PartControlTreeItem::Container::Container(QString name, bool closed, QWidget* pa
 }
 
 void PartControlTreeItem::Container::showOutsideVolumeBadge(bool show) {
-    if (m_alignment_badge != nullptr)
-        m_alignment_badge->setVisible(show);
+    if (m_alignment_badge != nullptr) m_alignment_badge->setVisible(show);
 }
 
 void PartControlTreeItem::Container::showFloatingBadge(bool show) {
-    if (m_alignment_badge != nullptr)
-        m_alignment_badge->setVisible(show);
+    if (m_alignment_badge != nullptr) m_alignment_badge->setVisible(show);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/part_control/part_control_tree_widget.cpp
+++ b/src/widgets/part_widget/part_control/part_control_tree_widget.cpp
@@ -2,6 +2,7 @@
 
 #include <QStack>
 #include <QtGlobal>
+
 #include <qabstractitemmodel.h>
 #include <qitemselectionmodel.h>
 #include <qlist.h>
@@ -37,8 +38,7 @@ void PartControlTreeWidget::selectionChanged(const QItemSelection& selected, con
 
     // If a call occurs with no new selected items, we can bail immediately.
     QModelIndexList l = selected.indexes();
-    if (l.empty())
-        return;
+    if (l.empty()) return;
 
     QTreeWidgetItem* item = this->itemFromIndex(l.first());
 
@@ -46,28 +46,20 @@ void PartControlTreeWidget::selectionChanged(const QItemSelection& selected, con
     QTreeWidgetItem* par = item->parent();
 
     while (par) {
-        if (par->isSelected()) {
-            par->setSelected(false);
-        }
+        if (par->isSelected()) { par->setSelected(false); }
 
         par = par->parent();
     }
 
     QStack<QTreeWidgetItem*> queue;
-    for (int i = 0; i < item->childCount(); i++) {
-        queue.push(item->child(i));
-    }
+    for (int i = 0; i < item->childCount(); i++) { queue.push(item->child(i)); }
 
     while (!queue.empty()) {
         QTreeWidgetItem* curr_item = queue.pop();
 
-        for (int i = 0; i < curr_item->childCount(); i++) {
-            queue.push(curr_item->child(i));
-        }
+        for (int i = 0; i < curr_item->childCount(); i++) { queue.push(curr_item->child(i)); }
 
-        if (curr_item->isSelected()) {
-            curr_item->setSelected(false);
-        }
+        if (curr_item->isSelected()) { curr_item->setSelected(false); }
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/part_toolbar.cpp
+++ b/src/widgets/part_widget/part_toolbar.cpp
@@ -8,6 +8,7 @@
 #include <QMenu>
 #include <QPainter>
 #include <QPixmap>
+
 #include <qcontainerfwd.h>
 #include <qevent.h>
 #include <qicon.h>
@@ -47,13 +48,13 @@ QIcon measurementIcon() {
 
     return QIcon(pixmap);
 }
-} // namespace
+}  // namespace
 
 PartToolbar::PartToolbar(QSharedPointer<PartMetaModel> model, QWidget* parent)
     : m_model(model), m_parent(parent), QToolBar(parent) {
     m_translation_controls = new ToolbarInput(m_parent, false);
-    m_rotation_controls = new ToolbarInput(m_parent, false);
-    m_scale_controls = new ToolbarInput(m_parent, true);
+    m_rotation_controls    = new ToolbarInput(m_parent, false);
+    m_scale_controls       = new ToolbarInput(m_parent, true);
 
     setupWidget();
     setupSubWidgets();
@@ -130,9 +131,7 @@ void PartToolbar::resize(QSize new_size) {
     if (y_offset <= Constants::UI::PartToolbar::kMinTopOffset) {
         this->move(Constants::UI::PartToolbar::kLeftOffset, Constants::UI::PartToolbar::kMinTopOffset);
     }
-    else {
-        this->move(Constants::UI::PartToolbar::kLeftOffset, y_offset);
-    }
+    else { this->move(Constants::UI::PartToolbar::kLeftOffset, y_offset); }
 
     // Update size
     this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
@@ -155,7 +154,7 @@ void PartToolbar::closeAllControls() {
 }
 
 void PartToolbar::setEnabled(bool status) {
-    if (!status) // If we are disabling, close all the controls
+    if (!status)  // If we are disabling, close all the controls
         closeAllControls();
 
     m_translation_btn->setEnabled(status);
@@ -252,7 +251,6 @@ void PartToolbar::makeSpace() {
 }
 
 void PartToolbar::setupTranslation() {
-
     m_translation_btn = buildIconButton(":/icons/translate_black.png", "Translation Controls", false);
     this->addWidget(m_translation_btn);
     m_translation_controls->setMaximumValue(
@@ -267,7 +265,6 @@ void PartToolbar::setupTranslation() {
 }
 
 void PartToolbar::setupRotation() {
-
     m_rotation_btn = buildIconButton(":/icons/rotate_black.png",
                                      "Rotation Controls\r\nBefore applying any roation, previous scaling, if any,\r\n"
                                      "will be applied permenantly to current transformation and\r\n"
@@ -301,7 +298,7 @@ void PartToolbar::setupScale() {
     m_scale_btn = buildIconButton(":/icons/scale_black.png", "Scaling Controls", false);
     this->addWidget(m_scale_btn);
     m_scale_controls->setMaximumValue(Constants::Limits::Maximums::kMaxFloat);
-    m_scale_controls->setMinimumValue(0.0001f); // Shouldn't be able to scale a dimension to 0! Unphysical
+    m_scale_controls->setMinimumValue(0.0001f);  // Shouldn't be able to scale a dimension to 0! Unphysical
     m_scale_controls->setIncrement(0.1);
     m_scale_controls->setPrecision(4);
     m_scale_controls->setValue(Axis::kX, 1.0);
@@ -316,12 +313,10 @@ void PartToolbar::setupAlign() {
     this->addWidget(m_align_btn);
     m_align_controls = new ToolbarAlignInput(m_parent);
     connect(m_align_btn, &QToolButton::pressed, m_align_controls, &ToolbarAlignInput::toggleInput);
-    connect(m_align_controls, &ToolbarAlignInput::setAlignment, this,
-            [this](QVector3D dir) {
-                if (m_measure_btn != nullptr)
-                    m_measure_btn->setChecked(false);
-                emit setupAlignment(dir);
-            });
+    connect(m_align_controls, &ToolbarAlignInput::setAlignment, this, [this](QVector3D dir) {
+        if (m_measure_btn != nullptr) m_measure_btn->setChecked(false);
+        emit setupAlignment(dir);
+    });
 }
 
 void PartToolbar::setupMeasurement() {
@@ -350,4 +345,4 @@ QToolButton* PartToolbar::buildIconButton(const QString& icon_loc, const QString
     button->setCheckable(toggle);
     return button;
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/part_widget/part_widget.cpp
+++ b/src/widgets/part_widget/part_widget.cpp
@@ -2,6 +2,7 @@
 
 #include <QFileDialog>
 #include <QMessageBox>
+
 #include <qboxlayout.h>
 #include <qevent.h>
 #include <qimage.h>
@@ -31,7 +32,9 @@
 #include "widgets/view_controls_toolbar.h"
 
 namespace ORNL {
-PartWidget::PartWidget(QWidget* parent) : QWidget(parent) { this->setupWidget(); }
+PartWidget::PartWidget(QWidget* parent) : QWidget(parent) {
+    this->setupWidget();
+}
 
 QSet<QSharedPointer<Part>> PartWidget::parts() {
     QSet<QSharedPointer<Part>> ret;
@@ -41,8 +44,8 @@ QSet<QSharedPointer<Part>> PartWidget::parts() {
         QSharedPointer<Part> p = item->part();
 
         QVector3D gop_translation = item->translation();
-        QQuaternion gop_rotation = item->rotation();
-        QVector3D gop_scale = item->scale();
+        QQuaternion gop_rotation  = item->rotation();
+        QVector3D gop_scale       = item->scale();
 
         gop_translation *= Constants::OpenGL::kViewToObject;
 
@@ -57,9 +60,13 @@ QSet<QSharedPointer<Part>> PartWidget::parts() {
     return ret;
 }
 
-QSharedPointer<PartMetaModel> PartWidget::getPartMeta() { return m_model; }
+QSharedPointer<PartMetaModel> PartWidget::getPartMeta() {
+    return m_model;
+}
 
-QString PartWidget::getFirstPartName() { return m_part_control->nameOfFirstPart(); }
+QString PartWidget::getFirstPartName() {
+    return m_part_control->nameOfFirstPart();
+}
 
 PartView* PartWidget::view() {
     m_view_controls->raise();
@@ -76,9 +83,7 @@ void PartWidget::takeScreenshot() {
 
     if (!filepath.isNull()) {
         // If file has no file ending, just save as png
-        if (!filepath.contains(".")) {
-            filepath += ".png";
-        }
+        if (!filepath.contains(".")) { filepath += ".png"; }
         screenshot = m_part_view->grabFramebuffer();
         screenshot.save(filepath);
     }
@@ -88,9 +93,13 @@ void PartWidget::undo() {}
 
 void PartWidget::redo() {}
 
-void PartWidget::copy() { m_model->setSelectionCopied(); }
+void PartWidget::copy() {
+    m_model->setSelectionCopied();
+}
 
-void PartWidget::paste() { m_model->copySelection(); }
+void PartWidget::paste() {
+    m_model->copySelection();
+}
 
 void PartWidget::add(QSharedPointer<Part> part) {
     auto pm = m_model->newItem(part);
@@ -104,28 +113,36 @@ void PartWidget::add(QSharedPointer<Part> part) {
 }
 
 void PartWidget::reload() {
-    for (auto& pm : m_model->selectedItems()) {
-        m_model->reloadItem(pm);
-    }
+    for (auto& pm : m_model->selectedItems()) { m_model->reloadItem(pm); }
 }
 
 void PartWidget::remove() {
-    for (auto& pm : m_model->selectedItems()) {
-        m_model->removeItem(pm);
-    }
+    for (auto& pm : m_model->selectedItems()) { m_model->removeItem(pm); }
 }
 
-void PartWidget::remove(QSharedPointer<Part> part) { m_model->removeItem(m_model->lookupByPointer(part)); }
+void PartWidget::remove(QSharedPointer<Part> part) {
+    m_model->removeItem(m_model->lookupByPointer(part));
+}
 
-void PartWidget::clear() { m_model->clearItems(); }
+void PartWidget::clear() {
+    m_model->clearItems();
+}
 
-void PartWidget::zoomIn() { m_part_view->zoomIn(); }
+void PartWidget::zoomIn() {
+    m_part_view->zoomIn();
+}
 
-void PartWidget::zoomOut() { m_part_view->zoomOut(); }
+void PartWidget::zoomOut() {
+    m_part_view->zoomOut();
+}
 
-void PartWidget::resetZoom() { m_part_view->resetZoom(); }
+void PartWidget::resetZoom() {
+    m_part_view->resetZoom();
+}
 
-void PartWidget::resetCamera() { m_part_view->resetCamera(); }
+void PartWidget::resetCamera() {
+    m_part_view->resetCamera();
+}
 
 void PartWidget::handleModifiedSetting(const QString& setting_key) {
     static const auto printer_settings = QSet<QString> {PRS::Dimensions::kXMin,
@@ -183,58 +200,62 @@ void PartWidget::handleModifiedSetting(const QString& setting_key) {
 
     static const auto overhang_settings = QSet<QString> {PS::Support::kThresholdAngle};
 
-    if (printer_settings.contains(setting_key)) {
-        m_part_view->updatePrinterSettings(GSM->getGlobal());
-    }
+    if (printer_settings.contains(setting_key)) { m_part_view->updatePrinterSettings(GSM->getGlobal()); }
     else if (slicing_settings.contains(setting_key)) {
         m_part_view->updateSlicingSettings(GSM->getGlobal());
         if (slice_plane_normal_settings.contains(setting_key)) {
             m_part_view->updateOptimizationSettings(GSM->getGlobal());
         }
     }
-    else if (optimization_settings.contains(setting_key)) {
-        m_part_view->updateOptimizationSettings(GSM->getGlobal());
-    }
-    else if (overhang_settings.contains(setting_key)) {
-        m_part_view->updateOverhangSettings(GSM->getGlobal());
-    }
+    else if (optimization_settings.contains(setting_key)) { m_part_view->updateOptimizationSettings(GSM->getGlobal()); }
+    else if (overhang_settings.contains(setting_key)) { m_part_view->updateOverhangSettings(GSM->getGlobal()); }
 }
 
-void PartWidget::setEnabled(bool status) { m_toolbar->setEnabled(status); }
+void PartWidget::setEnabled(bool status) {
+    m_toolbar->setEnabled(status);
+}
 
 void PartWidget::preSliceUpdate() {
     CSM->clearParts();
 
     auto parts = this->parts();
 
-    for (auto p : parts) {
-        CSM->addPart(p, false);
-    }
+    for (auto p : parts) { CSM->addPart(p, false); }
 
     emit slice();
 }
 
-void PartWidget::showSlicingPlanes(bool show) { m_part_view->showSlicingPlanes(show); }
+void PartWidget::showSlicingPlanes(bool show) {
+    m_part_view->showSlicingPlanes(show);
+}
 
-void PartWidget::showLayerSettingsRange(bool show) { m_part_view->showLayerSettingsRange(show); }
+void PartWidget::showLayerSettingsRange(bool show) {
+    m_part_view->showLayerSettingsRange(show);
+}
 
 void PartWidget::setLayerSettingsRanges(QSharedPointer<Part> part, QList<QPair<int, int>> layer_ranges) {
     m_part_view->setLayerSettingsRanges(part, layer_ranges);
 }
 
-void PartWidget::showLabels(bool show) { m_part_view->showLabels(show); }
+void PartWidget::showLabels(bool show) {
+    m_part_view->showLabels(show);
+}
 
-void PartWidget::showSeams(bool show) { m_part_view->showSeams(show); }
+void PartWidget::showSeams(bool show) {
+    m_part_view->showSeams(show);
+}
 
-void PartWidget::showOverhang(bool show) { m_part_view->showOverhang(show); }
+void PartWidget::showOverhang(bool show) {
+    m_part_view->showOverhang(show);
+}
 
 void PartWidget::updatePartTransformations() {
     for (auto& item : m_model->items()) {
         QSharedPointer<Part> p = item->part();
 
         QVector3D gop_translation = item->translation();
-        QQuaternion gop_rotation = item->rotation();
-        QVector3D gop_scale = item->scale();
+        QQuaternion gop_rotation  = item->rotation();
+        QVector3D gop_scale       = item->scale();
 
         gop_translation *= Constants::OpenGL::kViewToObject;
 
@@ -245,7 +266,9 @@ void PartWidget::updatePartTransformations() {
     }
 }
 
-void PartWidget::modelAdditionUpdate(QSharedPointer<PartMetaItem> item) { emit added(item->part()); }
+void PartWidget::modelAdditionUpdate(QSharedPointer<PartMetaItem> item) {
+    emit added(item->part());
+}
 
 void PartWidget::modelSelectionUpdate(QSharedPointer<PartMetaItem> item) {
     QList<QSharedPointer<PartMetaItem>> selected_items = m_model->selectedItems();
@@ -263,9 +286,7 @@ void PartWidget::modelSelectionUpdate(QSharedPointer<PartMetaItem> item) {
     else
         this->setStatusSelection(manip_item->part()->name());
 
-    for (auto& pm : selected_items) {
-        selected_set.insert(pm->part());
-    }
+    for (auto& pm : selected_items) { selected_set.insert(pm->part()); }
 
     this->setEnabled(!selected_set.empty());
 
@@ -296,28 +317,26 @@ void PartWidget::positionIssues(QList<QSharedPointer<Part>> opl, QList<QSharedPo
         m_part_control->setOutsideStatus(part_meta_item->part()->name(), false);
     }
 
-    for (auto& part : opl) {
-        m_part_control->setOutsideStatus(part->name(), true);
-    }
+    for (auto& part : opl) { m_part_control->setOutsideStatus(part->name(), true); }
 
-    for (auto& part : fpl) {
-        m_part_control->setFloatingStatus(part->name(), true);
-    }
+    for (auto& part : fpl) { m_part_control->setFloatingStatus(part->name(), true); }
 }
 
 void PartWidget::setStatusSelection(QString name) {
     m_status_state.selected_part = name;
 
-    m_accentColor = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
+    m_accentColor  = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
     QString status = "Currently Manipulating: <font color=\"" % m_accentColor % "\">%1</font>";
-    status = status.arg(m_status_state.selected_part);
+    status         = status.arg(m_status_state.selected_part);
 
     m_selection_label->setText(status);
-    m_selection_label->setMinimumSize(200, 17); // size when no part is loaded
+    m_selection_label->setMinimumSize(200, 17);  // size when no part is loaded
     m_selection_label->adjustSize();
 }
 
-void PartWidget::setStatusIssue(QString issue) { m_status_state.issues = issue; }
+void PartWidget::setStatusIssue(QString issue) {
+    m_status_state.issues = issue;
+}
 
 void PartWidget::setMeasurementReadout(QString readout) {
     if (readout.isEmpty()) {
@@ -337,8 +356,7 @@ void PartWidget::setMeasurementReadout(QString readout) {
 
 void PartWidget::positionMeasurementReadout() {
     double toolbar_y = (this->height() / 3.0) - (Constants::UI::PartToolbar::kHeight / 2.0);
-    if (toolbar_y <= Constants::UI::PartToolbar::kMinTopOffset)
-        toolbar_y = Constants::UI::PartToolbar::kMinTopOffset;
+    if (toolbar_y <= Constants::UI::PartToolbar::kMinTopOffset) toolbar_y = Constants::UI::PartToolbar::kMinTopOffset;
 
     const int readout_x = Constants::UI::PartToolbar::kLeftOffset + Constants::UI::PartToolbar::kWidth + 8;
     m_measurement_label->move(readout_x, toolbar_y);
@@ -351,9 +369,9 @@ void PartWidget::resizeEvent(QResizeEvent* event) {
     m_part_control->move(Constants::UI::PartControl::kLeftOffset,
                          event->size().height() -
                              (Constants::UI::PartControl::kSize.height() + Constants::UI::PartControl::kBottomOffset));
-    m_selection_label->move(Constants::UI::PartControl::kLeftOffset + 10,
-                            event->size().height() -
-                                (Constants::UI::PartControl::kSize.height() + 10 + m_selection_label->height()));
+    m_selection_label->move(
+        Constants::UI::PartControl::kLeftOffset + 10,
+        event->size().height() - (Constants::UI::PartControl::kSize.height() + 10 + m_selection_label->height()));
     positionMeasurementReadout();
 
     emit resized(event->size());
@@ -419,16 +437,17 @@ void PartWidget::setupStyle() {
     m_view_controls->setupStyle();
     m_part_view->setupStyle();
     m_part_control->setupStyle();
-    m_accentColor = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
+    m_accentColor  = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
     QString status = "Currently Manipulating: <font color=\"" % m_accentColor % "\">%1</font>";
-    status = status.arg(m_status_state.selected_part);
+    status         = status.arg(m_status_state.selected_part);
     m_selection_label->setText(status);
 
     m_measurement_label->setStyleSheet(QString("QLabel { background: rgba(245, 245, 245, 220); color: %1; "
                                                "border: 1px solid rgba(0, 0, 0, 80); padding: 4px 7px; }")
                                            .arg(m_accentColor));
-    m_measurement_clear_btn->setStyleSheet("QToolButton { background: rgba(245, 245, 245, 220); "
-                                           "border: 1px solid rgba(0, 0, 0, 80); padding: 1px; }");
+    m_measurement_clear_btn->setStyleSheet(
+        "QToolButton { background: rgba(245, 245, 245, 220); "
+        "border: 1px solid rgba(0, 0, 0, 80); padding: 1px; }");
 }
 
 void PartWidget::setupLayouts() {
@@ -438,17 +457,17 @@ void PartWidget::setupLayouts() {
 
 void PartWidget::setupPosition() {
     // Status
-    m_selection_label->move(300, this->height() -
-                                     (Constants::UI::PartControl::kSize.height() + 15 + m_selection_label->height()));
+    m_selection_label->move(
+        300, this->height() - (Constants::UI::PartControl::kSize.height() + 15 + m_selection_label->height()));
     positionMeasurementReadout();
 
     // Projection Buttons
     QPoint new_size = QPoint(this->width(), this->height());
 
     // Part control
-    m_part_control->move(Constants::UI::PartControl::kLeftOffset,
-                         this->height() -
-                             (Constants::UI::PartControl::kSize.height() + Constants::UI::PartControl::kBottomOffset));
+    m_part_control->move(
+        Constants::UI::PartControl::kLeftOffset,
+        this->height() - (Constants::UI::PartControl::kSize.height() + Constants::UI::PartControl::kBottomOffset));
 }
 
 void PartWidget::setupInputs() {
@@ -492,4 +511,4 @@ void PartWidget::setupEvents() {
     connect(m_part_view, &PartView::positioningIssues, this, &PartWidget::positionIssues);
 }
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/part_widget/right_click_menu.cpp
+++ b/src/widgets/part_widget/right_click_menu.cpp
@@ -1,8 +1,5 @@
 #include "widgets/part_widget/right_click_menu.h"
 
-#include <algorithm>
-#include <cmath>
-
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -11,6 +8,9 @@
 #include <QLocale>
 #include <QMessageBox>
 #include <QWidgetAction>
+#include <algorithm>
+#include <cmath>
+
 #include <qaction.h>
 #include <qicon.h>
 #include <qlist.h>
@@ -46,34 +46,28 @@ QString meshTypeText(MeshType type) {
 }
 
 QString sourceFilePath(QSharedPointer<Part> part) {
-    if (part.isNull())
-        return QString();
+    if (part.isNull()) return QString();
 
-    if (!part->sourceFilePath().isEmpty())
-        return part->sourceFilePath();
+    if (!part->sourceFilePath().isEmpty()) return part->sourceFilePath();
 
-    if (!part->rootMesh().isNull())
-        return part->rootMesh()->path();
+    if (!part->rootMesh().isNull()) return part->rootMesh()->path();
 
     return QString();
 }
 
 QString fileTypeText(const QString& path) {
-    if (path.isEmpty())
-        return "Generated";
+    if (path.isEmpty()) return "Generated";
 
     const QString suffix = QFileInfo(path).suffix().toUpper();
     return suffix.isEmpty() ? "Unknown" : suffix;
 }
 
 int triangleCount(QSharedPointer<Part> part) {
-    if (part.isNull())
-        return 0;
+    if (part.isNull()) return 0;
 
     int count = 0;
     for (auto mesh : part->meshes()) {
-        if (mesh.isNull())
-            continue;
+        if (mesh.isNull()) continue;
 
         count += mesh->originalFaces().size();
     }
@@ -82,22 +76,20 @@ int triangleCount(QSharedPointer<Part> part) {
 }
 
 bool originalMeshDimensions(QSharedPointer<Part> part, Distance3D& dimensions) {
-    if (part.isNull())
-        return false;
+    if (part.isNull()) return false;
 
     bool found_vertex = false;
     QVector3D minimum;
     QVector3D maximum;
 
     for (auto mesh : part->meshes()) {
-        if (mesh.isNull())
-            continue;
+        if (mesh.isNull()) continue;
 
         const QVector<MeshVertex> vertices = mesh->originalVertices();
         for (const MeshVertex& vertex : vertices) {
             if (!found_vertex) {
-                minimum = vertex.location;
-                maximum = vertex.location;
+                minimum      = vertex.location;
+                maximum      = vertex.location;
                 found_vertex = true;
                 continue;
             }
@@ -111,8 +103,7 @@ bool originalMeshDimensions(QSharedPointer<Part> part, Distance3D& dimensions) {
         }
     }
 
-    if (!found_vertex)
-        return false;
+    if (!found_vertex) return false;
 
     dimensions = Distance3D(Distance(maximum.x() - minimum.x()), Distance(maximum.y() - minimum.y()),
                             Distance(maximum.z() - minimum.z()));
@@ -121,16 +112,15 @@ bool originalMeshDimensions(QSharedPointer<Part> part, Distance3D& dimensions) {
 
 QString formatDistance(double microns) {
     const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
-    return QString("%1 %2")
-        .arg(QString::number(Distance(microns).to(unit), 'f', 3),
-             PreferencesManager::getInstance()->getDistanceUnitText());
+    return QString("%1 %2").arg(QString::number(Distance(microns).to(unit), 'f', 3),
+                                PreferencesManager::getInstance()->getDistanceUnitText());
 }
 
 QString dimensionsText(double x_microns, double y_microns, double z_microns) {
     return QString("X %1, Y %2, Z %3")
         .arg(formatDistance(x_microns), formatDistance(y_microns), formatDistance(z_microns));
 }
-} // namespace
+}  // namespace
 
 RightClickMenu::RightClickMenu(QWidget* parent) : QMenu(("Context menu"), parent) {
     this->setupActions();
@@ -138,16 +128,16 @@ RightClickMenu::RightClickMenu(QWidget* parent) : QMenu(("Context menu"), parent
 }
 
 void RightClickMenu::setupActions() {
-    m_info_action = new QAction("Info", this);
-    m_switch_to_build_action = new QAction("Switch to Build", this);
-    m_switch_to_clipper_action = new QAction("Switch to Clipper", this);
-    m_switch_to_setting_action = new QAction("Switch to Setting", this);
+    m_info_action                 = new QAction("Info", this);
+    m_switch_to_build_action      = new QAction("Switch to Build", this);
+    m_switch_to_clipper_action    = new QAction("Switch to Clipper", this);
+    m_switch_to_setting_action    = new QAction("Switch to Setting", this);
     m_reset_transformation_action = new QAction("Reset Transformation", this);
-    m_replace_part_action = new QAction("Replace Part Model", this);
-    m_reload_part_action = new QAction("Reload Part Model(s)", this);
-    m_delete_part_action = new QAction("Delete Part(s)", this);
-    m_lock_part_action = new QAction("Toggle Part Lock(s)", this);
-    m_set_instances_action = new QAction("Set Number of Instances", this);
+    m_replace_part_action         = new QAction("Replace Part Model", this);
+    m_reload_part_action          = new QAction("Reload Part Model(s)", this);
+    m_delete_part_action          = new QAction("Delete Part(s)", this);
+    m_lock_part_action            = new QAction("Toggle Part Lock(s)", this);
+    m_set_instances_action        = new QAction("Set Number of Instances", this);
 
     m_info_action->setIcon(QIcon(":/icons/info.png"));
     m_switch_to_clipper_action->setIcon(QIcon(":/icons/clip.png"));
@@ -180,7 +170,7 @@ void RightClickMenu::setupActions() {
     this->addMenu(m_transparency_menu);
 
     QWidgetAction* m_widget_action = new QWidgetAction(this);
-    m_transparency_slider = new QSlider(Qt::Orientation::Horizontal);
+    m_transparency_slider          = new QSlider(Qt::Orientation::Horizontal);
     m_transparency_slider->setMinimum(0);
     m_transparency_slider->setMaximum(225);
     m_transparency_slider->setValue(0);
@@ -210,9 +200,7 @@ void RightClickMenu::setupEvents() {
         m_switch_to_setting_action->setDisabled(false);
         m_switch_to_clipper_action->setDisabled(true);
 
-        for (auto item : m_selected_items) {
-            item->setMeshType(MeshType::kClipping);
-        }
+        for (auto item : m_selected_items) { item->setMeshType(MeshType::kClipping); }
     });
 
     connect(m_switch_to_build_action, &QAction::triggered, this, [this]() {
@@ -220,9 +208,7 @@ void RightClickMenu::setupEvents() {
         m_switch_to_setting_action->setDisabled(false);
         m_switch_to_clipper_action->setDisabled(false);
 
-        for (auto item : m_selected_items) {
-            item->setMeshType(MeshType::kBuild);
-        }
+        for (auto item : m_selected_items) { item->setMeshType(MeshType::kBuild); }
     });
 
     connect(m_switch_to_setting_action, &QAction::triggered, this, [this]() {
@@ -230,14 +216,11 @@ void RightClickMenu::setupEvents() {
         m_switch_to_setting_action->setDisabled(true);
         m_switch_to_clipper_action->setDisabled(false);
 
-        for (auto item : m_selected_items) {
-            item->setMeshType(MeshType::kSettings);
-        }
+        for (auto item : m_selected_items) { item->setMeshType(MeshType::kSettings); }
     });
 
     connect(m_reset_transformation_action, &QAction::triggered, this, [this]() {
-        for (auto item : m_selected_items)
-            item->resetTransformation();
+        for (auto item : m_selected_items) item->resetTransformation();
     });
 
     connect(m_replace_part_action, &QAction::triggered, this, [this]() {
@@ -245,31 +228,23 @@ void RightClickMenu::setupEvents() {
             QFileDialog::getOpenFileName(nullptr, QObject::tr("Open model file"), CSM->getMostRecentModelLocation(),
                                          QObject::tr("Model File (*.stl *.3mf *.obj *.amf *.step *.stp)"));
 
-        if (filepath.isNull()) {
-            return;
-        }
+        if (filepath.isNull()) { return; }
 
         m_selected_items.first()->replaceInModel(filepath);
     });
 
     connect(m_reload_part_action, &QAction::triggered, this, [this]() {
-        for (auto item : m_selected_items) {
-            item->reloadInModel();
-        }
+        for (auto item : m_selected_items) { item->reloadInModel(); }
     });
 
     connect(m_delete_part_action, &QAction::triggered, this, [this]() {
-        for (auto item : m_selected_items) {
-            item->removeFromModel();
-        }
+        for (auto item : m_selected_items) { item->removeFromModel(); }
 
         m_selected_items.clear();
     });
 
     connect(m_transparency_slider, &QSlider::valueChanged, this, [this](int value) {
-        for (auto item : m_selected_items) {
-            item->setTransparency(255 - value);
-        }
+        for (auto item : m_selected_items) { item->setTransparency(255 - value); }
     });
 
     connect(m_wireframe_action, &QAction::triggered, this, [this]() {
@@ -281,22 +256,18 @@ void RightClickMenu::setupEvents() {
         }
     });
     connect(m_lock_part_action, &QAction::triggered, this, [this]() {
-        for (auto item : m_selected_items) {
-            item->graphicsPart()->setLocked(!item->graphicsPart()->locked());
-        }
+        for (auto item : m_selected_items) { item->graphicsPart()->setLocked(!item->graphicsPart()->locked()); }
     });
     connect(m_set_instances_action, &QAction::triggered, this, [this]() {
-        if (m_selected_items.size() != 1)
-            return;
+        if (m_selected_items.size() != 1) return;
 
         QSharedPointer<PartMetaItem> item = m_selected_items.first();
-        bool accepted = false;
-        const int current_count = item->instanceCount();
+        bool accepted                     = false;
+        const int current_count           = item->instanceCount();
         const int instance_count =
             QInputDialog::getInt(this, "Set Number of Instances", "Instances:", current_count, 1, 1000, 1, &accepted);
 
-        if (accepted)
-            item->setInstanceCount(instance_count);
+        if (accepted) item->setInstanceCount(instance_count);
     });
     connect(m_solidwireframe_action, &QAction::triggered, this, [this]() {
         for (auto item : m_selected_items) {
@@ -309,16 +280,14 @@ void RightClickMenu::setupEvents() {
 }
 
 void RightClickMenu::showInfoDialog() {
-    if (m_selected_items.size() != 1)
-        return;
+    if (m_selected_items.size() != 1) return;
 
     QSharedPointer<PartMetaItem> item = m_selected_items.first();
-    if (item.isNull() || item->part().isNull() || item->graphicsPart().isNull())
-        return;
+    if (item.isNull() || item->part().isNull() || item->graphicsPart().isNull()) return;
 
-    QSharedPointer<Part> part = item->part();
+    QSharedPointer<Part> part                = item->part();
     QSharedPointer<PartObject> graphics_part = item->graphicsPart();
-    const QString source_path = sourceFilePath(part);
+    const QString source_path                = sourceFilePath(part);
 
     const QVector3D current_dimensions = graphics_part->maximum() - graphics_part->minimum();
     QStringList lines;
@@ -337,7 +306,8 @@ void RightClickMenu::showInfoDialog() {
                      .arg(dimensionsText(original_dimensions.x(), original_dimensions.y(), original_dimensions.z()));
     }
 
-    lines << QString("Source: %1").arg(source_path.isEmpty() ? "Generated part" : QDir::toNativeSeparators(source_path));
+    lines
+        << QString("Source: %1").arg(source_path.isEmpty() ? "Generated part" : QDir::toNativeSeparators(source_path));
 
     QMessageBox::information(this, "Object Info", lines.join("\n"));
 }
@@ -359,7 +329,7 @@ void RightClickMenu::show(const QPointF& pos, QList<QSharedPointer<PartMetaItem>
 
 void RightClickMenu::disableActions() {
     if (!m_selected_items.empty()) {
-        bool enable_all = false;
+        bool enable_all   = false;
         MeshType all_type = m_selected_items.at(0)->meshType();
         for (auto item : m_selected_items) {
             if (all_type != item->meshType()) {
@@ -427,4 +397,4 @@ void RightClickMenu::disableActions() {
         m_solidwireframe_action->setDisabled(true);
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/programmatic_check_box.cpp
+++ b/src/widgets/programmatic_check_box.cpp
@@ -7,7 +7,9 @@
 
 namespace ORNL {
 
-ProgrammaticCheckBox::ProgrammaticCheckBox(QString str, QWidget* parent) : QCheckBox(str, parent) { setTristate(true); }
+ProgrammaticCheckBox::ProgrammaticCheckBox(QString str, QWidget* parent) : QCheckBox(str, parent) {
+    setTristate(true);
+}
 
 void ProgrammaticCheckBox::nextCheckState() {
     if (this->checkState() == Qt::Checked)
@@ -15,4 +17,4 @@ void ProgrammaticCheckBox::nextCheckState() {
     else
         setCheckState(Qt::Checked);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/scrollable_graphics_view.cpp
+++ b/src/widgets/scrollable_graphics_view.cpp
@@ -4,6 +4,7 @@
 #include <QLabel>
 #include <QResizeEvent>
 #include <QWheelEvent>
+
 #include <qgraphicsview.h>
 #include <qpainter.h>
 #include <qpoint.h>
@@ -16,24 +17,28 @@ ScrollableGraphicsView::ScrollableGraphicsView(QWidget* parent) : QGraphicsView(
     this->setDragMode(QGraphicsView::ScrollHandDrag);
     this->setMouseTracking(true);
 
-    m_pos_label = new QLabel("(0, 0)", this);
+    m_pos_label     = new QLabel("(0, 0)", this);
     m_scroll_factor = 0.1;
 }
 
-void ScrollableGraphicsView::setScrollFactor(double scroll_factor) { m_scroll_factor = scroll_factor; }
+void ScrollableGraphicsView::setScrollFactor(double scroll_factor) {
+    m_scroll_factor = scroll_factor;
+}
 
-double ScrollableGraphicsView::scrollFactor() { return m_scroll_factor; }
+double ScrollableGraphicsView::scrollFactor() {
+    return m_scroll_factor;
+}
 
 void ScrollableGraphicsView::resizeEvent(QResizeEvent* event) {
     QSize new_size = event->size();
-    int new_width = new_size.width();
+    int new_width  = new_size.width();
     int new_height = new_size.height();
 
     // Position label.
-    int pos_width = m_pos_label->width();
+    int pos_width  = m_pos_label->width();
     int pos_height = m_pos_label->height();
-    int pos_new_x = new_width - pos_width - 10;
-    int pos_new_y = new_height - pos_height - 10;
+    int pos_new_x  = new_width - pos_width - 10;
+    int pos_new_y  = new_height - pos_height - 10;
 
     m_pos_label->move(pos_new_x, pos_new_y);
 }
@@ -41,16 +46,14 @@ void ScrollableGraphicsView::resizeEvent(QResizeEvent* event) {
 void ScrollableGraphicsView::wheelEvent(QWheelEvent* event) {
     // Disallow scrolling beyond bounds.
     QRectF visible_rect = this->mapToScene(this->viewport()->rect()).boundingRect();
-    QRectF scene_rect = this->sceneRect();
+    QRectF scene_rect   = this->sceneRect();
 
     if (event->angleDelta().y() > 0) {
         double plus = 1.0 + m_scroll_factor;
         this->scale(plus, plus);
     }
     else {
-        if (visible_rect.width() > scene_rect.width() && visible_rect.height() > scene_rect.height()) {
-            return;
-        }
+        if (visible_rect.width() > scene_rect.width() && visible_rect.height() > scene_rect.height()) { return; }
         double minus = 1.0 - m_scroll_factor;
         this->scale(minus, minus);
     }
@@ -66,15 +69,15 @@ void ScrollableGraphicsView::mouseMoveEvent(QMouseEvent* event) {
     m_pos_label->setText("(" + QString::number(scene_pos.x()) + ", " + QString::number(scene_pos.y()) + ")");
     m_pos_label->adjustSize();
 
-    int width = this->viewport()->width();
+    int width  = this->viewport()->width();
     int height = this->viewport()->height();
 
     // Position label.
-    int pos_width = m_pos_label->width();
+    int pos_width  = m_pos_label->width();
     int pos_height = m_pos_label->height();
-    int pos_new_x = width - pos_width - 10;
-    int pos_new_y = height - pos_height - 10;
+    int pos_new_x  = width - pos_width - 10;
+    int pos_new_y  = height - pos_height - 10;
 
     m_pos_label->move(pos_new_x, pos_new_y);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_accel_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_accel_spin_box.cpp
@@ -20,7 +20,6 @@ namespace ORNL {
 SettingAccelSpinBox::SettingAccelSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                          fifojson json, QGridLayout* layout, int index)
     : SettingDoubleSpinBox(parent, sb, key, json, layout, index) {
-
     Acceleration cur;
     m_warn = false;
     if (sb->contains(key))
@@ -47,7 +46,7 @@ SettingRowBase* SettingAccelSpinBox::createInstance(SettingTab* parent, QSharedP
 
 void SettingAccelSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Acceleration base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getAccelerationUnit());
@@ -62,12 +61,11 @@ void SettingAccelSpinBox::reloadValue() {
 
     bool consistent = true;
     Acceleration cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_ang_vel_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_ang_vel_spin_box.cpp
@@ -51,7 +51,7 @@ SettingRowBase* SettingAngVelSpinBox::createInstance(SettingTab* parent, QShared
 
 void SettingAngVelSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     AngularVelocity base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getAngleUnit() /
@@ -69,12 +69,11 @@ void SettingAngVelSpinBox::reloadValue() {
 
     bool consistent = true;
     AngularVelocity cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_angle_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_angle_spin_box.cpp
@@ -47,7 +47,7 @@ SettingRowBase* SettingAngleSpinBox::createInstance(SettingTab* parent, QSharedP
 
 void SettingAngleSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Angle base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getAngleUnit());
@@ -63,12 +63,11 @@ void SettingAngleSpinBox::reloadValue() {
 
     bool consistent = true;
     Angle cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_area_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_area_spin_box.cpp
@@ -49,7 +49,7 @@ SettingRowBase* SettingAreaSpinBox::createInstance(SettingTab* parent, QSharedPo
 
 void SettingAreaSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Area base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getDistanceUnit() *
@@ -66,12 +66,11 @@ void SettingAreaSpinBox::reloadValue() {
 
     bool consistent = true;
     Area cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_density_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_density_spin_box.cpp
@@ -46,7 +46,7 @@ SettingRowBase* SettingDensitySpinBox::createInstance(SettingTab* parent, QShare
 
 void SettingDensitySpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Density base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getDensityUnit());
@@ -61,12 +61,11 @@ void SettingDensitySpinBox::reloadValue() {
 
     bool consistent = true;
     Density cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_distance_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_distance_spin_box.cpp
@@ -50,7 +50,7 @@ SettingRowBase* SettingDistanceSpinBox::createInstance(SettingTab* parent, QShar
 
 void SettingDistanceSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Distance base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getDistanceUnit());
@@ -69,12 +69,11 @@ void SettingDistanceSpinBox::reloadValue() {
 
     bool consistent = true;
     Distance cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     checkDynamicDependencies();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_speed_spin_box.cpp
@@ -18,7 +18,9 @@
 
 namespace ORNL {
 namespace {
-bool isActiveSpeedLimit(Velocity speed) { return speed > 0; }
+bool isActiveSpeedLimit(Velocity speed) {
+    return speed > 0;
+}
 
 QString masterString(const fifojson& json, const std::string& key) {
     return QString::fromStdString(json.at(key).get<std::string>());
@@ -29,14 +31,12 @@ bool isXYSpeedLimitKey(const QString& key) {
 }
 
 bool isPrinterXYMotionSpeed(const QString& key, const fifojson& json) {
-    if (isXYSpeedLimitKey(key))
-        return false;
+    if (isXYSpeedLimitKey(key)) return false;
 
     const QString major = masterString(json, Constants::Settings::Master::kMajor);
     const QString minor = masterString(json, Constants::Settings::Master::kMinor);
 
-    if (major == Constants::Settings::SettingTab::kPrinter)
-        return false;
+    if (major == Constants::Settings::SettingTab::kPrinter) return false;
 
     if (major == Constants::Settings::SettingTab::kMaterial &&
         (minor == "Extruder" || minor == "Purge" || minor == "Retraction"))
@@ -49,7 +49,7 @@ QString formatVelocity(Velocity speed) {
     const Velocity unit = PreferencesManager::getInstance()->getVelocityUnit();
     return QString::number(speed.to(unit), 'g', 6) + " " + PreferencesManager::getInstance()->getVelocityUnitText();
 }
-} // namespace
+}  // namespace
 
 SettingSpeedSpinBox::SettingSpeedSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                          fifojson json, QGridLayout* layout, int index)
@@ -79,7 +79,7 @@ SettingRowBase* SettingSpeedSpinBox::createInstance(SettingTab* parent, QSharedP
 
 void SettingSpeedSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Velocity base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getVelocityUnit());
@@ -94,8 +94,7 @@ void SettingSpeedSpinBox::reloadValue() {
 
     bool consistent = true;
     Velocity cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
@@ -118,7 +117,7 @@ void SettingSpeedSpinBox::checkDynamicDependencies() {
         return;
     }
 
-    const QString warning = speedLimitWarning();
+    const QString warning     = speedLimitWarning();
     const bool warning_active = !warning.isEmpty();
     if (warning_active) {
         applyNotification(warning, false);
@@ -135,11 +134,13 @@ void SettingSpeedSpinBox::checkDynamicDependencies() {
     emit warnParent(warningCountDelta(warning_active, m_warn));
 }
 
-Velocity SettingSpeedSpinBox::effectiveSpeed() const { return effectiveSpeed(0); }
+Velocity SettingSpeedSpinBox::effectiveSpeed() const {
+    return effectiveSpeed(0);
+}
 
 Velocity SettingSpeedSpinBox::effectiveSpeed(int settings_base_index) const {
     const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
-    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+    const double global_value  = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
 
     if (!m_settings_bases.isEmpty())
         return Velocity(effectiveValueHelper<double>(m_key, settings_base_index, global_value));
@@ -148,16 +149,14 @@ Velocity SettingSpeedSpinBox::effectiveSpeed(int settings_base_index) const {
 }
 
 bool SettingSpeedSpinBox::hasConsistentEffectiveSpeed() const {
-    if (m_settings_bases.size() <= 1)
-        return true;
+    if (m_settings_bases.size() <= 1) return true;
 
     const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
-    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
-    const double first_value = effectiveValueHelper<double>(m_key, 0, global_value);
+    const double global_value  = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+    const double first_value   = effectiveValueHelper<double>(m_key, 0, global_value);
 
     for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
-        if (effectiveValueHelper<double>(m_key, index, global_value) != first_value)
-            return false;
+        if (effectiveValueHelper<double>(m_key, index, global_value) != first_value) return false;
     }
 
     return true;
@@ -166,21 +165,19 @@ bool SettingSpeedSpinBox::hasConsistentEffectiveSpeed() const {
 QString SettingSpeedSpinBox::speedLimitWarning() const {
     for (int index = 0, end = effectiveSettingsBaseCount(); index < end; ++index) {
         const QString warning = speedLimitWarning(index);
-        if (!warning.isEmpty())
-            return warning;
+        if (!warning.isEmpty()) return warning;
     }
 
     return QString();
 }
 
 QString SettingSpeedSpinBox::speedLimitWarning(int settings_base_index) const {
-    if (m_sb.isNull())
-        return QString();
+    if (m_sb.isNull()) return QString();
 
     const Velocity min_xy_speed(effectiveDouble(PRS::MachineSpeed::kMinXYSpeed, settings_base_index));
     const Velocity max_xy_speed(effectiveDouble(PRS::MachineSpeed::kMaxXYSpeed, settings_base_index));
-    const bool has_min = isActiveSpeedLimit(min_xy_speed);
-    const bool has_max = isActiveSpeedLimit(max_xy_speed);
+    const bool has_min       = isActiveSpeedLimit(min_xy_speed);
+    const bool has_max       = isActiveSpeedLimit(max_xy_speed);
     const bool invalid_range = has_min && has_max && min_xy_speed > max_xy_speed;
 
     if (isXYSpeedLimitKey(m_key)) {
@@ -191,11 +188,10 @@ QString SettingSpeedSpinBox::speedLimitWarning(int settings_base_index) const {
         return QString();
     }
 
-    if (!isPrinterXYMotionSpeed(m_key, m_json) || invalid_range)
-        return QString();
+    if (!isPrinterXYMotionSpeed(m_key, m_json) || invalid_range) return QString();
 
     const Velocity current_speed = effectiveSpeed(settings_base_index);
-    const QString display = masterString(m_json, Constants::Settings::Master::kDisplay);
+    const QString display        = masterString(m_json, Constants::Settings::Master::kDisplay);
 
     if (has_min && current_speed < min_xy_speed)
         return display + " (" + formatVelocity(current_speed) + ") is below Minimum XY Speed (" +
@@ -207,4 +203,4 @@ QString SettingSpeedSpinBox::speedLimitWarning(int settings_base_index) const {
 
     return QString();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_temperature_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_temperature_spin_box.cpp
@@ -32,7 +32,7 @@ SettingTemperatureSpinBox::SettingTemperatureSpinBox(SettingTab* parent, QShared
     Temperature unit = PreferencesManager::getInstance()->getTemperatureUnit();
 
     this->setMaximum(Constants::Limits::Maximums::kMaxTemperature.to(unit));
-    this->setMinimum(-459.67); // absolute zero
+    this->setMinimum(-459.67);  // absolute zero
     this->setDecimals(m_precision);
     this->setValue(cur.to(unit));
 
@@ -47,7 +47,7 @@ SettingRowBase* SettingTemperatureSpinBox::createInstance(SettingTab* parent, QS
 
 void SettingTemperatureSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Temperature base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getTemperatureUnit());
@@ -70,12 +70,11 @@ void SettingTemperatureSpinBox::reloadValue() {
 
     bool consistent = true;
     Temperature cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_time_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_time_spin_box.cpp
@@ -46,7 +46,7 @@ SettingRowBase* SettingTimeSpinBox::createInstance(SettingTab* parent, QSharedPo
 
 void SettingTimeSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Time base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getTimeUnit());
@@ -62,12 +62,11 @@ void SettingTimeSpinBox::reloadValue() {
 
     bool consistent = true;
     Time cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     checkDynamicDependencies();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/double_spin_subtypes/setting_voltage_spin_box.cpp
+++ b/src/widgets/settings/double_spin_subtypes/setting_voltage_spin_box.cpp
@@ -46,7 +46,7 @@ SettingRowBase* SettingVoltageSpinBox::createInstance(SettingTab* parent, QShare
 
 void SettingVoltageSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     Voltage base_value;
     base_value.from(val.toDouble(), PreferencesManager::getInstance()->getVoltageUnit());
@@ -62,12 +62,11 @@ void SettingVoltageSpinBox::reloadValue() {
 
     bool consistent = true;
     Voltage cur(reloadValueHelper<double>(consistent));
-    if (consistent)
-        setValue(cur.to(unit));
+    if (consistent) setValue(cur.to(unit));
 
     this->blockSignals(false);
     emit modified(m_key);
 
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/setting_bar.cpp
+++ b/src/widgets/settings/setting_bar.cpp
@@ -32,25 +32,29 @@
 
 namespace ORNL {
 namespace {
-constexpr int kMaxVisibleSettingBaseItems = 16;
+constexpr int kMaxVisibleSettingBaseItems    = 16;
 constexpr int kSettingBaseItemHeightFallback = 22;
 
-bool supportsCylindricalSlicing(GcodeSyntax syntax) { return syntax == GcodeSyntax::kArcSpecialties; }
+bool supportsCylindricalSlicing(GcodeSyntax syntax) {
+    return syntax == GcodeSyntax::kArcSpecialties;
+}
 
 class DynamicDependencyRefreshBlocker {
-  public:
+   public:
     explicit DynamicDependencyRefreshBlocker(bool& suppressed)
         : m_suppressed(suppressed), m_previous_suppressed(suppressed) {
         m_suppressed = true;
     }
 
-    ~DynamicDependencyRefreshBlocker() { m_suppressed = m_previous_suppressed; }
+    ~DynamicDependencyRefreshBlocker() {
+        m_suppressed = m_previous_suppressed;
+    }
 
-  private:
+   private:
     bool& m_suppressed;
     bool m_previous_suppressed;
 };
-} // namespace
+}  // namespace
 
 SettingBar::SettingBar(QHash<QString, QString> selectedSettingBases)
     : QWidget(nullptr), mostRecentSetting(selectedSettingBases), m_range_selected(false) {
@@ -60,19 +64,19 @@ SettingBar::SettingBar(QHash<QString, QString> selectedSettingBases)
 SettingBar::~SettingBar() {
     for (SettingPane* cur_pane : m_panes) {
         for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows())
-                cur_row->clearDependencyLogic();
+            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) cur_row->clearDependencyLogic();
         }
     }
 }
 
-QVector<SettingPane*> SettingBar::getPanes() { return m_panes.values().toVector(); }
+QVector<SettingPane*> SettingBar::getPanes() {
+    return m_panes.values().toVector();
+}
 
 SettingPane* SettingBar::getPane(QString major) {
-    if (m_panes.contains(major))
-        return m_panes[major];
+    if (m_panes.contains(major)) return m_panes[major];
 
-    m_panes[major] = new SettingPane(m_tab_widget->count(), this, major);
+    m_panes[major]                     = new SettingPane(m_tab_widget->count(), this, major);
     paneMapping[m_tab_widget->count()] = major;
     m_tab_widget->addTab(m_panes[major], major);
 
@@ -89,9 +93,7 @@ void SettingBar::barTabWarning(int count, QString pane) {
         m_tab_widget->setTabIcon(m_tab_widget->indexOf(m_panes[pane]), QIcon(":/icons/warning.png"));
         m_tab_widget->setIconSize(QSize(16, 16));
     }
-    else {
-        m_tab_widget->setTabIcon(m_tab_widget->indexOf(m_panes[pane]), QIcon(""));
-    }
+    else { m_tab_widget->setTabIcon(m_tab_widget->indexOf(m_panes[pane]), QIcon("")); }
 }
 
 SettingTab* SettingBar::getTab(QString major, QString minor) {
@@ -108,8 +110,7 @@ void SettingBar::filter(QString str) {
     if (str.isEmpty()) {
         for (SettingPane* cur_pane : m_panes) {
             for (SettingTab* cur_tab : cur_pane->getTabs()) {
-                for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows())
-                    cur_row->show();
+                for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) cur_row->show();
                 cur_tab->show();
                 cur_tab->shrinkTab();
             }
@@ -156,8 +157,8 @@ void SettingBar::filter(QString str) {
 
 void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<SettingsBase>>> name_and_bases,
                                        QList<QSharedPointer<SettingsBase>> inherited_bases) {
-    auto settings_bases = name_and_bases.second;
-    m_selected_settings_bases = settings_bases;
+    auto settings_bases                 = name_and_bases.second;
+    m_selected_settings_bases           = settings_bases;
     m_selected_inherited_settings_bases = inherited_bases;
 
     // here we clear any warnings if a new settings base has been selected, or do nothing if the settings base remains
@@ -186,15 +187,13 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
             m_range_selected = false;
             for (QString key : m_panes.keys()) {
                 QList<QString> hiddenSettings = PreferencesManager::getInstance()->getHiddenSettings(key);
-                SettingPane* cur_pane = m_panes.value(key);
+                SettingPane* cur_pane         = m_panes.value(key);
 
                 for (SettingTab* cur_tab : cur_pane->getTabs()) {
                     cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
                     if (!hiddenSettings.contains(cur_tab->getName())) {
                         cur_tab->show();
-                        for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) {
-                            cur_row->show();
-                        }
+                        for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) { cur_row->show(); }
                     }
                 }
             }
@@ -203,11 +202,11 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
             m_range_selected = true;
             for (QString key : m_panes.keys()) {
                 QList<QString> hiddenSettings = PreferencesManager::getInstance()->getHiddenSettings(key);
-                SettingPane* cur_pane = m_panes.value(key);
+                SettingPane* cur_pane         = m_panes.value(key);
 
                 for (SettingTab* cur_tab : cur_pane->getTabs()) {
                     if (!hiddenSettings.contains(cur_tab->getName())) {
-                        int settingsHidden = 0;
+                        int settingsHidden                         = 0;
                         QList<QSharedPointer<SettingRowBase>> rows = cur_tab->getRows();
                         for (QSharedPointer<SettingRowBase> cur_row : rows) {
                             if (!cur_row->isLocal()) {
@@ -216,8 +215,7 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
                             }
                         }
 
-                        if (settingsHidden == rows.size())
-                            cur_tab->hide();
+                        if (settingsHidden == rows.size()) cur_tab->hide();
 
                         cur_tab->settingsBasesSelected(settings_bases, inherited_bases);
                     }
@@ -229,8 +227,7 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
     // Run through and check dependencies on everthing
     for (QString key : m_panes.keys())
         for (SettingTab* cur_tab : m_panes.value(key)->getTabs())
-            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows())
-                cur_row->checkDependencies();
+            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) cur_row->checkDependencies();
 
     refreshDependencyVisibility();
     this->blockSignals(false);
@@ -239,29 +236,27 @@ void SettingBar::settingsBasesSelected(QPair<QString, QList<QSharedPointer<Setti
 
 void SettingBar::closeAll() {
     for (SettingPane* cur_pane : m_panes) {
-        for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            cur_tab->shrinkTab();
-        }
+        for (SettingTab* cur_tab : cur_pane->getTabs()) { cur_tab->shrinkTab(); }
     }
 }
 
 void SettingBar::openAll() {
     for (SettingPane* cur_pane : m_panes) {
-        for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            cur_tab->expandTab();
-        }
+        for (SettingTab* cur_tab : cur_pane->getTabs()) { cur_tab->expandTab(); }
     }
 }
 
-void SettingBar::setLock(bool status, QString category) { m_panes[category]->setLock(status); }
+void SettingBar::setLock(bool status, QString category) {
+    m_panes[category]->setLock(status);
+}
 
 void SettingBar::setLock(bool status) {
-    for (SettingPane* cur_pane : m_panes) {
-        cur_pane->setLock(status);
-    }
+    for (SettingPane* cur_pane : m_panes) { cur_pane->setLock(status); }
 }
 
-void SettingBar::reloadDisplayedList() { updateDisplayedLists(m_tab_widget->currentIndex()); }
+void SettingBar::reloadDisplayedList() {
+    updateDisplayedLists(m_tab_widget->currentIndex());
+}
 
 // change tab index
 void SettingBar::updateDisplayedLists(int index) {
@@ -280,8 +275,7 @@ void SettingBar::updateDisplayedLists(int index) {
 
 void SettingBar::updateSettingBasePopupHeight() {
     QAbstractItemView* combo_view = m_combo_box->view();
-    if (combo_view == nullptr)
-        return;
+    if (combo_view == nullptr) return;
 
     const int visible_items = std::min(m_combo_box->count(), m_combo_box->maxVisibleItems());
     if (visible_items <= 0) {
@@ -290,8 +284,7 @@ void SettingBar::updateSettingBasePopupHeight() {
     }
 
     int row_height = combo_view->sizeHintForRow(std::max(0, m_combo_box->currentIndex()));
-    if (row_height <= 0)
-        row_height = kSettingBaseItemHeightFallback;
+    if (row_height <= 0) row_height = kSettingBaseItemHeightFallback;
 
     combo_view->setMinimumHeight(0);
     combo_view->setMaximumHeight((row_height * visible_items) + (combo_view->frameWidth() * 2));
@@ -333,8 +326,7 @@ void SettingBar::displayNewSetting(QStringList settingCategories, QString settin
     // Must preform a few related steps.  First, update the most recent for each category
     // so that the appropriate base is loaded when swapping tabs.  Then, reload the
     // currently displayed list choices.  Finally, set the actual values and reload.
-    for (QString category : settingCategories)
-        mostRecentSetting[category] = settingFile;
+    for (QString category : settingCategories) mostRecentSetting[category] = settingFile;
 
     reloadDisplayedList();
 
@@ -356,9 +348,7 @@ void SettingBar::forwardSettingAboutToChange(QString setting_key, QList<QSharedP
 }
 
 void SettingBar::forwardModifiedSetting(QString setting_key) {
-    if (m_syncing_radial_settings || m_restoring_settings) {
-        return;
-    }
+    if (m_syncing_radial_settings || m_restoring_settings) { return; }
 
     QStringList modified_keys {setting_key};
 
@@ -367,19 +357,12 @@ void SettingBar::forwardModifiedSetting(QString setting_key) {
     m_syncing_radial_settings = false;
 
     const bool dependencies_refreshed = modified_keys.size() > 1;
-    if (dependencies_refreshed) {
-        enableDependRows();
-    }
-    else {
-        refreshDependencyVisibility();
-    }
+    if (dependencies_refreshed) { enableDependRows(); }
+    else { refreshDependencyVisibility(); }
 
-    if (!m_suppress_dynamic_dependency_refresh && !dependencies_refreshed)
-        refreshDynamicDependencies();
+    if (!m_suppress_dynamic_dependency_refresh && !dependencies_refreshed) refreshDynamicDependencies();
 
-    for (const QString& modified_key : modified_keys) {
-        emit settingModified(modified_key);
-    }
+    for (const QString& modified_key : modified_keys) { emit settingModified(modified_key); }
 
     emitSelectedVisualizationSettings();
 }
@@ -390,7 +373,7 @@ QStringList SettingBar::syncCylindricalSlicingSettings(const QString& setting_ke
 
     if (setting_key == PS::Slicing::kSlicingMode) {
         const SlicingMode slicing_mode = static_cast<SlicingMode>(sb->setting<int>(PS::Slicing::kSlicingMode));
-        const GcodeSyntax syntax = sb->setting<GcodeSyntax>(PRS::MachineSetup::kSyntax);
+        const GcodeSyntax syntax       = sb->setting<GcodeSyntax>(PRS::MachineSetup::kSyntax);
         if (slicing_mode == SlicingMode::kCylindrical && !supportsCylindricalSlicing(syntax)) {
             emit settingAboutToChange(PRS::MachineSetup::kSyntax, QList<QSharedPointer<SettingsBase>>());
             sb->setSetting(PRS::MachineSetup::kSyntax, static_cast<int>(GcodeSyntax::kArcSpecialties));
@@ -404,35 +387,27 @@ QStringList SettingBar::syncCylindricalSlicingSettings(const QString& setting_ke
 
 void SettingBar::reloadSettingRow(const QString& setting_key) {
     fifojson& master_json = GSM->getMaster()->json();
-    auto setting = master_json.find(setting_key.toStdString());
-    if (setting == master_json.end()) {
-        return;
-    }
+    auto setting          = master_json.find(setting_key.toStdString());
+    if (setting == master_json.end()) { return; }
 
     SettingTab* tab = getTab(setting.value()[Constants::Settings::Master::kMajor],
                              setting.value()[Constants::Settings::Master::kMinor]);
-    if (tab == nullptr) {
-        return;
-    }
+    if (tab == nullptr) { return; }
 
     QSharedPointer<SettingRowBase> row = tab->getRow(setting_key);
-    if (!row.isNull()) {
-        row->reloadValue();
-    }
+    if (!row.isNull()) { row->reloadValue(); }
 }
 
 void SettingBar::refreshDynamicDependencies() {
     for (SettingPane* cur_pane : m_panes) {
         for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows())
-                cur_row->checkDynamicDependencies();
+            for (QSharedPointer<SettingRowBase> cur_row : cur_tab->getRows()) cur_row->checkDynamicDependencies();
         }
     }
 }
 
 QSharedPointer<SettingsBase> SettingBar::selectedVisualizationSettings() const {
-    if (m_selected_settings_bases.isEmpty() || m_selected_settings_bases.first().isNull())
-        return GSM->getGlobal();
+    if (m_selected_settings_bases.isEmpty() || m_selected_settings_bases.first().isNull()) return GSM->getGlobal();
 
     QSharedPointer<SettingsBase> effective_settings = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
 
@@ -446,32 +421,27 @@ QSharedPointer<SettingsBase> SettingBar::selectedVisualizationSettings() const {
 QList<QSharedPointer<SettingsBase>> SettingBar::selectedEditableSettingsBases() const {
     QList<QSharedPointer<SettingsBase>> settings_bases;
     for (const QSharedPointer<SettingsBase>& settings_base : m_selected_settings_bases) {
-        if (!settings_base.isNull())
-            settings_bases.append(settings_base);
+        if (!settings_base.isNull()) settings_bases.append(settings_base);
     }
 
     return settings_bases;
 }
 
 void SettingBar::removeRedundantSelectedLocalOverride(const QString& setting_key) {
-    if (m_selected_settings_bases.isEmpty())
-        return;
+    if (m_selected_settings_bases.isEmpty()) return;
 
     double global_value = 0.0;
-    if (GSM->getGlobal()->contains(setting_key)) {
-        global_value = GSM->getGlobal()->setting<double>(setting_key);
-    }
+    if (GSM->getGlobal()->contains(setting_key)) { global_value = GSM->getGlobal()->setting<double>(setting_key); }
     else {
         fifojson& master_json = GSM->getMaster()->json();
-        auto setting = master_json.find(setting_key.toStdString());
+        auto setting          = master_json.find(setting_key.toStdString());
         if (setting != master_json.end() && setting.value().contains(Constants::Settings::Master::kDefault))
             global_value = setting.value()[Constants::Settings::Master::kDefault].get<double>();
     }
 
     for (int index = 0, end = m_selected_settings_bases.size(); index < end; ++index) {
         QSharedPointer<SettingsBase> settings_base = m_selected_settings_bases[index];
-        if (settings_base.isNull() || !settings_base->contains(setting_key))
-            continue;
+        if (settings_base.isNull() || !settings_base->contains(setting_key)) continue;
 
         double inherited_value = global_value;
         if (index < m_selected_inherited_settings_bases.size()) {
@@ -480,8 +450,7 @@ void SettingBar::removeRedundantSelectedLocalOverride(const QString& setting_key
                 inherited_value = inherited_base->setting<double>(setting_key);
         }
 
-        if (settings_base->setting<double>(setting_key) == inherited_value)
-            settings_base->remove(setting_key);
+        if (settings_base->setting<double>(setting_key) == inherited_value) settings_base->remove(setting_key);
     }
 }
 
@@ -492,8 +461,7 @@ void SettingBar::emitSelectedVisualizationSettings() {
 void SettingBar::reloadRowsForUnitChange() {
     {
         DynamicDependencyRefreshBlocker blocker(m_suppress_dynamic_dependency_refresh);
-        for (SettingPane* cur_pane : m_panes)
-            cur_pane->reload();
+        for (SettingPane* cur_pane : m_panes) cur_pane->reload();
     }
 
     refreshDynamicDependencies();
@@ -518,8 +486,7 @@ void SettingBar::beginPairedGlobalSettingChange(QString first_key, QString secon
 void SettingBar::updatePairedGlobalSetting(QString first_key, double first_value, QString second_key,
                                            double second_value) {
     QList<QSharedPointer<SettingsBase>> settings_bases = selectedEditableSettingsBases();
-    if (settings_bases.isEmpty())
-        settings_bases.append(GSM->getGlobal());
+    if (settings_bases.isEmpty()) settings_bases.append(GSM->getGlobal());
 
     for (QSharedPointer<SettingsBase> settings_base : settings_bases) {
         settings_base->setSetting(first_key, first_value);
@@ -545,12 +512,14 @@ void SettingBar::finishPairedGlobalSettingChange(QString first_key, double first
     emitSelectedVisualizationSettings();
 }
 
-void SettingBar::forwardHideTab(QString pane, QString category) { emit tabHidden(pane, category); }
+void SettingBar::forwardHideTab(QString pane, QString category) {
+    emit tabHidden(pane, category);
+}
 
 void SettingBar::showHiddenSetting(QString panel, QString category) {
     if (m_range_selected) {
-        SettingTab* cur_tab = m_panes[panel]->getTab(category);
-        int settingsHidden = 0;
+        SettingTab* cur_tab                        = m_panes[panel]->getTab(category);
+        int settingsHidden                         = 0;
         QList<QSharedPointer<SettingRowBase>> rows = cur_tab->getRows();
         for (QSharedPointer<SettingRowBase> cur_row : rows) {
             if (!cur_row->isLocal()) {
@@ -559,14 +528,15 @@ void SettingBar::showHiddenSetting(QString panel, QString category) {
             }
         }
 
-        if (settingsHidden < rows.size())
-            cur_tab->show();
+        if (settingsHidden < rows.size()) cur_tab->show();
     }
     else
         m_panes[panel]->showTab(category);
 }
 
-void SettingBar::hideSetting(QString panel, QString category) { m_panes[panel]->hideTab(category); }
+void SettingBar::hideSetting(QString panel, QString category) {
+    m_panes[panel]->hideTab(category);
+}
 
 void SettingBar::setCurrentFolder(QString path) {
     m_current_folder->setText("Currently searching in: " % path % " for additional setting files");
@@ -576,9 +546,7 @@ void SettingBar::setupStyle() {
     m_accentColor = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
     m_current_editing->setText("Currently editing <font color=\"" % m_accentColor % "\">global</font> settings");
     for (SettingPane* cur_pane : m_panes) {
-        for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            cur_tab->setupStyle();
-        }
+        for (SettingTab* cur_tab : cur_pane->getTabs()) { cur_tab->setupStyle(); }
     }
     this->update();
 }
@@ -612,7 +580,7 @@ void SettingBar::setupSubWidgets() {
     m_current_folder = new QLabel(this);
     m_current_folder->setText("Currently searching in : <Not Set> for additional setting files");
 
-    m_accentColor = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
+    m_accentColor     = PreferencesManager::getInstance()->getTheme().getDotPairedColor().name();
     m_current_editing = new QLabel(this);
     m_current_editing->setText("Currently editing <font color=\"" % m_accentColor % "\">global</font> settings");
 
@@ -620,7 +588,9 @@ void SettingBar::setupSubWidgets() {
     m_current_editing->setStyleSheet(style);
 }
 
-void SettingBar::setupLayouts() { m_layout = new QVBoxLayout(this); }
+void SettingBar::setupLayouts() {
+    m_layout = new QVBoxLayout(this);
+}
 
 void SettingBar::setupInsert() {
     this->setLayout(m_layout);
@@ -633,16 +603,15 @@ void SettingBar::setupInsert() {
 }
 
 void SettingBar::setupGlobalSettings() {
-    if (GSM->getMaster() == nullptr)
-        return;
+    if (GSM->getMaster() == nullptr) return;
     fifojson master_json = GSM->getMaster()->json();
 
     for (auto& it : master_json.items()) {
-        fifojson curr_json = it.value();
+        fifojson curr_json   = it.value();
         SettingTab* curr_tab = this->getTab(curr_json[Constants::Settings::Master::kMajor],
                                             curr_json[Constants::Settings::Master::kMinor]);
-        QString key = QString::fromStdString(it.key());
-        fifojson input_json = GSM->getSettingInput(key);
+        QString key          = QString::fromStdString(it.key());
+        fifojson input_json  = GSM->getSettingInput(key);
 
         curr_tab->addRow(key, curr_json, input_json);
     }
@@ -675,7 +644,6 @@ void SettingBar::enableDependRows() {
 
     for (SettingPane* curr_pane : m_panes) {
         for (SettingTab* curr_tab : curr_pane->getTabs()) {
-
             for (QSharedPointer<SettingRowBase> row : curr_tab->getRows()) {
                 fifojson depends = row->getDependencies();
                 if (depends != "") {
@@ -683,9 +651,7 @@ void SettingBar::enableDependRows() {
                     row->setDependencyLogic(root);
                     row->checkDependencies();
                 }
-                else {
-                    row->checkDynamicDependencies();
-                }
+                else { row->checkDynamicDependencies(); }
             }
         }
     }
@@ -701,21 +667,17 @@ void SettingBar::refreshDependencyVisibility() {
 
     for (QString key : m_panes.keys()) {
         QList<QString> hidden_settings = PreferencesManager::getInstance()->getHiddenSettings(key);
-        SettingPane* cur_pane = m_panes.value(key);
-        bool pane_has_visible_tab = false;
+        SettingPane* cur_pane          = m_panes.value(key);
+        bool pane_has_visible_tab      = false;
 
         for (SettingTab* cur_tab : cur_pane->getTabs()) {
-            if (hidden_settings.contains(cur_tab->getName())) {
-                continue;
-            }
+            if (hidden_settings.contains(cur_tab->getName())) { continue; }
 
             if (cur_tab->hasShownRows()) {
                 cur_tab->show();
                 pane_has_visible_tab = true;
             }
-            else {
-                cur_tab->hide();
-            }
+            else { cur_tab->hide(); }
         }
 
         m_tab_widget->setTabEnabled(cur_pane->getIndex(), pane_has_visible_tab);
@@ -727,9 +689,7 @@ DependencyNode SettingBar::createNodes(fifojson& master, QSharedPointer<SettingR
     for (auto& el : json.items()) {
         root.key = QString::fromStdString(el.key());
         if (el.key() == "AND" || el.key() == "OR" || el.key() == "NOT") {
-            for (auto& el2 : el.value().items()) {
-                root.children.push_back(createNodes(master, row, el2.value()));
-            }
+            for (auto& el2 : el.value().items()) { root.children.push_back(createNodes(master, row, el2.value())); }
         }
         else {
             root.val = el.value();
@@ -747,4 +707,4 @@ DependencyNode SettingBar::createNodes(fifojson& master, QSharedPointer<SettingR
     }
     return root;
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_check_box.cpp
+++ b/src/widgets/settings/setting_check_box.cpp
@@ -1,6 +1,7 @@
 #include "widgets/settings/setting_check_box.h"
 
 #include <QToolTip>
+
 #include <qcheckbox.h>
 #include <qgridlayout.h>
 #include <qhashfunctions.h>
@@ -23,8 +24,7 @@ SettingCheckBox::SettingCheckBox(SettingTab* parent, QSharedPointer<SettingsBase
     bool cur;
     m_warn = false;
     // If the settings base contains the key, use its value. Otherwise, pull from the default.
-    if (m_sb->contains(key))
-        cur = m_sb->setting<bool>(key);
+    if (m_sb->contains(key)) cur = m_sb->setting<bool>(key);
     // Get the value as an int from the master since json throws an error reading 0 as false.
     else {
         cur = json.operator[](Constants::Settings::Master::kDefault).get<int>();
@@ -79,7 +79,7 @@ void SettingCheckBox::show() {
 
 void SettingCheckBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<bool>(val.toBool());
     emit modified(m_key);
@@ -88,12 +88,11 @@ void SettingCheckBox::valueChanged(QVariant val) {
 void SettingCheckBox::reloadValue() {
     this->blockSignals(true);
     bool consistent = true;
-    bool cur = reloadValueHelper<bool>(consistent);
-    if (consistent)
-        setChecked(cur);
+    bool cur        = reloadValueHelper<bool>(consistent);
+    if (consistent) setChecked(cur);
 
     this->blockSignals(false);
     emit modified(m_key);
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_combo_box.cpp
+++ b/src/widgets/settings/setting_combo_box.cpp
@@ -2,6 +2,7 @@
 
 #include <QToolTip>
 #include <QWheelEvent>
+
 #include <qcombobox.h>
 #include <qcontainerfwd.h>
 #include <qgridlayout.h>
@@ -25,9 +26,7 @@ SettingComboBox::SettingComboBox(SettingTab* parent, QSharedPointer<SettingsBase
     this->setFocusPolicy(Qt::StrongFocus);
     m_warn = false;
 
-    if (m_sb->contains(key)) {
-        m_cur = m_sb->setting<int>(key);
-    }
+    if (m_sb->contains(key)) { m_cur = m_sb->setting<int>(key); }
     else {
         m_cur = json.operator[](Constants::Settings::Master::kDefault).get<int>();
         m_sb->setSetting(key, m_cur);
@@ -37,8 +36,7 @@ SettingComboBox::SettingComboBox(SettingTab* parent, QSharedPointer<SettingsBase
     QStringList options = json.operator[]("options").get<QString>().split(',');
 
     // For each option, make sure it is trimmed.
-    for (QString& curr : options)
-        curr = curr.trimmed();
+    for (QString& curr : options) curr = curr.trimmed();
 
     this->addItems(options);
     this->setCurrentIndex(m_cur);
@@ -93,21 +91,18 @@ void SettingComboBox::show() {
 
 void SettingComboBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<int>(val.toInt());
-    if (m_prev != this->currentIndex()) {
-        emit modified(m_key);
-    }
+    if (m_prev != this->currentIndex()) { emit modified(m_key); }
     m_prev = this->currentIndex();
 }
 
 void SettingComboBox::reloadValue() {
     this->blockSignals(true);
     bool consistent = true;
-    int m_cur = reloadValueHelper<int>(consistent);
-    if (consistent)
-        setCurrentIndex(m_cur);
+    int m_cur       = reloadValueHelper<int>(consistent);
+    if (consistent) setCurrentIndex(m_cur);
 
     this->blockSignals(false);
     emit modified(m_key);
@@ -120,4 +115,4 @@ void SettingComboBox::wheelEvent(QWheelEvent* event) {
     else
         QComboBox::wheelEvent(event);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/setting_double_spin_box.cpp
+++ b/src/widgets/settings/setting_double_spin_box.cpp
@@ -2,6 +2,7 @@
 
 #include <QToolTip>
 #include <QWheelEvent>
+
 #include <qgridlayout.h>
 #include <qlabel.h>
 #include <qnamespace.h>
@@ -29,15 +30,21 @@ QString masterString(const fifojson& json, const std::string& key) {
     return QString::fromStdString(json.at(key).get<std::string>());
 }
 
-bool isOneOf(const QString& key, const QStringList& keys) { return keys.contains(key); }
+bool isOneOf(const QString& key, const QStringList& keys) {
+    return keys.contains(key);
+}
 
-bool isConfiguredRange(double min_value, double max_value) { return min_value != 0 || max_value != 0; }
+bool isConfiguredRange(double min_value, double max_value) {
+    return min_value != 0 || max_value != 0;
+}
 
 bool isValidRange(double min_value, double max_value) {
     return isConfiguredRange(min_value, max_value) && min_value < max_value;
 }
 
-QString formatRpm(double value) { return QString::number(value, 'g', 6) + " rpm"; }
+QString formatRpm(double value) {
+    return QString::number(value, 'g', 6) + " rpm";
+}
 
 QString formatDistance(double value) {
     const Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
@@ -51,22 +58,17 @@ QString formatTime(double value) {
 }
 
 QString formatTypedValue(double value, const QString& type) {
-    if (type == "distance" || type == "location")
-        return formatDistance(value);
-    if (type == "time")
-        return formatTime(value);
-    if (type == "rpm")
-        return formatRpm(value);
-    if (type == "percentage" || type == "percentage100")
-        return QString::number(value, 'g', 6) + "%";
+    if (type == "distance" || type == "location") return formatDistance(value);
+    if (type == "time") return formatTime(value);
+    if (type == "rpm") return formatRpm(value);
+    if (type == "percentage" || type == "percentage100") return QString::number(value, 'g', 6) + "%";
 
     return QString::number(value, 'g', 6);
 }
 
 QString dimensionRangeWarning(const QString& key, const QString& min_key, const QString& max_key, double min_value,
                               double max_value, const QString& min_label, const QString& max_label) {
-    if (!isConfiguredRange(min_value, max_value) || min_value < max_value)
-        return QString();
+    if (!isConfiguredRange(min_value, max_value) || min_value < max_value) return QString();
 
     if (key == min_key || key == max_key) {
         return min_label + " (" + formatDistance(min_value) + ") must be less than " + max_label + " (" +
@@ -77,8 +79,7 @@ QString dimensionRangeWarning(const QString& key, const QString& min_key, const 
 }
 
 QString boundsWarning(const QString& display, double value, double min_value, double max_value, const QString& axis) {
-    if (!isValidRange(min_value, max_value) || (value >= min_value && value <= max_value))
-        return QString();
+    if (!isValidRange(min_value, max_value) || (value >= min_value && value <= max_value)) return QString();
 
     return display + " (" + formatDistance(value) + ") is outside the " + axis + " build volume range (" +
            formatDistance(min_value) + " to " + formatDistance(max_value) + ").";
@@ -86,13 +87,12 @@ QString boundsWarning(const QString& display, double value, double min_value, do
 
 QString enabledSettingWarning(const QString& display, double value, const QString& required_description,
                               const QString& type) {
-    if (value > 0)
-        return QString();
+    if (value > 0) return QString();
 
     return display + " must be greater than zero " + required_description + " (currently " +
            formatTypedValue(value, type) + ").";
 }
-} // namespace
+}  // namespace
 
 SettingDoubleSpinBox::SettingDoubleSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
                                            fifojson json, QGridLayout* layout, int index)
@@ -115,7 +115,7 @@ SettingDoubleSpinBox::SettingDoubleSpinBox(SettingTab* parent, QSharedPointer<Se
         this->setMaximum(9999.99);
         unitText = "rpm";
     }
-    else if (type == "percentage100") // Percentage values with a maximum value of 100
+    else if (type == "percentage100")  // Percentage values with a maximum value of 100
     {
         this->setMinimum(0);
         this->setMaximum(100);
@@ -165,8 +165,7 @@ void SettingDoubleSpinBox::applyNotification(QString msg, bool show_tooltip) {
     // set pop-up/tooltip
     this->setStyleFromFile(this, m_theme_path + "setting_rows_warning.qss");
     this->setToolTip(msg);
-    if (show_tooltip)
-        QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
+    if (show_tooltip) QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
 }
 
 void SettingDoubleSpinBox::clearNotification() {
@@ -187,7 +186,7 @@ void SettingDoubleSpinBox::show() {
 
 void SettingDoubleSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<double>(val.toDouble());
     emit modified(m_key);
@@ -196,9 +195,8 @@ void SettingDoubleSpinBox::valueChanged(QVariant val) {
 void SettingDoubleSpinBox::reloadValue() {
     this->blockSignals(true);
     bool consistent = true;
-    double cur = reloadValueHelper<double>(consistent);
-    if (consistent)
-        setValue(cur);
+    double cur      = reloadValueHelper<double>(consistent);
+    if (consistent) setValue(cur);
 
     this->blockSignals(false);
     emit modified(m_key);
@@ -228,7 +226,7 @@ void SettingDoubleSpinBox::checkDynamicDependencies() {
         return;
     }
 
-    const QString warning = dynamicDependencyWarning();
+    const QString warning     = dynamicDependencyWarning();
     const bool warning_active = !warning.isEmpty();
     if (warning_active) {
         applyNotification(warning, false);
@@ -249,62 +247,64 @@ int SettingDoubleSpinBox::effectiveSettingsBaseCount() const {
     return m_settings_bases.isEmpty() ? 1 : m_settings_bases.size();
 }
 
-double SettingDoubleSpinBox::effectiveDouble() const { return effectiveDouble(0); }
+double SettingDoubleSpinBox::effectiveDouble() const {
+    return effectiveDouble(0);
+}
 
 double SettingDoubleSpinBox::effectiveDouble(int settings_base_index) const {
     const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
-    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+    const double global_value  = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
 
-    if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<double>(m_key, settings_base_index, global_value);
+    if (!m_settings_bases.isEmpty()) return effectiveValueHelper<double>(m_key, settings_base_index, global_value);
 
     return global_value;
 }
 
-double SettingDoubleSpinBox::effectiveDouble(const QString& key) const { return effectiveDouble(key, 0); }
+double SettingDoubleSpinBox::effectiveDouble(const QString& key) const {
+    return effectiveDouble(key, 0);
+}
 
 double SettingDoubleSpinBox::effectiveDouble(const QString& key, int settings_base_index) const {
     const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : 0.0;
 
-    if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<double>(key, settings_base_index, global_value);
+    if (!m_settings_bases.isEmpty()) return effectiveValueHelper<double>(key, settings_base_index, global_value);
 
     return global_value;
 }
 
-bool SettingDoubleSpinBox::effectiveBool(const QString& key) const { return effectiveBool(key, 0); }
+bool SettingDoubleSpinBox::effectiveBool(const QString& key) const {
+    return effectiveBool(key, 0);
+}
 
 bool SettingDoubleSpinBox::effectiveBool(const QString& key, int settings_base_index) const {
     const bool global_value = m_sb->contains(key) ? m_sb->setting<bool>(key) : false;
 
-    if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<bool>(key, settings_base_index, global_value);
+    if (!m_settings_bases.isEmpty()) return effectiveValueHelper<bool>(key, settings_base_index, global_value);
 
     return global_value;
 }
 
-int SettingDoubleSpinBox::effectiveInt(const QString& key) const { return effectiveInt(key, 0); }
+int SettingDoubleSpinBox::effectiveInt(const QString& key) const {
+    return effectiveInt(key, 0);
+}
 
 int SettingDoubleSpinBox::effectiveInt(const QString& key, int settings_base_index) const {
     const int global_value = m_sb->contains(key) ? m_sb->setting<int>(key) : 0;
 
-    if (!m_settings_bases.isEmpty())
-        return effectiveValueHelper<int>(key, settings_base_index, global_value);
+    if (!m_settings_bases.isEmpty()) return effectiveValueHelper<int>(key, settings_base_index, global_value);
 
     return global_value;
 }
 
 bool SettingDoubleSpinBox::hasConsistentEffectiveDouble() const {
-    if (m_settings_bases.size() <= 1)
-        return true;
+    if (m_settings_bases.size() <= 1) return true;
 
     const double default_value = m_json[Constants::Settings::Master::kDefault].get<double>();
-    const double global_value = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
-    const double first_value = effectiveValueHelper<double>(m_key, 0, global_value);
+    const double global_value  = m_sb->contains(m_key) ? m_sb->setting<double>(m_key) : default_value;
+    const double first_value   = effectiveValueHelper<double>(m_key, 0, global_value);
 
     for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
-        if (effectiveValueHelper<double>(m_key, index, global_value) != first_value)
-            return false;
+        if (effectiveValueHelper<double>(m_key, index, global_value) != first_value) return false;
     }
 
     return true;
@@ -313,23 +313,21 @@ bool SettingDoubleSpinBox::hasConsistentEffectiveDouble() const {
 QString SettingDoubleSpinBox::dynamicDependencyWarning() const {
     for (int index = 0, end = effectiveSettingsBaseCount(); index < end; ++index) {
         const QString warning = dynamicDependencyWarning(index);
-        if (!warning.isEmpty())
-            return warning;
+        if (!warning.isEmpty()) return warning;
     }
 
     return QString();
 }
 
 QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) const {
-    if (m_sb.isNull())
-        return QString();
+    if (m_sb.isNull()) return QString();
 
     const QString display = masterString(m_json, Constants::Settings::Master::kDisplay);
-    const QString type = masterString(m_json, Constants::Settings::Master::kType);
-    const double value = effectiveDouble(settings_base_index);
+    const QString type    = masterString(m_json, Constants::Settings::Master::kType);
+    const double value    = effectiveDouble(settings_base_index);
 
-    const double min_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMinExtruderSpeed, settings_base_index);
-    const double max_extruder_speed = effectiveDouble(PRS::MachineSpeed::kMaxExtruderSpeed, settings_base_index);
+    const double min_extruder_speed   = effectiveDouble(PRS::MachineSpeed::kMinExtruderSpeed, settings_base_index);
+    const double max_extruder_speed   = effectiveDouble(PRS::MachineSpeed::kMaxExtruderSpeed, settings_base_index);
     const bool has_min_extruder_speed = min_extruder_speed > 0;
     const bool has_max_extruder_speed = max_extruder_speed > 0;
     const bool invalid_extruder_range =
@@ -361,23 +359,19 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) 
 
     QString warning = dimensionRangeWarning(m_key, PRS::Dimensions::kXMin, PRS::Dimensions::kXMax, x_min, x_max,
                                             "Minimum X", "Maximum X");
-    if (!warning.isEmpty())
-        return warning;
+    if (!warning.isEmpty()) return warning;
 
     warning = dimensionRangeWarning(m_key, PRS::Dimensions::kYMin, PRS::Dimensions::kYMax, y_min, y_max, "Minimum Y",
                                     "Maximum Y");
-    if (!warning.isEmpty())
-        return warning;
+    if (!warning.isEmpty()) return warning;
 
     warning = dimensionRangeWarning(m_key, PRS::Dimensions::kZMin, PRS::Dimensions::kZMax, z_min, z_max, "Minimum Z",
                                     "Maximum Z");
-    if (!warning.isEmpty())
-        return warning;
+    if (!warning.isEmpty()) return warning;
 
     warning = dimensionRangeWarning(m_key, PRS::Dimensions::kWMin, PRS::Dimensions::kWMax, w_min, w_max, "Minimum W",
                                     "Maximum W");
-    if (!warning.isEmpty())
-        return warning;
+    if (!warning.isEmpty()) return warning;
 
     if (m_key == PRS::Dimensions::kPurgeX || m_key == PS::Perimeter::kEnableLeadInX)
         return boundsWarning(display, value, x_min, x_max, "X");
@@ -385,11 +379,9 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) 
     if (m_key == PRS::Dimensions::kPurgeY || m_key == PS::Perimeter::kEnableLeadInY)
         return boundsWarning(display, value, y_min, y_max, "Y");
 
-    if (m_key == PRS::Dimensions::kPurgeZ)
-        return boundsWarning(display, value, z_min, z_max, "Z");
+    if (m_key == PRS::Dimensions::kPurgeZ) return boundsWarning(display, value, z_min, z_max, "Z");
 
-    if (m_key == PRS::Dimensions::kDoffingHeight)
-        return boundsWarning(display, value, w_min, w_max, "W");
+    if (m_key == PRS::Dimensions::kDoffingHeight) return boundsWarning(display, value, w_min, w_max, "W");
 
     if (m_key == PS::Layer::kLayerHeight && value <= 0)
         return display + " must be greater than zero (currently " + formatDistance(value) + ").";
@@ -408,8 +400,7 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) 
 
     if (isOneOf(m_key, bead_width_keys)) {
         const double layer_height = effectiveDouble(PS::Layer::kLayerHeight, settings_base_index);
-        if (value <= 0)
-            return display + " must be greater than zero (currently " + formatDistance(value) + ").";
+        if (value <= 0) return display + " must be greater than zero (currently " + formatDistance(value) + ").";
 
         if (layer_height > 0 && value < layer_height)
             return display + " (" + formatDistance(value) + ") is smaller than Layer Height (" +
@@ -436,8 +427,7 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) 
 
     if (isOneOf(m_key, lift_distance_keys) && value > 0) {
         const double z_speed = effectiveDouble(PRS::MachineSpeed::kZSpeed, settings_base_index);
-        if (z_speed <= 0)
-            return display + " requires Z Speed to be greater than zero.";
+        if (z_speed <= 0) return display + " requires Z Speed to be greater than zero.";
 
         if (isValidRange(z_min, z_max) && value > (z_max - z_min))
             return display + " (" + formatDistance(value) + ") exceeds the Z build volume range (" +
@@ -483,4 +473,4 @@ QString SettingDoubleSpinBox::dynamicDependencyWarning(int settings_base_index) 
 
     return QString();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/setting_header.cpp
+++ b/src/widgets/settings/setting_header.cpp
@@ -2,6 +2,7 @@
 
 #include <QFile>
 #include <QHBoxLayout>
+
 #include <qframe.h>
 #include <qhashfunctions.h>
 #include <qicon.h>
@@ -21,12 +22,13 @@
 namespace ORNL {
 SettingHeader::SettingHeader(QWidget* parent, QString name, QIcon icon, bool canDelete)
     : QFrame(parent), m_name(name), m_icon(icon), m_can_delete(canDelete) {
-
     setupWidget();
     setupSubWidgets();
 }
 
-void SettingHeader::updateBackground() { this->update(); }
+void SettingHeader::updateBackground() {
+    this->update();
+}
 
 void SettingHeader::setName(QString new_name) {
     m_name = new_name;
@@ -63,7 +65,7 @@ void SettingHeader::setupSubWidgets() {
     QHBoxLayout* hlayout = new QHBoxLayout();
     hlayout->setContentsMargins(0, 0, 0, 0);
     QSpacerItem* hspacer = new QSpacerItem(0, 0, QSizePolicy::Expanding);
-    m_picture = new QLabel(this);
+    m_picture            = new QLabel(this);
     m_picture->setSizeIncrement(28, 28);
     m_picture->setPixmap(m_icon.pixmap(QSize(28, 28), QIcon::Normal, QIcon::On));
     m_label = new QLabel(this);
@@ -105,7 +107,9 @@ void SettingHeader::mousePressEvent(QMouseEvent* event) {
     this->update();
 }
 
-void SettingHeader::showHeader() { this->show(); }
+void SettingHeader::showHeader() {
+    this->show();
+}
 
 void SettingHeader::deleteOrHideHeader() {
     if (m_can_delete)
@@ -132,5 +136,7 @@ RemoveButton::RemoveButton(bool isDelete, QWidget* parent) : QPushButton(parent)
     this->setIcon(QIcon(hideOrDelete.scaled(22, 22, Qt::KeepAspectRatio)));
 }
 
-bool RemoveButton::isInside() { return m_inside; }
-} // Namespace ORNL
+bool RemoveButton::isInside() {
+    return m_inside;
+}
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_line_edit.cpp
+++ b/src/widgets/settings/setting_line_edit.cpp
@@ -1,6 +1,7 @@
 #include "widgets/settings/setting_line_edit.h"
 
 #include <QToolTip>
+
 #include <qgridlayout.h>
 #include <qlabel.h>
 #include <qlineedit.h>
@@ -80,7 +81,7 @@ void SettingLineEdit::show() {
 
 void SettingLineEdit::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<QString>(val.toString());
     emit modified(m_key);
@@ -89,12 +90,11 @@ void SettingLineEdit::valueChanged(QVariant val) {
 void SettingLineEdit::reloadValue() {
     this->blockSignals(true);
     bool consistent = true;
-    QString cur = reloadValueHelper<QString>(consistent);
-    if (consistent)
-        setText(cur);
+    QString cur     = reloadValueHelper<QString>(consistent);
+    if (consistent) setText(cur);
 
     this->blockSignals(false);
     emit modified(m_key);
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_numbered_list.cpp
+++ b/src/widgets/settings/setting_numbered_list.cpp
@@ -3,6 +3,7 @@
 #include <QDropEvent>
 #include <QHeaderView>
 #include <QToolTip>
+
 #include <qabstractitemview.h>
 #include <qcontainerfwd.h>
 #include <qgridlayout.h>
@@ -105,7 +106,7 @@ void SettingNumberedList::show() {
 
 void SettingNumberedList::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<QList<QString>>(val.value<QStringList>());
     emit modified(m_key);
@@ -114,10 +115,9 @@ void SettingNumberedList::valueChanged(QVariant val) {
 void SettingNumberedList::reloadValue() {
     this->blockSignals(true);
 
-    bool consistent = true;
+    bool consistent    = true;
     QList<QString> cur = reloadValueHelper<QList<QString>>(consistent);
-    if (consistent)
-        setEntries(cur);
+    if (consistent) setEntries(cur);
 
     this->blockSignals(false);
     emit modified(m_key);
@@ -125,9 +125,7 @@ void SettingNumberedList::reloadValue() {
 }
 
 void SettingNumberedList::setEntries(QList<QString> entries) {
-    for (int i = 0, end = entries.size(); i < end; ++i) {
-        this->item(i, 0)->setText(entries[i]);
-    }
+    for (int i = 0, end = entries.size(); i < end; ++i) { this->item(i, 0)->setText(entries[i]); }
 }
 
 void SettingNumberedList::dropEvent(QDropEvent* event) {
@@ -135,28 +133,23 @@ void SettingNumberedList::dropEvent(QDropEvent* event) {
         int newRow = this->indexAt(event->pos()).row();
         if (newRow != -1) {
             QTableWidgetItem* selectedItem = this->selectedItems()[0];
-            int originalRow = selectedItem->row();
+            int originalRow                = selectedItem->row();
             this->takeItem(originalRow, 0);
 
             if (newRow > originalRow) {
-                for (int i = originalRow; i < newRow; ++i) {
-                    this->setItem(i, 0, this->takeItem(i + 1, 0));
-                }
+                for (int i = originalRow; i < newRow; ++i) { this->setItem(i, 0, this->takeItem(i + 1, 0)); }
             }
             else {
-                for (int i = originalRow; i > newRow; --i) {
-                    this->setItem(i, 0, this->takeItem(i - 1, 0));
-                }
+                for (int i = originalRow; i > newRow; --i) { this->setItem(i, 0, this->takeItem(i - 1, 0)); }
             }
             this->setItem(newRow, 0, selectedItem);
             this->clearSelection();
 
             QList<QString> entries;
-            for (int i = 0, end = this->rowCount(); i < end; ++i)
-                entries.push_back(this->item(i, 0)->text());
+            for (int i = 0, end = this->rowCount(); i < end; ++i) entries.push_back(this->item(i, 0)->text());
 
             valueChanged(QVariant(entries));
         }
     }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/setting_pane.cpp
+++ b/src/widgets/settings/setting_pane.cpp
@@ -22,12 +22,13 @@ SettingPane::SettingPane(int idx, QWidget* parent, QString pane, int warnings)
 }
 
 SettingTab* SettingPane::getTab(QString category) {
-    if (!m_tabs.contains(category))
-        return nullptr;
+    if (!m_tabs.contains(category)) return nullptr;
     return m_tabs[category];
 }
 
-QVector<SettingTab*> SettingPane::getTabs() { return m_tabs.values().toVector(); }
+QVector<SettingTab*> SettingPane::getTabs() {
+    return m_tabs.values().toVector();
+}
 
 SettingTab* SettingPane::newTab(QString category, QIcon icon, bool isHidden) {
     QSharedPointer<SettingsBase> sb = GSM->getGlobal();
@@ -35,8 +36,7 @@ SettingTab* SettingPane::newTab(QString category, QIcon icon, bool isHidden) {
 
     m_tabs[category] = new SettingTab(this, category, icon, m_tabs.size(), isHidden, GSM->getGlobal());
     // -1 to insert before stretch.
-    if (!isHidden)
-        m_scroll_layout->insertWidget(m_scroll_layout->count() - 1, m_tabs[category]);
+    if (!isHidden) m_scroll_layout->insertWidget(m_scroll_layout->count() - 1, m_tabs[category]);
 
     connect(m_tabs[category], &SettingTab::settingAboutToChange, this, &SettingPane::forwardSettingAboutToChange);
     connect(m_tabs[category], &SettingTab::modified, this, &SettingPane::forwardModifiedSetting);
@@ -46,20 +46,18 @@ SettingTab* SettingPane::newTab(QString category, QIcon icon, bool isHidden) {
     return m_tabs[category];
 }
 
-int SettingPane::getIndex() { return m_idx; }
+int SettingPane::getIndex() {
+    return m_idx;
+}
 
 void SettingPane::setLock(bool status) {
     for (SettingTab* curr_tab : m_tabs) {
-        for (QSharedPointer<SettingRowBase> cur_row : curr_tab->getRows()) {
-            cur_row->setEnabled(status);
-        }
+        for (QSharedPointer<SettingRowBase> cur_row : curr_tab->getRows()) { cur_row->setEnabled(status); }
     }
 }
 
 void SettingPane::reload() {
-    for (SettingTab* curr_tab : m_tabs) {
-        curr_tab->reload();
-    }
+    for (SettingTab* curr_tab : m_tabs) { curr_tab->reload(); }
 }
 
 void SettingPane::hideTab(QString category) {
@@ -74,20 +72,18 @@ void SettingPane::showTab(QString category) {
 }
 
 void SettingPane::paneWarning(int count) {
-    m_pane_warning = m_pane_warning + count; // keep track of total number of warnings from all children (tabs)
-    if (m_pane_warning > 0) {
-        emit warnSettingBar(1, m_name);
-    }
-    else {
-        emit warnSettingBar(0, m_name);
-    }
+    m_pane_warning = m_pane_warning + count;  // keep track of total number of warnings from all children (tabs)
+    if (m_pane_warning > 0) { emit warnSettingBar(1, m_name); }
+    else { emit warnSettingBar(0, m_name); }
 }
 
 void SettingPane::forwardSettingAboutToChange(QString setting_key, QList<QSharedPointer<SettingsBase>> settings_bases) {
     emit settingAboutToChange(setting_key, settings_bases);
 }
 
-void SettingPane::forwardModifiedSetting(QString setting_key) { emit settingModified(setting_key); }
+void SettingPane::forwardModifiedSetting(QString setting_key) {
+    emit settingModified(setting_key);
+}
 
 void SettingPane::setupWidget() {
     this->setupSubWidgets();
@@ -98,7 +94,8 @@ void SettingPane::setupWidget() {
 void SettingPane::setupSubWidgets() {
     // ScrollArea
     m_scroll_area = new QScrollArea(this);
-    m_scroll_area->setStyleSheet("QScrollArea { background: transparent; border:0px;}\
+    m_scroll_area->setStyleSheet(
+        "QScrollArea { background: transparent; border:0px;}\
                             QScrollArea > QWidget > QWidget { background: transparent; }");
     m_scroll_area->setWidgetResizable(true);
     m_scroll_area->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
@@ -124,4 +121,4 @@ void SettingPane::setupInsert() {
     m_scroll_area->setWidget(m_scroll_container);
 }
 
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_plain_text_edit.cpp
+++ b/src/widgets/settings/setting_plain_text_edit.cpp
@@ -1,6 +1,7 @@
 #include "widgets/settings/setting_plain_text_edit.h"
 
 #include <QToolTip>
+
 #include <qgridlayout.h>
 #include <qlabel.h>
 #include <qnamespace.h>
@@ -79,7 +80,7 @@ void SettingPlainTextEdit::show() {
 
 void SettingPlainTextEdit::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<QString>(val.value<QString>());
     emit modified(m_key);
@@ -88,12 +89,11 @@ void SettingPlainTextEdit::valueChanged(QVariant val) {
 void SettingPlainTextEdit::reloadValue() {
     this->blockSignals(true);
     bool consistent = true;
-    QString cur = reloadValueHelper<QString>(consistent);
-    if (consistent)
-        setPlainText(cur);
+    QString cur     = reloadValueHelper<QString>(consistent);
+    if (consistent) setPlainText(cur);
 
     this->blockSignals(false);
     emit modified(m_key);
     emit warnParent(warningCountDelta(!consistent, m_warn));
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_row_base.cpp
+++ b/src/widgets/settings/setting_row_base.cpp
@@ -5,6 +5,7 @@
 #include <QIcon>
 #include <QSpinBox>
 #include <QToolButton>
+
 #include <qgridlayout.h>
 #include <qhashfunctions.h>
 #include <qlabel.h>
@@ -25,9 +26,15 @@ namespace ORNL {
 
 SettingRowBase::SettingRowBase(QWidget* parent, QSharedPointer<SettingsBase> sb, QString key, fifojson json,
                                QGridLayout* layout, int index)
-    : m_index(index), m_layout(layout), m_key(key), m_sb(sb), m_row_visible(true), m_row_enabled(true),
-      m_dependency_enabled(true), m_json(json) {
-    m_theme_path = PreferencesManager::getInstance()->getTheme().getFolderPath();
+    : m_index(index),
+      m_layout(layout),
+      m_key(key),
+      m_sb(sb),
+      m_row_visible(true),
+      m_row_enabled(true),
+      m_dependency_enabled(true),
+      m_json(json) {
+    m_theme_path          = PreferencesManager::getInstance()->getTheme().getFolderPath();
     m_local_override_keys = {m_key};
 
     m_key_label.reset(new QLabel());
@@ -63,7 +70,9 @@ void SettingRowBase::clearDependencyLogic() {
     m_dependency_logic.children.clear();
 }
 
-QString SettingRowBase::getLabelText() { return m_key_label->text(); }
+QString SettingRowBase::getLabelText() {
+    return m_key_label->text();
+}
 
 // This is to style inheritents of setting_row_base (i.e., all the different types of settings)
 bool SettingRowBase::setStyleFromFile(QWidget* target, QString file) {
@@ -108,9 +117,7 @@ void SettingRowBase::styleLabel(bool isConsistent) {
                 "<html><body><p><b>Locally overridden.</b> Click the reset button to use the inherited value.</p><p>" +
                 QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) + "</p></body></html>");
         }
-        else {
-            m_key_label->setToolTip(tooltip);
-        }
+        else { m_key_label->setToolTip(tooltip); }
     }
     else {
         this->styleLabelFromFile(m_theme_path + "setting_rows_warning.qss");
@@ -120,25 +127,29 @@ void SettingRowBase::styleLabel(bool isConsistent) {
     updateResetButton();
 }
 
-bool SettingRowBase::isLocal() { return m_json[Constants::Settings::Master::kLocal]; }
+bool SettingRowBase::isLocal() {
+    return m_json[Constants::Settings::Master::kLocal];
+}
 
-fifojson SettingRowBase::getDependencies() { return m_json[Constants::Settings::Master::kDepends]; }
+fifojson SettingRowBase::getDependencies() {
+    return m_json[Constants::Settings::Master::kDepends];
+}
 
 void SettingRowBase::addRowToNotify(QSharedPointer<SettingRowBase> row) {
-    if (!m_rows_to_notify.contains(row)) {
-        m_rows_to_notify.push_back(row);
-    }
+    if (!m_rows_to_notify.contains(row)) { m_rows_to_notify.push_back(row); }
 }
 
 void SettingRowBase::setBases(QList<QSharedPointer<SettingsBase>> settings_bases,
                               QList<QSharedPointer<SettingsBase>> inherited_bases) {
     m_warning_state_reset_pending = m_settings_bases != settings_bases || m_inherited_settings_bases != inherited_bases;
-    m_settings_bases = settings_bases;
-    m_inherited_settings_bases = inherited_bases;
+    m_settings_bases              = settings_bases;
+    m_inherited_settings_bases    = inherited_bases;
     updateResetButton();
 }
 
-QList<QSharedPointer<SettingsBase>> SettingRowBase::getBases() { return m_settings_bases; }
+QList<QSharedPointer<SettingsBase>> SettingRowBase::getBases() {
+    return m_settings_bases;
+}
 
 void SettingRowBase::checkDependencies() {
     setDependencyEnabled(checkLogic(m_dependency_logic));
@@ -155,7 +166,9 @@ void SettingRowBase::show() {
     applyBaseWidgetState();
 }
 
-bool SettingRowBase::isShown() const { return rowWidgetsVisible(); }
+bool SettingRowBase::isShown() const {
+    return rowWidgetsVisible();
+}
 
 bool SettingRowBase::rowWidgetsVisible() const {
     const bool show_disabled =
@@ -163,11 +176,12 @@ bool SettingRowBase::rowWidgetsVisible() const {
     return m_row_visible && (m_dependency_enabled || show_disabled);
 }
 
-bool SettingRowBase::rowWidgetsEnabled() const { return m_row_enabled && m_dependency_enabled; }
+bool SettingRowBase::rowWidgetsEnabled() const {
+    return m_row_enabled && m_dependency_enabled;
+}
 
 void SettingRowBase::applyWidgetState(QWidget* widget) const {
-    if (widget == nullptr)
-        return;
+    if (widget == nullptr) return;
 
     widget->setVisible(rowWidgetsVisible());
     widget->setEnabled(rowWidgetsEnabled());
@@ -178,8 +192,7 @@ void SettingRowBase::applyBaseWidgetState() {
     const bool enabled = rowWidgetsEnabled();
 
     for (QWidget* widget : m_row_widgets) {
-        if (widget == nullptr)
-            continue;
+        if (widget == nullptr) continue;
 
         widget->setVisible(visible);
         widget->setEnabled(enabled);
@@ -199,8 +212,7 @@ void SettingRowBase::applyBaseWidgetState() {
 }
 
 void SettingRowBase::registerRowWidget(QWidget* widget) {
-    if (widget == nullptr || m_row_widgets.contains(widget))
-        return;
+    if (widget == nullptr || m_row_widgets.contains(widget)) return;
 
     m_row_widgets.push_back(widget);
     applyWidgetState(widget);
@@ -212,41 +224,45 @@ void SettingRowBase::setEnabled(bool enabled) {
 }
 
 void SettingRowBase::setDependencyEnabled(bool enabled) {
-    const bool changed = m_dependency_enabled != enabled;
+    const bool changed   = m_dependency_enabled != enabled;
     m_dependency_enabled = enabled;
     applyBaseWidgetState();
 
     if (changed) {
-        for (QSharedPointer<SettingRowBase> row : m_rows_to_notify) {
-            row->checkDependencies();
-        }
+        for (QSharedPointer<SettingRowBase> row : m_rows_to_notify) { row->checkDependencies(); }
     }
 }
 
-void SettingRowBase::setDependencyLogic(DependencyNode root) { m_dependency_logic = root; }
+void SettingRowBase::setDependencyLogic(DependencyNode root) {
+    m_dependency_logic = root;
+}
 
-void SettingRowBase::setSettingsBase(QSharedPointer<SettingsBase> sb) { m_sb = sb; }
+void SettingRowBase::setSettingsBase(QSharedPointer<SettingsBase> sb) {
+    m_sb = sb;
+}
 
-void SettingRowBase::setValueChangeCallback(ValueChangeCallback callback) { m_value_change_callback = callback; }
+void SettingRowBase::setValueChangeCallback(ValueChangeCallback callback) {
+    m_value_change_callback = callback;
+}
 
 void SettingRowBase::notifyValueAboutToChange(const QString& key) {
-    if (m_value_change_callback) {
-        m_value_change_callback(key, m_settings_bases);
-    }
+    if (m_value_change_callback) { m_value_change_callback(key, m_settings_bases); }
 }
 
 int SettingRowBase::warningCountDelta(bool warning_active, bool& previous_warning_active) {
     if (m_warning_state_reset_pending) {
-        previous_warning_active = false;
+        previous_warning_active       = false;
         m_warning_state_reset_pending = false;
     }
 
-    const int delta = static_cast<int>(warning_active) - static_cast<int>(previous_warning_active);
+    const int delta         = static_cast<int>(warning_active) - static_cast<int>(previous_warning_active);
     previous_warning_active = warning_active;
     return delta;
 }
 
-void SettingRowBase::setLocalOverrideKeys(QList<QString> keys) { m_local_override_keys = keys; }
+void SettingRowBase::setLocalOverrideKeys(QList<QString> keys) {
+    m_local_override_keys = keys;
+}
 
 QString SettingRowBase::baseToolTip() const {
     return "<html><body><p>" + QString::fromStdString(m_json.at(Constants::Settings::Master::kToolTip)) +
@@ -254,14 +270,12 @@ QString SettingRowBase::baseToolTip() const {
 }
 
 bool SettingRowBase::hasLocalOverride() const {
-    if (m_settings_bases.isEmpty())
-        return false;
+    if (m_settings_bases.isEmpty()) return false;
 
     for (int index = 0, end = m_settings_bases.size(); index < end; ++index) {
         const QSharedPointer<SettingsBase>& settings_base = m_settings_bases[index];
         for (const QString& key : m_local_override_keys) {
-            if (settings_base->contains(key) && !matchesInheritedValue(key, index))
-                return true;
+            if (settings_base->contains(key) && !matchesInheritedValue(key, index)) return true;
         }
     }
 
@@ -269,8 +283,7 @@ bool SettingRowBase::hasLocalOverride() const {
 }
 
 bool SettingRowBase::matchesInheritedValue(const QString& key, int index) const {
-    if (index < 0 || index >= m_settings_bases.size() || !m_settings_bases[index]->contains(key))
-        return true;
+    if (index < 0 || index >= m_settings_bases.size() || !m_settings_bases[index]->contains(key)) return true;
 
     const fifojson local_value = m_settings_bases[index]->setting<fifojson>(key);
     if (index < m_inherited_settings_bases.size()) {
@@ -279,8 +292,7 @@ bool SettingRowBase::matchesInheritedValue(const QString& key, int index) const 
             return local_value == inherited_base->setting<fifojson>(key);
     }
 
-    if (m_sb->contains(key))
-        return local_value == m_sb->setting<fifojson>(key);
+    if (m_sb->contains(key)) return local_value == m_sb->setting<fifojson>(key);
 
     if (key == m_key && m_json.contains(Constants::Settings::Master::kDefault))
         return local_value == m_json[Constants::Settings::Master::kDefault];
@@ -289,8 +301,7 @@ bool SettingRowBase::matchesInheritedValue(const QString& key, int index) const 
 }
 
 void SettingRowBase::updateResetButton() {
-    if (m_reset_button.isNull())
-        return;
+    if (m_reset_button.isNull()) return;
 
     const bool should_show = rowWidgetsVisible() && hasLocalOverride();
     m_reset_button->setVisible(should_show);
@@ -298,8 +309,7 @@ void SettingRowBase::updateResetButton() {
 }
 
 void SettingRowBase::resetLocalOverrides() {
-    if (m_settings_bases.isEmpty())
-        return;
+    if (m_settings_bases.isEmpty()) return;
 
     for (const QString& key : m_local_override_keys) {
         bool key_removed = false;
@@ -316,26 +326,18 @@ void SettingRowBase::resetLocalOverrides() {
 
     reloadValue();
 
-    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
-        row->checkDependencies();
+    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify) row->checkDependencies();
 
     checkDynamicDependencies();
     updateResetButton();
 }
 
 bool SettingRowBase::checkLogic(DependencyNode root) {
-    if (root.key == "AND") {
-        return checkLogic(root.children[0]) && checkLogic(root.children[1]);
-    }
-    else if (root.key == "OR") {
-        return checkLogic(root.children[0]) || checkLogic(root.children[1]);
-    }
-    else if (root.key == "NOT") {
-        return !checkLogic(root.children[0]);
-    }
+    if (root.key == "AND") { return checkLogic(root.children[0]) && checkLogic(root.children[1]); }
+    else if (root.key == "OR") { return checkLogic(root.children[0]) || checkLogic(root.children[1]); }
+    else if (root.key == "NOT") { return !checkLogic(root.children[0]); }
     else {
-        if (root.dependentRow.isNull())
-            return true;
+        if (root.dependentRow.isNull()) return true;
 
         if (QCheckBox* checkBox = dynamic_cast<QCheckBox*>(root.dependentRow.get())) {
             for (auto& el : root.val.items()) {
@@ -368,4 +370,4 @@ bool SettingRowBase::checkLogic(DependencyNode root) {
 }
 
 void SettingRowBase::checkDynamicDependencies() {}
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_spin_box.cpp
+++ b/src/widgets/settings/setting_spin_box.cpp
@@ -1,9 +1,9 @@
 #include "widgets/settings/setting_spin_box.h"
 
-#include <climits>
-
 #include <QToolTip>
 #include <QWheelEvent>
+#include <climits>
+
 #include <qgridlayout.h>
 #include <qlabel.h>
 #include <qnamespace.h>
@@ -36,8 +36,7 @@ SettingSpinBox::SettingSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> 
     }
 
     QString type = json[Constants::Settings::Master::kType];
-    if (type == "positive_int" || type == "power")
-        this->setMinimum(1);
+    if (type == "positive_int" || type == "power") this->setMinimum(1);
 
     this->setMaximum(INT_MAX);
     this->setAlignment(Qt::AlignRight);
@@ -91,7 +90,7 @@ void SettingSpinBox::show() {
 
 void SettingSpinBox::valueChanged(QVariant val) {
     if (m_warn)
-        emit warnParent(-1); // if a value is changed, it changes for all selected settings bases, so remove a warning.
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
     m_warn = false;
     valueChangedHelper<int>(val.toInt());
     emit modified(m_key);
@@ -100,9 +99,8 @@ void SettingSpinBox::valueChanged(QVariant val) {
 void SettingSpinBox::reloadValue() {
     this->blockSignals(true);
     bool consistent = true;
-    int cur = reloadValueHelper<int>(consistent);
-    if (consistent)
-        setValue(cur);
+    int cur         = reloadValueHelper<int>(consistent);
+    if (consistent) setValue(cur);
 
     this->blockSignals(false);
     emit modified(m_key);
@@ -115,4 +113,4 @@ void SettingSpinBox::wheelEvent(QWheelEvent* event) {
     else
         QSpinBox::wheelEvent(event);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/setting_tab.cpp
+++ b/src/widgets/settings/setting_tab.cpp
@@ -47,26 +47,28 @@ QString componentSetting(const fifojson& component) {
     return jsonString(component, Constants::Settings::Input::kSetting);
 }
 
-QString componentLabel(const fifojson& component) { return jsonString(component, Constants::Settings::Input::kLabel); }
+QString componentLabel(const fifojson& component) {
+    return jsonString(component, Constants::Settings::Input::kLabel);
+}
 
 fifojson makeInputRowJson(const fifojson& setting_json, const fifojson& input) {
-    fifojson row_json = setting_json;
+    fifojson row_json                               = setting_json;
     row_json[Constants::Settings::Master::kDisplay] = input.at(Constants::Settings::Input::kDisplay);
     row_json[Constants::Settings::Master::kToolTip] = input.at(Constants::Settings::Input::kToolTip);
     row_json[Constants::Settings::Master::kDepends] = input.at(Constants::Settings::Input::kDepends);
-    row_json[Constants::Settings::Master::kMinor] = input.at(Constants::Settings::Input::kMinor);
-    row_json[Constants::Settings::Master::kMajor] = input.at(Constants::Settings::Input::kMajor);
-    row_json[Constants::Settings::Master::kLocal] = input.at(Constants::Settings::Input::kLocal);
+    row_json[Constants::Settings::Master::kMinor]   = input.at(Constants::Settings::Input::kMinor);
+    row_json[Constants::Settings::Master::kMajor]   = input.at(Constants::Settings::Input::kMajor);
+    row_json[Constants::Settings::Master::kLocal]   = input.at(Constants::Settings::Input::kLocal);
     return row_json;
 }
-} // namespace
+}  // namespace
 
 SettingTab::SettingTab(QWidget* parent, QString name, QIcon icon, int index, bool isHidden,
                        QSharedPointer<SettingsBase> sb)
     : QWidget(parent), m_name(name), m_icon(icon), m_sb(sb), m_index(index) {
     this->setupWidget(isHidden);
 
-    m_size = 0;
+    m_size          = 0;
     m_warning_count = 0;
 
     m_creation_mapping = {{"number", &SettingSpinBox::createInstance},
@@ -97,44 +99,44 @@ SettingTab::SettingTab(QWidget* parent, QString name, QIcon icon, int index, boo
 
 void SettingTab::setSettingBase(QSharedPointer<SettingsBase> sb) {
     m_sb = sb;
-    for (QSharedPointer<SettingRowBase> curr_row : m_rows) {
-        curr_row->setSettingsBase(m_sb);
-    }
+    for (QSharedPointer<SettingRowBase> curr_row : m_rows) { curr_row->setSettingsBase(m_sb); }
 }
 
-QList<QSharedPointer<SettingRowBase>> SettingTab::getRows() { return m_rows.values(); }
+QList<QSharedPointer<SettingRowBase>> SettingTab::getRows() {
+    return m_rows.values();
+}
 
 QSharedPointer<SettingRowBase> SettingTab::getRow(QString key) {
-    if (m_rows.contains(key))
-        return m_rows[key];
+    if (m_rows.contains(key)) return m_rows[key];
 
     return m_row_aliases.value(key);
 }
 
-int SettingTab::getIndex() { return m_index; }
+int SettingTab::getIndex() {
+    return m_index;
+}
 
-QString SettingTab::getName() { return m_name; }
+QString SettingTab::getName() {
+    return m_name;
+}
 
 bool SettingTab::hasShownRows() const {
     for (const QSharedPointer<SettingRowBase>& row : m_rows) {
-        if (row->isShown())
-            return true;
+        if (row->isShown()) return true;
     }
 
     return false;
 }
 
 void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input) {
-    if (m_row_aliases.contains(key))
-        return;
+    if (m_row_aliases.contains(key)) return;
 
     if (!input.is_null()) {
         const fifojson& components = input.at(Constants::Settings::Input::kComponents);
-        const QString primary_key = componentSetting(components.at(0));
-        if (key != primary_key)
-            return;
+        const QString primary_key  = componentSetting(components.at(0));
+        if (key != primary_key) return;
 
-        const fifojson row_json = makeInputRowJson(json, input);
+        const fifojson row_json  = makeInputRowJson(json, input);
         const std::string widget = input.at(Constants::Settings::Input::kWidget).get<std::string>();
 
         QSharedPointer<SettingRowBase> newRow;
@@ -181,7 +183,9 @@ void SettingTab::addRow(QString key, const fifojson& json, const fifojson& input
     ++m_size;
 }
 
-void SettingTab::keyModified(QString key) { emit modified(key); }
+void SettingTab::keyModified(QString key) {
+    emit modified(key);
+}
 
 void SettingTab::expandTab() {
     m_container->show();
@@ -198,19 +202,19 @@ void SettingTab::hideTab() {
     emit removeTabFromList(m_name);
 }
 
-void SettingTab::showTab() { m_header->showHeader(); }
+void SettingTab::showTab() {
+    m_header->showHeader();
+}
 
 void SettingTab::reload() {
-    for (QSharedPointer<SettingRowBase> curr_row : m_rows) {
-        curr_row->reloadValue();
-    }
+    for (QSharedPointer<SettingRowBase> curr_row : m_rows) { curr_row->reloadValue(); }
 }
 
 void SettingTab::settingsBasesSelected(QList<QSharedPointer<SettingsBase>> settings_bases,
                                        QList<QSharedPointer<SettingsBase>> inherited_bases) {
     if (m_settings_bases != settings_bases || m_inherited_settings_bases != inherited_bases) {
-        m_warning_count = 0; // reset the count of warnings if a new settings base has been selected
-        m_settings_bases = settings_bases;
+        m_warning_count            = 0;  // reset the count of warnings if a new settings base has been selected
+        m_settings_bases           = settings_bases;
         m_inherited_settings_bases = inherited_bases;
         for (QSharedPointer<SettingRowBase> curr_row : m_rows) {
             curr_row->setBases(m_settings_bases, m_inherited_settings_bases);
@@ -221,14 +225,10 @@ void SettingTab::settingsBasesSelected(QList<QSharedPointer<SettingsBase>> setti
 
 void SettingTab::headerWarning(int count) {
     emit warnPane(count);
-    m_warning_count = m_warning_count + count; // keep track of all warnings from children (setting_rows)
+    m_warning_count = m_warning_count + count;  // keep track of all warnings from children (setting_rows)
     // if there is more than 1 warning, change the header icon to show the warning
-    if (m_warning_count > 0) {
-        m_header->setIcon(QIcon(":/icons/warning.png"));
-    }
-    else {
-        m_header->setIcon(QIcon(":/icons/ornlslicer_logo.png"));
-    }
+    if (m_warning_count > 0) { m_header->setIcon(QIcon(":/icons/warning.png")); }
+    else { m_header->setIcon(QIcon(":/icons/ornlslicer_logo.png")); }
 }
 
 void SettingTab::setupWidget(bool isHidden) {
@@ -241,8 +241,7 @@ void SettingTab::setupWidget(bool isHidden) {
 void SettingTab::setupSubWidgets(bool isHidden) {
     // Header
     m_header = new SettingHeader(this, m_name, m_icon);
-    if (isHidden)
-        m_header->hide();
+    if (isHidden) m_header->hide();
 
     // Container
     m_container = new QFrame(this);
@@ -262,7 +261,9 @@ void SettingTab::setupLayouts() {
     m_container_layout->setColumnStretch(1, 1);
 }
 
-void SettingTab::setupStyle() { m_header->setupStyle(); }
+void SettingTab::setupStyle() {
+    m_header->setupStyle();
+}
 
 void SettingTab::setupInsert() {
     m_layout->addWidget(m_header);
@@ -274,4 +275,4 @@ void SettingTab::setupEvents() {
     connect(m_header, &SettingHeader::shrink, this, &SettingTab::shrinkTab);
     connect(m_header, &SettingHeader::hideHeader, this, &SettingTab::hideTab);
 }
-} // Namespace ORNL
+}  // Namespace ORNL

--- a/src/widgets/settings/vector2_input_widget.cpp
+++ b/src/widgets/settings/vector2_input_widget.cpp
@@ -7,6 +7,7 @@
 #include <QRect>
 #include <QSizePolicy>
 #include <QToolTip>
+
 #include <qevent.h>
 #include <qnamespace.h>
 #include <qoverload.h>
@@ -17,11 +18,11 @@
 
 namespace ORNL {
 namespace {
-constexpr int kComponentLabelWidth = 18;
+constexpr int kComponentLabelWidth    = 18;
 constexpr int kComponentMinimumHeight = 22;
-constexpr int kComponentSpacing = 4;
-constexpr int kComponentGroupSpacing = 6;
-constexpr int kSpinBoxWidth = 96;
+constexpr int kComponentSpacing       = 4;
+constexpr int kComponentGroupSpacing  = 6;
+constexpr int kSpinBoxWidth           = 96;
 
 QLabel* createComponentLabel(QWidget* parent, const QString& text) {
     QLabel* label = new QLabel(text, parent);
@@ -41,13 +42,14 @@ void addComponentEditor(QHBoxLayout* layout, QWidget* parent, const QString& lab
     layout->addWidget(createComponentLabel(parent, label_text));
     layout->addWidget(spin_box);
 }
-} // namespace
+}  // namespace
 
 Vector2InputWidget::Vector2InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key,
                                        QString secondary_key, fifojson json, QGridLayout* layout, int index,
                                        Distance primary_default, Distance secondary_default, QString primary_label,
                                        QString secondary_label)
-    : QWidget(parent), SettingRowBase(parent, sb, primary_key, json, layout, index),
+    : QWidget(parent),
+      SettingRowBase(parent, sb, primary_key, json, layout, index),
       m_components {{{primary_key, new QDoubleSpinBox(this), primary_default},
                      {secondary_key, new QDoubleSpinBox(this), secondary_default}}},
       m_warn(false) {
@@ -64,8 +66,7 @@ Vector2InputWidget::Vector2InputWidget(SettingTab* parent, QSharedPointer<Settin
         Component& component = m_components[i];
         ensureSetting(component.key, component.default_value);
 
-        if (i != 0)
-            vector_layout->addSpacing(kComponentGroupSpacing);
+        if (i != 0) vector_layout->addSpacing(kComponentGroupSpacing);
         addComponentEditor(vector_layout, this, labels[i], component.spin_box);
 
         configureSpinBox(component.spin_box);
@@ -102,11 +103,12 @@ void Vector2InputWidget::setEnabled(bool enabled) {
     applyWidgetState(static_cast<QWidget*>(this));
 }
 
-void Vector2InputWidget::valueChanged(QVariant val) { updateSetting(m_components[0].key, val.toDouble()); }
+void Vector2InputWidget::valueChanged(QVariant val) {
+    updateSetting(m_components[0].key, val.toDouble());
+}
 
 void Vector2InputWidget::reloadValue() {
-    for (Component& component : m_components)
-        component.spin_box->blockSignals(true);
+    for (Component& component : m_components) component.spin_box->blockSignals(true);
 
     m_unit_label->setText(PreferencesManager::getInstance()->getDistanceUnitText());
 
@@ -119,11 +121,9 @@ void Vector2InputWidget::reloadValue() {
         all_consistent = all_consistent && component_consistent;
     }
 
-    for (Component& component : m_components)
-        component.spin_box->blockSignals(false);
+    for (Component& component : m_components) component.spin_box->blockSignals(false);
 
-    for (const Component& component : m_components)
-        emit modified(component.key);
+    for (const Component& component : m_components) emit modified(component.key);
 
     if (!all_consistent) {
         setNotification("Multiple Values");
@@ -179,8 +179,7 @@ void Vector2InputWidget::configureSpinBox(QDoubleSpinBox* spin_box) {
 }
 
 void Vector2InputWidget::ensureSetting(const QString& key, Distance default_value) {
-    if (!m_sb->contains(key))
-        m_sb->setSetting(key, default_value());
+    if (!m_sb->contains(key)) m_sb->setSetting(key, default_value());
 }
 
 void Vector2InputWidget::updateSetting(const QString& key, double displayed_value) {
@@ -190,18 +189,14 @@ void Vector2InputWidget::updateSetting(const QString& key, double displayed_valu
     notifyValueAboutToChange(key);
 
     if (m_settings_bases.size() != 0) {
-        for (QSharedPointer<SettingsBase> range : m_settings_bases)
-            range->setSetting(key, base_value());
+        for (QSharedPointer<SettingsBase> range : m_settings_bases) range->setSetting(key, base_value());
 
         const Distance global_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : base_value;
         removeRedundantLocalOverrides<Distance>(key, global_value);
     }
-    else {
-        m_sb->setSetting(key, base_value());
-    }
+    else { m_sb->setSetting(key, base_value()); }
 
-    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
-        row->checkDependencies();
+    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify) row->checkDependencies();
 
     checkDynamicDependencies();
     updateWarningStateAfterEdit();
@@ -211,35 +206,31 @@ void Vector2InputWidget::updateSetting(const QString& key, double displayed_valu
 Distance Vector2InputWidget::reloadDistanceValue(const QString& key, Distance default_value, bool& consistent) {
     if (m_settings_bases.size() > 0) {
         const Distance global_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
-        const Distance first_value = effectiveValueHelper<Distance>(key, 0, global_value);
+        const Distance first_value  = effectiveValueHelper<Distance>(key, 0, global_value);
 
         bool all_bases_consistent = true;
         for (int index = 1, end = m_settings_bases.size(); index < end; ++index)
             all_bases_consistent =
                 all_bases_consistent && effectiveValueHelper<Distance>(key, index, global_value) == first_value;
 
-        if (all_bases_consistent)
-            return first_value;
+        if (all_bases_consistent) return first_value;
 
         consistent = false;
         return default_value;
     }
 
-    if (m_sb->contains(key))
-        return m_sb->setting<Distance>(key);
+    if (m_sb->contains(key)) return m_sb->setting<Distance>(key);
 
     return default_value;
 }
 
 bool Vector2InputWidget::hasConsistentEffectiveValues(const QString& key, Distance default_value) {
-    if (m_settings_bases.size() <= 1)
-        return true;
+    if (m_settings_bases.size() <= 1) return true;
 
     const Distance global_value = m_sb->contains(key) ? m_sb->setting<Distance>(key) : default_value;
-    const Distance first_value = effectiveValueHelper<Distance>(key, 0, global_value);
+    const Distance first_value  = effectiveValueHelper<Distance>(key, 0, global_value);
     for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
-        if (effectiveValueHelper<Distance>(key, index, global_value) != first_value)
-            return false;
+        if (effectiveValueHelper<Distance>(key, index, global_value) != first_value) return false;
     }
 
     return true;
@@ -247,8 +238,7 @@ bool Vector2InputWidget::hasConsistentEffectiveValues(const QString& key, Distan
 
 bool Vector2InputWidget::hasAnyInconsistentValue() {
     for (const Component& component : m_components) {
-        if (!hasConsistentEffectiveValues(component.key, component.default_value))
-            return true;
+        if (!hasConsistentEffectiveValues(component.key, component.default_value)) return true;
     }
 
     return false;
@@ -269,12 +259,11 @@ void Vector2InputWidget::updateWarningStateAfterEdit() {
 
 void Vector2InputWidget::setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, Distance default_value,
                                          bool only_if_consistent, bool& consistent) {
-    Distance unit = PreferencesManager::getInstance()->getDistanceUnit();
+    Distance unit           = PreferencesManager::getInstance()->getDistanceUnit();
     bool setting_consistent = true;
-    Distance value = reloadDistanceValue(key, default_value, setting_consistent);
-    consistent = setting_consistent;
+    Distance value          = reloadDistanceValue(key, default_value, setting_consistent);
+    consistent              = setting_consistent;
 
-    if (!only_if_consistent || setting_consistent)
-        spin_box->setValue(value.to(unit));
+    if (!only_if_consistent || setting_consistent) spin_box->setValue(value.to(unit));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/settings/vector3_input_widget.cpp
+++ b/src/widgets/settings/vector3_input_widget.cpp
@@ -7,6 +7,7 @@
 #include <QRect>
 #include <QSizePolicy>
 #include <QToolTip>
+
 #include <qevent.h>
 #include <qnamespace.h>
 #include <qoverload.h>
@@ -16,10 +17,10 @@
 
 namespace ORNL {
 namespace {
-constexpr int kComponentLabelWidth = 18;
+constexpr int kComponentLabelWidth    = 18;
 constexpr int kComponentMinimumHeight = 22;
-constexpr int kComponentSpacing = 4;
-constexpr int kSpinBoxWidth = 82;
+constexpr int kComponentSpacing       = 4;
+constexpr int kSpinBoxWidth           = 82;
 
 QLabel* createComponentLabel(QWidget* parent, const QString& text) {
     QLabel* label = new QLabel(text, parent);
@@ -39,14 +40,15 @@ void addComponentEditor(QHBoxLayout* layout, QWidget* parent, const QString& lab
     layout->addWidget(createComponentLabel(parent, label_text));
     layout->addWidget(spin_box);
 }
-} // namespace
+}  // namespace
 
 Vector3InputWidget::Vector3InputWidget(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString primary_key,
                                        QString secondary_key, QString tertiary_key, fifojson json, QGridLayout* layout,
                                        int index, double primary_default, double secondary_default,
                                        double tertiary_default, QString primary_label, QString secondary_label,
                                        QString tertiary_label)
-    : QWidget(parent), SettingRowBase(parent, sb, primary_key, json, layout, index),
+    : QWidget(parent),
+      SettingRowBase(parent, sb, primary_key, json, layout, index),
       m_components {{{primary_key, new QDoubleSpinBox(this), primary_default},
                      {secondary_key, new QDoubleSpinBox(this), secondary_default},
                      {tertiary_key, new QDoubleSpinBox(this), tertiary_default}}},
@@ -63,8 +65,7 @@ Vector3InputWidget::Vector3InputWidget(SettingTab* parent, QSharedPointer<Settin
         Component& component = m_components[i];
         ensureSetting(component.key, component.default_value);
 
-        if (i != 0)
-            vector_layout->addSpacing(kComponentSpacing);
+        if (i != 0) vector_layout->addSpacing(kComponentSpacing);
         addComponentEditor(vector_layout, this, labels[i], component.spin_box);
 
         configureSpinBox(component.spin_box);
@@ -101,11 +102,12 @@ void Vector3InputWidget::setEnabled(bool enabled) {
     applyWidgetState(static_cast<QWidget*>(this));
 }
 
-void Vector3InputWidget::valueChanged(QVariant val) { updateSetting(m_components[0].key, val.toDouble()); }
+void Vector3InputWidget::valueChanged(QVariant val) {
+    updateSetting(m_components[0].key, val.toDouble());
+}
 
 void Vector3InputWidget::reloadValue() {
-    for (Component& component : m_components)
-        component.spin_box->blockSignals(true);
+    for (Component& component : m_components) component.spin_box->blockSignals(true);
 
     bool all_consistent = true;
     for (Component& component : m_components) {
@@ -116,11 +118,9 @@ void Vector3InputWidget::reloadValue() {
         all_consistent = all_consistent && component_consistent;
     }
 
-    for (Component& component : m_components)
-        component.spin_box->blockSignals(false);
+    for (Component& component : m_components) component.spin_box->blockSignals(false);
 
-    for (const Component& component : m_components)
-        emit modified(component.key);
+    for (const Component& component : m_components) emit modified(component.key);
 
     if (!all_consistent) {
         setNotification("Multiple Values");
@@ -172,26 +172,21 @@ void Vector3InputWidget::configureSpinBox(QDoubleSpinBox* spin_box) {
 }
 
 void Vector3InputWidget::ensureSetting(const QString& key, double default_value) {
-    if (!m_sb->contains(key))
-        m_sb->setSetting(key, default_value);
+    if (!m_sb->contains(key)) m_sb->setSetting(key, default_value);
 }
 
 void Vector3InputWidget::updateSetting(const QString& key, double value) {
     notifyValueAboutToChange(key);
 
     if (m_settings_bases.size() != 0) {
-        for (QSharedPointer<SettingsBase> range : m_settings_bases)
-            range->setSetting(key, value);
+        for (QSharedPointer<SettingsBase> range : m_settings_bases) range->setSetting(key, value);
 
         const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : value;
         removeRedundantLocalOverrides<double>(key, global_value);
     }
-    else {
-        m_sb->setSetting(key, value);
-    }
+    else { m_sb->setSetting(key, value); }
 
-    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify)
-        row->checkDependencies();
+    for (QSharedPointer<SettingRowBase> row : m_rows_to_notify) row->checkDependencies();
 
     checkDynamicDependencies();
     updateWarningStateAfterEdit();
@@ -201,35 +196,31 @@ void Vector3InputWidget::updateSetting(const QString& key, double value) {
 double Vector3InputWidget::reloadDoubleValue(const QString& key, double default_value, bool& consistent) {
     if (m_settings_bases.size() > 0) {
         const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
-        const double first_value = effectiveValueHelper<double>(key, 0, global_value);
+        const double first_value  = effectiveValueHelper<double>(key, 0, global_value);
 
         bool all_bases_consistent = true;
         for (int index = 1, end = m_settings_bases.size(); index < end; ++index)
             all_bases_consistent =
                 all_bases_consistent && effectiveValueHelper<double>(key, index, global_value) == first_value;
 
-        if (all_bases_consistent)
-            return first_value;
+        if (all_bases_consistent) return first_value;
 
         consistent = false;
         return default_value;
     }
 
-    if (m_sb->contains(key))
-        return m_sb->setting<double>(key);
+    if (m_sb->contains(key)) return m_sb->setting<double>(key);
 
     return default_value;
 }
 
 bool Vector3InputWidget::hasConsistentEffectiveValues(const QString& key, double default_value) {
-    if (m_settings_bases.size() <= 1)
-        return true;
+    if (m_settings_bases.size() <= 1) return true;
 
     const double global_value = m_sb->contains(key) ? m_sb->setting<double>(key) : default_value;
-    const double first_value = effectiveValueHelper<double>(key, 0, global_value);
+    const double first_value  = effectiveValueHelper<double>(key, 0, global_value);
     for (int index = 1, end = m_settings_bases.size(); index < end; ++index) {
-        if (effectiveValueHelper<double>(key, index, global_value) != first_value)
-            return false;
+        if (effectiveValueHelper<double>(key, index, global_value) != first_value) return false;
     }
 
     return true;
@@ -237,8 +228,7 @@ bool Vector3InputWidget::hasConsistentEffectiveValues(const QString& key, double
 
 bool Vector3InputWidget::hasAnyInconsistentValue() {
     for (const Component& component : m_components) {
-        if (!hasConsistentEffectiveValues(component.key, component.default_value))
-            return true;
+        if (!hasConsistentEffectiveValues(component.key, component.default_value)) return true;
     }
 
     return false;
@@ -260,10 +250,9 @@ void Vector3InputWidget::updateWarningStateAfterEdit() {
 void Vector3InputWidget::setSpinBoxValue(QDoubleSpinBox* spin_box, const QString& key, double default_value,
                                          bool only_if_consistent, bool& consistent) {
     bool setting_consistent = true;
-    double value = reloadDoubleValue(key, default_value, setting_consistent);
-    consistent = setting_consistent;
+    double value            = reloadDoubleValue(key, default_value, setting_consistent);
+    consistent              = setting_consistent;
 
-    if (!only_if_consistent || setting_consistent)
-        spin_box->setValue(value);
+    if (!only_if_consistent || setting_consistent) spin_box->setValue(value);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/view_controls_toolbar.cpp
+++ b/src/widgets/view_controls_toolbar.cpp
@@ -5,6 +5,7 @@
 #include <QLayout>
 #include <QSignalBlocker>
 #include <QToolButton>
+
 #include <qfiledevice.h>
 #include <qicon.h>
 #include <qnamespace.h>
@@ -20,11 +21,17 @@
 namespace ORNL {
 namespace {
 constexpr int kOrthographicButtonWidth = 70;
-} // namespace
+}  // namespace
 
 ViewControlsToolbar::ViewControlsToolbar(QWidget* parent, bool show_orthographic_button)
-    : QToolBar(parent), m_parent(parent), m_show_orthographic_button(show_orthographic_button), m_iso_btn(nullptr),
-      m_front_btn(nullptr), m_side_btn(nullptr), m_top_btn(nullptr), m_ortho_btn(nullptr) {
+    : QToolBar(parent),
+      m_parent(parent),
+      m_show_orthographic_button(show_orthographic_button),
+      m_iso_btn(nullptr),
+      m_front_btn(nullptr),
+      m_side_btn(nullptr),
+      m_top_btn(nullptr),
+      m_ortho_btn(nullptr) {
     setupWidget();
     setupSubWidgets();
 }
@@ -92,9 +99,7 @@ void ViewControlsToolbar::setupSubWidgets() {
         m_ortho_btn->setIcon(QIcon(":/icons/orthogonal_view.png"));
         m_ortho_btn->setToolTip("Overhead Orthographic Projection");
         m_ortho_btn->setCheckable(true);
-        connect(m_ortho_btn, &QToolButton::toggled, this, [this](bool checked) {
-            emit setOrthographicView(checked);
-        });
+        connect(m_ortho_btn, &QToolButton::toggled, this, [this](bool checked) { emit setOrthographicView(checked); });
 
         this->addWidget(m_ortho_btn);
         this->makeSpace();
@@ -124,8 +129,8 @@ void ViewControlsToolbar::makeSpacedSeparator() {
 void ViewControlsToolbar::resize(QSize new_size) {
     // Update position
     auto parent_size = m_parent->size();
-    const int toolbar_width = Constants::UI::ViewControlsToolbar::kWidth +
-                              (m_show_orthographic_button ? kOrthographicButtonWidth : 0);
+    const int toolbar_width =
+        Constants::UI::ViewControlsToolbar::kWidth + (m_show_orthographic_button ? kOrthographicButtonWidth : 0);
 
     this->move(parent_size.width() - toolbar_width - Constants::UI::ViewControlsToolbar::kRightOffset,
                parent_size.height() - Constants::UI::ViewControlsToolbar::kHeight -
@@ -147,9 +152,7 @@ void ViewControlsToolbar::setProjectionControlsEnabled(bool status) {
 }
 
 void ViewControlsToolbar::setOrthographicViewChecked(bool status) {
-    if (m_ortho_btn == nullptr) {
-        return;
-    }
+    if (m_ortho_btn == nullptr) { return; }
 
     const QSignalBlocker blocker(m_ortho_btn);
     m_ortho_btn->setChecked(status);
@@ -159,8 +162,6 @@ void ViewControlsToolbar::setEnabled(bool status) {
     QToolBar::setEnabled(status);
     setProjectionControlsEnabled(status);
 
-    if (m_ortho_btn != nullptr) {
-        m_ortho_btn->setEnabled(status);
-    }
+    if (m_ortho_btn != nullptr) { m_ortho_btn->setEnabled(status); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/visualization_color_picker.cpp
+++ b/src/widgets/visualization_color_picker.cpp
@@ -13,15 +13,15 @@
 namespace ORNL {
 
 VisualizationColorPicker::VisualizationColorPicker(QString name, QColor color, QWidget* parent) : QWidget {parent} {
-    this->name = name;
+    this->name  = name;
     this->color = color;
 
     QGridLayout* color_tab_layout = new QGridLayout(this);
     color_tab_layout->setVerticalSpacing(0);
 
-    colorTypeLbl = new QLabel(name);
-    sampleTextLbl = new QLabel("(This is how it looks!!!)");
-    colorResetBtn = new QPushButton();
+    colorTypeLbl     = new QLabel(name);
+    sampleTextLbl    = new QLabel("(This is how it looks!!!)");
+    colorResetBtn    = new QPushButton();
     colorSelectorBtn = new QPushButton();
 
     colorResetBtn->setMaximumWidth(80);
@@ -48,7 +48,9 @@ VisualizationColorPicker::VisualizationColorPicker(QString name, QColor color, Q
     updateDisplay();
 }
 
-void VisualizationColorPicker::mousePressEvent(QMouseEvent*) { selectSetColor(); }
+void VisualizationColorPicker::mousePressEvent(QMouseEvent*) {
+    selectSetColor();
+}
 
 void ORNL::VisualizationColorPicker::selectSetColor() {
     QColorDialog dlg(this->color);
@@ -70,4 +72,4 @@ void VisualizationColorPicker::updateDisplay() {
 
     colorResetBtn->setEnabled(!PreferencesManager::getInstance()->isDefaultVisualizationColor(name));
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/widgets/xyz_input.cpp
+++ b/src/widgets/xyz_input.cpp
@@ -23,31 +23,57 @@ XYZInputWidget::XYZInputWidget(QWidget* parent) : QWidget(parent) {
     this->setupEvents();
 }
 
-QVector3D XYZInputWidget::value() { return QVector3D(m_x_dsb->value(), m_y_dsb->value(), m_z_dsb->value()); }
+QVector3D XYZInputWidget::value() {
+    return QVector3D(m_x_dsb->value(), m_y_dsb->value(), m_z_dsb->value());
+}
 
-void XYZInputWidget::showLabel(bool show) { m_front_label->setHidden(!show); }
+void XYZInputWidget::showLabel(bool show) {
+    m_front_label->setHidden(!show);
+}
 
-void XYZInputWidget::showUnit(bool show) { m_unit_label->setHidden(!show); }
+void XYZInputWidget::showUnit(bool show) {
+    m_unit_label->setHidden(!show);
+}
 
-void XYZInputWidget::showLock(bool show) { m_lock_check->setHidden(!show); }
+void XYZInputWidget::showLock(bool show) {
+    m_lock_check->setHidden(!show);
+}
 
-void XYZInputWidget::setLabelText(QString str) { m_front_label->setText(str); }
+void XYZInputWidget::setLabelText(QString str) {
+    m_front_label->setText(str);
+}
 
-void XYZInputWidget::setUnitText(QString str) { m_unit_label->setText(str); }
+void XYZInputWidget::setUnitText(QString str) {
+    m_unit_label->setText(str);
+}
 
-void XYZInputWidget::setLock(bool lock) { m_lock_check->setChecked(lock); }
+void XYZInputWidget::setLock(bool lock) {
+    m_lock_check->setChecked(lock);
+}
 
-void XYZInputWidget::setXText(QString x) { m_x_label->setText(x + " "); }
+void XYZInputWidget::setXText(QString x) {
+    m_x_label->setText(x + " ");
+}
 
-void XYZInputWidget::setYText(QString y) { m_y_label->setText(y + " "); }
+void XYZInputWidget::setYText(QString y) {
+    m_y_label->setText(y + " ");
+}
 
-void XYZInputWidget::setZText(QString z) { m_z_label->setText(z + " "); }
+void XYZInputWidget::setZText(QString z) {
+    m_z_label->setText(z + " ");
+}
 
-void XYZInputWidget::setXValue(double val) { m_x_dsb->setValue(val); }
+void XYZInputWidget::setXValue(double val) {
+    m_x_dsb->setValue(val);
+}
 
-void XYZInputWidget::setYValue(double val) { m_y_dsb->setValue(val); }
+void XYZInputWidget::setYValue(double val) {
+    m_y_dsb->setValue(val);
+}
 
-void XYZInputWidget::setZValue(double val) { m_z_dsb->setValue(val); }
+void XYZInputWidget::setZValue(double val) {
+    m_z_dsb->setValue(val);
+}
 
 void XYZInputWidget::setValue(QVector3D xyz) {
     m_x_dsb->setValue(xyz.x());
@@ -63,7 +89,7 @@ void XYZInputWidget::setIncrement(double inc) {
 
 void XYZInputWidget::readValue(double val) {
     QObject* dsb = QObject::sender();
-    Axis ax = Axis::kX;
+    Axis ax      = Axis::kX;
 
     if (dsb == m_y_dsb)
         ax = Axis::kY;
@@ -177,4 +203,4 @@ void XYZInputWidget::setupEvents() {
         }
     });
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/about.cpp
+++ b/src/windows/about.cpp
@@ -7,6 +7,7 @@
 #include <QIcon>
 #include <QLabel>
 #include <QUrl>
+
 #include <qdatetime.h>
 #include <qfont.h>
 #include <qnamespace.h>
@@ -58,4 +59,4 @@ AboutWindow::AboutWindow(QWidget* parent) : QWidget() {
 }
 
 AboutWindow::~AboutWindow() {}
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/dialogs/cs_dbg.cpp
+++ b/src/windows/dialogs/cs_dbg.cpp
@@ -9,6 +9,7 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QToolTip>
+
 #include <qbrush.h>
 #include <qcontainerfwd.h>
 #include <qcursor.h>
@@ -32,10 +33,11 @@
 #include "part/part.h"
 
 namespace ORNL {
-CsDebugDialog::CsDebugDialog(QWidget* parent) : QDialog(parent) { this->setupUi(); }
+CsDebugDialog::CsDebugDialog(QWidget* parent) : QDialog(parent) {
+    this->setupUi();
+}
 
 void CsDebugDialog::paintGraphicsView(int height) {
-
     // Each part is maintained such that the cross section the user selects will appear parallel
     // to the XZ plane, as this aligns with the wall. However, the cross section algorithm only takes
     // horizontal (XY) cross sections. In order to display the correct cross section, we need to
@@ -60,11 +62,10 @@ void CsDebugDialog::paintGraphicsView(int height) {
     // For each list in the split polygons, construct a QPolygon.
     for (const PolygonList& poly : splitpoly) {
         QVector<QPolygon> qpolylist = poly.toQPolygons();
-        QPolygon qpoly = qpolylist.front();
+        QPolygon qpoly              = qpolylist.front();
 
         // Starting at one, subtract all holes.
-        for (int i = 1; i < qpolylist.size(); i++)
-            qpoly = qpoly.subtracted(qpolylist[i]);
+        for (int i = 1; i < qpolylist.size(); i++) qpoly = qpoly.subtracted(qpolylist[i]);
 
         gs->addPolygon(qpoly, QPen(Qt::black), QBrush(Qt::red));
     }
@@ -88,10 +89,10 @@ void CsDebugDialog::updateAxis(int idx) {
 
     QMatrix4x4 rotation;
     switch (idx) {
-        case 0: // YZ
+        case 0:  // YZ
             rotation.rotate(QQuaternion::fromAxisAndAngle(QVector3D(0, 0, 1), 90.0f));
             break;
-        case 2: // XY
+        case 2:  // XY
             rotation.rotate(QQuaternion::fromAxisAndAngle(QVector3D(1, 0, 0), 90.0f));
             break;
         default:
@@ -115,14 +116,15 @@ void CsDebugDialog::selectFromRow(int row, int col) {
 }
 
 void CsDebugDialog::changeLayer(int height) {
-    if (m_part.isNull())
-        return;
+    if (m_part.isNull()) return;
     this->paintGraphicsView(height);
 
     QToolTip::showText(QCursor::pos(), QString::number(height));
 }
 
-void CsDebugDialog::changePart(QSharedPointer<Part> part) { m_part = part; }
+void CsDebugDialog::changePart(QSharedPointer<Part> part) {
+    m_part = part;
+}
 
 void CsDebugDialog::updateScroll() {
     m_scrollbar->setMinimum(m_scroll_min);
@@ -161,7 +163,9 @@ void CsDebugDialog::setupWidgets() {
     m_spinbox = new QSpinBox(this);
 }
 
-void CsDebugDialog::setupLayouts() { m_layout = new QHBoxLayout(this); }
+void CsDebugDialog::setupLayouts() {
+    m_layout = new QHBoxLayout(this);
+}
 
 void CsDebugDialog::setupTable() {
     // Create the table with our desired dimensions.
@@ -227,4 +231,4 @@ void CsDebugDialog::setupEvents() {
     //        connect(m_scrollbar, &QScrollBar::sliderMoved, m_spinbox, &QSpinBox::setValue);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/dialogs/slice_dialog.cpp
+++ b/src/windows/dialogs/slice_dialog.cpp
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include <QPalette>
 #include <QPushButton>
+
 #include <qdialog.h>
 #include <qfont.h>
 #include <qnamespace.h>
@@ -25,11 +26,13 @@ QColor progressBarFillColor() {
                : QColor(0, 102, 44);
 }
 
-} // namespace
+}  // namespace
 
 namespace ORNL {
 
-SliceDialog::SliceDialog(QWidget* parent) : QDialog(parent) { this->setupUi(); }
+SliceDialog::SliceDialog(QWidget* parent) : QDialog(parent) {
+    this->setupUi();
+}
 
 void SliceDialog::setupUi() {
     this->setWindowTitle("Slice Progress");
@@ -72,4 +75,4 @@ void SliceDialog::updateStatus(StatusUpdateStepType type, int percentage) {
     m_progress_bars[(int)type]->setValue(percentage);
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/dialogs/template_save.cpp
+++ b/src/windows/dialogs/template_save.cpp
@@ -39,17 +39,22 @@ TemplateSaveDialog::TemplateSaveDialog(QWidget* parent)
     this->setupUi();
 }
 
-QStringList& TemplateSaveDialog::keys() { return m_keys; }
+QStringList& TemplateSaveDialog::keys() {
+    return m_keys;
+}
 
-QString& TemplateSaveDialog::filename() { return m_filename; }
+QString& TemplateSaveDialog::filename() {
+    return m_filename;
+}
 
-QString TemplateSaveDialog::name() { return m_name_edit->text(); }
+QString TemplateSaveDialog::name() {
+    return m_name_edit->text();
+}
 
 void TemplateSaveDialog::checkSelection(QTableWidgetItem* item) {
-
-    QString major_key = m_table->item(item->row(), 2)->text();
+    QString major_key                         = m_table->item(item->row(), 2)->text();
     m_setting_status[major_key][item->text()] = (bool)item->checkState();
-    QList<bool> valuesToCheck = m_setting_status[major_key].values();
+    QList<bool> valuesToCheck                 = m_setting_status[major_key].values();
 
     if (item->checkState() == Qt::CheckState::Checked) {
         if (std::all_of(valuesToCheck.begin(), valuesToCheck.end(), [](bool b) { return b; })) {
@@ -81,8 +86,7 @@ void TemplateSaveDialog::checkSelection(QTableWidgetItem* item) {
 
         for (QHash<QString, bool> major_category : m_setting_status) {
             for (bool b : major_category.values())
-                if (b)
-                    goto skip;
+                if (b) goto skip;
         }
 
         m_browse_btn->setEnabled(false);
@@ -92,13 +96,10 @@ void TemplateSaveDialog::checkSelection(QTableWidgetItem* item) {
     }
 
     // If the clicked item is not in the selection, only select the clicked item.
-    if (!m_table->selectedItems().contains(item))
-        return;
+    if (!m_table->selectedItems().contains(item)) return;
 
     m_table->blockSignals(true);
-    for (QTableWidgetItem* cur : m_table->selectedItems()) {
-        cur->setCheckState(item->checkState());
-    }
+    for (QTableWidgetItem* cur : m_table->selectedItems()) { cur->setCheckState(item->checkState()); }
     m_table->blockSignals(false);
 }
 
@@ -108,8 +109,7 @@ void TemplateSaveDialog::updateSelection() {
     m_table->blockSignals(true);
     // If all, select everything.
     if (sender->text() == "All") {
-        for (QCheckBox* box : m_category_check_boxes.values())
-            box->setCheckState(sender->checkState());
+        for (QCheckBox* box : m_category_check_boxes.values()) box->setCheckState(sender->checkState());
 
         for (int i = 0; i < m_table->rowCount(); i++) {
             m_table->item(i, 0)->setCheckState(sender->checkState());
@@ -164,8 +164,7 @@ void TemplateSaveDialog::fileDialog() {
     save_dialog.setDirectory(m_filename);
     save_dialog.setDefaultSuffix("s2c");
 
-    if (!save_dialog.exec())
-        return;
+    if (!save_dialog.exec()) return;
 
     m_filename = save_dialog.selectedFiles().first();
     m_edit->setText(m_filename);
@@ -193,9 +192,7 @@ void TemplateSaveDialog::accept() {
 
 bool TemplateSaveDialog::itemChecked() {
     for (int i = 0; i < m_table->rowCount(); i++) {
-        if (m_table->item(i, 0)->checkState()) {
-            return true;
-        }
+        if (m_table->item(i, 0)->checkState()) { return true; }
     }
     return false;
 }
@@ -254,7 +251,7 @@ void TemplateSaveDialog::setupWidgets() {
 }
 
 void TemplateSaveDialog::setupLayouts() {
-    m_layout = new QGridLayout(this);
+    m_layout      = new QGridLayout(this);
     m_file_layout = new QGridLayout(m_file_container);
 }
 
@@ -271,8 +268,8 @@ void TemplateSaveDialog::setupTable() {
     m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
     // For each item in the master, fetch the display name, category, and current value.
-    int pos = 0;
-    int index = 0;
+    int pos      = 0;
+    int index    = 0;
     bool isFound = true;
 
     while (true) {
@@ -285,13 +282,12 @@ void TemplateSaveDialog::setupTable() {
             QString type = QString::fromStdString(it.value()["type"]);
             if (m_convertable_types.contains(type)) {
                 double rawVal = GSM->getGlobal()->setting<double>(QString::fromStdString(it.key()), index);
-                val = convertRawValue(type, rawVal);
+                val           = convertRawValue(type, rawVal);
             }
             else
                 val = QString::fromStdString(GSM->getGlobal()->json()[0][it.key()].dump());
 
-            if (val == "null")
-                val = "(unset)";
+            if (val == "null") val = "(unset)";
 
             QTableWidgetItem* dis =
                 new QTableWidgetItem(QString::fromStdString(it.value()[Constants::Settings::Master::kDisplay]));
@@ -302,8 +298,7 @@ void TemplateSaveDialog::setupTable() {
             QTableWidgetItem* cur = new QTableWidgetItem(val);
 
             // Add the major category to our list if required.
-            if (Q_UNLIKELY(!m_maj.contains(maj->text())))
-                m_maj.insert(maj->text());
+            if (Q_UNLIKELY(!m_maj.contains(maj->text()))) m_maj.insert(maj->text());
 
             // Adds checkboxes to display name.
             dis->setCheckState(Qt::Unchecked);
@@ -329,8 +324,7 @@ void TemplateSaveDialog::setupTable() {
             // ++index;
         }
         ++index;
-        if (!isFound)
-            break;
+        if (!isFound) break;
     }
 
     // Sort by category.
@@ -384,7 +378,7 @@ void TemplateSaveDialog::setupEvents() {
         connect(box, &QCheckBox::clicked, this, &TemplateSaveDialog::updateSelection);
 
     // Connect the ok and cancel buttons.
-    QPushButton* ok = m_button_container->button(QDialogButtonBox::Ok);
+    QPushButton* ok     = m_button_container->button(QDialogButtonBox::Ok);
     QPushButton* cancel = m_button_container->button(QDialogButtonBox::Cancel);
     connect(ok, &QPushButton::pressed, this, &TemplateSaveDialog::accept);
     connect(cancel, &QPushButton::pressed, this, &TemplateSaveDialog::reject);
@@ -436,8 +430,6 @@ QString TemplateSaveDialog::convertRawValue(QString type, double value) {
         return QString::number(base_value.to(PreferencesManager::getInstance()->getDistanceUnit() *
                                              PreferencesManager::getInstance()->getDistanceUnit()));
     }
-    else {
-        return QString::number(value);
-    }
+    else { return QString::number(value); }
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/flowratecalc.cpp
+++ b/src/windows/flowratecalc.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include <QApplication>
+
 #include <qcombobox.h>
 #include <qcontainerfwd.h>
 #include <qfont.h>
@@ -23,10 +24,10 @@ namespace ORNL {
 //  1. Use unit class
 //  2. Provide unit choices: metric or British
 FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
-    m_parent = parent;
-    m_density_metric = g / (cm * cm * cm);
+    m_parent               = parent;
+    m_density_metric       = g / (cm * cm * cm);
     Density IS_unit_chosen = lbm / (inch * inch * inch);
-    m_density_metric_to_is = m_density_metric() / IS_unit_chosen(); // around 0.036127292
+    m_density_metric_to_is = m_density_metric() / IS_unit_chosen();  // around 0.036127292
 
     // setFixedSize(420,260);
     setWindowTitle(QApplication::applicationDisplayName() + ": Flowrate Calculator");
@@ -34,7 +35,7 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     icon.addFile(QStringLiteral(":/icons/ornlslicer_logo.png"), QSize(), QIcon::Normal, QIcon::Off);
     setWindowIcon(icon);
 
-    m_layout = new QGridLayout();
+    m_layout            = new QGridLayout();
     QLabel* lblFlowrate = new QLabel("Flowrate Measurement");
     QFont titleFont("Arial", 10, QFont::Bold);
     lblFlowrate->setFont(titleFont);
@@ -45,12 +46,12 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     m_layout->addWidget(lblPrintParams, 0, 3, 1, 2);
 
     QLabel* lblRPM = new QLabel("Speed (RPM):");
-    m_speed_rpm = new QLineEdit();
+    m_speed_rpm    = new QLineEdit();
     m_layout->addWidget(lblRPM, 1, 0);
     m_layout->addWidget(m_speed_rpm, 1, 1);
 
     QLabel* lblHour = new QLabel("Lbs/Hour:");
-    m_lbs_hour = new QLineEdit();
+    m_lbs_hour      = new QLineEdit();
     m_layout->addWidget(lblHour, 2, 0);
     m_layout->addWidget(m_lbs_hour, 2, 1);
 
@@ -58,30 +59,30 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     m_layout->setColumnMinimumWidth(2, 50);
 
     QLabel* lbl_beadWidth = new QLabel("Bead Width (in):");
-    m_bead_width = new QLineEdit();
+    m_bead_width          = new QLineEdit();
     m_layout->addWidget(lbl_beadWidth, 1, 3);
     m_layout->addWidget(m_bead_width, 1, 4);
 
     QLabel* lbl_layerHeight = new QLabel("Layer Height (in):");
-    m_layer_height = new QLineEdit();
+    m_layer_height          = new QLineEdit();
     m_layout->addWidget(lbl_layerHeight, 2, 3);
     m_layout->addWidget(m_layer_height, 2, 4);
 
     QLabel* lbl_printRate = new QLabel("Desired Print Rate (lbs/hr):");
-    m_print_rate = new QLineEdit();
+    m_print_rate          = new QLineEdit();
     m_layout->addWidget(lbl_printRate, 3, 3);
     m_layout->addWidget(m_print_rate, 3, 4);
 
     QLabel* lbl_materialType = new QLabel("Material Type:");
-    QStringList commands = {"20% CF-ABS", "ABS",         "PPS", "50% CF-PPS", "PPSU", "25% CF-PPSU",
-                            "PESU",       "25% CF-PESU", "PLA", "Concrete",   "Other"};
-    m_material_type = new QComboBox();
+    QStringList commands     = {"20% CF-ABS", "ABS",         "PPS", "50% CF-PPS", "PPSU", "25% CF-PPSU",
+                                "PESU",       "25% CF-PESU", "PLA", "Concrete",   "Other"};
+    m_material_type          = new QComboBox();
     m_material_type->addItems(commands);
     m_layout->addWidget(lbl_materialType, 4, 3);
     m_layout->addWidget(m_material_type, 4, 4);
 
     QLabel* lbl_density = new QLabel("Density (g/cm³):");
-    m_density = new QLineEdit();
+    m_density           = new QLineEdit();
     m_density->setReadOnly(true);
     m_density->setText(QString::number(toDensityValue(PrintMaterial::kABS20CF)() / m_density_metric(), 'f', 5));
     m_density->setEnabled(false);
@@ -94,13 +95,13 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     m_layout->addWidget(line, 6, 0, 1, 5);
 
     QLabel* lbl_gantrySpeed = new QLabel("Gantry Speed (in/sec):");
-    m_gantry_speed = new QLineEdit();
+    m_gantry_speed          = new QLineEdit();
     m_gantry_speed->setReadOnly(true);
     m_layout->addWidget(lbl_gantrySpeed, 7, 3);
     m_layout->addWidget(m_gantry_speed, 7, 4);
 
     QLabel* lbl_sprindleSpeed = new QLabel("Spindle Speed (RPM):");
-    m_spindle_speed = new QLineEdit();
+    m_spindle_speed           = new QLineEdit();
     m_spindle_speed->setReadOnly(true);
     m_layout->addWidget(lbl_sprindleSpeed, 8, 3);
     m_layout->addWidget(m_spindle_speed, 8, 4);
@@ -150,9 +151,7 @@ void FlowrateCalcWindow::enableDensity(int index) {
 
 void FlowrateCalcWindow::saveOtherDensity() {
     // if enabled, Other must be selected
-    if (m_material_type->isEnabled()) {
-        m_saved_other_density = m_density->text();
-    }
+    if (m_material_type->isEnabled()) { m_saved_other_density = m_density->text(); }
 }
 
 void FlowrateCalcWindow::checkInputAndCalculate() {
@@ -218,10 +217,10 @@ void FlowrateCalcWindow::checkInputAndCalculate() {
     v_density = m_density->text().toDouble(&densityOk) * m_density_metric_to_is;
 
     // calculations
-    double ratio = v_printRate / v_lbsHour;
+    double ratio     = v_printRate / v_lbsHour;
     double volumeSec = (v_printRate / 3600) / v_density;
-    double area = v_layerHeight * (v_beadWidth - v_layerHeight) + M_PI * (v_layerHeight / 2) * (v_layerHeight / 2);
-    double gantrySpeed = volumeSec / area;
+    double area      = v_layerHeight * (v_beadWidth - v_layerHeight) + M_PI * (v_layerHeight / 2) * (v_layerHeight / 2);
+    double gantrySpeed  = volumeSec / area;
     double spindleSpeed = ratio * v_speedRPM;
 
     // write to textboxes
@@ -230,9 +229,7 @@ void FlowrateCalcWindow::checkInputAndCalculate() {
 
     // Warning message in the same window - thus no need for an additional click
     m_status_label->clear();
-    if (spindleSpeed > 400) {
-        m_status_label->setText("Warning: Spindle Speed Exceeds 400 RPM");
-    }
+    if (spindleSpeed > 400) { m_status_label->setText("Warning: Spindle Speed Exceeds 400 RPM"); }
 }
 
 void FlowrateCalcWindow::closeEvent(QCloseEvent* event) {
@@ -250,10 +247,8 @@ void FlowrateCalcWindow::closeEvent(QCloseEvent* event) {
     m_print_rate->clear();
 
     // set the focus back to the main window
-    if (m_parent->isMinimized()) {
-        m_parent->showNormal();
-    }
+    if (m_parent->isMinimized()) { m_parent->showNormal(); }
     // setFocus() doesn't deliver, but activateWindow() serves the purpose
     m_parent->activateWindow();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/gcode_export.cpp
+++ b/src/windows/gcode_export.cpp
@@ -1,7 +1,5 @@
 #include "windows/gcode_export.h"
 
-#include <algorithm>
-
 #include <QApplication>
 #include <QDir>
 #include <QDirIterator>
@@ -11,6 +9,8 @@
 #include <QLabel>
 #include <QMessageBox>
 #include <QStringBuilder>
+#include <algorithm>
+
 #include <qboxlayout.h>
 #include <qdebug.h>
 #include <qfiledevice.h>
@@ -54,7 +54,7 @@ bool hasVisualizationSegments(const QVector<QVector<QSharedPointer<SegmentBase>>
     return std::any_of(gcode.cbegin(), gcode.cend(),
                        [](const QVector<QSharedPointer<SegmentBase>>& layer) { return !layer.isEmpty(); });
 }
-} // namespace
+}  // namespace
 
 GcodeExport::GcodeExport(QWidget* parent) : m_has_gcode_visualization(false) {
     setWindowTitle(QApplication::applicationDisplayName() + ": G-Code/Project Export");
@@ -65,10 +65,10 @@ GcodeExport::GcodeExport(QWidget* parent) : m_has_gcode_visualization(false) {
 
     m_layout = new QVBoxLayout();
 
-    QGroupBox* headerBox = new QGroupBox("Optional G-Code Header Information");
+    QGroupBox* headerBox    = new QGroupBox("Optional G-Code Header Information");
     QGridLayout* headerGrid = new QGridLayout();
 
-    m_operator_input = new QLineEdit();
+    m_operator_input    = new QLineEdit();
     m_description_input = new QTextEdit();
 
     headerBox->setLayout(headerGrid);
@@ -79,9 +79,9 @@ GcodeExport::GcodeExport(QWidget* parent) : m_has_gcode_visualization(false) {
 
     m_layout->addWidget(headerBox);
 
-    QGroupBox* optionsBox = new QGroupBox("Export Options");
+    QGroupBox* optionsBox    = new QGroupBox("Export Options");
     QVBoxLayout* optionsGrid = new QVBoxLayout();
-    m_gcode_file_checkbox = new QCheckBox("Save G-Code file(s)");
+    m_gcode_file_checkbox    = new QCheckBox("Save G-Code file(s)");
     m_gcode_file_checkbox->setChecked(true);
     m_auxiliary_file_checkbox = new QCheckBox("Save Auxiliary files (if applicable)");
     m_auxiliary_file_checkbox->setChecked(true);
@@ -113,16 +113,18 @@ GcodeExport::GcodeExport(QWidget* parent) : m_has_gcode_visualization(false) {
 
 GcodeExport::~GcodeExport() {}
 
-void GcodeExport::setDefaultName(QString name) { m_default_name = removeModelFileExtension(name); }
+void GcodeExport::setDefaultName(QString name) {
+    m_default_name = removeModelFileExtension(name);
+}
 
 void GcodeExport::updateOutputInformation(QString tempLocation, GcodeMeta meta) {
-    m_location = tempLocation;
+    m_location         = tempLocation;
     m_most_recent_meta = meta;
     clearVisualizationInformation();
 }
 
 void GcodeExport::updateVisualizationInformation(QVector<QVector<QSharedPointer<SegmentBase>>> gcode) {
-    m_gcode = gcode;
+    m_gcode                   = gcode;
     m_has_gcode_visualization = hasVisualizationSegments(m_gcode);
     updateAsPrintedModelOptionState();
 }
@@ -147,15 +149,11 @@ void GcodeExport::closeEvent(QCloseEvent* event) {
 
 void GcodeExport::updateAsPrintedModelOptionState() {
     m_as_printed_model_checkbox->setEnabled(m_has_gcode_visualization);
-    if (!m_has_gcode_visualization) {
-        m_as_printed_model_checkbox->setChecked(false);
-    }
+    if (!m_has_gcode_visualization) { m_as_printed_model_checkbox->setChecked(false); }
 
     const bool centerline_enabled = m_has_gcode_visualization && m_as_printed_model_checkbox->isChecked();
     m_as_printed_centerline_checkbox->setEnabled(centerline_enabled);
-    if (!centerline_enabled) {
-        m_as_printed_centerline_checkbox->setChecked(false);
-    }
+    if (!centerline_enabled) { m_as_printed_centerline_checkbox->setChecked(false); }
 }
 
 void GcodeExport::exportGcode() {
@@ -163,23 +161,23 @@ void GcodeExport::exportGcode() {
     QFileDialog exportDialog;
     QString filter = "G-Code File (*" % m_most_recent_meta.m_file_suffix % ")";
     if (m_bundle_files_checkbox->isChecked()) {
-        filepath = exportDialog.getSaveFileName(this, "Export G-Code",
-                                                CSM->getMostRecentGcodeLocation() % '/' % m_default_name %
-                                                    m_most_recent_meta.m_file_suffix,
-                                                filter, &filter, QFileDialog::DontConfirmOverwrite);
+        filepath = exportDialog.getSaveFileName(
+            this, "Export G-Code",
+            CSM->getMostRecentGcodeLocation() % '/' % m_default_name % m_most_recent_meta.m_file_suffix, filter,
+            &filter, QFileDialog::DontConfirmOverwrite);
     }
     else {
-        filepath = exportDialog.getSaveFileName(this, "Export G-Code",
-                                                CSM->getMostRecentGcodeLocation() % '/' % m_default_name %
-                                                    m_most_recent_meta.m_file_suffix,
-                                                filter, &filter);
+        filepath = exportDialog.getSaveFileName(
+            this, "Export G-Code",
+            CSM->getMostRecentGcodeLocation() % '/' % m_default_name % m_most_recent_meta.m_file_suffix, filter,
+            &filter);
     }
 
     if (filepath != QString()) {
         QFileInfo info(filepath);
         QString partName;
         QString fullName = info.fileName();
-        filepath = info.absolutePath();
+        filepath         = info.absolutePath();
 
         CSM->setMostRecentGcodeLocation(info.absolutePath());
 
@@ -187,9 +185,7 @@ void GcodeExport::exportGcode() {
         if (fullName.endsWith(m_most_recent_meta.m_file_suffix)) {
             partName = fullName.left(fullName.length() - m_most_recent_meta.m_file_suffix.length());
         }
-        else {
-            partName = fullName;
-        }
+        else { partName = fullName; }
 
         // if bundling files, create folder based on name
         if (m_bundle_files_checkbox->isChecked()) {
@@ -201,11 +197,8 @@ void GcodeExport::exportGcode() {
         if (m_most_recent_meta == GcodeMetaList::AdamantineMeta) {
             gcodeFileName = filepath % '/' % partName % "_scan_path" % m_most_recent_meta.m_file_suffix;
         }
-        else {
-            gcodeFileName = filepath % '/' % partName % m_most_recent_meta.m_file_suffix;
-        }
-        if (QFile::exists(gcodeFileName))
-            QFile::remove(gcodeFileName);
+        else { gcodeFileName = filepath % '/' % partName % m_most_recent_meta.m_file_suffix; }
+        if (QFile::exists(gcodeFileName)) QFile::remove(gcodeFileName);
 
         QString projectFileName = filepath % '/' % partName % ".s2p";
 
@@ -220,9 +213,7 @@ void GcodeExport::exportGcode() {
                     CSM->saveSession(projectFileName, false);
                 }
             }
-            else {
-                CSM->saveSession(projectFileName, false);
-            }
+            else { CSM->saveSession(projectFileName, false); }
         }
 
         QString text;
@@ -235,23 +226,21 @@ void GcodeExport::exportGcode() {
 
         // Insert comment start/end characters to the description
         QString description = m_description_input->toPlainText();
-        int lineEnd = 0;
+        int lineEnd         = 0;
         while (lineEnd > -1) {
             if (lineEnd + 1 <
-                description.length()) // Check to make sure lineEnd + 1 exists before potentially trying to access it
+                description.length())  // Check to make sure lineEnd + 1 exists before potentially trying to access it
             {
                 lineEnd = description.indexOf("\n", lineEnd);
-                if (lineEnd > -1) // "\n" is found, -1 means not found
+                if (lineEnd > -1)  // "\n" is found, -1 means not found
                 {
                     description.insert(lineEnd, m_most_recent_meta.m_comment_ending_delimiter);
                     lineEnd = description.indexOf("\n", lineEnd);
                     description.insert(lineEnd + 1, m_most_recent_meta.m_comment_starting_delimiter);
-                    lineEnd++; // Increment lineEnd so that the next search doesn't find the same result
+                    lineEnd++;  // Increment lineEnd so that the next search doesn't find the same result
                 }
             }
-            else {
-                break;
-            }
+            else { break; }
         }
 
         // Add header information to the gcode file
@@ -262,7 +251,7 @@ void GcodeExport::exportGcode() {
 
         if (m_auxiliary_file_checkbox->isChecked()) {
             if (CSM->sensorFilesGenerated()) {
-                bool overwrite = false;
+                bool overwrite   = false;
                 bool hasAnswered = false;
                 text.replace("#TEMPFILENAME#", partName + "-");
 
@@ -288,7 +277,7 @@ void GcodeExport::exportGcode() {
                         QFile::copy(sensorFile.fileName(), outputLoc);
                 }
 
-                int i = 1;
+                int i          = 1;
                 bool moreFound = true;
                 while (moreFound) {
                     moreFound = false;
@@ -432,4 +421,4 @@ void GcodeExport::showComplete(QString path, QString filename) {
     QMessageBox::information(this, "File Export", filename % " has been succesfully exported to " % path);
     close();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/gcode_to_s2c.cpp
+++ b/src/windows/gcode_to_s2c.cpp
@@ -7,6 +7,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QStringBuilder>
+
 #include <qcontainerfwd.h>
 
 #include "gcode/gcode_settings_importer.h"
@@ -16,9 +17,8 @@ namespace ORNL {
 namespace {
 QString errorPreview(const QStringList& errors) {
     constexpr int kMaxErrors = 10;
-    QStringList preview = errors.mid(0, kMaxErrors);
-    if (errors.size() > kMaxErrors)
-        preview.append(QString("...and %1 more.").arg(errors.size() - kMaxErrors));
+    QStringList preview      = errors.mid(0, kMaxErrors);
+    if (errors.size() > kMaxErrors) preview.append(QString("...and %1 more.").arg(errors.size() - kMaxErrors));
     return preview.join("\n");
 }
 
@@ -29,10 +29,9 @@ QString comparableFilePath(const QString& path) {
 }
 
 bool pathsReferToSameFile(const QString& first, const QString& second) {
-    if (first.isEmpty() || second.isEmpty())
-        return false;
+    if (first.isEmpty() || second.isEmpty()) return false;
 
-    const QString first_path = comparableFilePath(first);
+    const QString first_path  = comparableFilePath(first);
     const QString second_path = comparableFilePath(second);
 #ifdef Q_OS_WIN
     return first_path.compare(second_path, Qt::CaseInsensitive) == 0;
@@ -40,11 +39,15 @@ bool pathsReferToSameFile(const QString& first, const QString& second) {
     return first_path == second_path;
 #endif
 }
-} // namespace
+}  // namespace
 
-GcodeToS2CDialog::GcodeToS2CDialog(QWidget* parent) : QDialog(parent) { setupUi(); }
+GcodeToS2CDialog::GcodeToS2CDialog(QWidget* parent) : QDialog(parent) {
+    setupUi();
+}
 
-QString GcodeToS2CDialog::outputFilePath() const { return m_output_edit->text().trimmed(); }
+QString GcodeToS2CDialog::outputFilePath() const {
+    return m_output_edit->text().trimmed();
+}
 
 void GcodeToS2CDialog::setupUi() {
     setWindowTitle("G-Code to S2C");
@@ -53,12 +56,12 @@ void GcodeToS2CDialog::setupUi() {
     m_layout = new QGridLayout(this);
 
     QLabel* gcode_label = new QLabel("G-Code file:", this);
-    m_gcode_edit = new QLineEdit(this);
+    m_gcode_edit        = new QLineEdit(this);
     m_gcode_edit->setReadOnly(true);
     m_gcode_browse = new QPushButton("Browse...", this);
 
     QLabel* output_label = new QLabel("Settings file:", this);
-    m_output_edit = new QLineEdit(this);
+    m_output_edit        = new QLineEdit(this);
     m_output_edit->setReadOnly(true);
     m_output_browse = new QPushButton("Browse...", this);
 
@@ -96,8 +99,7 @@ void GcodeToS2CDialog::browseGcodeFile() {
     dialog.setAcceptMode(QFileDialog::AcceptOpen);
     dialog.setNameFilters(QStringList() << "G-Code Files (*.gcode *.nc *.mpf *.eia *.txt)" << "Any Files (*)");
 
-    if (!dialog.exec())
-        return;
+    if (!dialog.exec()) return;
 
     m_gcode_edit->setText(dialog.selectedFiles().first());
     setDefaultOutputPath();
@@ -110,11 +112,9 @@ void GcodeToS2CDialog::browseOutputFile() {
     dialog.setNameFilters(QStringList() << "ORNLSlicer Configuration/Template File (*.s2c)" << "Any Files (*)");
     dialog.setDefaultSuffix("s2c");
 
-    if (!m_output_edit->text().isEmpty())
-        dialog.selectFile(m_output_edit->text());
+    if (!m_output_edit->text().isEmpty()) dialog.selectFile(m_output_edit->text());
 
-    if (!dialog.exec())
-        return;
+    if (!dialog.exec()) return;
 
     m_output_edit->setText(dialog.selectedFiles().first());
 }
@@ -128,7 +128,7 @@ void GcodeToS2CDialog::accept() {
     m_status_label->setText("Creating settings file...");
     QApplication::processEvents();
 
-    const QString gcode_path = m_gcode_edit->text().trimmed();
+    const QString gcode_path  = m_gcode_edit->text().trimmed();
     const QString output_path = outputFilePath();
     if (pathsReferToSameFile(gcode_path, output_path)) {
         m_status_label->setText("Choose a different settings file path.");
@@ -166,32 +166,29 @@ void GcodeToS2CDialog::accept() {
         message += QString(" Used defaults for %1 missing settings.").arg(result.defaulted_keys.size());
     if (!result.prompted_keys.isEmpty())
         message += QString(" Prompted for %1 missing settings.").arg(result.prompted_keys.size());
-    if (!result.warnings.isEmpty())
-        message += "\n\nWarnings:\n" + errorPreview(result.warnings);
+    if (!result.warnings.isEmpty()) message += "\n\nWarnings:\n" + errorPreview(result.warnings);
 
     QMessageBox::information(this, "G-Code to S2C", message);
     QDialog::accept();
 }
 
 void GcodeToS2CDialog::setDefaultOutputPath() {
-    if (m_gcode_edit->text().isEmpty() || !m_output_edit->text().isEmpty())
-        return;
+    if (m_gcode_edit->text().isEmpty() || !m_output_edit->text().isEmpty()) return;
 
     QFileInfo info(m_gcode_edit->text());
     m_output_edit->setText(info.absolutePath() % "/" % info.completeBaseName() % ".s2c");
 }
 
 std::optional<fifojson> GcodeToS2CDialog::promptForMissingValue(const QString& key, const fifojson& master_entry) {
-    const QString display = GcodeSettingsImporter::displayName(master_entry);
-    const QString label = display + " (" + key + ") is missing.\nEnter the raw setting value:";
+    const QString display      = GcodeSettingsImporter::displayName(master_entry);
+    const QString label        = display + " (" + key + ") is missing.\nEnter the raw setting value:";
     const QString default_text = QString::fromStdString(master_entry.at(Constants::Settings::Master::kDefault).dump());
 
     while (true) {
         bool ok = false;
         const QString text =
             QInputDialog::getText(this, "Missing Setting Value", label, QLineEdit::Normal, default_text, &ok);
-        if (!ok)
-            return std::nullopt;
+        if (!ok) return std::nullopt;
 
         fifojson candidate;
         try {
@@ -207,4 +204,4 @@ std::optional<fifojson> GcodeToS2CDialog::promptForMissingValue(const QString& k
     }
 }
 
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/layer_times_window.cpp
+++ b/src/windows/layer_times_window.cpp
@@ -1,10 +1,10 @@
 #include "windows/layer_times_window.h"
 
-#include <climits>
-
 #include <QIcon>
 #include <QLabel>
 #include <QStringBuilder>
+#include <climits>
+
 #include <qgridlayout.h>
 #include <qlineedit.h>
 #include <qlist.h>
@@ -24,9 +24,9 @@ LayerTimesWindow::LayerTimesWindow(QWidget* parent) {
     icon.addFile(QStringLiteral(":/icons/ornlslicer_logo.png"), QSize(), QIcon::Normal, QIcon::Off);
     setWindowIcon(icon);
 
-    m_layout = new QGridLayout();
+    m_layout                = new QGridLayout();
     QLabel* lblMinLayerTime = new QLabel("Minimum Layer Time (seconds):");
-    m_min_layer_time_edit = new QLineEdit();
+    m_min_layer_time_edit   = new QLineEdit();
     m_layout->addWidget(lblMinLayerTime, 0, 0);
     m_layout->addWidget(m_min_layer_time_edit, 0, 1);
 
@@ -45,13 +45,13 @@ void LayerTimesWindow::setupEvents() {
 
 void LayerTimesWindow::updateTimeInformation(QList<Time> layer_times, QList<Time> adjusted_layer_times,
                                              QList<double> layer_FR_modifiers, bool adjusted_layer_time) {
-    m_layer_times = layer_times;
+    m_layer_times          = layer_times;
     m_adjusted_layer_times = adjusted_layer_times;
-    m_layer_FR_modifiers = layer_FR_modifiers;
-    m_adjusted_layer_time = adjusted_layer_time;
+    m_layer_FR_modifiers   = layer_FR_modifiers;
+    m_adjusted_layer_time  = adjusted_layer_time;
     m_min = INT_MAX, m_max = INT_MIN;
     m_min_index = -1, m_max_index = -1;
-    m_total_time = 0;
+    m_total_time          = 0;
     m_total_adjusted_time = 0;
 
     for (int i = 1; i < m_layer_times.size(); ++i) {
@@ -59,12 +59,12 @@ void LayerTimesWindow::updateTimeInformation(QList<Time> layer_times, QList<Time
 
         if (current_time < m_min) {
             m_min_index = i;
-            m_min = current_time;
+            m_min       = current_time;
         }
 
         if (current_time > m_max) {
             m_max_index = i;
-            m_max = current_time;
+            m_max       = current_time;
         }
 
         m_total_adjusted_time += m_adjusted_layer_times[i];
@@ -77,7 +77,7 @@ void LayerTimesWindow::updateTimeInformation(QList<Time> layer_times, QList<Time
 
 void LayerTimesWindow::updateText() {
     Time layerTimeThreshold(0);
-    bool flag = false;
+    bool flag          = false;
     layerTimeThreshold = Time(m_min_layer_time_edit->text().toInt(&flag));
 
     QString layerTimeString = "Total print time: " % MathUtils::formattedTimeSpan(m_total_time()) % "<br>";
@@ -101,7 +101,7 @@ void LayerTimesWindow::updateText() {
 
         Time display_time = current_time;
         if (m_adjusted_layer_time) {
-            display_time = m_adjusted_layer_times[i];
+            display_time         = m_adjusted_layer_times[i];
             double adjusted_time = m_adjusted_layer_times[i]();
             if (i > 0 && current_time > 1 && m_layer_FR_modifiers[i] != 1) {
                 oneLayer += " Adjusted " % MathUtils::formattedTimeSpanHHMMSS(adjusted_time) % ",";
@@ -111,15 +111,13 @@ void LayerTimesWindow::updateText() {
 
         oneLayer += " Total Time So Far " % MathUtils::formattedTimeSpanHHMMSS(currentTotal());
 
-        if (display_time < layerTimeThreshold) {
-            layerTimeString += "<font color=\"red\">" % oneLayer % "</font><br>";
-        }
-        else {
-            layerTimeString += oneLayer % "<br>";
-        }
+        if (display_time < layerTimeThreshold) { layerTimeString += "<font color=\"red\">" % oneLayer % "</font><br>"; }
+        else { layerTimeString += oneLayer % "<br>"; }
     }
     m_layer_times_edit->setText(layerTimeString);
 }
 
-void LayerTimesWindow::clear() { m_layer_times_edit->setText(""); }
-} // namespace ORNL
+void LayerTimesWindow::clear() {
+    m_layer_times_edit->setText("");
+}
+}  // namespace ORNL

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -7,6 +7,7 @@
 #include <QStatusBar>
 #include <QTimer>
 #include <QUndoCommand>
+
 #include <qaction.h>
 #include <qapplication.h>
 #include <qcontainerfwd.h>
@@ -79,10 +80,10 @@
 
 namespace ORNL {
 constexpr int kPartTransformUndoCommandId = 1;
-constexpr int kSettingValueUndoCommandId = 2;
+constexpr int kSettingValueUndoCommandId  = 2;
 
 class PartTransformUndoCommand : public QUndoCommand {
-  public:
+   public:
     PartTransformUndoCommand(MainWindow* window, QSharedPointer<PartMetaItem> item,
                              const MainWindow::PartTransformSnapshot& before,
                              const MainWindow::PartTransformSnapshot& after)
@@ -90,19 +91,21 @@ class PartTransformUndoCommand : public QUndoCommand {
         setText("part position change");
     }
 
-    int id() const override { return kPartTransformUndoCommandId; }
+    int id() const override {
+        return kPartTransformUndoCommandId;
+    }
 
     bool mergeWith(const QUndoCommand* command) override {
         const auto* other = dynamic_cast<const PartTransformUndoCommand*>(command);
-        if (other == nullptr || other->m_window != m_window || other->m_item != m_item) {
-            return false;
-        }
+        if (other == nullptr || other->m_window != m_window || other->m_item != m_item) { return false; }
 
         m_after = other->m_after;
         return true;
     }
 
-    void undo() override { m_window->applyPartTransformSnapshot(m_item, m_before); }
+    void undo() override {
+        m_window->applyPartTransformSnapshot(m_item, m_before);
+    }
 
     void redo() override {
         if (m_skip_first_redo) {
@@ -113,7 +116,7 @@ class PartTransformUndoCommand : public QUndoCommand {
         m_window->applyPartTransformSnapshot(m_item, m_after);
     }
 
-  private:
+   private:
     MainWindow* m_window;
     QSharedPointer<PartMetaItem> m_item;
     MainWindow::PartTransformSnapshot m_before;
@@ -122,7 +125,7 @@ class PartTransformUndoCommand : public QUndoCommand {
 };
 
 class SettingValueUndoCommand : public QUndoCommand {
-  public:
+   public:
     SettingValueUndoCommand(MainWindow* window, const QString& key,
                             const QVector<MainWindow::SettingValueSnapshot>& before,
                             const QVector<MainWindow::SettingValueSnapshot>& after)
@@ -130,7 +133,9 @@ class SettingValueUndoCommand : public QUndoCommand {
         setText("setting change");
     }
 
-    int id() const override { return kSettingValueUndoCommandId; }
+    int id() const override {
+        return kSettingValueUndoCommandId;
+    }
 
     bool mergeWith(const QUndoCommand* command) override {
         const auto* other = dynamic_cast<const SettingValueUndoCommand*>(command);
@@ -150,7 +155,9 @@ class SettingValueUndoCommand : public QUndoCommand {
         return true;
     }
 
-    void undo() override { m_window->applySettingValueSnapshots(m_before); }
+    void undo() override {
+        m_window->applySettingValueSnapshots(m_before);
+    }
 
     void redo() override {
         if (m_skip_first_redo) {
@@ -161,7 +168,7 @@ class SettingValueUndoCommand : public QUndoCommand {
         m_window->applySettingValueSnapshots(m_after);
     }
 
-  private:
+   private:
     MainWindow* m_window;
     QString m_key;
     QVector<MainWindow::SettingValueSnapshot> m_before;
@@ -172,12 +179,13 @@ class SettingValueUndoCommand : public QUndoCommand {
 MainWindow* MainWindow::m_singleton = nullptr;
 
 MainWindow* MainWindow::getInstance() {
-    if (m_singleton == nullptr)
-        m_singleton = new MainWindow();
+    if (m_singleton == nullptr) m_singleton = new MainWindow();
     return m_singleton;
 }
 
-MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), m_status(false) { continueStartup(); }
+MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), m_status(false) {
+    continueStartup();
+}
 
 void MainWindow::continueStartup() {
     PreferencesManager::getInstance()->importPreferences();
@@ -190,24 +198,16 @@ void MainWindow::continueStartup() {
     QString templates;
 
     for (QString path : template_paths) {
-        if (QDir(path).exists()) {
-            templates = path;
-        }
+        if (QDir(path).exists()) { templates = path; }
     }
 
-    if (!templates.isEmpty()) {
-        GSM->loadAllGlobals(templates);
-    }
-    else {
-        qWarning() << "Cannot find base templates directory.";
-    }
+    if (!templates.isEmpty()) { GSM->loadAllGlobals(templates); }
+    else { qWarning() << "Cannot find base templates directory."; }
 
     QString tmp = CSM->getMostRecentSettingFolderLocation();
 
 #ifndef WIN32
-    if (tmp == QStandardPaths::writableLocation(QStandardPaths::HomeLocation)) {
-        tmp = "/tmp/";
-    }
+    if (tmp == QStandardPaths::writableLocation(QStandardPaths::HomeLocation)) { tmp = "/tmp/"; }
 #endif
 
     GSM->loadAllGlobals(tmp);
@@ -248,7 +248,9 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     QApplication::quit();
 }
 
-CmdWidget* MainWindow::getCmdOut() { return m_cmdbar; }
+CmdWidget* MainWindow::getCmdOut() {
+    return m_cmdbar;
+}
 
 void MainWindow::showEvent(QShowEvent* event) {
     QMainWindow::showEvent(event);
@@ -289,9 +291,7 @@ void MainWindow::setupClasses() {
 }
 
 void MainWindow::teardownClasses() {
-
-    if (PreferencesManager::getInstance()->isDirty())
-        PreferencesManager::getInstance()->exportPreferences();
+    if (PreferencesManager::getInstance()->isDirty()) PreferencesManager::getInstance()->exportPreferences();
 }
 
 void MainWindow::setupUi() {
@@ -311,8 +311,7 @@ void MainWindow::setupUi() {
 
 void MainWindow::setupWindows() {
     // Main Window
-    if (this->objectName().isEmpty())
-        this->setObjectName(QStringLiteral("MainWindow"));
+    if (this->objectName().isEmpty()) this->setObjectName(QStringLiteral("MainWindow"));
     this->resize(Constants::UI::MainWindow::kWindowSize);
 
     QIcon icon;
@@ -320,11 +319,11 @@ void MainWindow::setupWindows() {
     this->setWindowIcon(icon);
 
     // Preferences Window
-    m_pref_window = new PreferencesWindow(this);
+    m_pref_window          = new PreferencesWindow(this);
     m_flowrate_calc_window = new FlowrateCalcWindow(this);
-    m_xtrude_calc_window = new XtrudeCalcWindow(this);
-    m_export_window = new GcodeExport(this);
-    m_layertimebar = new LayerTimesWindow(this);
+    m_xtrude_calc_window   = new XtrudeCalcWindow(this);
+    m_export_window        = new GcodeExport(this);
+    m_layertimebar         = new LayerTimesWindow(this);
     // m_ingersollPostProcessor = new IngersollPostProcessor(this);
     m_about_window = new AboutWindow(this);
 }
@@ -507,51 +506,51 @@ void MainWindow::setupActions() {
 
     // Menu File
     m_actions["sel_printer"] = {"Select Printer", ":/icons/3d_printer.png", false, QKeySequence(), nullptr};
-    m_actions["load_model"] = {"Load Model for Building", ":/icons/file_black.png", false, QKeySequence(tr("Ctrl+o")),
-                               nullptr};
+    m_actions["load_model"]  = {"Load Model for Building", ":/icons/file_black.png", false, QKeySequence(tr("Ctrl+o")),
+                                nullptr};
     m_actions["load_point_cloud"] = {"Load Point Cloud", ":/icons/file_cloud_black.png", false, QKeySequence(),
                                      nullptr};
-    m_actions["last_session"] = {"Restore Last Session", ":/icons/restore_session_black.png", false, QKeySequence(),
-                                 nullptr};
-    m_actions["slice"] = {"Slice", ":/icons/layers_black.png", false, QKeySequence(tr("Ctrl+g")), nullptr};
-    m_actions["screenshot"] = {"Take Screenshot", ":/icons/screenshot_black.png", false, QKeySequence(), nullptr};
-    m_actions["exit"] = {"Exit", ":/icons/exit_black.png", false, QKeySequence(), nullptr};
+    m_actions["last_session"]     = {"Restore Last Session", ":/icons/restore_session_black.png", false, QKeySequence(),
+                                     nullptr};
+    m_actions["slice"]            = {"Slice", ":/icons/layers_black.png", false, QKeySequence(tr("Ctrl+g")), nullptr};
+    m_actions["screenshot"]       = {"Take Screenshot", ":/icons/screenshot_black.png", false, QKeySequence(), nullptr};
+    m_actions["exit"]             = {"Exit", ":/icons/exit_black.png", false, QKeySequence(), nullptr};
 
     // Menu Edit
-    m_actions["undo"] = {"Undo", ":/icons/undo_black.png", false, QKeySequence(QKeySequence::Undo), nullptr};
-    m_actions["redo"] = {"Redo", ":/icons/redo_black.png", false, QKeySequence(QKeySequence::Redo), nullptr};
-    m_actions["copy"] = {"Copy", ":/icons/copy_black.png", false, QKeySequence(tr("Ctrl+c")), nullptr};
-    m_actions["paste"] = {"Paste", ":/icons/paste_black.png", false, QKeySequence(tr("Ctrl+v")), nullptr};
+    m_actions["undo"]   = {"Undo", ":/icons/undo_black.png", false, QKeySequence(QKeySequence::Undo), nullptr};
+    m_actions["redo"]   = {"Redo", ":/icons/redo_black.png", false, QKeySequence(QKeySequence::Redo), nullptr};
+    m_actions["copy"]   = {"Copy", ":/icons/copy_black.png", false, QKeySequence(tr("Ctrl+c")), nullptr};
+    m_actions["paste"]  = {"Paste", ":/icons/paste_black.png", false, QKeySequence(tr("Ctrl+v")), nullptr};
     m_actions["reload"] = {"Reload", ":/icons/file_refresh_black.png", false, QKeySequence(tr("Ctrl+r")), nullptr};
     m_actions["delete"] = {"Delete", ":/icons/delete_black.png", false, QKeySequence(tr("Ctrl+Delete")), nullptr};
 
     // Menu Zoom
-    m_actions["zoom_in"] = {"Zoom In", ":/icons/magnify_plus_black.png", false, QKeySequence(tr("Ctrl+=")), nullptr};
+    m_actions["zoom_in"]  = {"Zoom In", ":/icons/magnify_plus_black.png", false, QKeySequence(tr("Ctrl+=")), nullptr};
     m_actions["zoom_out"] = {"Zoom Out", ":/icons/magnify_minus_black.png", false, QKeySequence(tr("Ctrl+-")), nullptr};
     m_actions["zoom_reset"] = {"Reset", ":/icons/magnify_reset_black.png", false, QKeySequence(tr("Ctrl+0")), nullptr};
 
     // Menu Hidden Settings
-    m_actions["show_all"] = {"Show All Settings", ":/icons/eye_black.png", false, QKeySequence(), nullptr};
-    m_actions["show_all_printer"] = {"Show All Printer Settings", ":/icons/eye_black.png", false, QKeySequence(),
-                                     nullptr};
-    m_actions["show_all_material"] = {"Show All Material Settings", ":/icons/eye_black.png", false, QKeySequence(),
-                                      nullptr};
-    m_actions["show_all_profile"] = {"Show All Profile Settings", ":/icons/eye_black.png", false, QKeySequence(),
-                                     nullptr};
+    m_actions["show_all"]              = {"Show All Settings", ":/icons/eye_black.png", false, QKeySequence(), nullptr};
+    m_actions["show_all_printer"]      = {"Show All Printer Settings", ":/icons/eye_black.png", false, QKeySequence(),
+                                          nullptr};
+    m_actions["show_all_material"]     = {"Show All Material Settings", ":/icons/eye_black.png", false, QKeySequence(),
+                                          nullptr};
+    m_actions["show_all_profile"]      = {"Show All Profile Settings", ":/icons/eye_black.png", false, QKeySequence(),
+                                          nullptr};
     m_actions["show_all_experimental"] = {"Show All Experimental Settings", ":/icons/eye_black.png", false,
                                           QKeySequence(), nullptr};
 
     // Menu View
-    m_actions["part_view"] = {"Part View", ":/icons/cube_black.png", false, QKeySequence(), nullptr};
-    m_actions["gcode_view"] = {"G-Code View", ":/icons/3d_black.png", false, QKeySequence(), nullptr};
+    m_actions["part_view"]    = {"Part View", ":/icons/cube_black.png", false, QKeySequence(), nullptr};
+    m_actions["gcode_view"]   = {"G-Code View", ":/icons/3d_black.png", false, QKeySequence(), nullptr};
     m_actions["reset_camera"] = {"Reset Camera", ":/icons/camera_reset_black.png", false, QKeySequence(), nullptr};
 
     // Menu Settings
-    m_actions["template_load"] = {"Load from Template", ":/icons/settings_file_black.png", false,
-                                  QKeySequence(tr("Ctrl+t")), nullptr};
-    m_actions["template_save"] = {"Save as Template", ":/icons/settings_save_black.png", false,
-                                  QKeySequence(tr("Ctrl+Shift+t")), nullptr};
-    m_actions["gcode_to_s2c"] = {"G-Code to S2C", ":/icons/settings_save_black.png", false, QKeySequence(), nullptr};
+    m_actions["template_load"]  = {"Load from Template", ":/icons/settings_file_black.png", false,
+                                   QKeySequence(tr("Ctrl+t")), nullptr};
+    m_actions["template_save"]  = {"Save as Template", ":/icons/settings_save_black.png", false,
+                                   QKeySequence(tr("Ctrl+Shift+t")), nullptr};
+    m_actions["gcode_to_s2c"]   = {"G-Code to S2C", ":/icons/settings_save_black.png", false, QKeySequence(), nullptr};
     m_actions["setting_folder"] = {"Additional Setting Location", ":/icons/settings_folder_black.png", false,
                                    QKeySequence(), nullptr};
     m_actions["layer_bar_setting_folder"] = {"Additional Layer Bar Setting Location",
@@ -560,7 +559,7 @@ void MainWindow::setupActions() {
                          nullptr};
 
     // Menu Project
-    m_actions["project_new"] = {"New Project", ":/icons/file_add_black.png", false, QKeySequence(), nullptr};
+    m_actions["project_new"]  = {"New Project", ":/icons/file_add_black.png", false, QKeySequence(), nullptr};
     m_actions["project_load"] = {"Load Project", ":/icons/folder_black.png", false, QKeySequence(tr("Ctrl+Shift+o")),
                                  nullptr};
     m_actions["project_save"] = {"Save Project", ":/icons/save_project_black.png", false, QKeySequence(tr("Ctrl+s")),
@@ -569,10 +568,10 @@ void MainWindow::setupActions() {
     m_actions["gcode_export"] = {"Export G-Code", ":/icons/export_black.png", false, QKeySequence(), nullptr};
 
     // Menu Tools
-    m_actions["flowrate_calc"] = {"Flowrate Calculator", ":/icons/calculator_black.png", false, QKeySequence(),
-                                  nullptr};
-    m_actions["xtrude_calc"] = {"Xtrude Calculator", ":/icons/print_head.png", false, QKeySequence(), nullptr};
-    m_actions["build_log"] = {"Build Log", ":/icons/list.png", false, QKeySequence(), nullptr};
+    m_actions["flowrate_calc"]       = {"Flowrate Calculator", ":/icons/calculator_black.png", false, QKeySequence(),
+                                        nullptr};
+    m_actions["xtrude_calc"]         = {"Xtrude Calculator", ":/icons/print_head.png", false, QKeySequence(), nullptr};
+    m_actions["build_log"]           = {"Build Log", ":/icons/list.png", false, QKeySequence(), nullptr};
     m_actions["remote_connectivity"] = {"Remote Connectivity", ":/icons/remote_connect_black.png", false,
                                         QKeySequence(), nullptr};
 
@@ -580,16 +579,16 @@ void MainWindow::setupActions() {
     m_actions["python_int"] = {"Python Interpreter", ":/icons/python.ico", false, QKeySequence(), nullptr};
 
     // Menu Help
-    m_actions["manual"] = {"User's Manual", ":/icons/help_black.png", false, QKeySequence(), nullptr};
-    m_actions["repo"] = {"Open Website/Repository", ":/icons/web_black.png", false, QKeySequence(), nullptr};
-    m_actions["bug"] = {"Report Bug", ":/icons/bug_black.png", false, QKeySequence(), nullptr};
+    m_actions["manual"]   = {"User's Manual", ":/icons/help_black.png", false, QKeySequence(), nullptr};
+    m_actions["repo"]     = {"Open Website/Repository", ":/icons/web_black.png", false, QKeySequence(), nullptr};
+    m_actions["bug"]      = {"Report Bug", ":/icons/bug_black.png", false, QKeySequence(), nullptr};
     m_actions["about_s2"] = {QString("About %1").arg(QApplication::applicationDisplayName()),
                              ":/icons/ornlslicer_logo.png", false, QKeySequence(), nullptr};
     m_actions["about_qt"] = {"About Qt", ":/icons/qt.png", false, QKeySequence(), nullptr};
 
     // Menu Debug
-    m_actions["debug"] = {"Run MainWindow::debug()", ":/icons/test_black.png", false, QKeySequence(tr("Ctrl+Space")),
-                          nullptr};
+    m_actions["debug"]   = {"Run MainWindow::debug()", ":/icons/test_black.png", false, QKeySequence(tr("Ctrl+Space")),
+                            nullptr};
     m_actions["cs_view"] = {"Cross-section Viewer", ":/icons/layers_black.png", false, QKeySequence(), nullptr};
 
     // Setup all defined actions above.
@@ -984,8 +983,9 @@ void MainWindow::setupEvents() {
         }
     });
     connect(m_part_widget, &PartWidget::displayRotationInfoMsg, this, [this]() {
-        m_cmdbar->append("\r\nScaling applied permenantly to current transformation\r\n"
-                         "Scaling factors are reset to 100%\r\n");
+        m_cmdbar->append(
+            "\r\nScaling applied permenantly to current transformation\r\n"
+            "Scaling factors are reset to 100%\r\n");
     });
     connect(m_part_widget->getPartMeta().get(), &PartMetaModel::itemAddedUpdate, this,
             [this](QSharedPointer<PartMetaItem>) { this->markProjectModified(); });
@@ -1110,44 +1110,36 @@ void MainWindow::switchViews(int index) {
 MainWindow::PartTransformSnapshot MainWindow::partTransformSnapshot(QSharedPointer<PartMetaItem> item) const {
     PartTransformSnapshot snapshot;
     if (!item.isNull()) {
-        snapshot.transformation = item->transformation();
+        snapshot.transformation   = item->transformation();
         snapshot.scale_unit_index = item->scaleUnitIndex();
     }
     return snapshot;
 }
 
 void MainWindow::applyPartTransformSnapshot(QSharedPointer<PartMetaItem> item, const PartTransformSnapshot& snapshot) {
-    if (item.isNull() || !m_part_transform_snapshots.contains(item)) {
-        return;
-    }
+    if (item.isNull() || !m_part_transform_snapshots.contains(item)) { return; }
 
     m_applying_undo_redo = true;
     item->setTransformation(snapshot.transformation);
     item->setScaleUnitIndex(snapshot.scale_unit_index);
     m_part_transform_snapshots[item] = snapshot;
-    m_applying_undo_redo = false;
+    m_applying_undo_redo             = false;
 }
 
-QVector<MainWindow::SettingValueSnapshot>
-MainWindow::settingValueSnapshots(const QString& key, const QList<QSharedPointer<SettingsBase>>& settings_bases) const {
+QVector<MainWindow::SettingValueSnapshot> MainWindow::settingValueSnapshots(
+    const QString& key, const QList<QSharedPointer<SettingsBase>>& settings_bases) const {
     QList<QSharedPointer<SettingsBase>> targets = settings_bases;
-    if (targets.isEmpty()) {
-        targets.push_back(GSM->getGlobal());
-    }
+    if (targets.isEmpty()) { targets.push_back(GSM->getGlobal()); }
 
     QVector<SettingValueSnapshot> snapshots;
     for (const QSharedPointer<SettingsBase>& settings_base : targets) {
-        if (settings_base.isNull()) {
-            continue;
-        }
+        if (settings_base.isNull()) { continue; }
 
         SettingValueSnapshot snapshot;
-        snapshot.key = key;
+        snapshot.key           = key;
         snapshot.settings_base = settings_base;
-        snapshot.existed = settings_base->contains(key);
-        if (snapshot.existed) {
-            snapshot.value = settings_base->json()[0][key.toStdString()];
-        }
+        snapshot.existed       = settings_base->contains(key);
+        if (snapshot.existed) { snapshot.value = settings_base->json()[0][key.toStdString()]; }
 
         snapshots.push_back(snapshot);
     }
@@ -1156,36 +1148,24 @@ MainWindow::settingValueSnapshots(const QString& key, const QList<QSharedPointer
 }
 
 void MainWindow::applySettingValueSnapshots(const QVector<SettingValueSnapshot>& snapshots) {
-    if (snapshots.isEmpty()) {
-        return;
-    }
+    if (snapshots.isEmpty()) { return; }
 
     QSet<QString> restored_keys;
 
     m_applying_undo_redo = true;
     for (const SettingValueSnapshot& snapshot : snapshots) {
-        if (snapshot.settings_base.isNull()) {
-            continue;
-        }
+        if (snapshot.settings_base.isNull()) { continue; }
 
         fifojson& settings_json = snapshot.settings_base->json();
-        if (settings_json.empty()) {
-            settings_json.push_back(fifojson::object());
-        }
+        if (settings_json.empty()) { settings_json.push_back(fifojson::object()); }
 
-        if (snapshot.existed) {
-            settings_json[0][snapshot.key.toStdString()] = snapshot.value;
-        }
-        else {
-            snapshot.settings_base->remove(snapshot.key);
-        }
+        if (snapshot.existed) { settings_json[0][snapshot.key.toStdString()] = snapshot.value; }
+        else { snapshot.settings_base->remove(snapshot.key); }
 
         restored_keys.insert(snapshot.key);
     }
 
-    for (const QString& key : restored_keys) {
-        m_settingbar->restoreSettingValue(key);
-    }
+    for (const QString& key : restored_keys) { m_settingbar->restoreSettingValue(key); }
     m_applying_undo_redo = false;
 }
 
@@ -1195,9 +1175,7 @@ bool MainWindow::partTransformSnapshotsEqual(const PartTransformSnapshot& lhs, c
 
 bool MainWindow::settingValueSnapshotsEqual(const QVector<SettingValueSnapshot>& lhs,
                                             const QVector<SettingValueSnapshot>& rhs) const {
-    if (lhs.size() != rhs.size()) {
-        return false;
-    }
+    if (lhs.size() != rhs.size()) { return false; }
 
     for (int i = 0, end = lhs.size(); i < end; ++i) {
         if (lhs[i].key != rhs[i].key || lhs[i].settings_base != rhs[i].settings_base ||
@@ -1205,33 +1183,25 @@ bool MainWindow::settingValueSnapshotsEqual(const QVector<SettingValueSnapshot>&
             return false;
         }
 
-        if (lhs[i].existed && lhs[i].value != rhs[i].value) {
-            return false;
-        }
+        if (lhs[i].existed && lhs[i].value != rhs[i].value) { return false; }
     }
 
     return true;
 }
 
 void MainWindow::captureSettingChange(QString key, QList<QSharedPointer<SettingsBase>> settings_bases) {
-    if (m_applying_undo_redo || m_pending_setting_snapshots.contains(key)) {
-        return;
-    }
+    if (m_applying_undo_redo || m_pending_setting_snapshots.contains(key)) { return; }
 
     m_pending_setting_snapshots[key] = settingValueSnapshots(key, settings_bases);
 }
 
 void MainWindow::recordSettingChange(QString key) {
-    if (m_applying_undo_redo || !m_pending_setting_snapshots.contains(key)) {
-        return;
-    }
+    if (m_applying_undo_redo || !m_pending_setting_snapshots.contains(key)) { return; }
 
     QVector<SettingValueSnapshot> before = m_pending_setting_snapshots.take(key);
-    QStringList coupled_keys = m_pending_setting_snapshots.keys();
+    QStringList coupled_keys             = m_pending_setting_snapshots.keys();
     coupled_keys.sort();
-    for (const QString& coupled_key : coupled_keys) {
-        before.append(m_pending_setting_snapshots.take(coupled_key));
-    }
+    for (const QString& coupled_key : coupled_keys) { before.append(m_pending_setting_snapshots.take(coupled_key)); }
 
     QVector<SettingValueSnapshot> after;
     after.reserve(before.size());
@@ -1240,30 +1210,24 @@ void MainWindow::recordSettingChange(QString key) {
         settings_bases.push_back(snapshot.settings_base);
 
         const QVector<SettingValueSnapshot> current = settingValueSnapshots(snapshot.key, settings_bases);
-        if (!current.isEmpty()) {
-            after.push_back(current[0]);
-        }
+        if (!current.isEmpty()) { after.push_back(current[0]); }
     }
 
-    if (settingValueSnapshotsEqual(before, after)) {
-        return;
-    }
+    if (settingValueSnapshotsEqual(before, after)) { return; }
 
     m_undo_stack->push(new SettingValueUndoCommand(this, key, before, after));
 }
 
 void MainWindow::initializePartTransform(QSharedPointer<PartMetaItem> item) {
-    if (!item.isNull()) {
-        m_part_transform_snapshots[item] = partTransformSnapshot(item);
-    }
+    if (!item.isNull()) { m_part_transform_snapshots[item] = partTransformSnapshot(item); }
 }
 
-void MainWindow::removePartTransform(QSharedPointer<PartMetaItem> item) { m_part_transform_snapshots.remove(item); }
+void MainWindow::removePartTransform(QSharedPointer<PartMetaItem> item) {
+    m_part_transform_snapshots.remove(item);
+}
 
 void MainWindow::recordPartTransform(QSharedPointer<PartMetaItem> item) {
-    if (m_applying_undo_redo || item.isNull()) {
-        return;
-    }
+    if (m_applying_undo_redo || item.isNull()) { return; }
 
     const PartTransformSnapshot current = partTransformSnapshot(item);
     if (!m_part_transform_snapshots.contains(item)) {
@@ -1272,9 +1236,7 @@ void MainWindow::recordPartTransform(QSharedPointer<PartMetaItem> item) {
     }
 
     const PartTransformSnapshot before = m_part_transform_snapshots[item];
-    if (partTransformSnapshotsEqual(before, current)) {
-        return;
-    }
+    if (partTransformSnapshotsEqual(before, current)) { return; }
 
     m_undo_stack->push(new PartTransformUndoCommand(this, item, before, current));
     m_part_transform_snapshots[item] = current;
@@ -1381,8 +1343,7 @@ void MainWindow::doSlice() {
     m_gcodebar->clear();
     m_layertimebar->clear();
 
-    if (!CSM->isBuildMode())
-        return;
+    if (!CSM->isBuildMode()) return;
 
     m_slice_dialog.reset(new SliceDialog(this));
     connect(CSM.get(), &SessionManager::updateDialog, m_slice_dialog.get(),
@@ -1418,16 +1379,13 @@ void MainWindow::loadModel(MeshType mt) {
                                                   CSM->getMostRecentModelLocation(), model_filter);
     }
 
-    if (filepaths.isEmpty())
-        return;
+    if (filepaths.isEmpty()) return;
 
     QString statusMsg = "Loading model(s): " + filepaths.join("\n");
     m_cmdbar->append(statusMsg);
 
     // For each file in the selection, load it.
-    for (QString file : filepaths) {
-        CSM->loadModel(file, true, mt);
-    }
+    for (QString file : filepaths) { CSM->loadModel(file, true, mt); }
 }
 
 void MainWindow::loadPointCloud() {
@@ -1435,8 +1393,7 @@ void MainWindow::loadPointCloud() {
     QStringList filepaths =
         QFileDialog::getOpenFileNames(nullptr, QObject::tr("Open point cloud file"), CSM->getMostRecentModelLocation(),
                                       QObject::tr("Point Cloud (*.matrix *.xyz)"));
-    if (filepaths.isEmpty())
-        return;
+    if (filepaths.isEmpty()) return;
 
     QString statusMsg = "Loading model(s): " + filepaths.join("\n");
     m_cmdbar->append(statusMsg);
@@ -1444,8 +1401,7 @@ void MainWindow::loadPointCloud() {
     // Add parts/ load into graphics
     for (QString file : filepaths) {
         auto new_mesh = OpenMesh::BuildMeshFromPointCloud(file);
-        if (new_mesh != nullptr)
-            CSM->addPart(new_mesh);
+        if (new_mesh != nullptr) CSM->addPart(new_mesh);
     }
 }
 
@@ -1491,9 +1447,7 @@ void MainWindow::importGCodeHelper(QString filepath, bool alterFile) {
 
     connect(loader, &GCodeLoader::gcodeLoadedVisualization, this,
             [this](QVector<QVector<QSharedPointer<SegmentBase>>> segments) {
-                if (segments.empty()) {
-                    return;
-                }
+                if (segments.empty()) { return; }
 
                 m_gcodebar->setMaxLayer(qMax(segments.size() - 1, 0));
                 if (segments.size() > 1)
@@ -1510,7 +1464,9 @@ void MainWindow::importGCodeHelper(QString filepath, bool alterFile) {
     enableExportMenu();
 }
 
-void MainWindow::importFile(QString filepath, bool alterFile) { importGCodeHelper(filepath, alterFile); }
+void MainWindow::importFile(QString filepath, bool alterFile) {
+    importGCodeHelper(filepath, alterFile);
+}
 
 void MainWindow::updateStatus(QString status) {
     m_cmdbar->append(status);
@@ -1524,18 +1480,14 @@ bool MainWindow::saveSessionToSelectedFile(bool notifyOnSuccess, bool waitForSav
     save_dialog.setAcceptMode(QFileDialog::AcceptSave);
     save_dialog.setNameFilters(QStringList() << "ORNLSlicer Project File (*.s2p)" << "Any Files (*)");
     save_dialog.setDefaultSuffix("s2p");
-    if (!save_dialog.exec())
-        return false;
+    if (!save_dialog.exec()) return false;
 
     QString filename = save_dialog.selectedFiles().first();
-    if (filename.isEmpty())
-        return false;
-    if (selectedFile != nullptr)
-        *selectedFile = filename;
+    if (filename.isEmpty()) return false;
+    if (selectedFile != nullptr) *selectedFile = filename;
 
     SessionLoader* loader = CSM->saveSession(filename, true, notifyOnSuccess);
-    if (waitForSave)
-        loader->wait();
+    if (waitForSave) loader->wait();
 
     CSM->saveSession(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/_lastsession.s2p", false);
     updateSavedProjectState();
@@ -1546,27 +1498,25 @@ bool MainWindow::saveSessionToSelectedFile(bool notifyOnSuccess, bool waitForSav
 
 void MainWindow::saveSession() {
     QString filename;
-    if (!saveSessionToSelectedFile(true, false, &filename))
-        return;
+    if (!saveSessionToSelectedFile(true, false, &filename)) return;
 
     m_statusbar->showMessage("Session saved");
     m_cmdbar->append("Session saved: " + filename);
 }
 
 QString MainWindow::projectStateSnapshot() {
-    if (m_part_widget != nullptr)
-        m_part_widget->updatePartTransformations();
+    if (m_part_widget != nullptr) m_part_widget->updatePartTransformations();
 
     fifojson snapshot;
     snapshot[Constants::Settings::Session::Files::kSession] = CSM->partsJson();
-    snapshot[Constants::Settings::Session::Files::kGlobal] = GSM->globalJson();
+    snapshot[Constants::Settings::Session::Files::kGlobal]  = GSM->globalJson();
 
     fifojson local_settings = fifojson::array();
     for (auto& part : CSM->parts()) {
         fifojson part_json;
-        part_json[Constants::Settings::Session::LocalFile::kName] = part->name();
+        part_json[Constants::Settings::Session::LocalFile::kName]     = part->name();
         part_json[Constants::Settings::Session::LocalFile::kSettings] = part->getSb()->json();
-        part_json[Constants::Settings::Session::LocalFile::kRanges] = part->SettingsRangesToJson();
+        part_json[Constants::Settings::Session::LocalFile::kRanges]   = part->SettingsRangesToJson();
         local_settings.push_back(part_json);
     }
     snapshot[Constants::Settings::Session::Files::kLocal] = local_settings;
@@ -1576,24 +1526,23 @@ QString MainWindow::projectStateSnapshot() {
 
 void MainWindow::updateSavedProjectState() {
     m_saved_project_state = projectStateSnapshot();
-    m_project_modified = false;
+    m_project_modified    = false;
 }
 
-void MainWindow::markProjectModified() { m_project_modified = true; }
+void MainWindow::markProjectModified() {
+    m_project_modified = true;
+}
 
 bool MainWindow::hasUnsavedProjectChanges() {
-    if (!m_project_modified)
-        return false;
+    if (!m_project_modified) return false;
 
     return projectStateSnapshot() != m_saved_project_state;
 }
 
 bool MainWindow::confirmProjectClose() {
-    if (!PreferencesManager::getInstance()->getWarnUnsavedProjectOnClosePreference())
-        return true;
+    if (!PreferencesManager::getInstance()->getWarnUnsavedProjectOnClosePreference()) return true;
 
-    if (!hasUnsavedProjectChanges())
-        return true;
+    if (!hasUnsavedProjectChanges()) return true;
 
     QMessageBox dialog(this);
     dialog.setIcon(QMessageBox::Warning);
@@ -1622,12 +1571,10 @@ void MainWindow::loadSession() {
     load_dialog.setAcceptMode(QFileDialog::AcceptOpen);
     load_dialog.setNameFilters(QStringList() << "ORNLSlicer Project File (*.s2p)" << "Any Files (*)");
     load_dialog.setDefaultSuffix("s2p");
-    if (!load_dialog.exec())
-        return;
+    if (!load_dialog.exec()) return;
 
     QString filename = load_dialog.selectedFiles().first();
-    if (filename.isEmpty())
-        return;
+    if (filename.isEmpty()) return;
 
     SessionLoader* loader = loadASession(filename);
     if (loader != nullptr) {
@@ -1643,8 +1590,7 @@ void MainWindow::loadSession() {
 SessionLoader* MainWindow::loadASession(const QString& filename) {
     m_part_widget->clear();
     SessionLoader* loader = CSM->loadSession(true, filename);
-    if (loader != nullptr)
-        connect(loader, &SessionLoader::loadSucceeded, this, &MainWindow::updateSavedProjectState);
+    if (loader != nullptr) connect(loader, &SessionLoader::loadSucceeded, this, &MainWindow::updateSavedProjectState);
     return loader;
 }
 
@@ -1656,14 +1602,11 @@ void MainWindow::updateSettings(const QString& name) {
 
 void MainWindow::showAllSettings(QString key, QMenu* menu) {
     QList<QString> settings = PreferencesManager::getInstance()->getHiddenSettings(key);
-    for (QString setting : settings) {
-        this->removeHiddenSetting(menu, key, setting);
-    }
+    for (QString setting : settings) { this->removeHiddenSetting(menu, key, setting); }
 }
 
 void MainWindow::autoSave() {
-    if (m_status)
-        return;
+    if (m_status) return;
 
     if (CSM->parts().count() == 0) {
         qDebug() << "Not auto saving session - no part exists";
@@ -1673,14 +1616,12 @@ void MainWindow::autoSave() {
     QString homePathStr = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QDir homePath(homePathStr);
     try {
-        if (!homePath.exists())
-            QDir().mkpath(homePathStr);
+        if (!homePath.exists()) QDir().mkpath(homePathStr);
     } catch (...) { qWarning() << "Check your path, cannot create directory:" + homePathStr; }
     CSM->saveSession(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/_lastsession.s2p", false);
 }
 
 void MainWindow::autoLoad() {
-
     QString filename = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/_lastsession.s2p";
     QFileInfo file(filename);
     if (!file.exists() || !file.isFile()) {
@@ -1695,12 +1636,13 @@ void MainWindow::autoLoad() {
 
 // New Project: delete all existing loaded parts, start from scratch
 //   it does not replace the existing settings though
-void MainWindow::createProject() { m_part_widget->clear(); }
+void MainWindow::createProject() {
+    m_part_widget->clear();
+}
 
 void MainWindow::saveTemplate() {
     TemplateSaveDialog dialog;
-    if (!dialog.exec())
-        return;
+    if (!dialog.exec()) return;
 
     GSM->saveTemplate(dialog.keys(), dialog.filename(), dialog.name());
     GSM->loadGlobalJson(dialog.filename());
@@ -1716,19 +1658,16 @@ void MainWindow::loadTemplate() {
     load_dialog.setNameFilters(QStringList() << "ORNLSlicer Configuration/Template File (*.s2c)"
                                              << "Any Files (*)");
     load_dialog.setDefaultSuffix("s2c");
-    if (!load_dialog.exec())
-        return;
+    if (!load_dialog.exec()) return;
 
     QString filename = load_dialog.selectedFiles().first();
-    if (filename.isEmpty())
-        return;
+    if (filename.isEmpty()) return;
 
     loadTemplateFile(filename);
 }
 
 void MainWindow::loadTemplateFile(const QString& filename) {
-    if (filename.isEmpty())
-        return;
+    if (filename.isEmpty()) return;
 
     GSM->loadGlobalJson(filename);
     QFileInfo fileInfo(filename);
@@ -1736,13 +1675,11 @@ void MainWindow::loadTemplateFile(const QString& filename) {
     QStringList tabs {Constants::Settings::SettingTab::kPrinter, Constants::Settings::SettingTab::kMaterial,
                       Constants::Settings::SettingTab::kProfile, Constants::Settings::SettingTab::kExperimental};
 
-    for (QString tab : tabs)
-        GSM->constructActiveGlobal(tab, actualFilename);
+    for (QString tab : tabs) GSM->constructActiveGlobal(tab, actualFilename);
 
     QMap<QString, QMap<QString, QSharedPointer<SettingsBase>>> allGlobalCopy = GSM->getAllGlobals();
     for (int i = tabs.size() - 1; i >= 0; --i) {
-        if (!allGlobalCopy[tabs[i]].contains(actualFilename))
-            tabs.removeAt(i);
+        if (!allGlobalCopy[tabs[i]].contains(actualFilename)) tabs.removeAt(i);
     }
     m_settingbar->displayNewSetting(tabs, actualFilename);
     markProjectModified();
@@ -1750,8 +1687,7 @@ void MainWindow::loadTemplateFile(const QString& filename) {
 
 void MainWindow::convertGcodeToS2C() {
     GcodeToS2CDialog dialog(this);
-    if (!dialog.exec())
-        return;
+    if (!dialog.exec()) return;
 
     loadTemplateFile(dialog.outputFilePath());
 }
@@ -1762,12 +1698,10 @@ void MainWindow::setSettingFolder() {
     load_dialog.setWindowTitle("Select Directory");
     load_dialog.setAcceptMode(QFileDialog::AcceptOpen);
 
-    if (!load_dialog.exec())
-        return;
+    if (!load_dialog.exec()) return;
 
     QString path = load_dialog.selectedFiles().first() + "/";
-    if (path.isEmpty())
-        return;
+    if (path.isEmpty()) return;
 
     CSM->setMostRecentSettingFolderLocation(path);
     GSM->loadAllGlobals(path);
@@ -1781,12 +1715,10 @@ void MainWindow::setLayerBarSettingFolder() {
     load_dialog.setWindowTitle("Select Directory");
     load_dialog.setAcceptMode(QFileDialog::AcceptOpen);
 
-    if (!load_dialog.exec())
-        return;
+    if (!load_dialog.exec()) return;
 
     QString path = load_dialog.selectedFiles().first() + "/";
-    if (path.isEmpty())
-        return;
+    if (path.isEmpty()) return;
 
     CSM->setMostRecentLayerBarSettingFolderLocation(path);
     GSM->loadLayerBarTemplate(path);
@@ -1809,7 +1741,9 @@ void MainWindow::setLock(bool lock) {
     m_gcodebar->setDisabled(lock);
 }
 
-void MainWindow::setTitleInfo(const QString& str) { this->setWindowTitle(str); }
+void MainWindow::setTitleInfo(const QString& str) {
+    this->setWindowTitle(str);
+}
 
 void MainWindow::enableSelectionMenu(bool partSelected) {
     m_actions["reload"].action->setEnabled(partSelected);
@@ -1817,9 +1751,13 @@ void MainWindow::enableSelectionMenu(bool partSelected) {
     m_actions["copy"].action->setEnabled(partSelected);
 }
 
-void MainWindow::enableSliceMenu(bool partExists) { m_actions["slice"].action->setEnabled(partExists); }
+void MainWindow::enableSliceMenu(bool partExists) {
+    m_actions["slice"].action->setEnabled(partExists);
+}
 
-void MainWindow::enableExportBuildLogMenu() { m_actions["build_log"].action->setEnabled(true); }
+void MainWindow::enableExportBuildLogMenu() {
+    m_actions["build_log"].action->setEnabled(true);
+}
 
 void MainWindow::enableExportMenu() {
     m_actions["gcode_export"].action->setEnabled(true);
@@ -1832,4 +1770,4 @@ void MainWindow::showGCodeKeyInfo(QString msg) {
 
     m_cmdbar->append(msg);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/preferences_window.cpp
+++ b/src/windows/preferences_window.cpp
@@ -1,7 +1,5 @@
 #include "windows/preferences_window.h"
 
-#include <algorithm>
-
 #include <QFileDialog>
 #include <QGridLayout>
 #include <QLabel>
@@ -11,6 +9,8 @@
 #include <QSpinBox>
 #include <QStandardPaths>
 #include <QTabWidget>
+#include <algorithm>
+
 #include <qboxlayout.h>
 #include <qcheckbox.h>
 #include <qcombobox.h>
@@ -193,8 +193,8 @@ void PreferencesWindow::setupLayout() {
     m_notifications_tab_layout->addWidget(fileshiftBox, 1, 0);
     m_boxes.push_back(fileshiftBox);
 
-    QGroupBox* unsavedProjectCloseBox = new QGroupBox("Close Project");
-    QVBoxLayout* unsavedProjectCloseLayout = new QVBoxLayout();
+    QGroupBox* unsavedProjectCloseBox        = new QGroupBox("Close Project");
+    QVBoxLayout* unsavedProjectCloseLayout   = new QVBoxLayout();
     m_warn_unsaved_project_on_close_checkbox = new QCheckBox("Warn before closing unsaved projects");
     m_warn_unsaved_project_on_close_checkbox->setChecked(
         m_preferences_manager->getWarnUnsavedProjectOnClosePreference());
@@ -364,8 +364,8 @@ QGroupBox* PreferencesWindow::createContainer(PreferenceChoice choice, QList<QSt
                                               void (PreferencesWindow::*func)(PreferenceChoice)) {
     QGroupBox* groupBox = new QGroupBox(displayStrings[0]);
 
-    QRadioButton* m_ask_radio_button = new QRadioButton(displayStrings[1]);
-    QRadioButton* m_do_automatically_radio_button = new QRadioButton(displayStrings[2]);
+    QRadioButton* m_ask_radio_button                = new QRadioButton(displayStrings[1]);
+    QRadioButton* m_do_automatically_radio_button   = new QRadioButton(displayStrings[2]);
     QRadioButton* m_skip_automatically_radio_button = new QRadioButton(displayStrings[3]);
 
     if (choice == PreferenceChoice::kAsk)
@@ -465,8 +465,7 @@ void PreferencesWindow::setupEvents() {
 
 void PreferencesWindow::closeEvent(QCloseEvent* event) {
     // if window closed and changes made, save them
-    if (m_preferences_manager->isDirty())
-        m_preferences_manager->exportPreferences();
+    if (m_preferences_manager->isDirty()) m_preferences_manager->exportPreferences();
 
     // m_window_manager->removePreferencesWindow();
     event->accept();
@@ -576,9 +575,7 @@ void PreferencesWindow::exportPreferences() {
     QString filepath = QFileDialog::getSaveFileName(this, "Save .preferences file",
                                                     QStandardPaths::writableLocation(QStandardPaths::DesktopLocation),
                                                     "*.preferences");
-    if (!filepath.isNull()) {
-        m_preferences_manager->exportPreferences(filepath);
-    }
+    if (!filepath.isNull()) { m_preferences_manager->exportPreferences(filepath); }
 }
 
 void PreferencesWindow::shiftProjectPreferenceChanged(PreferenceChoice shift) {
@@ -592,4 +589,4 @@ void PreferencesWindow::shiftFilePreferenceChanged(PreferenceChoice shift) {
 void PreferencesWindow::alignPreferenceChanged(PreferenceChoice align) {
     m_preferences_manager->setAlignPreference(align);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/windows/xtrudecalc.cpp
+++ b/src/windows/xtrudecalc.cpp
@@ -1,6 +1,7 @@
 #include "windows/xtrudecalc.h"
 
 #include <QApplication>
+
 #include <qcombobox.h>
 #include <qcontainerfwd.h>
 #include <qfont.h>
@@ -32,14 +33,14 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     m_mass_pref = PreferencesManager::getInstance()->getMassUnit();
     m_velo_pref = PreferencesManager::getInstance()->getVelocityUnit();
 
-    m_time_text = "(" + PreferencesManager::getInstance()->getTimeUnitText() + "):";
-    m_dist_text = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "):";
-    m_mass_text = "(" + PreferencesManager::getInstance()->getMassUnitText() + "):";
+    m_time_text    = "(" + PreferencesManager::getInstance()->getTimeUnitText() + "):";
+    m_dist_text    = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "):";
+    m_mass_text    = "(" + PreferencesManager::getInstance()->getMassUnitText() + "):";
     m_density_text = "(" + PreferencesManager::getInstance()->getMassUnitText() + "/" +
                      PreferencesManager::getInstance()->getDistanceUnitText() + "³):";
     m_spindle_text = "(rev/" + PreferencesManager::getInstance()->getTimeUnitText() + "):";
-    m_feed_text = "(" + PreferencesManager::getInstance()->getVelocityUnitText() + "):";
-    m_fpr_text = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "/rev):";
+    m_feed_text    = "(" + PreferencesManager::getInstance()->getVelocityUnitText() + "):";
+    m_fpr_text     = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "/rev):";
 
     // setFixedSize(420,260);
     setWindowTitle(QApplication::applicationDisplayName() + ": Xtrude Calculator");
@@ -48,22 +49,22 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     setWindowIcon(icon);
 
     // Printing Parameter Section
-    m_layout = new QGridLayout();
+    m_layout                = new QGridLayout();
     QLabel* lbl_PrintParams = new QLabel("Printing Parameters");
     QFont titleFont("Arial", 10, QFont::Bold);
     lbl_PrintParams->setFont(titleFont);
     m_layout->addWidget(lbl_PrintParams, 0, 0, 1, 2);
 
     QLabel* lbl_materialType = new QLabel("Material Type:");
-    QStringList commands = {"20% CF-ABS", "ABS",         "PPS", "50% CF-PPS", "PPSU", "25% CF-PPSU",
-                            "PESU",       "25% CF-PESU", "PLA", "Concrete",   "Other"};
-    m_material_type = new QComboBox();
+    QStringList commands     = {"20% CF-ABS", "ABS",         "PPS", "50% CF-PPS", "PPSU", "25% CF-PPSU",
+                                "PESU",       "25% CF-PESU", "PLA", "Concrete",   "Other"};
+    m_material_type          = new QComboBox();
     m_material_type->addItems(commands);
     m_layout->addWidget(lbl_materialType, 1, 0);
     m_layout->addWidget(m_material_type, 1, 1);
 
     m_density_label = new QLabel("Density " + m_density_text);
-    m_density = new QLineEdit();
+    m_density       = new QLineEdit();
     m_density->setReadOnly(true);
     m_density->setText(QString::number(toDensityValue(PrintMaterial::kABS20CF)() / m_dens_pref(), 'g', 5));
     m_density->setEnabled(false);
@@ -71,32 +72,32 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     m_layout->addWidget(m_density, 2, 1);
 
     m_spindle_speed_label = new QLabel("Test Spindle Speed " + m_spindle_text);
-    m_spindle_speed = new QLineEdit();
+    m_spindle_speed       = new QLineEdit();
     m_layout->addWidget(m_spindle_speed_label, 3, 0);
     m_layout->addWidget(m_spindle_speed, 3, 1);
 
     m_2mtm_label = new QLabel("2 Minute Test Mass " + m_mass_text);
-    m_2mtm = new QLineEdit();
+    m_2mtm       = new QLineEdit();
     m_layout->addWidget(m_2mtm_label, 4, 0);
     m_layout->addWidget(m_2mtm, 4, 1);
 
     m_min_layer_time_label = new QLabel("Minimum Layer Time " + m_time_text);
-    m_min_layer_time = new QLineEdit();
+    m_min_layer_time       = new QLineEdit();
     m_layout->addWidget(m_min_layer_time_label, 5, 0);
     m_layout->addWidget(m_min_layer_time, 5, 1);
 
     m_layer_height_label = new QLabel("Layer Height " + m_dist_text);
-    m_layer_height = new QLineEdit();
+    m_layer_height       = new QLineEdit();
     m_layout->addWidget(m_layer_height_label, 6, 0);
     m_layout->addWidget(m_layer_height, 6, 1);
 
     m_bead_width_label = new QLabel("Bead Width " + m_dist_text);
-    m_bead_width = new QLineEdit();
+    m_bead_width       = new QLineEdit();
     m_layout->addWidget(m_bead_width_label, 7, 0);
     m_layout->addWidget(m_bead_width, 7, 1);
 
     m_fpr_label = new QLabel("FPR " + m_fpr_text);
-    m_fpr = new QLineEdit();
+    m_fpr       = new QLineEdit();
     m_layout->addWidget(m_fpr_label, 9, 0);
     m_layout->addWidget(m_fpr, 9, 1);
     m_fpr->setEnabled(false);
@@ -107,19 +108,19 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     m_layout->addWidget(lbl_Option1, 0, 3, 1, 2);
 
     m_toolpath_length_label = new QLabel("Toolpath Length " + m_dist_text);
-    m_toolpath_length = new QLineEdit();
+    m_toolpath_length       = new QLineEdit();
     m_layout->addWidget(m_toolpath_length_label, 1, 3);
     m_layout->addWidget(m_toolpath_length, 1, 4);
 
     m_o1_feed_rate_label = new QLabel("Feed Rate " + m_feed_text);
-    m_o1_feed_rate = new QLineEdit();
+    m_o1_feed_rate       = new QLineEdit();
     m_o1_feed_rate->setReadOnly(true);
     m_layout->addWidget(m_o1_feed_rate_label, 2, 3);
     m_layout->addWidget(m_o1_feed_rate, 2, 4);
     m_o1_feed_rate->setEnabled(false);
 
     m_o1_spindle_speed_label = new QLabel("Spindle Speed " + m_spindle_text);
-    m_o1_spindle_speed = new QLineEdit();
+    m_o1_spindle_speed       = new QLineEdit();
     ;
     m_o1_spindle_speed->setReadOnly(true);
     m_layout->addWidget(m_o1_spindle_speed_label, 3, 3);
@@ -132,12 +133,12 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     m_layout->addWidget(lbl_Option2, 4, 3, 1, 2);
 
     m_d_spindle_speed_label = new QLabel("Desired Spindle Speed " + m_spindle_text);
-    m_d_spindle_speed = new QLineEdit();
+    m_d_spindle_speed       = new QLineEdit();
     m_layout->addWidget(m_d_spindle_speed_label, 5, 3);
     m_layout->addWidget(m_d_spindle_speed, 5, 4);
 
     m_o2_feed_rate_label = new QLabel("Feed Rate " + m_feed_text);
-    m_o2_feed_rate = new QLineEdit();
+    m_o2_feed_rate       = new QLineEdit();
     m_o2_feed_rate->setReadOnly(true);
     m_layout->addWidget(m_o2_feed_rate_label, 6, 3);
     m_layout->addWidget(m_o2_feed_rate, 6, 4);
@@ -149,19 +150,20 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     m_layout->addWidget(lbl_Option3, 7, 3, 1, 2);
 
     m_d_feed_rate_label = new QLabel("Desired Feed Rate " + m_feed_text);
-    m_d_feed_rate = new QLineEdit();
+    m_d_feed_rate       = new QLineEdit();
     m_layout->addWidget(m_d_feed_rate_label, 8, 3);
     m_layout->addWidget(m_d_feed_rate, 8, 4);
 
     m_o3_spindle_speed_label = new QLabel("Spindle Speed " + m_spindle_text);
-    m_o3_spindle_speed = new QLineEdit();
+    m_o3_spindle_speed       = new QLineEdit();
     m_o3_spindle_speed->setReadOnly(true);
     m_layout->addWidget(m_o3_spindle_speed_label, 9, 3);
     m_layout->addWidget(m_o3_spindle_speed, 9, 4);
     m_o3_spindle_speed->setEnabled(false);
 
-    QLabel* lbl_Option4 = new QLabel("(You can also use the FPR (i.e. feed per tooth with 1 tooth or simply feed per "
-                                     "rev) as your feed in Option 3)");
+    QLabel* lbl_Option4 = new QLabel(
+        "(You can also use the FPR (i.e. feed per tooth with 1 tooth or simply feed per "
+        "rev) as your feed in Option 3)");
     lbl_Option4->setWordWrap(true);
     lbl_Option4->setStyleSheet("QLabel { color : blue; }");
     m_layout->addWidget(lbl_Option4, 10, 3, 2, 2);
@@ -177,14 +179,14 @@ XtrudeCalcWindow::XtrudeCalcWindow(QWidget* parent) : QWidget() {
     genDirections->setFont(titleFont);
     m_layout->addWidget(genDirections, 13, 3);
 
-    m_directions =
-        new QLabel("Run a 2 minute test with a set spindle speed onto a scale. Input the results for the spindle "
-                   "speed, mass, density, and minimum layer time "
-                   "under Printing Parameters along with a desired bead width and layer height. Once all the data is "
-                   "entered, fill out an option to recieve a spindle speed and/or "
-                   "feed rate based on calculations from your entered data. Note that all units are based off user "
-                   "preferences and will change if preferences are modified whether "
-                   "the Xtrude calculator is opened or closed, and any entered data will become less precise.");
+    m_directions = new QLabel(
+        "Run a 2 minute test with a set spindle speed onto a scale. Input the results for the spindle "
+        "speed, mass, density, and minimum layer time "
+        "under Printing Parameters along with a desired bead width and layer height. Once all the data is "
+        "entered, fill out an option to recieve a spindle speed and/or "
+        "feed rate based on calculations from your entered data. Note that all units are based off user "
+        "preferences and will change if preferences are modified whether "
+        "the Xtrude calculator is opened or closed, and any entered data will become less precise.");
     m_directions->setWordWrap(true);
     m_directions->setAlignment(Qt::AlignTop);
     m_layout->addWidget(m_directions, 14, 3, 5, 2);
@@ -257,9 +259,7 @@ void XtrudeCalcWindow::checkUnitPref() {
     }
 
     check = m_2mtm->text().toDouble(&textOkay);
-    if (textOkay && !m_2mtm->text().isEmpty()) {
-        m_2mtm->setText(QString::number(check * m_mass_conv, 'g', 5));
-    }
+    if (textOkay && !m_2mtm->text().isEmpty()) { m_2mtm->setText(QString::number(check * m_mass_conv, 'g', 5)); }
 
     check = m_layer_height->text().toDouble(&textOkay);
     if (textOkay && !m_layer_height->text().isEmpty()) {
@@ -306,14 +306,14 @@ void XtrudeCalcWindow::checkUnitPref() {
     m_velo_pref = PreferencesManager::getInstance()->getVelocityUnit();
 
     // Rebuilds strings using new unit preferences
-    m_time_text = "(" + PreferencesManager::getInstance()->getTimeUnitText() + "):";
-    m_dist_text = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "):";
-    m_mass_text = "(" + PreferencesManager::getInstance()->getMassUnitText() + "):";
+    m_time_text    = "(" + PreferencesManager::getInstance()->getTimeUnitText() + "):";
+    m_dist_text    = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "):";
+    m_mass_text    = "(" + PreferencesManager::getInstance()->getMassUnitText() + "):";
     m_density_text = "(" + PreferencesManager::getInstance()->getMassUnitText() + "/" +
                      PreferencesManager::getInstance()->getDistanceUnitText() + "³):";
     m_spindle_text = "(rev/" + PreferencesManager::getInstance()->getTimeUnitText() + "):";
-    m_feed_text = "(" + PreferencesManager::getInstance()->getVelocityUnitText() + "):";
-    m_fpr_text = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "/rev):";
+    m_feed_text    = "(" + PreferencesManager::getInstance()->getVelocityUnitText() + "):";
+    m_fpr_text     = "(" + PreferencesManager::getInstance()->getDistanceUnitText() + "/rev):";
 
     // Rebuilds labels using strings
     m_density_label->setText("Density " + m_density_text);
@@ -370,8 +370,8 @@ void XtrudeCalcWindow::checkInputAndCalculate() {
     // check each user input field
     bool textOkay;
     bool toolpathok = true;
-    bool feedok = true;
-    bool spindok = true;
+    bool feedok     = true;
+    bool spindok    = true;
 
     double v_beadWidth;
     double v_layerHeight;
@@ -427,20 +427,18 @@ void XtrudeCalcWindow::checkInputAndCalculate() {
     double timeMod = PreferencesManager::getInstance()->getTimeUnit()() / minute();
     double disttimevelo =
         PreferencesManager::getInstance()->getDistanceUnit()() / PreferencesManager::getInstance()->getTimeUnit()();
-    double veloMod = PreferencesManager::getInstance()->getVelocityUnit()() / disttimevelo;
-    double massCalc = v_2mtm * timeMod / 2;
+    double veloMod              = PreferencesManager::getInstance()->getVelocityUnit()() / disttimevelo;
+    double massCalc             = v_2mtm * timeMod / 2;
     double extrusionCoefficient = massCalc / v_spindleSpeed;
-    double FPR = extrusionCoefficient / (v_density * v_layerHeight * v_beadWidth);
+    double FPR                  = extrusionCoefficient / (v_density * v_layerHeight * v_beadWidth);
     m_fpr->setText(QString::number(FPR, 'g', 5));
 
     // Option 1 check
     v_toolpathLength = m_toolpath_length->text().toDouble(&textOkay);
-    if (!textOkay && !m_toolpath_length->text().isEmpty()) {
-        toolpathok = false;
-    }
+    if (!textOkay && !m_toolpath_length->text().isEmpty()) { toolpathok = false; }
 
     else if (!m_toolpath_length->text().isEmpty()) {
-        o1feedRate = v_toolpathLength / (v_minLayerTime);
+        o1feedRate     = v_toolpathLength / (v_minLayerTime);
         o1spindleSpeed = o1feedRate / FPR;
         m_o1_feed_rate->setText(QString::number(o1feedRate / veloMod, 'g', 5));
         m_o1_spindle_speed->setText(QString::number(o1spindleSpeed, 'g', 5));
@@ -448,9 +446,7 @@ void XtrudeCalcWindow::checkInputAndCalculate() {
 
     // Option 2 check
     v_dSpindleSpeed = m_d_spindle_speed->text().toDouble(&textOkay);
-    if (!textOkay && !m_d_spindle_speed->text().isEmpty()) {
-        spindok = false;
-    }
+    if (!textOkay && !m_d_spindle_speed->text().isEmpty()) { spindok = false; }
 
     else if (!m_d_spindle_speed->text().isEmpty()) {
         o2feedRate = v_dSpindleSpeed * FPR;
@@ -459,9 +455,7 @@ void XtrudeCalcWindow::checkInputAndCalculate() {
 
     // Option 3 check
     v_dFeedRate = m_d_feed_rate->text().toDouble(&textOkay);
-    if (!textOkay && !m_d_feed_rate->text().isEmpty()) {
-        feedok = false;
-    }
+    if (!textOkay && !m_d_feed_rate->text().isEmpty()) { feedok = false; }
 
     else if (!m_d_feed_rate->text().isEmpty()) {
         o3spindleSpeed = v_dFeedRate / FPR;
@@ -504,10 +498,8 @@ void XtrudeCalcWindow::closeEvent(QCloseEvent* event) {
     m_material_type->setCurrentIndex(0);
 
     // set the focus back to the main window
-    if (m_parent->isMinimized()) {
-        m_parent->showNormal();
-    }
+    if (m_parent->isMinimized()) { m_parent->showNormal(); }
     // setFocus() doesn't deliver, but activateWindow() serves the purpose
     m_parent->activateWindow();
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -1,13 +1,12 @@
+#include <QCoreApplication>
+#include <QSharedPointer>
+#include <QStringList>
+#include <QVector3D>
 #include <cmath>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
 #include <optional>
-
-#include <QCoreApplication>
-#include <QSharedPointer>
-#include <QStringList>
-#include <QVector3D>
 
 #include "configs/settings_base.h"
 #include "gcode/arc_specialties_axis_inference.h"
@@ -20,8 +19,7 @@
 
 namespace {
 bool expect(bool condition, const char* message) {
-    if (!condition)
-        std::cerr << message << '\n';
+    if (!condition) std::cerr << message << '\n';
     return condition;
 }
 
@@ -88,7 +86,7 @@ bool writesInlineArcOptionalStop() {
     const ORNL::Point end(1.0 * ORNL::mm, 0.0 * ORNL::mm);
     const ORNL::Point center(0.5 * ORNL::mm, 0.0 * ORNL::mm);
 
-    const QString first_arc = writer.writeArc(start, end, center, 180.0 * ORNL::degree, false, segment_settings);
+    const QString first_arc  = writer.writeArc(start, end, center, 180.0 * ORNL::degree, false, segment_settings);
     const QString second_arc = writer.writeArc(start, end, center, 180.0 * ORNL::degree, false, segment_settings);
 
     return first_arc.contains("F600.0000 G81 ;") && second_arc.contains("F600.0000 G81 ;") &&
@@ -128,17 +126,19 @@ bool writesCompactCylindricalPrintComments() {
 
 QString lineContaining(const QString& block, const QString& marker) {
     for (const QString& line : block.split('\n', Qt::SkipEmptyParts)) {
-        if (line.contains(marker)) {
-            return line;
-        }
+        if (line.contains(marker)) { return line; }
     }
 
     return QString();
 }
 
-int occurrenceCount(const QString& block, const QString& marker) { return block.count(marker); }
+int occurrenceCount(const QString& block, const QString& marker) {
+    return block.count(marker);
+}
 
-bool near(double actual, double expected) { return std::abs(actual - expected) <= 1e-6; }
+bool near(double actual, double expected) {
+    return std::abs(actual - expected) <= 1e-6;
+}
 
 bool infersLeftHandedHelicalAxisFromReversedCpDelta() {
     ORNL::Point center;
@@ -171,7 +171,7 @@ bool writesFirstTravelWithWorkObjectToolFrame() {
                                                     ORNL::TravelLiftType::kNoLift, settings);
 
     const QString world_approach_line = lineContaining(travel_block, ";WORLD APPROACH TRAVEL");
-    const QString first_travel_line = lineContaining(travel_block, ";TRAVEL");
+    const QString first_travel_line   = lineContaining(travel_block, ";TRAVEL");
 
     return world_approach_line.contains("ZR=-90.0000") && first_travel_line.contains("ZR=-135.0000");
 }
@@ -240,7 +240,7 @@ bool writesCylindricalTravelWithConfiguredArcDensity() {
 
     return occurrenceCount(travel_block, ";TRAVEL ARC") == 4;
 }
-} // namespace
+}  // namespace
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);

--- a/tests/as_printed_model_exporter_tests.cpp
+++ b/tests/as_printed_model_exporter_tests.cpp
@@ -1,10 +1,3 @@
-#include <algorithm>
-#include <cmath>
-#include <cstdlib>
-#include <iostream>
-#include <limits>
-#include <string>
-
 #include <QByteArray>
 #include <QColor>
 #include <QCoreApplication>
@@ -16,6 +9,12 @@
 #include <QTemporaryDir>
 #include <QTextStream>
 #include <QVector>
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <string>
 
 #include "gcode/as_printed_model_exporter.h"
 #include "geometry/point.h"
@@ -25,11 +24,11 @@
 #include "utilities/enums.h"
 
 namespace {
-constexpr float kLength = 10.0f;
-constexpr float kWidth = 2.0f;
-constexpr float kHeight = 1.0f;
+constexpr float kLength             = 10.0f;
+constexpr float kWidth              = 2.0f;
+constexpr float kHeight             = 1.0f;
 constexpr float kCenterlineDiameter = 0.1f;
-constexpr float kTolerance = 0.001f;
+constexpr float kTolerance          = 0.001f;
 
 struct Bounds {
     QVector3D min = QVector3D(std::numeric_limits<float>::max(), std::numeric_limits<float>::max(),
@@ -39,8 +38,7 @@ struct Bounds {
 };
 
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
@@ -67,9 +65,7 @@ Bounds boundsFor(const std::vector<ORNL::AsPrintedModelExporter::Triangle>& tria
 
 QVector3D normalFor(const ORNL::AsPrintedModelExporter::Triangle& triangle) {
     QVector3D normal = QVector3D::crossProduct(triangle.b - triangle.a, triangle.c - triangle.a);
-    if (normal.lengthSquared() > std::numeric_limits<float>::epsilon()) {
-        normal.normalize();
-    }
+    if (normal.lengthSquared() > std::numeric_limits<float>::epsilon()) { normal.normalize(); }
     return normal;
 }
 
@@ -86,9 +82,9 @@ QSharedPointer<ORNL::SegmentBase> makeArcSegment(const ORNL::Point& start, const
 
 QSharedPointer<ORNL::SegmentBase> makeLineSegment(const ORNL::Point& start, const ORNL::Point& end, uint line_number,
                                                   ORNL::SegmentDisplayType type = ORNL::SegmentDisplayType::kLine,
-                                                  bool deposition_active = true) {
+                                                  bool deposition_active        = true) {
     const float scale = ORNL::Constants::OpenGL::kObjectToView;
-    auto segment = QSharedPointer<ORNL::LineSegment>::create(start * scale, end * scale);
+    auto segment      = QSharedPointer<ORNL::LineSegment>::create(start * scale, end * scale);
     segment->setDisplayInfo(kWidth * ORNL::mm() * scale, start.distance(end)() * scale, kHeight * ORNL::mm() * scale,
                             type, QColor(255, 255, 255), line_number, 0);
     segment->setDepositionActive(deposition_active);
@@ -104,19 +100,20 @@ QSharedPointer<ORNL::SegmentBase> makeLineSegment(ORNL::SegmentDisplayType type,
 QSharedPointer<ORNL::SegmentBase> makeArcSegment(const ORNL::Point& start, const ORNL::Point& end,
                                                  const ORNL::Point& center, uint line_number, bool deposition_active) {
     const float scale = ORNL::Constants::OpenGL::kObjectToView;
-    auto segment = QSharedPointer<ORNL::ArcSegment>::create(start * scale, end * scale, center * scale, true);
+    auto segment      = QSharedPointer<ORNL::ArcSegment>::create(start * scale, end * scale, center * scale, true);
     segment->setDisplayInfo(kWidth * ORNL::mm() * scale, start.distance(end)() * scale, kHeight * ORNL::mm() * scale,
                             ORNL::SegmentDisplayType::kLine, QColor(255, 255, 255), line_number, 0);
     segment->setDepositionActive(deposition_active);
     return segment;
 }
 
-int countFacets(const QString& text) { return text.count(QStringLiteral("facet normal")); }
+int countFacets(const QString& text) {
+    return text.count(QStringLiteral("facet normal"));
+}
 
 bool readFile(const QString& path, QString& text) {
     QFile file(path);
-    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
-        return false;
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return false;
 
     QTextStream in(&file);
     text = in.readAll();
@@ -125,22 +122,20 @@ bool readFile(const QString& path, QString& text) {
 
 bool readBytes(const QString& path, QByteArray& bytes) {
     QFile file(path);
-    if (!file.open(QIODevice::ReadOnly))
-        return false;
+    if (!file.open(QIODevice::ReadOnly)) return false;
 
     bytes = file.readAll();
     return true;
 }
 
 quint32 binaryFacetCount(const QByteArray& bytes) {
-    if (bytes.size() < 84)
-        return 0;
+    if (bytes.size() < 84) return 0;
 
     const auto* data = reinterpret_cast<const uchar*>(bytes.constData() + 80);
     return static_cast<quint32>(data[0]) | (static_cast<quint32>(data[1]) << 8) |
            (static_cast<quint32>(data[2]) << 16) | (static_cast<quint32>(data[3]) << 24);
 }
-} // namespace
+}  // namespace
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);
@@ -163,8 +158,8 @@ int main(int argc, char* argv[]) {
 
     ORNL::AsPrintedModelExporter::Options include_all;
     include_all.include_support = true;
-    include_all.include_travel = true;
-    const auto all_triangles = ORNL::AsPrintedModelExporter::generateTriangles(mixed_segments, include_all);
+    include_all.include_travel  = true;
+    const auto all_triangles    = ORNL::AsPrintedModelExporter::generateTriangles(mixed_segments, include_all);
     passed &= expect(all_triangles.size() == printable_triangles.size() * 3,
                      "Expected optional support and travel output to include all three segments.");
 
@@ -199,9 +194,7 @@ int main(int argc, char* argv[]) {
         const QVector3D centroid = (triangle.a + triangle.b + triangle.c) / 3.0f;
         QVector3D outward(0.0f, centroid.y() - (kCenterlineDiameter / 2.0f),
                           centroid.z() - (kCenterlineDiameter / 2.0f));
-        if (outward.lengthSquared() <= std::numeric_limits<float>::epsilon()) {
-            continue;
-        }
+        if (outward.lengthSquared() <= std::numeric_limits<float>::epsilon()) { continue; }
         outward.normalize();
 
         passed &= expect(QVector3D::dotProduct(normal, outward) > 0.0f,
@@ -217,7 +210,7 @@ int main(int argc, char* argv[]) {
     QVector<QVector<QSharedPointer<ORNL::SegmentBase>>> radial_segments;
     radial_segments.push_back({radial_segment});
     const auto radial_triangles = ORNL::AsPrintedModelExporter::generateTriangles(radial_segments);
-    const Bounds radial_bounds = boundsFor(radial_triangles);
+    const Bounds radial_bounds  = boundsFor(radial_triangles);
     passed &= expect(near(radial_bounds.max.x() - radial_bounds.min.x(), kHeight),
                      "Expected cylindrical bead radial thickness to match bead height.");
     passed &= expect(near(radial_bounds.max.z() - radial_bounds.min.z(), kWidth),
@@ -230,7 +223,7 @@ int main(int argc, char* argv[]) {
     transformed_axis_segment->rotate(QQuaternion::fromAxisAndAngle(QVector3D(0.0f, 0.0f, 1.0f), 90.0f));
     transformed_axis_segment->shift(pointFromMm(3.0f, 4.0f) * ORNL::Constants::OpenGL::kObjectToView);
     const ORNL::Point transformed_axis = transformed_axis_segment->cylindricalBeadCenter();
-    const ORNL::Point expected_axis = pointFromMm(1.0f, 5.0f) * ORNL::Constants::OpenGL::kObjectToView;
+    const ORNL::Point expected_axis    = pointFromMm(1.0f, 5.0f) * ORNL::Constants::OpenGL::kObjectToView;
     passed &= expect(near(transformed_axis.x(), expected_axis.x()) && near(transformed_axis.y(), expected_axis.y()),
                      "Expected transformed segments to carry the cylindrical bead center.");
 
@@ -239,7 +232,7 @@ int main(int argc, char* argv[]) {
     const ORNL::Point lfam_end(136.0f * ORNL::in(), 42.5f * ORNL::in(), -15.25f * ORNL::in());
     lfam_style_segments.push_back({makeLineSegment(lfam_start, lfam_end, 1)});
     const auto lfam_triangles = ORNL::AsPrintedModelExporter::generateTriangles(lfam_style_segments);
-    const Bounds lfam_bounds = boundsFor(lfam_triangles);
+    const Bounds lfam_bounds  = boundsFor(lfam_triangles);
     passed &= expect(near(lfam_bounds.min.x(), 0.0f), "Expected LFAM-style export to use local X zero.");
     passed &= expect(near(lfam_bounds.max.x() - lfam_bounds.min.x(), 16.0f * 25.4f, 0.01f),
                      "Expected LFAM-style inch coordinates to export as millimeters.");

--- a/tests/common_parser_tests.cpp
+++ b/tests/common_parser_tests.cpp
@@ -1,9 +1,8 @@
+#include <QCoreApplication>
+#include <QStringList>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
-
-#include <QCoreApplication>
-#include <QStringList>
 
 #include "gcode/gcode_meta.h"
 #include "gcode/parsers/common_parser.h"
@@ -11,16 +10,13 @@
 
 namespace {
 bool expect(bool condition, const char* message) {
-    if (!condition)
-        std::cerr << message << '\n';
+    if (!condition) std::cerr << message << '\n';
     return condition;
 }
 
 QStringList upperLines(const QStringList& lines) {
     QStringList upper_lines;
-    for (const QString& line : lines) {
-        upper_lines.append(line.toUpper());
-    }
+    for (const QString& line : lines) { upper_lines.append(line.toUpper()); }
 
     return upper_lines;
 }
@@ -46,16 +42,15 @@ bool accumulatesTravelTimeForTravelCommentAfterDepositionMove() {
 
     try {
         const QList<QList<ORNL::GcodeCommand>> commands = parser.parseLines();
-        return commands.size() == 1 && commands.first().size() == 2 &&
-               commands.first().first().getDepositionActive() && !commands.first().last().getDepositionActive() &&
-               parser.getPrintingDistance() > 0.0 * ORNL::mm && parser.getTravelDistance() > 0.0 * ORNL::mm &&
-               parser.getTravelTime() > 0.0 * ORNL::s;
+        return commands.size() == 1 && commands.first().size() == 2 && commands.first().first().getDepositionActive() &&
+               !commands.first().last().getDepositionActive() && parser.getPrintingDistance() > 0.0 * ORNL::mm &&
+               parser.getTravelDistance() > 0.0 * ORNL::mm && parser.getTravelTime() > 0.0 * ORNL::s;
     } catch (const std::exception& ex) {
         std::cerr << ex.what() << '\n';
         return false;
     }
 }
-} // namespace
+}  // namespace
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);

--- a/tests/gcode_settings_importer_tests.cpp
+++ b/tests/gcode_settings_importer_tests.cpp
@@ -1,11 +1,10 @@
-#include <cstdlib>
-#include <iostream>
-#include <optional>
-
 #include <QCoreApplication>
 #include <QFile>
 #include <QStringBuilder>
 #include <QTemporaryDir>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
 
 #include "gcode/gcode_settings_importer.h"
 #include "utilities/constants.h"
@@ -13,40 +12,36 @@
 namespace {
 bool writeFile(const QString& path, const QString& text) {
     QFile file(path);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
-        return false;
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) return false;
 
     file.write(text.toUtf8());
     return true;
 }
 
 bool expect(bool condition, const char* message) {
-    if (!condition)
-        std::cerr << message << '\n';
+    if (!condition) std::cerr << message << '\n';
     return condition;
 }
-} // namespace
+}  // namespace
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);
 
     QTemporaryDir temp_dir;
-    if (!expect(temp_dir.isValid(), "Could not create temporary directory."))
-        return EXIT_FAILURE;
+    if (!expect(temp_dir.isValid(), "Could not create temporary directory.")) return EXIT_FAILURE;
 
     const QString semicolon_path = temp_dir.path() + "/semicolon.gcode";
-    const QString semicolon_gcode = "G1 X0 Y0\n"
-                                    ";Settings Footer\n"
-                                    ";layer_height 200\n"
-                                    ";default_width 400\n";
-    if (!expect(writeFile(semicolon_path, semicolon_gcode), "Could not write semicolon fixture."))
-        return EXIT_FAILURE;
+    const QString semicolon_gcode =
+        "G1 X0 Y0\n"
+        ";Settings Footer\n"
+        ";layer_height 200\n"
+        ";default_width 400\n";
+    if (!expect(writeFile(semicolon_path, semicolon_gcode), "Could not write semicolon fixture.")) return EXIT_FAILURE;
 
     const ORNL::GcodeSettingsImporter::ImportResult semicolon_result =
         ORNL::GcodeSettingsImporter::importFile(semicolon_path, true);
 
-    if (!expect(semicolon_result.errors.isEmpty(), qPrintable(semicolon_result.errors.join("\n"))))
-        return EXIT_FAILURE;
+    if (!expect(semicolon_result.errors.isEmpty(), qPrintable(semicolon_result.errors.join("\n")))) return EXIT_FAILURE;
 
     const auto semicolon_settings =
         semicolon_result.settings_file[ORNL::Constants::SettingFileStrings::kSettings].at(0);
@@ -58,17 +53,16 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
 
     const QString paren_path = temp_dir.path() + "/paren.nc";
-    const QString paren_gcode = "(Settings Footer)\n"
-                                "(layer_height 300)\n"
-                                "(default_width 500)\n";
-    if (!expect(writeFile(paren_path, paren_gcode), "Could not write parenthesized fixture."))
-        return EXIT_FAILURE;
+    const QString paren_gcode =
+        "(Settings Footer)\n"
+        "(layer_height 300)\n"
+        "(default_width 500)\n";
+    if (!expect(writeFile(paren_path, paren_gcode), "Could not write parenthesized fixture.")) return EXIT_FAILURE;
 
     const ORNL::GcodeSettingsImporter::ImportResult paren_result =
         ORNL::GcodeSettingsImporter::importFile(paren_path, true);
 
-    if (!expect(paren_result.errors.isEmpty(), qPrintable(paren_result.errors.join("\n"))))
-        return EXIT_FAILURE;
+    if (!expect(paren_result.errors.isEmpty(), qPrintable(paren_result.errors.join("\n")))) return EXIT_FAILURE;
 
     const auto paren_settings = paren_result.settings_file[ORNL::Constants::SettingFileStrings::kSettings].at(0);
     if (!expect(paren_settings.at(ORNL::PS::Layer::kLayerHeight.toStdString()).get<double>() == 300.0,
@@ -79,26 +73,25 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
 
     const QString legacy_path = temp_dir.path() + "/legacy.gcode";
-    const QString legacy_gcode = ";Settings Footer\n"
-                                 ";layer_height 200\n"
-                                 ";default_width 400\n"
-                                 ";slicer_type 0\n"
-                                 ";slicing_vector_x 0.25\n"
-                                 ";slicing_vector_y 0.5\n"
-                                 ";slicing_vector_z 0.75\n"
-                                 ";image_resolution_x 0.8\n"
-                                 ";image_resolution_y 0.9\n";
-    if (!expect(writeFile(legacy_path, legacy_gcode), "Could not write legacy key fixture."))
-        return EXIT_FAILURE;
+    const QString legacy_gcode =
+        ";Settings Footer\n"
+        ";layer_height 200\n"
+        ";default_width 400\n"
+        ";slicer_type 0\n"
+        ";slicing_vector_x 0.25\n"
+        ";slicing_vector_y 0.5\n"
+        ";slicing_vector_z 0.75\n"
+        ";image_resolution_x 0.8\n"
+        ";image_resolution_y 0.9\n";
+    if (!expect(writeFile(legacy_path, legacy_gcode), "Could not write legacy key fixture.")) return EXIT_FAILURE;
 
     const ORNL::GcodeSettingsImporter::ImportResult legacy_result =
         ORNL::GcodeSettingsImporter::importFile(legacy_path, true);
 
-    if (!expect(legacy_result.errors.isEmpty(), qPrintable(legacy_result.errors.join("\n"))))
-        return EXIT_FAILURE;
+    if (!expect(legacy_result.errors.isEmpty(), qPrintable(legacy_result.errors.join("\n")))) return EXIT_FAILURE;
 
     const auto legacy_settings = legacy_result.settings_file[ORNL::Constants::SettingFileStrings::kSettings].at(0);
-    using Slicing = ORNL::Constants::ProfileSettings::Slicing;
+    using Slicing              = ORNL::Constants::ProfileSettings::Slicing;
     if (!expect(legacy_settings.at(Slicing::kSlicingMode.toStdString()).get<int>() == 0,
                 "Did not migrate legacy slicer_type footer key."))
         return EXIT_FAILURE;
@@ -121,10 +114,10 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
 
     const QString cancel_path = temp_dir.path() + "/cancel.gcode";
-    const QString cancel_gcode = ";Settings Footer\n"
-                                 ";layer_height 200\n";
-    if (!expect(writeFile(cancel_path, cancel_gcode), "Could not write cancel fixture."))
-        return EXIT_FAILURE;
+    const QString cancel_gcode =
+        ";Settings Footer\n"
+        ";layer_height 200\n";
+    if (!expect(writeFile(cancel_path, cancel_gcode), "Could not write cancel fixture.")) return EXIT_FAILURE;
 
     int prompt_count = 0;
     const ORNL::GcodeSettingsImporter::ImportResult cancel_result =

--- a/tests/mesh_repair_tests.cpp
+++ b/tests/mesh_repair_tests.cpp
@@ -16,8 +16,9 @@ struct Triangle {
     int c;
 };
 
-template <class HDS> class PolyhedronBuilder : public CGAL::Modifier_base<HDS> {
-  public:
+template <class HDS>
+class PolyhedronBuilder : public CGAL::Modifier_base<HDS> {
+   public:
     PolyhedronBuilder(const std::vector<ORNL::MeshTypes::Point_3>& points, const std::vector<Triangle>& triangles)
         : m_points(points), m_triangles(triangles) {}
 
@@ -25,8 +26,7 @@ template <class HDS> class PolyhedronBuilder : public CGAL::Modifier_base<HDS> {
         CGAL::Polyhedron_incremental_builder_3<HDS> builder(hds, true);
         builder.begin_surface(m_points.size(), m_triangles.size());
 
-        for (const ORNL::MeshTypes::Point_3& point : m_points)
-            builder.add_vertex(point);
+        for (const ORNL::MeshTypes::Point_3& point : m_points) builder.add_vertex(point);
 
         for (const Triangle& triangle : m_triangles) {
             builder.begin_facet();
@@ -51,9 +51,11 @@ template <class HDS> class PolyhedronBuilder : public CGAL::Modifier_base<HDS> {
         builder.end_surface();
     }
 
-    bool wasError() const { return m_error; }
+    bool wasError() const {
+        return m_error;
+    }
 
-  private:
+   private:
     const std::vector<ORNL::MeshTypes::Point_3>& m_points;
     const std::vector<Triangle>& m_triangles;
     bool m_error = false;
@@ -86,8 +88,8 @@ ORNL::MeshTypes::Polyhedron buildLargeBoundaryOpenStrip() {
     std::vector<Triangle> triangles;
     triangles.reserve(strip_segments * 2);
     for (int x = 0; x < strip_segments; ++x) {
-        const int lower_left = x * 2;
-        const int upper_left = lower_left + 1;
+        const int lower_left  = x * 2;
+        const int upper_left  = lower_left + 1;
         const int lower_right = lower_left + 2;
         const int upper_right = lower_left + 3;
 
@@ -109,18 +111,17 @@ ORNL::MeshTypes::Polyhedron buildClosedTetrahedron() {
 }
 
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;
 
-    ORNL::MeshTypes::Polyhedron open_strip = buildLargeBoundaryOpenStrip();
+    ORNL::MeshTypes::Polyhedron open_strip     = buildLargeBoundaryOpenStrip();
     ORNL::ClosedMesh::RepairResult open_result = ORNL::ClosedMesh::CleanPolyhedronWithStatus(open_strip);
     passed &= expect(open_result == ORNL::ClosedMesh::RepairResult::kSkippedLargeBoundary,
                      "Expected large-boundary open strip repair to be skipped.");

--- a/tests/optimization_anchor_tests.cpp
+++ b/tests/optimization_anchor_tests.cpp
@@ -1,10 +1,9 @@
+#include <QSharedPointer>
+#include <QVector3D>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>
-
-#include <QSharedPointer>
-#include <QVector3D>
 
 #include "configs/settings_base.h"
 #include "geometry/plane.h"
@@ -15,14 +14,15 @@
 
 namespace {
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
 }
 
-bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-5; }
+bool closeTo(double lhs, double rhs) {
+    return std::abs(lhs - rhs) <= 1.0e-5;
+}
 
 QSharedPointer<ORNL::SettingsBase> settingsWithSeamAttractor(ORNL::PointOrderOptimization point_order) {
     QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
@@ -46,7 +46,7 @@ QSharedPointer<ORNL::SettingsBase> settingsWithSeamAttractor(ORNL::PointOrderOpt
 
     return settings;
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;
@@ -63,8 +63,8 @@ int main() {
         settingsWithSeamAttractor(ORNL::PointOrderOptimization::kNextClosest);
     custom_island_settings->setSetting(ORNL::PS::Optimizations::kIslandOrder,
                                        static_cast<int>(ORNL::IslandOrderOptimization::kCustomPoint));
-    const ORNL::Point custom_island_anchor = ORNL::OptimizationAnchor::customIslandOrderPoint(
-        custom_island_settings, slicing_plane, optimization_shift);
+    const ORNL::Point custom_island_anchor =
+        ORNL::OptimizationAnchor::customIslandOrderPoint(custom_island_settings, slicing_plane, optimization_shift);
     passed &= expect(closeTo(custom_island_anchor.x(), 12.0) && closeTo(custom_island_anchor.y(), 3.0) &&
                          closeTo(custom_island_anchor.z(), 10.0),
                      "Expected seam attractor vector to project the anchor for Custom Island Location order.");
@@ -81,9 +81,8 @@ int main() {
 
     QSharedPointer<ORNL::SettingsBase> custom_region_path_settings =
         settingsWithSeamAttractor(ORNL::PointOrderOptimization::kNextClosest);
-    custom_region_path_settings->setSetting(
-        ORNL::PS::Optimizations::kSkinPathOrder,
-        static_cast<int>(ORNL::PathOrderOptimization::kCustomPoint) + 1);
+    custom_region_path_settings->setSetting(ORNL::PS::Optimizations::kSkinPathOrder,
+                                            static_cast<int>(ORNL::PathOrderOptimization::kCustomPoint) + 1);
     const ORNL::Point custom_region_path_anchor =
         ORNL::OptimizationAnchor::customPathOrderPoint(custom_region_path_settings, slicing_plane, optimization_shift);
     passed &= expect(closeTo(custom_region_path_anchor.x(), 12.0) && closeTo(custom_region_path_anchor.y(), 3.0) &&
@@ -99,9 +98,9 @@ int main() {
 
     const ORNL::Point custom_anchor = ORNL::OptimizationAnchor::customPointOrderPoint(
         settingsWithSeamAttractor(ORNL::PointOrderOptimization::kCustomPoint), slicing_plane, optimization_shift);
-    passed &= expect(closeTo(custom_anchor.x(), 12.0) && closeTo(custom_anchor.y(), 3.0) &&
-                         closeTo(custom_anchor.z(), 10.0),
-                     "Expected seam attractor vector to project the anchor for Custom Location point order.");
+    passed &=
+        expect(closeTo(custom_anchor.x(), 12.0) && closeTo(custom_anchor.y(), 3.0) && closeTo(custom_anchor.z(), 10.0),
+               "Expected seam attractor vector to project the anchor for Custom Location point order.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/optimizer_empty_input_tests.cpp
+++ b/tests/optimizer_empty_input_tests.cpp
@@ -1,10 +1,9 @@
-#include <cstdlib>
-#include <iostream>
-#include <string>
-
 #include <QList>
 #include <QSharedPointer>
 #include <QVector>
+#include <cstdlib>
+#include <iostream>
+#include <string>
 
 #include "configs/settings_base.h"
 #include "geometry/path.h"
@@ -21,13 +20,12 @@
 
 namespace {
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;
@@ -69,7 +67,8 @@ int main() {
     polylines.append(one_point_polyline);
     polyline_optimizer.setGeometryToEvaluate(polylines, ORNL::RegionType::kSkeleton,
                                              ORNL::PathOrderOptimization::kNextClosest);
-    passed &= expect(polyline_optimizer.getCurrentPolylineCount() == 0, "Expected degenerate polylines to be filtered.");
+    passed &=
+        expect(polyline_optimizer.getCurrentPolylineCount() == 0, "Expected degenerate polylines to be filtered.");
     passed &= expect(polyline_optimizer.linkNextPolyline().isEmpty(), "Expected empty polyline optimizer result.");
 
     ORNL::Polyline zero_distance_polyline;

--- a/tests/path_modifier_tests.cpp
+++ b/tests/path_modifier_tests.cpp
@@ -1,9 +1,8 @@
+#include <QSharedPointer>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>
-
-#include <QSharedPointer>
 
 #include "configs/settings_base.h"
 #include "geometry/path.h"
@@ -15,14 +14,15 @@
 
 namespace {
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
 }
 
-bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-4; }
+bool closeTo(double lhs, double rhs) {
+    return std::abs(lhs - rhs) <= 1.0e-4;
+}
 
 bool expectPoint(const ORNL::Point& point, double x, double y, const std::string& message) {
     return expect(closeTo(point.x(), x) && closeTo(point.y(), y), message);
@@ -41,7 +41,7 @@ QSharedPointer<ORNL::SettingsBase> sharpCornerSettings(ORNL::Distance close_poin
     settings->setSetting(ORNL::PS::SpecialModes::kSharpCornerSharpeningLegLength, ORNL::Distance(4.0));
     return settings;
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;

--- a/tests/point_order_optimizer_tests.cpp
+++ b/tests/point_order_optimizer_tests.cpp
@@ -12,23 +12,24 @@
 
 namespace {
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
 }
 
-bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-5; }
+bool closeTo(double lhs, double rhs) {
+    return std::abs(lhs - rhs) <= 1.0e-5;
+}
 
 ORNL::Polyline squareLoop() {
     return ORNL::Polyline {ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
                            ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f)};
 }
-} // namespace
+}  // namespace
 
 int main() {
-    bool passed = true;
+    bool passed                   = true;
     const ORNL::Polyline polyline = squareLoop();
 
     const auto physical_selection = ORNL::PointOrderOptimizer::linkToPoint(
@@ -40,9 +41,9 @@ int main() {
                      "Expected consecutive physical selection to split at the requested XY distance.");
     passed &= expect(physical_selection.insertion_index == 1,
                      "Expected consecutive split to be inserted before the second square vertex.");
-    passed &= expect(closeTo(physical_selection.split_point.x(), 5.0) &&
-                         closeTo(physical_selection.split_point.y(), 0.0),
-                     "Expected consecutive split point at (5, 0).");
+    passed &=
+        expect(closeTo(physical_selection.split_point.x(), 5.0) && closeTo(physical_selection.split_point.y(), 0.0),
+               "Expected consecutive split point at (5, 0).");
 
     const auto randomized_split_selection = ORNL::PointOrderOptimizer::linkToPoint(
         ORNL::Point(999.0f, 999.0f, 0.0f), polyline, 4, ORNL::PointOrderOptimization::kConsecutive, false,

--- a/tests/session_manager_tests.cpp
+++ b/tests/session_manager_tests.cpp
@@ -1,12 +1,12 @@
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QTemporaryDir>
+#include <QTimer>
 #include <cstdlib>
 #include <iostream>
 #include <optional>
 #include <string>
 
-#include <QCoreApplication>
-#include <QEventLoop>
-#include <QTemporaryDir>
-#include <QTimer>
 #include <zip/zip.h>
 
 #include "managers/session_manager.h"
@@ -16,14 +16,12 @@
 
 namespace {
 bool expect(bool condition, const char* message) {
-    if (!condition)
-        std::cerr << message << '\n';
+    if (!condition) std::cerr << message << '\n';
     return condition;
 }
 
 bool writeZipEntry(zip_t* zip, const std::string& name, const std::string& text) {
-    if (zip_entry_open(zip, name.c_str()) < 0)
-        return false;
+    if (zip_entry_open(zip, name.c_str()) < 0) return false;
 
     int result = zip_entry_write(zip, text.c_str(), text.size());
     zip_entry_close(zip);
@@ -32,22 +30,20 @@ bool writeZipEntry(zip_t* zip, const std::string& name, const std::string& text)
 
 bool writeProjectWithOldGlobal(const QString& path) {
     QByteArray path_bytes = path.toUtf8();
-    zip_t* zip = zip_open(path_bytes.constData(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
-    if (zip == nullptr)
-        return false;
+    zip_t* zip            = zip_open(path_bytes.constData(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+    if (zip == nullptr) return false;
 
     fifojson global = fifojson::object();
     global[ORNL::Constants::SettingFileStrings::kHeader][ORNL::Constants::SettingFileStrings::kVersion] = 2.0;
-    global[ORNL::Constants::SettingFileStrings::kSettings] = fifojson::array(
-        {fifojson::object({{"slicer_type", 0}, {"slicing_vector_x", 0.25}})});
+    global[ORNL::Constants::SettingFileStrings::kSettings] =
+        fifojson::array({fifojson::object({{"slicer_type", 0}, {"slicing_vector_x", 0.25}})});
 
-    fifojson session = fifojson::object();
+    fifojson session                                    = fifojson::object();
     session[ORNL::Constants::Settings::Session::kParts] = fifojson::object();
 
-    bool success =
-        writeZipEntry(zip, ORNL::Constants::Settings::Session::Files::kGlobal, global.dump(4)) &&
-        writeZipEntry(zip, ORNL::Constants::Settings::Session::Files::kSession, session.dump(4)) &&
-        writeZipEntry(zip, ORNL::Constants::Settings::Session::Files::kLocal, fifojson::array().dump(4));
+    bool success = writeZipEntry(zip, ORNL::Constants::Settings::Session::Files::kGlobal, global.dump(4)) &&
+                   writeZipEntry(zip, ORNL::Constants::Settings::Session::Files::kSession, session.dump(4)) &&
+                   writeZipEntry(zip, ORNL::Constants::Settings::Session::Files::kLocal, fifojson::array().dump(4));
 
     zip_close(zip);
     return success;
@@ -55,11 +51,10 @@ bool writeProjectWithOldGlobal(const QString& path) {
 
 std::optional<fifojson> readGlobalFromProject(const QString& path) {
     QByteArray path_bytes = path.toUtf8();
-    zip_t* zip = zip_open(path_bytes.constData(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'r');
-    if (zip == nullptr)
-        return std::nullopt;
+    zip_t* zip            = zip_open(path_bytes.constData(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'r');
+    if (zip == nullptr) return std::nullopt;
 
-    void* buffer = nullptr;
+    void* buffer       = nullptr;
     size_t buffer_size = 0;
     if (zip_entry_open(zip, ORNL::Constants::Settings::Session::Files::kGlobal.c_str()) < 0 ||
         zip_entry_read(zip, &buffer, &buffer_size) < 0) {
@@ -74,25 +69,23 @@ std::optional<fifojson> readGlobalFromProject(const QString& path) {
 
     return fifojson::parse(text);
 }
-} // namespace
+}  // namespace
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);
 
     QTemporaryDir temp_dir;
-    if (!expect(temp_dir.isValid(), "Could not create temporary directory."))
-        return EXIT_FAILURE;
+    if (!expect(temp_dir.isValid(), "Could not create temporary directory.")) return EXIT_FAILURE;
 
     QString project_path = temp_dir.path() + "/old-settings-project.s2p";
-    if (!expect(writeProjectWithOldGlobal(project_path), "Could not write project fixture."))
-        return EXIT_FAILURE;
+    if (!expect(writeProjectWithOldGlobal(project_path), "Could not write project fixture.")) return EXIT_FAILURE;
 
     ORNL::SessionLoader* loader = ORNL::CSM->loadSession(false, project_path, false);
     if (!expect(loader != nullptr, "CLI-style session load rejected the old project before auto-updating settings."))
         return EXIT_FAILURE;
 
     QEventLoop loop;
-    bool finished = false;
+    bool finished  = false;
     bool succeeded = false;
     QObject::connect(loader, &ORNL::SessionLoader::loadSucceeded, &loop, [&succeeded]() { succeeded = true; });
     QObject::connect(loader, &ORNL::SessionLoader::finished, &loop, [&finished, &loop]() {
@@ -102,22 +95,20 @@ int main(int argc, char* argv[]) {
     QTimer::singleShot(5000, &loop, [&loop]() { loop.quit(); });
     loop.exec();
 
-    if (!expect(finished, "Timed out waiting for CLI-style session load to finish."))
-        return EXIT_FAILURE;
-    if (!expect(succeeded, "CLI-style session load did not complete successfully."))
-        return EXIT_FAILURE;
+    if (!expect(finished, "Timed out waiting for CLI-style session load to finish.")) return EXIT_FAILURE;
+    if (!expect(succeeded, "CLI-style session load did not complete successfully.")) return EXIT_FAILURE;
 
     std::optional<fifojson> archived_global = readGlobalFromProject(project_path);
     if (!expect(archived_global.has_value(), "Could not read archived global settings from project."))
         return EXIT_FAILURE;
 
-    double archived_version = (*archived_global)[ORNL::Constants::SettingFileStrings::kHeader]
-                                               [ORNL::Constants::SettingFileStrings::kVersion];
+    double archived_version =
+        (*archived_global)[ORNL::Constants::SettingFileStrings::kHeader][ORNL::Constants::SettingFileStrings::kVersion];
     if (!expect(archived_version == 2.0, "CLI-style session load unexpectedly modified the project archive."))
         return EXIT_FAILURE;
 
-    double loaded_slice_normal_x = ORNL::GSM->getGlobal()->setting<double>(
-        ORNL::Constants::ProfileSettings::Slicing::kSlicePlaneNormalX);
+    double loaded_slice_normal_x =
+        ORNL::GSM->getGlobal()->setting<double>(ORNL::Constants::ProfileSettings::Slicing::kSlicePlaneNormalX);
     if (!expect(loaded_slice_normal_x == 0.25,
                 "CLI-style session load did not use migrated global settings in memory."))
         return EXIT_FAILURE;

--- a/tests/spiral_path_tests.cpp
+++ b/tests/spiral_path_tests.cpp
@@ -1,9 +1,8 @@
+#include <QVector>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>
-
-#include <QVector>
 
 #include "geometry/point.h"
 #include "geometry/polyline.h"
@@ -12,14 +11,15 @@
 
 namespace {
 bool expect(bool condition, const std::string& message) {
-    if (condition)
-        return true;
+    if (condition) return true;
 
     std::cerr << message << '\n';
     return false;
 }
 
-bool closeTo(double lhs, double rhs) { return std::abs(lhs - rhs) <= 1.0e-4; }
+bool closeTo(double lhs, double rhs) {
+    return std::abs(lhs - rhs) <= 1.0e-4;
+}
 
 bool expectPoint(const ORNL::Point& point, double x, double y, const std::string& message) {
     return expect(closeTo(point.x(), x) && closeTo(point.y(), y), message);
@@ -43,7 +43,7 @@ ORNL::Polyline rectangleStartingOnLeftEdge(double min_x, double min_y, double ma
     line.push_back(ORNL::Point(min_x, max_y, 0.0f));
     return line;
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-    "major":  "2",
-    "minor":  "1",
-    "patch":  "0",
+    "major": "2",
+    "minor": "1",
+    "patch": "0",
     "suffix": ""
 }


### PR DESCRIPTION
## Summary

This pull request introduces automated C++ code formatting using `clang-format` integrated with pre-commit hooks and pre-commit.ci, and updates documentation and code style accordingly. It also applies minor code formatting improvements to several header files for consistency.

## Related issues

- No related issues.

## Details

**Automated formatting integration and documentation updates:**

- Added a `.pre-commit-config.yaml` to enable `clang-format` via pre-commit and configure pre-commit.ci for automatic formatting fixes on pull requests.
- Updated `CONTRIBUTING.md` and `docs/contributing/formatting.md` to instruct contributors to use `clang-format` or the pre-commit hook, and clarified that pre-commit.ci will auto-fix formatting issues in PRs. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L12-R12) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L42-R42) [[3]](diffhunk://#diff-7e0102f3f85f64b871ff32b32fead147f0073a789556cf1d10dd00d9bb2be3dcL28-R28) [[4]](diffhunk://#diff-267ea7502f076fe10f04d6cd86477e880e444b2491eb9f3ecd09ac14507912fdR9) [[5]](diffhunk://#diff-267ea7502f076fe10f04d6cd86477e880e444b2491eb9f3ecd09ac14507912fdR18-R19) [[6]](diffhunk://#diff-267ea7502f076fe10f04d6cd86477e880e444b2491eb9f3ecd09ac14507912fdR60-R84)

**Formatting configuration:**

- Replaced the existing `.clang-format` with a comprehensive configuration based on the Google style, including detailed alignment, spacing, and include ordering rules.

**Code formatting and consistency improvements:**

- Reformatted template declarations and function definitions for better readability in `include/configs/settings_base.h` and `include/cross_section/sparse_grid.h`. [[1]](diffhunk://#diff-f0a2c9c867df0dbb1727f5a18fcec54f506fde7689a55bd3ec8a766cc77bfa2fL25-R27) [[2]](diffhunk://#diff-f0a2c9c867df0dbb1727f5a18fcec54f506fde7689a55bd3ec8a766cc77bfa2fL34-R37) [[3]](diffhunk://#diff-1e7df0c7662b809849f447f308da4424b28c3b837749d423faef3ba07781a467L26-R27) [[4]](diffhunk://#diff-1e7df0c7662b809849f447f308da4424b28c3b837749d423faef3ba07781a467L56-R59)
- Adjusted include ordering and spacing in several headers (`tsp_brute.h`, `settings_base.h`, `command_line_processor.h`, `cross_section_object.h`, `sparse_grid.h`) to match the updated style guidelines. [[1]](diffhunk://#diff-cf72efdc8dfbfa3a1ac3ef435a221186c05ac5975fb75c1b07f9efc2983d29d9R4) [[2]](diffhunk://#diff-f0a2c9c867df0dbb1727f5a18fcec54f506fde7689a55bd3ec8a766cc77bfa2fR5) [[3]](diffhunk://#diff-aef18c66f5f26b70f45400dc791b2a74e3f06e460978ce04e55d17f17fc24955R4) [[4]](diffhunk://#diff-a19dbbc309cbf62e5578c345bf2bd9b3503eb9d5698a8d4d6931b6ed944eca30R3-L7) [[5]](diffhunk://#diff-1e7df0c7662b809849f447f308da4424b28c3b837749d423faef3ba07781a467R3-L8)
- Simplified and compacted some function bodies and conditional statements for style consistency in `sparse_grid.h`. [[1]](diffhunk://#diff-1e7df0c7662b809849f447f308da4424b28c3b837749d423faef3ba07781a467L134-R137) [[2]](diffhunk://#diff-1e7df0c7662b809849f447f308da4424b28c3b837749d423faef3ba07781a467L175-R176) [[3]](diffhunk://#diff-1e7df0c7662b809849f447f308da4424b28c3b837749d423faef3ba07781a467L207-R206)

