### PR TITLE
Add cylindrical-specific path ordering controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,17 @@ if(ORNLSLICER_BUILD_TESTS)
     target_link_libraries(${PROJECT_NAME}_spiral_path_tests PRIVATE ${PROJECT_NAME}_obj)
     add_test(NAME spiral_path_tests COMMAND ${PROJECT_NAME}_spiral_path_tests)
 
+    add_executable(${PROJECT_NAME}_helical_clip_rounding_tests tests/helical_clip_rounding_tests.cpp)
+    target_include_directories(
+        ${PROJECT_NAME}_helical_clip_rounding_tests
+        PRIVATE
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_CURRENT_BINARY_DIR}/generated/include
+            ${ORNLSLICER_INCLUDE_DIRS}
+    )
+    target_link_libraries(${PROJECT_NAME}_helical_clip_rounding_tests PRIVATE ${PROJECT_NAME}_obj)
+    add_test(NAME helical_clip_rounding_tests COMMAND ${PROJECT_NAME}_helical_clip_rounding_tests)
+
     set(ORNLSLICER_NEW_IMPACT_PROJECT "/home/rhc/develop/new-impact.s2p" CACHE FILEPATH
         "Optional local project used for the new-impact planar slicing regression test.")
     if(EXISTS "${ORNLSLICER_NEW_IMPACT_PROJECT}")

--- a/docs/slicing/cylindrical-slicing.md
+++ b/docs/slicing/cylindrical-slicing.md
@@ -15,13 +15,14 @@ This slicer currently requires the `Arc Specialties` G-code syntax, but this pag
 7. Set `Cylinder Axis Source` if the cylinder axis should use a custom XY coordinate instead of the part centroid.
 8. Set `Cylinder Inner Radius` if the first cylinder or helix should begin away from the axis.
 9. Set `Cylinder Height` to limit generated cylindrical paths above the part base. Leave it at `0` to use the part height.
-10. Set the path boundary policy for the selected `Cylindrical Path Pattern`.
-11. Set the radial or helical path start angle if the first point should begin somewhere other than the default.
-12. For `Helical`, set `Helical Path Handedness` if the helix should sweep clockwise rather than the default counter-clockwise direction as Z rises.
-13. For `Helical`, set `Max Helical Path Length` when long generated helices should be split into shorter paths. Leave it at `0` to keep each clipped helix fragment as one path.
-14. Confirm the printer `Syntax` is `Arc Specialties`. Selecting `Cylindrical` defaults to `Arc Specialties` when the current syntax is not cylindrical-capable.
-15. Configure the required Arc Specialties machine output settings, including positioner axes, frame rotation, `TRAFO`, and G2/G3 center mode, using the [Arc Specialties](../gcode/arc-specialties.md) syntax documentation.
-16. Slice and inspect the generated G-code preview before running the machine.
+10. Set `Cylindrical Path Order Optimization` to choose `Next Closest` or `Next Farthest` ordering between retained cylindrical paths.
+11. Set the path boundary policy for the selected `Cylindrical Path Pattern`.
+12. Set the radial or helical path start angle if the first point should begin somewhere other than the default.
+13. For `Helical`, set `Helical Path Handedness` if the helix should sweep clockwise rather than the default counter-clockwise direction as Z rises.
+14. For `Helical`, set `Max Helical Path Length` when long generated helices should be split into shorter paths. Leave it at `0` to keep each clipped helix fragment as one path.
+15. Confirm the printer `Syntax` is `Arc Specialties`. Selecting `Cylindrical` defaults to `Arc Specialties` when the current syntax is not cylindrical-capable.
+16. Configure the required Arc Specialties machine output settings, including positioner axes, frame rotation, `TRAFO`, and G2/G3 center mode, using the [Arc Specialties](../gcode/arc-specialties.md) syntax documentation.
+17. Slice and inspect the generated G-code preview before running the machine.
 
 ## Path Patterns
 
@@ -39,6 +40,8 @@ If `Max Helical Path Length` is greater than `0`, each generated helical fragmen
 
 `Cylinder Height` limits radial and helical candidate paths above the retained part base. Values of `0` or smaller use the retained part height, preserving the default model-bounded behavior.
 
+`Cylindrical Path Order Optimization` controls how retained radial arcs or helical fragments are selected after clipping. `Next Closest` minimizes travel from the current machine location to the next path. `Next Farthest` selects the farthest available path first. Closed radial paths can be rotated so travel enters at the selected segment start. Open radial arcs stay endpoint-only so they are not split. Helical fragments are selected by start or end endpoint and may be reordered or reversed.
+
 ## Required Settings
 
 | Setting | Location | Effect |
@@ -52,6 +55,7 @@ If `Max Helical Path Length` is greater than `0`, each generated helical fragmen
 | `Cylinder Axis - X` / `Cylinder Axis - Y` | Profile > Slicing | Custom cylinder axis coordinates when `Cylinder Axis Source` is `Custom XY`. |
 | `Cylinder Inner Radius` | Profile > Slicing | Inner radial boundary before the half-layer offset is applied. |
 | `Cylinder Height` | Profile > Slicing | Upper height limit for generated cylindrical paths above the part base. Values less than or equal to `0` use the retained part height. |
+| `Cylindrical Path Order Optimization` | Profile > Optimizations | Selects `Next Closest` or `Next Farthest` ordering between retained radial or helical paths. Closed radial paths may rotate to the selected segment start. |
 | `Radial Path Start Angle` | Profile > Slicing | For `Radial`, angular start position around the cylinder axis. |
 | `Helical Path Start Angle` | Profile > Slicing | For `Helical`, angular start position around the cylinder axis. Defaults to `90 deg` for a +Y start. |
 | `Helical Path Handedness` | Profile > Slicing | For `Helical`, selects `Right Handed` counter-clockwise rise or `Left Handed` clockwise rise. |
@@ -60,7 +64,7 @@ If `Max Helical Path Length` is greater than `0`, each generated helical fragmen
 
 Only relevant settings are shown for the selected path pattern. `Radial` shows `Radial Path Boundary Policy` with `Clip`, `Keep`, and `Discard`, plus `Radial Path Start Angle`. `Helical` shows `Helical Path Boundary Policy` with `Clip` and `Clip Z`, plus helical-only controls such as `Helical Path Start Angle` and `Helical Path Handedness`.
 
-Planar-only path settings, including Perimeter, Inset, Skeleton, Skin, Infill, Support, Ordering, Platform Adhesion, and their region-specific material modifiers, are hidden or disabled while `Slicing Mode` is `Cylindrical`.
+Planar-only path settings, including Perimeter, Inset, Skeleton, Skin, Infill, Support, Ordering, Platform Adhesion, and their region-specific material modifiers, are hidden or disabled while `Slicing Mode` is `Cylindrical`. Cylindrical mode shows the two-option `Cylindrical Path Order Optimization` setting instead of the planar path-order controls.
 
 ## Boundary Policies
 
@@ -83,7 +87,7 @@ When `Clip Z` finds no boundary crossing, a helix that is wholly inside the mode
 
 ## G-code Output Handoff
 
-Cylindrical slicing hands radial and helical paths to the Arc Specialties writer. The generated header reports the cylindrical geometry, selected path pattern, path start angle, helical handedness, boundary policy, and travel lift distance. Print moves are marked with `RADIAL` or `HELICAL` comments so the preview path can classify cylindrical bead motion.
+Cylindrical slicing hands radial and helical paths to the Arc Specialties writer. The generated header reports the cylindrical geometry, selected path pattern, cylindrical path order, path start angle, helical handedness, boundary policy, and travel lift distance. Print moves are marked with `RADIAL` or `HELICAL` comments so the preview path can classify cylindrical bead motion.
 
 When `Supports G2/G3` is disabled, cylindrical print paths are written as sampled G1 segments. When `Supports G2/G3` is enabled, complete rings or helical revolutions are divided according to `Arcs per Revolution`; clipped or partial paths may include a shorter final arc. The exact G00/G01/G02/G03 syntax, positioner fields, center modes, and startup commands are described in [Arc Specialties](../gcode/arc-specialties.md).
 
@@ -101,6 +105,7 @@ When `Supports G2/G3` is disabled, cylindrical print paths are written as sample
 After slicing, verify that:
 
 - The G-code header identifies the selected `Cylindrical Path Pattern` and selected path start angle.
+- The G-code header identifies the selected `Cylindrical Path Order Optimization`.
 - For `Helical`, the G-code header identifies the selected `Helical Path Handedness`.
 - A complete radial ring or helical revolution contains the configured `Arcs per Revolution`; clipped or partial paths may include a shorter final arc.
 - Printed paths lie on the part rather than above or below it.

--- a/docs/slicing/cylindrical-slicing.md
+++ b/docs/slicing/cylindrical-slicing.md
@@ -17,12 +17,13 @@ This slicer currently requires the `Arc Specialties` G-code syntax, but this pag
 9. Set `Cylinder Height` to limit generated cylindrical paths above the part base. Leave it at `0` to use the part height.
 10. Set `Cylindrical Path Order Optimization` to choose `Next Closest` or `Next Farthest` ordering between retained cylindrical paths.
 11. Set the path boundary policy for the selected `Cylindrical Path Pattern`.
-12. Set the radial or helical path start angle if the first point should begin somewhere other than the default.
-13. For `Helical`, set `Helical Path Handedness` if the helix should sweep clockwise rather than the default counter-clockwise direction as Z rises.
-14. For `Helical`, set `Max Helical Path Length` when long generated helices should be split into shorter paths. Leave it at `0` to keep each clipped helix fragment as one path.
-15. Confirm the printer `Syntax` is `Arc Specialties`. Selecting `Cylindrical` defaults to `Arc Specialties` when the current syntax is not cylindrical-capable.
-16. Configure the required Arc Specialties machine output settings, including positioner axes, frame rotation, `TRAFO`, and G2/G3 center mode, using the [Arc Specialties](../gcode/arc-specialties.md) syntax documentation.
-17. Slice and inspect the generated G-code preview before running the machine.
+12. For `Helical` with `Clip Z`, set `Helical Z Clip Rounding` to choose whether the path stops at the model intersection or rounds to a full revolution.
+13. Set the radial or helical path start angle if the first point should begin somewhere other than the default.
+14. For `Helical`, set `Helical Path Handedness` if the helix should sweep clockwise rather than the default counter-clockwise direction as Z rises.
+15. For `Helical`, set `Max Helical Path Length` when long generated helices should be split into shorter paths. Leave it at `0` to keep each clipped helix fragment as one path.
+16. Confirm the printer `Syntax` is `Arc Specialties`. Selecting `Cylindrical` defaults to `Arc Specialties` when the current syntax is not cylindrical-capable.
+17. Configure the required Arc Specialties machine output settings, including positioner axes, frame rotation, `TRAFO`, and G2/G3 center mode, using the [Arc Specialties](../gcode/arc-specialties.md) syntax documentation.
+18. Slice and inspect the generated G-code preview before running the machine.
 
 ## Path Patterns
 
@@ -58,11 +59,12 @@ If `Max Helical Path Length` is greater than `0`, each generated helical fragmen
 | `Cylindrical Path Order Optimization` | Profile > Optimizations | Selects `Next Closest` or `Next Farthest` ordering between retained radial or helical paths. Closed radial paths may rotate to the selected segment start. |
 | `Radial Path Start Angle` | Profile > Slicing | For `Radial`, angular start position around the cylinder axis. |
 | `Helical Path Start Angle` | Profile > Slicing | For `Helical`, angular start position around the cylinder axis. Defaults to `90 deg` for a +Y start. |
+| `Helical Z Clip Rounding` | Profile > Slicing | For `Helical` with `Clip Z`, controls whether the path ends at the model intersection, the next complete revolution, or the previous complete revolution. |
 | `Helical Path Handedness` | Profile > Slicing | For `Helical`, selects `Right Handed` counter-clockwise rise or `Left Handed` clockwise rise. |
 | `Max Helical Path Length` | Profile > Slicing | For `Helical`, maximum length of each generated helical path segment before it is split. |
 | `Arcs per Revolution` | Profile > Slicing | Sets how many G2/G3 moves represent one complete revolution when `Supports G2/G3` is enabled. |
 
-Only relevant settings are shown for the selected path pattern. `Radial` shows `Radial Path Boundary Policy` with `Clip`, `Keep`, and `Discard`, plus `Radial Path Start Angle`. `Helical` shows `Helical Path Boundary Policy` with `Clip` and `Clip Z`, plus helical-only controls such as `Helical Path Start Angle` and `Helical Path Handedness`.
+Only relevant settings are shown for the selected path pattern. `Radial` shows `Radial Path Boundary Policy` with `Clip`, `Keep`, and `Discard`, plus `Radial Path Start Angle`. `Helical` shows `Helical Path Boundary Policy` with `Clip` and `Clip Z`, plus helical-only controls such as `Helical Path Start Angle` and `Helical Path Handedness`. `Helical Z Clip Rounding` is shown only when `Helical Path Boundary Policy` is `Clip Z`.
 
 Planar-only path settings, including Perimeter, Inset, Skeleton, Skin, Infill, Support, Ordering, Platform Adhesion, and their region-specific material modifiers, are hidden or disabled while `Slicing Mode` is `Cylindrical`. Cylindrical mode shows the two-option `Cylindrical Path Order Optimization` setting instead of the planar path-order controls.
 
@@ -83,11 +85,13 @@ For `Helical`, model clipping retains helix portions according to the selected m
 | `Clip` | Outputs every contiguous helix portion that lies inside the model. |
 | `Clip Z` | Outputs one continuous prefix of the original helix, from its generated start through the boundary intersection with the greatest Z value. |
 
+`Helical Z Clip Rounding` refines `Clip Z`. `Exact Intersection` stops at the highest-Z model intersection. `Complete Revolution` continues to the next complete revolution and may extend above the model or configured `Cylinder Height`. `Last Full Revolution` stops at the previous complete revolution; if the intersection occurs before the first complete revolution, that radius is omitted.
+
 When `Clip Z` finds no boundary crossing, a helix that is wholly inside the model is kept in full and a helix that is wholly outside is omitted.
 
 ## G-code Output Handoff
 
-Cylindrical slicing hands radial and helical paths to the Arc Specialties writer. The generated header reports the cylindrical geometry, selected path pattern, cylindrical path order, path start angle, helical handedness, boundary policy, and travel lift distance. Print moves are marked with `RADIAL` or `HELICAL` comments so the preview path can classify cylindrical bead motion.
+Cylindrical slicing hands radial and helical paths to the Arc Specialties writer. The generated header reports the cylindrical geometry, selected path pattern, cylindrical path order, path start angle, helical handedness, boundary policy, Clip Z rounding when applicable, and travel lift distance. Print moves are marked with `RADIAL` or `HELICAL` comments so the preview path can classify cylindrical bead motion.
 
 When `Supports G2/G3` is disabled, cylindrical print paths are written as sampled G1 segments. When `Supports G2/G3` is enabled, complete rings or helical revolutions are divided according to `Arcs per Revolution`; clipped or partial paths may include a shorter final arc. The exact G00/G01/G02/G03 syntax, positioner fields, center modes, and startup commands are described in [Arc Specialties](../gcode/arc-specialties.md).
 
@@ -107,6 +111,7 @@ After slicing, verify that:
 - The G-code header identifies the selected `Cylindrical Path Pattern` and selected path start angle.
 - The G-code header identifies the selected `Cylindrical Path Order Optimization`.
 - For `Helical`, the G-code header identifies the selected `Helical Path Handedness`.
+- For `Helical` with `Clip Z`, the G-code header identifies the selected `Helical Z Clip Rounding`.
 - A complete radial ring or helical revolution contains the configured `Arcs per Revolution`; clipped or partial paths may include a shorter final arc.
 - Printed paths lie on the part rather than above or below it.
 - Travel moves and configured travel lift stay clear of the printed cylindrical paths.

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -45,8 +45,16 @@ class ArcSpecialtiesWriter : public WriterBase {
     void setHelicalPathBoundaryPolicy(const QVector<QPair<QString, HelicalPathBoundaryPolicy>>& methods);
 
     /*!
+     * @brief Supplies the effective part-local helical Z clip rounding values for the settings header.
+     *
+     * @param rounding Part name and rounding pairs for Clip Z parts that produced helical paths.
+     */
+    void setHelicalPathZClipRounding(const QVector<QPair<QString, HelicalPathZClipRounding>>& rounding);
+
+    /*!
      * @brief Supplies the effective part-local helical handedness values for the settings header.
-     * @param handedness Part name and handedness pairs for parts that produced helical paths.
+     * @param
+     * handedness Part name and handedness pairs for parts that produced helical paths.
      */
     void setHelicalPathHandedness(const QVector<QPair<QString, HelicalPathHandedness>>& handedness);
 
@@ -319,6 +327,9 @@ class ArcSpecialtiesWriter : public WriterBase {
 
     //! @brief Effective part-local boundary policies reported in helical G-code headers.
     QVector<QPair<QString, HelicalPathBoundaryPolicy>> m_helical_path_boundary_policy;
+
+    //! @brief Effective part-local Clip Z rounding values reported in helical G-code headers.
+    QVector<QPair<QString, HelicalPathZClipRounding>> m_helical_path_z_clip_rounding;
 
     //! @brief Effective part-local handedness values reported in helical G-code headers.
     QVector<QPair<QString, HelicalPathHandedness>> m_helical_path_handedness;

--- a/include/optimizers/path_order_optimizer.h
+++ b/include/optimizers/path_order_optimizer.h
@@ -39,11 +39,16 @@ class PathOrderOptimizer {
     Path linkNextPath(QVector<Path> paths = QVector<Path>());
 
     /*!
-     * @brief Links the next open radial arc using the configured path and point order settings.
-     * @param center Cylinder center used to turn outside-in and inside-out into angular sweep ordering.
+     * @brief Links the next radial path using cylindrical path-order settings.
      * @return Linked radial path with a travel prepended.
      */
-    Path linkNextRadialPath(const Point& center);
+    Path linkNextRadialPath();
+
+    /*!
+     * @brief Links the next open helical fragment from the selected endpoint.
+     * @return Linked helical path with a travel prepended.
+     */
+    Path linkNextHelicalPath();
 
     //! \brief Set paths to evaluate
     //! \param paths: Copy of paths to evaluate
@@ -97,6 +102,20 @@ class PathOrderOptimizer {
         }
     };
 
+    //! \brief Selected radial path and entry point.
+    struct RadialPathSelection {
+        int path_index = -1;
+        int segment_index = 0;
+        bool start_from_front = true;
+        bool rotate_to_segment = false;
+    };
+
+    //! \brief Selected open path endpoint.
+    struct OpenPathSelection {
+        int path_index = -1;
+        bool start_from_front = true;
+    };
+
     //! \brief Links the POO position to the given path with a travel (used for closed contours)
     Path linkTo();
 
@@ -110,11 +129,22 @@ class PathOrderOptimizer {
     Path linkNextSkeletonPath();
 
     /*!
-     * @brief Selects an open radial arc and endpoint using radial-compatible path-order semantics.
-     * @param center Cylinder center used for angular ordering.
-     * @return Selected path index and true when the path should start from its front endpoint.
+     * @brief Selects a radial path and safe entry point using cylindrical path-order semantics.
+     * @return Selected path index plus either a closed-path rotation index or open-path endpoint.
      */
-    QPair<int, bool> radialOpenPath(const Point& center);
+    RadialPathSelection radialPathSelection();
+
+    /*!
+     * @brief Selects a helical fragment endpoint using cylindrical path-order settings.
+     * @return Selected path index plus whether to enter from its front endpoint.
+     */
+    OpenPathSelection helicalOpenPath() const;
+
+    /*!
+     * @brief Returns the supported cylindrical path-order setting.
+     * @return Next Closest or Next Farthest.
+     */
+    PathOrderOptimization cylindricalPathOrderOptimization() const;
 
     /*!
      * @brief Returns the query point used by radial path ordering.
@@ -137,21 +167,6 @@ class PathOrderOptimizer {
      * @return Shortest endpoint distance.
      */
     Distance nearestOpenEndpointDistance(const Point& query, const Path& path) const;
-
-    /*!
-     * @brief Returns the angular midpoint of an open radial arc about a center.
-     * @param path Open radial arc path.
-     * @param center Cylinder center.
-     * @return Representative midpoint angle in radians.
-     */
-    double radialArcMidpointAngle(const Path& path, const Point& center) const;
-
-    /*!
-     * @brief Normalizes an angular delta to [0, 2*pi).
-     * @param delta Angle delta in radians.
-     * @return Positive equivalent angle delta.
-     */
-    double positiveAngularDelta(double delta) const;
 
     //! \brief Links one line infill path
     //! \return Next path linked via travel

--- a/include/optimizers/path_order_optimizer.h
+++ b/include/optimizers/path_order_optimizer.h
@@ -104,15 +104,15 @@ class PathOrderOptimizer {
 
     //! \brief Selected radial path and entry point.
     struct RadialPathSelection {
-        int path_index = -1;
-        int segment_index = 0;
-        bool start_from_front = true;
+        int path_index         = -1;
+        int segment_index      = 0;
+        bool start_from_front  = true;
         bool rotate_to_segment = false;
     };
 
     //! \brief Selected open path endpoint.
     struct OpenPathSelection {
-        int path_index = -1;
+        int path_index        = -1;
         bool start_from_front = true;
     };
 

--- a/include/slicing/helical_path_rounding.h
+++ b/include/slicing/helical_path_rounding.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <QVector>
+
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "units/unit.h"
+#include "utilities/enums.h"
+
+namespace ORNL {
+struct HelicalPathBoundaryIntersection {
+    Point point;
+    int segment_end_index = 0;
+};
+
+namespace HelicalPathRounding {
+Polyline createHelixForRevolutions(const Point& center, Distance radius, Distance start_z, Distance bead_width,
+                                   HelicalPathHandedness handedness, Angle start_angle, double revolutions);
+
+QVector<Polyline> clipAtHighestIntersection(const Polyline& helix,
+                                            const QVector<HelicalPathBoundaryIntersection>& intersections,
+                                            bool has_inside_points, bool has_outside_points, const Point& center,
+                                            Distance radius, Distance start_z, Distance bead_width,
+                                            HelicalPathHandedness handedness, Angle start_angle,
+                                            HelicalPathZClipRounding rounding, Distance min_path_segment_length);
+} // namespace HelicalPathRounding
+} // namespace ORNL

--- a/include/slicing/helical_path_rounding.h
+++ b/include/slicing/helical_path_rounding.h
@@ -23,5 +23,5 @@ QVector<Polyline> clipAtHighestIntersection(const Polyline& helix,
                                             Distance radius, Distance start_z, Distance bead_width,
                                             HelicalPathHandedness handedness, Angle start_angle,
                                             HelicalPathZClipRounding rounding, Distance min_path_segment_length);
-} // namespace HelicalPathRounding
-} // namespace ORNL
+}  // namespace HelicalPathRounding
+}  // namespace ORNL

--- a/include/threading/slicers/helical_slicer.h
+++ b/include/threading/slicers/helical_slicer.h
@@ -130,5 +130,11 @@ class HelicalSlicer : public TraditionalAST {
 
     //! @brief Ordered helical layers generated during helical path computation.
     QList<QSharedPointer<HelicalLayer>> m_helical_layers;
+
+    //! @brief Whether generated helical paths exceeded or confirmed the mesh-derived build maximum.
+    bool m_has_generated_path_max_z = false;
+
+    //! @brief Maximum Z reached by generated helical paths, including rounded Clip Z extensions.
+    Distance m_generated_path_max_z = 0;
 };
 }  // namespace ORNL

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -820,6 +820,7 @@ class Constants {
             static const QString kLayerGroupingTolerance;
             static const QString kIslandOrder;
             static const QString kPathOrder;
+            static const QString kCylindricalPathOrder;
             static const QString kPerimeterPathOrder;
             static const QString kInsetPathOrder;
             static const QString kSkinPathOrder;

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -909,6 +909,7 @@ class Constants {
             static const QString kRadialPathBoundaryPolicy;
             static const QString kRadialPathStartAngle;
             static const QString kHelicalPathBoundaryPolicy;
+            static const QString kHelicalPathZClipRounding;
             static const QString kHelicalPathHandedness;
             static const QString kHelicalPathStartAngle;
             static const QString kMaxHelicalPathLength;

--- a/include/utilities/enums.h
+++ b/include/utilities/enums.h
@@ -135,6 +135,34 @@ inline QString toString(HelicalPathBoundaryPolicy handling) {
 }
 
 /*!
+ * @enum HelicalPathZClipRounding
+ * @brief Controls where Clip Z helical paths end relative to full revolutions.
+
+ */
+enum class HelicalPathZClipRounding : uint8_t {
+    //! @brief End exactly at the highest-Z model intersection.
+    kExactIntersection = 0,
+
+    //! @brief Continue upward to the next complete revolution.
+    kCompleteRevolution = 1,
+
+    //! @brief End at the previous complete revolution.
+    kLastFullRevolution = 2
+};
+
+inline QString toString(HelicalPathZClipRounding rounding) {
+    switch (rounding) {
+        case HelicalPathZClipRounding::kCompleteRevolution:
+            return "Complete Revolution";
+        case HelicalPathZClipRounding::kLastFullRevolution:
+            return "Last Full Revolution";
+        case HelicalPathZClipRounding::kExactIntersection:
+        default:
+            return "Exact Intersection";
+    }
+}
+
+/*!
  * @enum HelicalPathHandedness
  * @brief Selects the angular direction of rising helical paths.
  */

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5992,6 +5992,19 @@
       "symbol":"kPathOrderOptimization",
       "local":true
   },
+  "cylindrical_path_order_optimization": {
+      "display":"Cylindrical Path Order Optimization",
+      "type":"enumeration",
+      "tooltip":"Type of path order optimizer to use for radial and helical cylindrical slicing paths.",
+      "depends":{"slicing_mode":1},
+      "options":"Next Closest, Next Farthest",
+      "default":0,
+      "minor":"Optimizations",
+      "major":"Profile",
+      "namespace":"Profile::Optimizations",
+      "symbol":"kCylindricalPathOrderOptimization",
+      "local":true
+  },
   "perimeter_path_order_optimization": {
       "display":"Perimeter Path Order Optimization",
       "type":"enumeration",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -3665,6 +3665,19 @@
       "symbol":"kHelicalPathBoundaryPolicy",
       "local":true
   },
+  "helical_path_z_clip_rounding": {
+      "display":"Helical Z Clip Rounding",
+      "type":"enumeration",
+      "tooltip":"Controls how Clip Z rounds the helical path endpoint at the highest model intersection. Exact Intersection stops at the intersection. Complete Revolution continues to the next full revolution. Last Full Revolution stops at the previous full revolution.",
+      "depends":{"AND":[{"AND":[{"slicing_mode":1},{"cylindrical_path_pattern":1}]},{"helical_path_boundary_policy":1}]},
+      "options":"Exact Intersection, Complete Revolution, Last Full Revolution",
+      "default":0,
+      "minor":"Slicing",
+      "major":"Profile",
+      "namespace":"Profile::Slicing",
+      "symbol":"kHelicalPathZClipRounding",
+      "local":true
+  },
   "helical_path_handedness": {
       "display":"Helical Path Handedness",
       "type":"enumeration",

--- a/resources/settings/019_profile_slicing.yaml
+++ b/resources/settings/019_profile_slicing.yaml
@@ -169,6 +169,21 @@ settings:
     namespace: "Profile::Slicing"
     symbol: "kHelicalPathBoundaryPolicy"
     local: true
+  - name: "helical_path_z_clip_rounding"
+    display: "Helical Z Clip Rounding"
+    type: "enumeration"
+    tooltip: "Controls how Clip Z rounds the helical path endpoint at the highest model intersection. Exact Intersection stops at the intersection. Complete Revolution continues to the next full revolution. Last Full Revolution stops at the previous full revolution."
+    depends: {"AND":[{"AND":[{"slicing_mode":1},{"cylindrical_path_pattern":1}]},{"helical_path_boundary_policy":1}]}
+    options:
+      - "Exact Intersection"
+      - "Complete Revolution"
+      - "Last Full Revolution"
+    default: 0
+    minor: "Slicing"
+    major: "Profile"
+    namespace: "Profile::Slicing"
+    symbol: "kHelicalPathZClipRounding"
+    local: true
   - name: "helical_path_handedness"
     display: "Helical Path Handedness"
     type: "enumeration"

--- a/resources/settings/030_profile_optimizations.yaml
+++ b/resources/settings/030_profile_optimizations.yaml
@@ -101,6 +101,20 @@ settings:
     namespace: "Profile::Optimizations"
     symbol: "kPathOrderOptimization"
     local: true
+  - name: "cylindrical_path_order_optimization"
+    display: "Cylindrical Path Order Optimization"
+    type: "enumeration"
+    tooltip: "Type of path order optimizer to use for radial and helical cylindrical slicing paths."
+    depends: {"slicing_mode":1}
+    options:
+      - "Next Closest"
+      - "Next Farthest"
+    default: 0
+    minor: "Optimizations"
+    major: "Profile"
+    namespace: "Profile::Optimizations"
+    symbol: "kCylindricalPathOrderOptimization"
+    local: true
   - name: "perimeter_path_order_optimization"
     display: "Perimeter Path Order Optimization"
     type: "enumeration"

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -122,6 +122,11 @@ void ArcSpecialtiesWriter::setHelicalPathBoundaryPolicy(
     m_helical_path_boundary_policy = methods;
 }
 
+void ArcSpecialtiesWriter::setHelicalPathZClipRounding(
+    const QVector<QPair<QString, HelicalPathZClipRounding>>& rounding) {
+    m_helical_path_z_clip_rounding = rounding;
+}
+
 void ArcSpecialtiesWriter::setHelicalPathHandedness(const QVector<QPair<QString, HelicalPathHandedness>>& handedness) {
     m_helical_path_handedness = handedness;
 }
@@ -211,6 +216,24 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
                 text += commentLine("Helical Path Boundary Policy: " %
                                     toString(static_cast<HelicalPathBoundaryPolicy>(
                                         m_sb->setting<int>(PS::Slicing::kHelicalPathBoundaryPolicy))));
+            }
+
+            if (m_helical_path_z_clip_rounding.size() == 1) {
+                text +=
+                    commentLine("Helical Z Clip Rounding: " % toString(m_helical_path_z_clip_rounding.first().second));
+            }
+            else if (m_helical_path_z_clip_rounding.size() > 1) {
+                for (const QPair<QString, HelicalPathZClipRounding>& part_rounding : m_helical_path_z_clip_rounding) {
+                    const QString part_name = part_rounding.first.isEmpty() ? "Unnamed Part" : part_rounding.first;
+                    text +=
+                        commentLine("Helical Z Clip Rounding (" % part_name % "): " % toString(part_rounding.second));
+                }
+            }
+            else if (static_cast<HelicalPathBoundaryPolicy>(m_sb->setting<int>(
+                         PS::Slicing::kHelicalPathBoundaryPolicy)) == HelicalPathBoundaryPolicy::kClipZ) {
+                text += commentLine("Helical Z Clip Rounding: " %
+                                    toString(static_cast<HelicalPathZClipRounding>(
+                                        m_sb->setting<int>(PS::Slicing::kHelicalPathZClipRounding))));
             }
 
             if (m_helical_path_handedness.size() == 1) {

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -106,13 +106,15 @@ QString formatDistance(Distance value, Distance unit) {
 }
 
 //! @brief Formats an angle using the output unit declared by the active gcode metadata.
-QString formatAngle(Angle value, Angle unit) { return QString::number(value.to(unit), 'f', 4) % unit.toString(); }
+QString formatAngle(Angle value, Angle unit) {
+    return QString::number(value.to(unit), 'f', 4) % unit.toString();
+}
 
 //! @brief Returns the display label for supported cylindrical path order choices.
 QString cylindricalPathOrderText(PathOrderOptimization path_order) {
     return path_order == PathOrderOptimization::kNextFarthest ? "Next Farthest" : "Next Closest";
 }
-} // namespace
+}  // namespace
 
 ArcSpecialtiesWriter::ArcSpecialtiesWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
     : WriterBase(meta, sb) {}
@@ -145,8 +147,9 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
         text += commentLine("Cylindrical Path Order Optimization: " %
                             cylindricalPathOrderText(static_cast<PathOrderOptimization>(
                                 m_sb->setting<int>(PS::Optimizations::kCylindricalPathOrder))));
-        text += commentLine("Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
-                            "offset");
+        text += commentLine(
+            "Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
+            "offset");
         text += commentLine(
             "G-Code Coordinate Frame Rotation: X=" %
             formatAngle(m_sb->setting<Angle>(PRS::MachineSetup::kGCodeCoordinateFrameRotationX), m_meta.m_angle_unit) %

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -106,10 +106,13 @@ QString formatDistance(Distance value, Distance unit) {
 }
 
 //! @brief Formats an angle using the output unit declared by the active gcode metadata.
-QString formatAngle(Angle value, Angle unit) {
-    return QString::number(value.to(unit), 'f', 4) % unit.toString();
+QString formatAngle(Angle value, Angle unit) { return QString::number(value.to(unit), 'f', 4) % unit.toString(); }
+
+//! @brief Returns the display label for supported cylindrical path order choices.
+QString cylindricalPathOrderText(PathOrderOptimization path_order) {
+    return path_order == PathOrderOptimization::kNextFarthest ? "Next Farthest" : "Next Closest";
 }
-}  // namespace
+} // namespace
 
 ArcSpecialtiesWriter::ArcSpecialtiesWriter(GcodeMeta meta, const QSharedPointer<SettingsBase>& sb)
     : WriterBase(meta, sb) {}
@@ -134,9 +137,11 @@ QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
         text += commentLine(helical_mode ? "Arc Specialties Helical Slicing Parameters"
                                          : "Arc Specialties Radial Slicing Parameters");
         text += commentLine("Cylindrical Path Pattern: " % toString(path_pattern));
-        text += commentLine(
-            "Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
-            "offset");
+        text += commentLine("Cylindrical Path Order Optimization: " %
+                            cylindricalPathOrderText(static_cast<PathOrderOptimization>(
+                                m_sb->setting<int>(PS::Optimizations::kCylindricalPathOrder))));
+        text += commentLine("Motion Coordinates: X/Y/Z are user-frame endpoint coordinates relative to the active work "
+                            "offset");
         text += commentLine(
             "G-Code Coordinate Frame Rotation: X=" %
             formatAngle(m_sb->setting<Angle>(PRS::MachineSetup::kGCodeCoordinateFrameRotationX), m_meta.m_angle_unit) %

--- a/src/optimizers/path_order_optimizer.cpp
+++ b/src/optimizers/path_order_optimizer.cpp
@@ -287,25 +287,37 @@ Path PathOrderOptimizer::linkNextSkeletonPath() {
     return new_path;
 }
 
-Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
+Path PathOrderOptimizer::linkNextRadialPath() {
     Path new_path;
     if (m_paths.isEmpty()) { return new_path; }
 
-    QPair<int, bool> location = radialOpenPath(center);
-    int index                 = location.first;
-    bool start                = location.second;
-    if (index < 0 || index >= m_paths.size()) return new_path;
+    RadialPathSelection location = radialPathSelection();
+    int index = location.path_index;
+    if (index < 0 || index >= m_paths.size())
+        return new_path;
 
+    new_path = m_paths[index];
     new_path.setCCW(m_paths[index].getCCW());
 
+    if (location.rotate_to_segment) {
+        addTravel(location.segment_index, new_path);
+        m_current_location = new_path.back()->end();
+        m_paths.remove(index);
+        return new_path;
+    }
+
     QSharedPointer<TravelSegment> travel_segment = QSharedPointer<TravelSegment>::create(
-        m_current_location, start ? m_paths[index].front()->start() : m_paths[index].back()->end());
+        m_current_location, location.start_from_front ? m_paths[index].front()->start() : m_paths[index].back()->end());
     Velocity velocity = m_sb->setting<Velocity>(PS::Travel::kSpeed);
     travel_segment->getSb()->setSetting(SS::kSpeed, velocity);
+    new_path.clear();
+    new_path.setCCW(m_paths[index].getCCW());
     new_path.append(travel_segment);
 
-    if (start) {
-        for (QSharedPointer<SegmentBase> seg : m_paths[index]) { new_path.append(seg); }
+    if (location.start_from_front) {
+        for (QSharedPointer<SegmentBase> seg : m_paths[index]) {
+            new_path.append(seg);
+        }
     }
     else {
         QList<QSharedPointer<SegmentBase>> segments = m_paths[index].getSegments();
@@ -322,77 +334,141 @@ Path PathOrderOptimizer::linkNextRadialPath(const Point& center) {
     return new_path;
 }
 
-QPair<int, bool> PathOrderOptimizer::radialOpenPath(const Point& center) {
-    if (m_paths.isEmpty()) return QPair<int, bool>(-1, true);
+Path PathOrderOptimizer::linkNextHelicalPath() {
+    Path new_path;
+    if (m_paths.isEmpty()) {
+        return new_path;
+    }
 
-    PathOrderOptimization path_order =
-        static_cast<PathOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPathOrder));
+    OpenPathSelection location = helicalOpenPath();
+    const int index = location.path_index;
+    if (index < 0 || index >= m_paths.size())
+        return new_path;
+
+    new_path.setCCW(m_paths[index].getCCW());
+
+    QSharedPointer<TravelSegment> travel_segment = QSharedPointer<TravelSegment>::create(
+        m_current_location, location.start_from_front ? m_paths[index].front()->start() : m_paths[index].back()->end());
+    Velocity velocity = m_sb->setting<Velocity>(PS::Travel::kSpeed);
+    travel_segment->getSb()->setSetting(SS::kSpeed, velocity);
+    new_path.append(travel_segment);
+
+    if (location.start_from_front) {
+        for (QSharedPointer<SegmentBase> seg : m_paths[index]) {
+            new_path.append(seg);
+        }
+    }
+    else {
+        QList<QSharedPointer<SegmentBase>> segments = m_paths[index].getSegments();
+        while (!segments.isEmpty()) {
+            QSharedPointer<SegmentBase> seg = segments.back();
+            seg->reverse();
+            new_path.append(seg);
+            segments.removeLast();
+        }
+    }
+
+    m_current_location = new_path.back()->end();
+    m_paths.remove(index);
+    return new_path;
+}
+
+PathOrderOptimizer::RadialPathSelection PathOrderOptimizer::radialPathSelection() {
+    RadialPathSelection selection;
+    if (m_paths.isEmpty())
+        return selection;
+
+    PathOrderOptimization path_order = cylindricalPathOrderOptimization();
     Point query_point = radialPathQueryPoint(path_order);
+    const bool find_farthest = path_order == PathOrderOptimization::kNextFarthest;
 
-    int selected_index = 0;
-    switch (path_order) {
-        case PathOrderOptimization::kNextFarthest: {
-            double farthest = -1.0;
-            for (int i = 0, end = m_paths.size(); i < end; ++i) {
-                const double distance = nearestOpenEndpointDistance(query_point, m_paths[i])();
-                if (distance > farthest) {
-                    farthest       = distance;
-                    selected_index = i;
+    double selected_distance = 0.0;
+    for (int i = 0, end = m_paths.size(); i < end; ++i) {
+        if (m_paths[i].isClosed()) {
+            for (int j = 0, segment_count = m_paths[i].size(); j < segment_count; ++j) {
+                QSharedPointer<SegmentBase> segment = m_paths[i][j];
+                if (segment.isNull()) {
+                    continue;
+                }
+
+                const double distance = query_point.distance(segment->start())();
+                if (selection.path_index < 0 || (find_farthest && distance > selected_distance) ||
+                    (!find_farthest && distance < selected_distance)) {
+                    selected_distance = distance;
+                    selection.path_index = i;
+                    selection.segment_index = j;
+                    selection.start_from_front = true;
+                    selection.rotate_to_segment = true;
                 }
             }
-            break;
         }
-        case PathOrderOptimization::kRandom:
-            selected_index = QRandomGenerator::global()->bounded(m_paths.size());
-            break;
-        case PathOrderOptimization::kOutsideIn:
-        case PathOrderOptimization::kInsideOut: {
-            const double query_radius = std::hypot(query_point.x() - center.x(), query_point.y() - center.y());
-            const bool reverse_sweep  = path_order == PathOrderOptimization::kInsideOut;
-            double best_sweep         = std::numeric_limits<double>::max();
-
-            for (int i = 0, end = m_paths.size(); i < end; ++i) {
-                const double path_angle = radialArcMidpointAngle(m_paths[i], center);
-                double sweep            = path_angle;
-                if (query_radius > std::numeric_limits<double>::epsilon()) {
-                    const double query_angle = std::atan2(query_point.y() - center.y(), query_point.x() - center.x());
-                    sweep                    = reverse_sweep ? positiveAngularDelta(query_angle - path_angle)
-                                                             : positiveAngularDelta(path_angle - query_angle);
-                }
-                else if (reverse_sweep) { sweep = positiveAngularDelta(-path_angle); }
-                else { sweep = positiveAngularDelta(path_angle); }
-
-                if (sweep < best_sweep) {
-                    best_sweep     = sweep;
-                    selected_index = i;
-                }
+        else {
+            const double distance = nearestOpenEndpointDistance(query_point, m_paths[i])();
+            if (selection.path_index < 0 || (find_farthest && distance > selected_distance) ||
+                (!find_farthest && distance < selected_distance)) {
+                selected_distance = distance;
+                selection.path_index = i;
+                selection.segment_index = 0;
+                selection.start_from_front = true;
+                selection.rotate_to_segment = false;
             }
-            break;
         }
-        case PathOrderOptimization::kNextClosest:
-        case PathOrderOptimization::kCustomPoint:
-        default: {
-            double closest = std::numeric_limits<double>::max();
-            for (int i = 0, end = m_paths.size(); i < end; ++i) {
-                const double distance = nearestOpenEndpointDistance(query_point, m_paths[i])();
-                if (distance < closest) {
-                    closest        = distance;
-                    selected_index = i;
-                }
-            }
-            break;
-        }
+    }
+
+    if (selection.path_index < 0 || selection.rotate_to_segment) {
+        return selection;
     }
 
     PointOrderOptimization point_order =
         static_cast<PointOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPointOrder));
     Point point_query = radialPointQueryPoint(point_order);
-    Polyline endpoints {m_paths[selected_index].front()->start(), m_paths[selected_index].back()->end()};
+    Polyline endpoints {m_paths[selection.path_index].front()->start(), m_paths[selection.path_index].back()->end()};
     const bool reverse = PointOrderOptimizer::findSkeletonPointOrder(
         point_query, endpoints, point_order, m_sb->setting<bool>(PS::Optimizations::kMinDistanceEnabled),
         m_sb->setting<Distance>(PS::Optimizations::kMinDistanceThreshold));
 
-    return QPair<int, bool>(selected_index, !reverse);
+    selection.start_from_front = !reverse;
+    return selection;
+}
+
+PathOrderOptimizer::OpenPathSelection PathOrderOptimizer::helicalOpenPath() const {
+    OpenPathSelection selection;
+    if (m_paths.isEmpty())
+        return selection;
+
+    const PathOrderOptimization path_order = cylindricalPathOrderOptimization();
+    const Point query_point = m_current_location;
+    const bool find_farthest = path_order == PathOrderOptimization::kNextFarthest;
+
+    double selected_distance = 0.0;
+    for (int i = 0, end = m_paths.size(); i < end; ++i) {
+        const double start_distance = query_point.distance(m_paths[i].front()->start())();
+        if (selection.path_index < 0 || (find_farthest && start_distance > selected_distance) ||
+            (!find_farthest && start_distance < selected_distance)) {
+            selected_distance = start_distance;
+            selection.path_index = i;
+            selection.start_from_front = true;
+        }
+
+        const double end_distance = query_point.distance(m_paths[i].back()->end())();
+        if ((find_farthest && end_distance > selected_distance) ||
+            (!find_farthest && end_distance < selected_distance)) {
+            selected_distance = end_distance;
+            selection.path_index = i;
+            selection.start_from_front = false;
+        }
+    }
+
+    return selection;
+}
+
+PathOrderOptimization PathOrderOptimizer::cylindricalPathOrderOptimization() const {
+    const int path_order = m_sb->setting<int>(PS::Optimizations::kCylindricalPathOrder);
+    if (path_order == static_cast<int>(PathOrderOptimization::kNextFarthest)) {
+        return PathOrderOptimization::kNextFarthest;
+    }
+
+    return PathOrderOptimization::kNextClosest;
 }
 
 Point PathOrderOptimizer::radialPathQueryPoint(PathOrderOptimization optimization) const {
@@ -419,26 +495,6 @@ Point PathOrderOptimizer::radialPointQueryPoint(PointOrderOptimization optimizat
 
 Distance PathOrderOptimizer::nearestOpenEndpointDistance(const Point& query, const Path& path) const {
     return std::min(query.distance(path.front()->start()), query.distance(path.back()->end()));
-}
-
-double PathOrderOptimizer::radialArcMidpointAngle(const Path& path, const Point& center) const {
-    const double start_angle =
-        std::atan2(path.front()->start().y() - center.y(), path.front()->start().x() - center.x());
-    const double end_angle = std::atan2(path.back()->end().y() - center.y(), path.back()->end().x() - center.x());
-    const double pi        = std::acos(-1.0);
-    double delta           = end_angle - start_angle;
-    while (delta > pi) { delta -= 2.0 * pi; }
-    while (delta < -pi) { delta += 2.0 * pi; }
-
-    return start_angle + delta / 2.0;
-}
-
-double PathOrderOptimizer::positiveAngularDelta(double delta) const {
-    const double two_pi = 2.0 * std::acos(-1.0);
-    while (delta < 0.0) { delta += two_pi; }
-    while (delta >= two_pi) { delta -= two_pi; }
-
-    return delta;
 }
 
 bool PathOrderOptimizer::linkIntersects(Point link_start, Point link_end, QVector<Path> infill_geometry,

--- a/src/optimizers/path_order_optimizer.cpp
+++ b/src/optimizers/path_order_optimizer.cpp
@@ -292,9 +292,8 @@ Path PathOrderOptimizer::linkNextRadialPath() {
     if (m_paths.isEmpty()) { return new_path; }
 
     RadialPathSelection location = radialPathSelection();
-    int index = location.path_index;
-    if (index < 0 || index >= m_paths.size())
-        return new_path;
+    int index                    = location.path_index;
+    if (index < 0 || index >= m_paths.size()) return new_path;
 
     new_path = m_paths[index];
     new_path.setCCW(m_paths[index].getCCW());
@@ -315,9 +314,7 @@ Path PathOrderOptimizer::linkNextRadialPath() {
     new_path.append(travel_segment);
 
     if (location.start_from_front) {
-        for (QSharedPointer<SegmentBase> seg : m_paths[index]) {
-            new_path.append(seg);
-        }
+        for (QSharedPointer<SegmentBase> seg : m_paths[index]) { new_path.append(seg); }
     }
     else {
         QList<QSharedPointer<SegmentBase>> segments = m_paths[index].getSegments();
@@ -336,14 +333,11 @@ Path PathOrderOptimizer::linkNextRadialPath() {
 
 Path PathOrderOptimizer::linkNextHelicalPath() {
     Path new_path;
-    if (m_paths.isEmpty()) {
-        return new_path;
-    }
+    if (m_paths.isEmpty()) { return new_path; }
 
     OpenPathSelection location = helicalOpenPath();
-    const int index = location.path_index;
-    if (index < 0 || index >= m_paths.size())
-        return new_path;
+    const int index            = location.path_index;
+    if (index < 0 || index >= m_paths.size()) return new_path;
 
     new_path.setCCW(m_paths[index].getCCW());
 
@@ -354,9 +348,7 @@ Path PathOrderOptimizer::linkNextHelicalPath() {
     new_path.append(travel_segment);
 
     if (location.start_from_front) {
-        for (QSharedPointer<SegmentBase> seg : m_paths[index]) {
-            new_path.append(seg);
-        }
+        for (QSharedPointer<SegmentBase> seg : m_paths[index]) { new_path.append(seg); }
     }
     else {
         QList<QSharedPointer<SegmentBase>> segments = m_paths[index].getSegments();
@@ -375,29 +367,26 @@ Path PathOrderOptimizer::linkNextHelicalPath() {
 
 PathOrderOptimizer::RadialPathSelection PathOrderOptimizer::radialPathSelection() {
     RadialPathSelection selection;
-    if (m_paths.isEmpty())
-        return selection;
+    if (m_paths.isEmpty()) return selection;
 
     PathOrderOptimization path_order = cylindricalPathOrderOptimization();
-    Point query_point = radialPathQueryPoint(path_order);
-    const bool find_farthest = path_order == PathOrderOptimization::kNextFarthest;
+    Point query_point                = radialPathQueryPoint(path_order);
+    const bool find_farthest         = path_order == PathOrderOptimization::kNextFarthest;
 
     double selected_distance = 0.0;
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
         if (m_paths[i].isClosed()) {
             for (int j = 0, segment_count = m_paths[i].size(); j < segment_count; ++j) {
                 QSharedPointer<SegmentBase> segment = m_paths[i][j];
-                if (segment.isNull()) {
-                    continue;
-                }
+                if (segment.isNull()) { continue; }
 
                 const double distance = query_point.distance(segment->start())();
                 if (selection.path_index < 0 || (find_farthest && distance > selected_distance) ||
                     (!find_farthest && distance < selected_distance)) {
-                    selected_distance = distance;
-                    selection.path_index = i;
-                    selection.segment_index = j;
-                    selection.start_from_front = true;
+                    selected_distance           = distance;
+                    selection.path_index        = i;
+                    selection.segment_index     = j;
+                    selection.start_from_front  = true;
                     selection.rotate_to_segment = true;
                 }
             }
@@ -406,18 +395,16 @@ PathOrderOptimizer::RadialPathSelection PathOrderOptimizer::radialPathSelection(
             const double distance = nearestOpenEndpointDistance(query_point, m_paths[i])();
             if (selection.path_index < 0 || (find_farthest && distance > selected_distance) ||
                 (!find_farthest && distance < selected_distance)) {
-                selected_distance = distance;
-                selection.path_index = i;
-                selection.segment_index = 0;
-                selection.start_from_front = true;
+                selected_distance           = distance;
+                selection.path_index        = i;
+                selection.segment_index     = 0;
+                selection.start_from_front  = true;
                 selection.rotate_to_segment = false;
             }
         }
     }
 
-    if (selection.path_index < 0 || selection.rotate_to_segment) {
-        return selection;
-    }
+    if (selection.path_index < 0 || selection.rotate_to_segment) { return selection; }
 
     PointOrderOptimization point_order =
         static_cast<PointOrderOptimization>(m_sb->setting<int>(PS::Optimizations::kPointOrder));
@@ -433,28 +420,27 @@ PathOrderOptimizer::RadialPathSelection PathOrderOptimizer::radialPathSelection(
 
 PathOrderOptimizer::OpenPathSelection PathOrderOptimizer::helicalOpenPath() const {
     OpenPathSelection selection;
-    if (m_paths.isEmpty())
-        return selection;
+    if (m_paths.isEmpty()) return selection;
 
     const PathOrderOptimization path_order = cylindricalPathOrderOptimization();
-    const Point query_point = m_current_location;
-    const bool find_farthest = path_order == PathOrderOptimization::kNextFarthest;
+    const Point query_point                = m_current_location;
+    const bool find_farthest               = path_order == PathOrderOptimization::kNextFarthest;
 
     double selected_distance = 0.0;
     for (int i = 0, end = m_paths.size(); i < end; ++i) {
         const double start_distance = query_point.distance(m_paths[i].front()->start())();
         if (selection.path_index < 0 || (find_farthest && start_distance > selected_distance) ||
             (!find_farthest && start_distance < selected_distance)) {
-            selected_distance = start_distance;
-            selection.path_index = i;
+            selected_distance          = start_distance;
+            selection.path_index       = i;
             selection.start_from_front = true;
         }
 
         const double end_distance = query_point.distance(m_paths[i].back()->end())();
         if ((find_farthest && end_distance > selected_distance) ||
             (!find_farthest && end_distance < selected_distance)) {
-            selected_distance = end_distance;
-            selection.path_index = i;
+            selected_distance          = end_distance;
+            selection.path_index       = i;
             selection.start_from_front = false;
         }
     }

--- a/src/slicing/helical_path_rounding.cpp
+++ b/src/slicing/helical_path_rounding.cpp
@@ -14,18 +14,16 @@ const Distance kMinHelixSegmentLength = 100.0 * micron;
 
 Point pointAtRevolutions(const Point& center, Distance radius, Distance start_z, Distance bead_width,
                          HelicalPathHandedness handedness, Angle start_angle, double revolutions) {
-    const double t = revolutions * 2.0 * M_PI;
+    const double t         = revolutions * 2.0 * M_PI;
     const double direction = handedness == HelicalPathHandedness::kLeftHanded ? -1.0 : 1.0;
-    const double angle = start_angle() + direction * t;
+    const double angle     = start_angle() + direction * t;
 
     return Point(center.x() + radius() * std::cos(angle), center.y() + radius() * std::sin(angle),
                  start_z() + bead_width() * revolutions);
 }
 
 double revolutionsAtZ(Distance z, Distance start_z, Distance bead_width) {
-    if (bead_width <= 0) {
-        return 0.0;
-    }
+    if (bead_width <= 0) { return 0.0; }
 
     return (z() - start_z()) / bead_width();
 }
@@ -40,41 +38,33 @@ bool appendDistinct(Polyline& polyline, const Point& point) {
 }
 
 QVector<Polyline> filteredResult(const Polyline& polyline, Distance min_path_segment_length) {
-    if (polyline.size() < 2 || polyline.length() <= min_path_segment_length) {
-        return {};
-    }
+    if (polyline.size() < 2 || polyline.length() <= min_path_segment_length) { return {}; }
 
     return {polyline};
 }
 
 Polyline exactIntersectionPrefix(const Polyline& helix, const HelicalPathBoundaryIntersection& intersection) {
     Polyline clipped_helix;
-    if (helix.isEmpty()) {
-        return clipped_helix;
-    }
+    if (helix.isEmpty()) { return clipped_helix; }
 
     const int prefix_end = std::clamp(intersection.segment_end_index, 0, static_cast<int>(helix.size()));
     clipped_helix.reserve(prefix_end + 1);
-    for (int i = 0; i < prefix_end; ++i) {
-        clipped_helix.push_back(helix[i]);
-    }
+    for (int i = 0; i < prefix_end; ++i) { clipped_helix.push_back(helix[i]); }
 
     appendDistinct(clipped_helix, intersection.point);
     return clipped_helix;
 }
-} // namespace
+}  // namespace
 
 Polyline HelicalPathRounding::createHelixForRevolutions(const Point& center, Distance radius, Distance start_z,
                                                         Distance bead_width, HelicalPathHandedness handedness,
                                                         Angle start_angle, double revolutions) {
     Polyline helix;
-    if (revolutions <= 0.0 || bead_width <= 0) {
-        return helix;
-    }
+    if (revolutions <= 0.0 || bead_width <= 0) { return helix; }
 
-    const double max_t = revolutions * 2.0 * M_PI;
+    const double max_t                    = revolutions * 2.0 * M_PI;
     const double vertical_rise_per_radian = bead_width() / (2.0 * M_PI);
-    const double length_per_radian = std::hypot(radius(), vertical_rise_per_radian);
+    const double length_per_radian        = std::hypot(radius(), vertical_rise_per_radian);
     const Distance target_segment_length =
         bead_width / 2.0 > kMinHelixSegmentLength ? bead_width / 2.0 : kMinHelixSegmentLength;
     const int segments =
@@ -95,9 +85,7 @@ QVector<Polyline> HelicalPathRounding::clipAtHighestIntersection(
     bool has_outside_points, const Point& center, Distance radius, Distance start_z, Distance bead_width,
     HelicalPathHandedness handedness, Angle start_angle, HelicalPathZClipRounding rounding,
     Distance min_path_segment_length) {
-    if (helix.size() < 2) {
-        return {};
-    }
+    if (helix.size() < 2) { return {}; }
 
     if (intersections.isEmpty()) {
         return has_inside_points && !has_outside_points ? QVector<Polyline> {helix} : QVector<Polyline>();
@@ -113,17 +101,15 @@ QVector<Polyline> HelicalPathRounding::clipAtHighestIntersection(
         return filteredResult(exactIntersectionPrefix(helix, *highest_intersection), min_path_segment_length);
     }
 
-    const double raw_revolutions = revolutionsAtZ(Distance(highest_intersection->point.z()), start_z, bead_width);
+    const double raw_revolutions     = revolutionsAtZ(Distance(highest_intersection->point.z()), start_z, bead_width);
     const double rounded_revolutions = rounding == HelicalPathZClipRounding::kCompleteRevolution
                                            ? std::ceil(raw_revolutions - kRevolutionTolerance)
                                            : std::floor(raw_revolutions + kRevolutionTolerance);
 
-    if (rounded_revolutions <= kRevolutionTolerance) {
-        return {};
-    }
+    if (rounded_revolutions <= kRevolutionTolerance) { return {}; }
 
     return filteredResult(
         createHelixForRevolutions(center, radius, start_z, bead_width, handedness, start_angle, rounded_revolutions),
         min_path_segment_length);
 }
-} // namespace ORNL
+}  // namespace ORNL

--- a/src/slicing/helical_path_rounding.cpp
+++ b/src/slicing/helical_path_rounding.cpp
@@ -1,0 +1,129 @@
+#include "slicing/helical_path_rounding.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "units/unit.h"
+
+namespace ORNL {
+namespace {
+constexpr double kRevolutionTolerance = 1.0e-9;
+const Distance kMinHelixSegmentLength = 100.0 * micron;
+
+Point pointAtRevolutions(const Point& center, Distance radius, Distance start_z, Distance bead_width,
+                         HelicalPathHandedness handedness, Angle start_angle, double revolutions) {
+    const double t = revolutions * 2.0 * M_PI;
+    const double direction = handedness == HelicalPathHandedness::kLeftHanded ? -1.0 : 1.0;
+    const double angle = start_angle() + direction * t;
+
+    return Point(center.x() + radius() * std::cos(angle), center.y() + radius() * std::sin(angle),
+                 start_z() + bead_width() * revolutions);
+}
+
+double revolutionsAtZ(Distance z, Distance start_z, Distance bead_width) {
+    if (bead_width <= 0) {
+        return 0.0;
+    }
+
+    return (z() - start_z()) / bead_width();
+}
+
+bool appendDistinct(Polyline& polyline, const Point& point) {
+    if (polyline.isEmpty() || polyline.last() != point) {
+        polyline.push_back(point);
+        return true;
+    }
+
+    return false;
+}
+
+QVector<Polyline> filteredResult(const Polyline& polyline, Distance min_path_segment_length) {
+    if (polyline.size() < 2 || polyline.length() <= min_path_segment_length) {
+        return {};
+    }
+
+    return {polyline};
+}
+
+Polyline exactIntersectionPrefix(const Polyline& helix, const HelicalPathBoundaryIntersection& intersection) {
+    Polyline clipped_helix;
+    if (helix.isEmpty()) {
+        return clipped_helix;
+    }
+
+    const int prefix_end = std::clamp(intersection.segment_end_index, 0, static_cast<int>(helix.size()));
+    clipped_helix.reserve(prefix_end + 1);
+    for (int i = 0; i < prefix_end; ++i) {
+        clipped_helix.push_back(helix[i]);
+    }
+
+    appendDistinct(clipped_helix, intersection.point);
+    return clipped_helix;
+}
+} // namespace
+
+Polyline HelicalPathRounding::createHelixForRevolutions(const Point& center, Distance radius, Distance start_z,
+                                                        Distance bead_width, HelicalPathHandedness handedness,
+                                                        Angle start_angle, double revolutions) {
+    Polyline helix;
+    if (revolutions <= 0.0 || bead_width <= 0) {
+        return helix;
+    }
+
+    const double max_t = revolutions * 2.0 * M_PI;
+    const double vertical_rise_per_radian = bead_width() / (2.0 * M_PI);
+    const double length_per_radian = std::hypot(radius(), vertical_rise_per_radian);
+    const Distance target_segment_length =
+        bead_width / 2.0 > kMinHelixSegmentLength ? bead_width / 2.0 : kMinHelixSegmentLength;
+    const int segments =
+        std::clamp(static_cast<int>(std::ceil(max_t * length_per_radian / target_segment_length())), 1, 20000);
+
+    helix.reserve(segments + 1);
+    for (int i = 0; i <= segments; ++i) {
+        const double revolutions_at_sample = revolutions * static_cast<double>(i) / static_cast<double>(segments);
+        helix.push_back(
+            pointAtRevolutions(center, radius, start_z, bead_width, handedness, start_angle, revolutions_at_sample));
+    }
+
+    return helix;
+}
+
+QVector<Polyline> HelicalPathRounding::clipAtHighestIntersection(
+    const Polyline& helix, const QVector<HelicalPathBoundaryIntersection>& intersections, bool has_inside_points,
+    bool has_outside_points, const Point& center, Distance radius, Distance start_z, Distance bead_width,
+    HelicalPathHandedness handedness, Angle start_angle, HelicalPathZClipRounding rounding,
+    Distance min_path_segment_length) {
+    if (helix.size() < 2) {
+        return {};
+    }
+
+    if (intersections.isEmpty()) {
+        return has_inside_points && !has_outside_points ? QVector<Polyline> {helix} : QVector<Polyline>();
+    }
+
+    const auto highest_intersection =
+        std::max_element(intersections.cbegin(), intersections.cend(),
+                         [](const HelicalPathBoundaryIntersection& lhs, const HelicalPathBoundaryIntersection& rhs) {
+                             return lhs.point.z() < rhs.point.z();
+                         });
+
+    if (rounding == HelicalPathZClipRounding::kExactIntersection) {
+        return filteredResult(exactIntersectionPrefix(helix, *highest_intersection), min_path_segment_length);
+    }
+
+    const double raw_revolutions = revolutionsAtZ(Distance(highest_intersection->point.z()), start_z, bead_width);
+    const double rounded_revolutions = rounding == HelicalPathZClipRounding::kCompleteRevolution
+                                           ? std::ceil(raw_revolutions - kRevolutionTolerance)
+                                           : std::floor(raw_revolutions + kRevolutionTolerance);
+
+    if (rounded_revolutions <= kRevolutionTolerance) {
+        return {};
+    }
+
+    return filteredResult(
+        createHelixForRevolutions(center, radius, start_z, bead_width, handedness, start_angle, rounded_revolutions),
+        min_path_segment_length);
+}
+} // namespace ORNL

--- a/src/slicing/preprocessor.cpp
+++ b/src/slicing/preprocessor.cpp
@@ -11,7 +11,6 @@
 #include "part/part.h"
 #include "slicing/buffered_slicer.h"
 #include "slicing/slicing_utilities.h"
-#include "units/unit.h"
 #include "utilities/enums.h"
 
 namespace ORNL {
@@ -30,9 +29,9 @@ Preprocessor::Preprocessor(bool use_cgal_cross_section, bool include_build_plate
 void Preprocessor::processAll() {
     QSharedPointer<SettingsBase> global_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
 
-    if (m_initial_processing != nullptr)
-        if (m_initial_processing(m_parts, global_sb)) return;  // halt slicing
-
+    if (m_initial_processing != nullptr) {
+        if (m_initial_processing(m_parts, global_sb)) { return; }  // halt slicing
+    }
     int total_num_parts = m_parts.build_parts.size();
     int parts_done      = 0;
     for (const QSharedPointer<Part>& part : m_parts.build_parts) {
@@ -42,9 +41,9 @@ void Preprocessor::processAll() {
 
         ActivePartMeta part_meta(part, part_sb);
 
-        if (m_part_processing != nullptr)
-            if (m_part_processing(part, part_sb)) return;  // halt slicing
-
+        if (m_part_processing != nullptr) {
+            if (m_part_processing(part, part_sb)) { return; }  // halt slicing
+        }
         part_meta.steps_processed = part->countStepPairs();
         part_meta.part_start      = SlicingUtilities::GetPartStart(part, part_meta.steps_processed);
 
@@ -52,13 +51,12 @@ void Preprocessor::processAll() {
             QSharedPointer<MeshBase> mesh;
             // Make a new copy of the mesh to prevent the original one from being contaminated
             auto closed_mesh = dynamic_cast<ClosedMesh*>(original_mesh.get());
-            if (closed_mesh != nullptr)
-                mesh = QSharedPointer<ClosedMesh>::create(ClosedMesh(*closed_mesh));
-            else
-                mesh = QSharedPointer<OpenMesh>::create(OpenMesh(*dynamic_cast<OpenMesh*>(original_mesh.get())));
+            if (closed_mesh != nullptr) { mesh = QSharedPointer<ClosedMesh>::create(ClosedMesh(*closed_mesh)); }
+            else { mesh = QSharedPointer<OpenMesh>::create(OpenMesh(*dynamic_cast<OpenMesh*>(original_mesh.get()))); }
 
-            if (m_mesh_processing != nullptr)
-                if (m_mesh_processing(mesh, part_sb)) return;  // halt slicing
+            if (m_mesh_processing != nullptr) {
+                if (m_mesh_processing(mesh, part_sb)) { return; }  // halt slicing
+            }
 
             part_meta.steps_processed = part->countStepPairs();
             part_meta.part_start      = SlicingUtilities::GetPartStart(part, part_meta.steps_processed);
@@ -70,27 +68,29 @@ void Preprocessor::processAll() {
             do {
                 next_layer_meta = slicer.processNextSlice();
 
-                if (next_layer_meta == nullptr) break;
+                if (next_layer_meta == nullptr) { break; }
 
                 // Build steps using slicing info
-                if (m_step_builder != nullptr)
-                    if (m_step_builder(next_layer_meta, part_meta)) return;  // halt slicing
-
+                if (m_step_builder != nullptr) {
+                    if (m_step_builder(next_layer_meta, part_meta)) { return; }  // halt slicing
+                }
                 last_step_count = next_layer_meta->number;
             } while (next_layer_meta != nullptr);
 
             part_meta.last_step_count = last_step_count;
 
-            if (m_cross_section_processing != nullptr)
-                if (m_cross_section_processing(part_meta)) return;  // halt slicing
+            if (m_cross_section_processing != nullptr) {
+                if (m_cross_section_processing(part_meta)) { return; }  // halt slicing
+            }
         }
 
         ++parts_done;
-        if (m_status_update != nullptr) m_status_update((double)parts_done / (double)total_num_parts * 100);
+        if (m_status_update != nullptr) { m_status_update((double)parts_done / (double)total_num_parts * 100); }
     }
 
-    if (m_final_processing != nullptr)
-        if (m_final_processing(m_parts, global_sb)) return;  // halt slicing
+    if (m_final_processing != nullptr) {
+        if (m_final_processing(m_parts, global_sb)) { return; }  // halt slicing
+    }
 }
 
 void Preprocessor::addInitialProcessing(Processing processing) {

--- a/src/step/layer/helical_layer.cpp
+++ b/src/step/layer/helical_layer.cpp
@@ -12,6 +12,7 @@
 #include "geometry/point.h"
 #include "geometry/segment_base.h"
 #include "geometry/segments/travel.h"
+#include "optimizers/path_order_optimizer.h"
 #include "step/layer/layer.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -100,14 +101,14 @@ void HelicalLayer::calculateModifiers(Point& currentLocation) {
 
     QVector<Path> ordered_paths;
     ordered_paths.reserve(print_paths.size());
-    for (Path path : print_paths) {
-        // Helical fragments encode angular and Z progression; keep their generated direction and order.
-        QSharedPointer<TravelSegment> travel =
-            QSharedPointer<TravelSegment>::create(currentLocation, path.front()->start());
-        path.prepend(travel);
-        restoreHelicalPathSettings(path, m_sb);
-        currentLocation = path.back()->end();
-        ordered_paths.push_back(path);
+    PathOrderOptimizer path_optimizer(currentLocation, getLayerNumber(), m_sb);
+    path_optimizer.setPathsToEvaluate(print_paths);
+    while (path_optimizer.getCurrentPathCount() > 0) {
+        Path next_path = path_optimizer.linkNextHelicalPath();
+        if (next_path.size() > 0) {
+            restoreHelicalPathSettings(next_path, m_sb);
+            ordered_paths.push_back(next_path);
+        }
     }
 
     m_paths = ordered_paths;

--- a/src/step/layer/radial_layer.cpp
+++ b/src/step/layer/radial_layer.cpp
@@ -1,6 +1,5 @@
 #include "step/layer/radial_layer.h"
 
-#include <cmath>
 #include <limits>
 
 #include <qcontainerfwd.h>
@@ -19,18 +18,6 @@
 
 namespace ORNL {
 namespace {
-//! @brief Segment setting key used by the radial writer to recover the cylinder center X.
-const QString kRadialCenterX = "radial_center_x";
-
-//! @brief Segment setting key used by the radial writer to recover the cylinder center Y.
-const QString kRadialCenterY = "radial_center_y";
-
-//! @brief Group of disconnected arcs that belong to the same horizontal radial circle.
-struct CirclePathGroup {
-    long long z_key;
-    QVector<Path> paths;
-};
-
 //! @brief Returns the first printable radial segment in a path, or nullptr when the path only contains travels.
 QSharedPointer<SegmentBase> firstPrintSegment(const Path& path) {
     for (const QSharedPointer<SegmentBase>& segment : path) {
@@ -46,31 +33,6 @@ QSharedPointer<SettingsBase> firstPrintSettings(const Path& path, const QSharedP
     if (print_segment != nullptr) { return print_segment->getSb(); }
 
     return fallback;
-}
-
-//! @brief Returns the radial center stored on the path's printable segment settings.
-Point radialCenter(const Path& path) {
-    QSharedPointer<SettingsBase> settings = firstPrintSettings(path, QSharedPointer<SettingsBase>::create());
-    return Point(settings->setting<Distance>(kRadialCenterX), settings->setting<Distance>(kRadialCenterY), 0);
-}
-
-//! @brief Key used to group arcs that share the same radial circle.
-long long circleKey(const Path& path) {
-    QSharedPointer<SegmentBase> print_segment = firstPrintSegment(path);
-    return print_segment == nullptr ? 0 : std::llround(print_segment->start().z());
-}
-
-//! @brief Adds a path to the group matching its bead Z, preserving first-seen group order.
-void addToCircleGroup(QVector<CirclePathGroup>& groups, const Path& path) {
-    const long long key = circleKey(path);
-    for (CirclePathGroup& group : groups) {
-        if (group.z_key == key) {
-            group.paths.push_back(path);
-            return;
-        }
-    }
-
-    groups.push_back(CirclePathGroup {key, QVector<Path> {path}});
 }
 
 //! @brief Restores radial print metadata and gives optimizer-created travels radial center settings.
@@ -118,30 +80,30 @@ void RadialLayer::compute() {
 }
 
 void RadialLayer::calculateModifiers(Point& currentLocation) {
-    QVector<CirclePathGroup> circle_groups;
+    QVector<Path> print_paths;
+    print_paths.reserve(m_paths.size());
     for (Path path : m_paths) {
         path.removeTravels();
-        if (firstPrintSegment(path) != nullptr) { addToCircleGroup(circle_groups, path); }
+        if (firstPrintSegment(path) != nullptr) {
+            print_paths.push_back(path);
+        }
     }
 
-    if (circle_groups.isEmpty()) {
+    if (print_paths.isEmpty()) {
         m_paths.clear();
         return;
     }
 
     QVector<Path> optimized_paths;
     optimized_paths.reserve(m_paths.size());
-    for (CirclePathGroup& group : circle_groups) {
-        PathOrderOptimizer path_optimizer(currentLocation, getLayerNumber(), m_sb);
-        path_optimizer.setPathsToEvaluate(group.paths);
-        const Point center = radialCenter(group.paths.front());
+    PathOrderOptimizer path_optimizer(currentLocation, getLayerNumber(), m_sb);
+    path_optimizer.setPathsToEvaluate(print_paths);
 
-        while (path_optimizer.getCurrentPathCount() > 0) {
-            Path next_path = path_optimizer.linkNextRadialPath(center);
-            if (next_path.size() > 0) {
-                restoreRadialPathSettings(next_path, m_sb);
-                optimized_paths.push_back(next_path);
-            }
+    while (path_optimizer.getCurrentPathCount() > 0) {
+        Path next_path = path_optimizer.linkNextRadialPath();
+        if (next_path.size() > 0) {
+            restoreRadialPathSettings(next_path, m_sb);
+            optimized_paths.push_back(next_path);
         }
     }
 

--- a/src/step/layer/radial_layer.cpp
+++ b/src/step/layer/radial_layer.cpp
@@ -84,9 +84,7 @@ void RadialLayer::calculateModifiers(Point& currentLocation) {
     print_paths.reserve(m_paths.size());
     for (Path path : m_paths) {
         path.removeTravels();
-        if (firstPrintSegment(path) != nullptr) {
-            print_paths.push_back(path);
-        }
+        if (firstPrintSegment(path) != nullptr) { print_paths.push_back(path); }
     }
 
     if (print_paths.isEmpty()) {

--- a/src/threading/slicers/helical_slicer.cpp
+++ b/src/threading/slicers/helical_slicer.cpp
@@ -30,6 +30,7 @@
 #include "managers/session_manager.h"
 #include "managers/settings/settings_manager.h"
 #include "part/part.h"
+#include "slicing/helical_path_rounding.h"
 #include "slicing/slicing_utilities.h"
 #include "step/layer/helical_layer.h"
 #include "threading/traditional_ast.h"
@@ -53,9 +54,6 @@ Distance positiveOrFallback(Distance value, Distance fallback) {
 //! @brief Physical fallback used when the radial layer spacing setting is invalid.
 const Distance kDefaultHelicalLayerHeight = 1.0 * mm;
 
-//! @brief Smallest helix approximation segment used to avoid excessive candidate points.
-const Distance kMinHelixSegmentLength = 100.0 * micron;
-
 //! @brief Smallest Z spacing used for model cross sections.
 const Distance kMinSectionSpacing = 100.0 * micron;
 
@@ -68,17 +66,11 @@ struct HelicalCrossSection {
     PolygonList geometry;
 };
 
-//! @brief Approximate model-boundary crossing on a sampled helix segment.
-struct HelicalBoundaryIntersection {
-    Point point;
-    int segment_end_index;
-};
-
 //! @brief Model-clipping result for one sampled helix.
 struct HelixClipResult {
     QVector<Polyline> fragments;
-    QVector<HelicalBoundaryIntersection> intersections;
-    bool has_inside_points  = false;
+    QVector<HelicalPathBoundaryIntersection> intersections;
+    bool has_inside_points = false;
     bool has_outside_points = false;
 };
 
@@ -178,7 +170,7 @@ HelixClipResult clipHelixToSections(const Polyline& helix, const QVector<Helical
         }
         else if (previous_inside && !current_inside) {
             const Point boundary_point = findBoundaryPoint(previous, current, true, sections, first_z, section_spacing);
-            result.intersections.push_back(HelicalBoundaryIntersection {boundary_point, i});
+            result.intersections.push_back(HelicalPathBoundaryIntersection {boundary_point, i});
             current_line.push_back(boundary_point);
             if (current_line.size() > 1 && current_line.length() > kMinPathSegmentLength) {
                 result.fragments.push_back(current_line);
@@ -188,7 +180,7 @@ HelixClipResult clipHelixToSections(const Polyline& helix, const QVector<Helical
         else if (!previous_inside && current_inside) {
             const Point boundary_point =
                 findBoundaryPoint(previous, current, false, sections, first_z, section_spacing);
-            result.intersections.push_back(HelicalBoundaryIntersection {boundary_point, i});
+            result.intersections.push_back(HelicalPathBoundaryIntersection {boundary_point, i});
             current_line.clear();
             current_line.push_back(boundary_point);
             current_line.push_back(current);
@@ -203,34 +195,6 @@ HelixClipResult clipHelixToSections(const Polyline& helix, const QVector<Helical
     }
 
     return result;
-}
-
-//! @brief Keeps a continuous helix prefix through its highest-Z model-boundary crossing.
-QVector<Polyline> clipHelixAtHighestIntersection(const Polyline& helix, const HelixClipResult& clip_result) {
-    if (helix.size() < 2) { return {}; }
-
-    if (clip_result.intersections.isEmpty()) {
-        return clip_result.has_inside_points && !clip_result.has_outside_points ? QVector<Polyline> {helix}
-                                                                                : QVector<Polyline>();
-    }
-
-    const auto highest_intersection =
-        std::max_element(clip_result.intersections.cbegin(), clip_result.intersections.cend(),
-                         [](const HelicalBoundaryIntersection& lhs, const HelicalBoundaryIntersection& rhs) {
-                             return lhs.point.z() < rhs.point.z();
-                         });
-
-    Polyline clipped_helix;
-    clipped_helix.reserve(highest_intersection->segment_end_index + 1);
-    for (int i = 0; i < highest_intersection->segment_end_index; ++i) { clipped_helix.push_back(helix[i]); }
-
-    if (clipped_helix.isEmpty() || clipped_helix.last() != highest_intersection->point) {
-        clipped_helix.push_back(highest_intersection->point);
-    }
-
-    if (clipped_helix.size() < 2 || clipped_helix.length() <= kMinPathSegmentLength) { return {}; }
-
-    return {clipped_helix};
 }
 
 //! @brief Splits a sampled helical fragment into path-length-limited fragments.
@@ -326,6 +290,13 @@ void HelicalSlicer::doSlice() {
 
     if (!m_skip_gcode) {
         this->writeGCodeSetup();
+        if (m_has_generated_path_max_z) {
+            Distance build_maximum_z = m_generated_path_max_z;
+            if (m_base->hasBuildMaximumZ() && m_base->getBuildMaximumZ() > build_maximum_z) {
+                build_maximum_z = m_base->getBuildMaximumZ();
+            }
+            m_base->setBuildMaximumZ(build_maximum_z);
+        }
         this->writeGCode();
         this->writeGCodeShutdown();
     }
@@ -337,6 +308,8 @@ void HelicalSlicer::doSlice() {
 
 void HelicalSlicer::preProcess(nlohmann::json opt_data) {
     m_helical_layers.clear();
+    m_has_generated_path_max_z = false;
+    m_generated_path_max_z = 0;
     this->setMaxSteps(0);
 
     QSharedPointer<SettingsBase> global_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
@@ -346,6 +319,7 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
     QVector<QSharedPointer<MeshBase>> clipping_meshes =
         SlicingUtilities::GetMeshesByType(CSM->parts(), MeshType::kClipping);
     QVector<QPair<QString, HelicalPathBoundaryPolicy>> effective_boundary_policy;
+    QVector<QPair<QString, HelicalPathZClipRounding>> effective_z_clip_rounding;
     QVector<QPair<QString, HelicalPathHandedness>> effective_handedness;
 
     int last_preprocess_percent = -1;
@@ -407,6 +381,8 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
         const Distance section_spacing = bead_width / 2.0 > kMinSectionSpacing ? bead_width / 2.0 : kMinSectionSpacing;
         const HelicalPathBoundaryPolicy boundary_policy =
             static_cast<HelicalPathBoundaryPolicy>(part_sb->setting<int>(PS::Slicing::kHelicalPathBoundaryPolicy));
+        const HelicalPathZClipRounding z_clip_rounding =
+            static_cast<HelicalPathZClipRounding>(part_sb->setting<int>(PS::Slicing::kHelicalPathZClipRounding));
         const HelicalPathHandedness handedness =
             static_cast<HelicalPathHandedness>(part_sb->setting<int>(PS::Slicing::kHelicalPathHandedness));
         const bool helix_counterclockwise = handedness == HelicalPathHandedness::kRightHanded;
@@ -491,13 +467,17 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
             QSharedPointer<HelicalLayer> helical_layer =
                 QSharedPointer<HelicalLayer>::create(helical_layer_number + 1, layer_settings);
 
-            Polyline helix = createHelix(center, radius, first_bead_z, top_z, bead_width, handedness,
-                                         layer_settings->setting<Angle>(PS::Slicing::kHelicalPathStartAngle));
+            const Angle helical_start_angle = layer_settings->setting<Angle>(PS::Slicing::kHelicalPathStartAngle);
+            Polyline helix =
+                createHelix(center, radius, first_bead_z, top_z, bead_width, handedness, helical_start_angle);
             const HelixClipResult clip_result =
                 clipHelixToSections(helix, cross_sections, first_bead_z, section_spacing);
             QVector<Polyline> clipped_lines = clip_result.fragments;
             if (boundary_policy == HelicalPathBoundaryPolicy::kClipZ) {
-                clipped_lines = clipHelixAtHighestIntersection(helix, clip_result);
+                clipped_lines = HelicalPathRounding::clipAtHighestIntersection(
+                    helix, clip_result.intersections, clip_result.has_inside_points, clip_result.has_outside_points,
+                    center, radius, first_bead_z, bead_width, handedness, helical_start_angle, z_clip_rounding,
+                    kMinPathSegmentLength);
             }
 
             const Distance max_path_length = layer_settings->setting<Distance>(PS::Slicing::kMaxHelicalPathLength);
@@ -508,7 +488,17 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
                 for (const Polyline& path_line : path_lines) {
                     Path path =
                         createPath(path_line, layer_settings, center, radius, helix_counterclockwise, current_location);
-                    if (path.size() > 0) { helical_layer->addPath(path); }
+
+                    if (path.size() > 0) {
+                        helical_layer->addPath(path);
+                        for (const Point& point : path_line) {
+                            const Distance point_z(point.z());
+                            if (!m_has_generated_path_max_z || point_z > m_generated_path_max_z) {
+                                m_generated_path_max_z = point_z;
+                                m_has_generated_path_max_z = true;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -528,6 +518,10 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
         if (part_generated_paths) {
             effective_boundary_policy.push_back(
                 QPair<QString, HelicalPathBoundaryPolicy> {part->name(), boundary_policy});
+            if (boundary_policy == HelicalPathBoundaryPolicy::kClipZ) {
+                effective_z_clip_rounding.push_back(
+                    QPair<QString, HelicalPathZClipRounding> {part->name(), z_clip_rounding});
+            }
             effective_handedness.push_back(QPair<QString, HelicalPathHandedness> {part->name(), handedness});
         }
 
@@ -539,6 +533,7 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
     QSharedPointer<ArcSpecialtiesWriter> arc_specialties_writer = m_base.dynamicCast<ArcSpecialtiesWriter>();
     if (!arc_specialties_writer.isNull()) {
         arc_specialties_writer->setHelicalPathBoundaryPolicy(effective_boundary_policy);
+        arc_specialties_writer->setHelicalPathZClipRounding(effective_z_clip_rounding);
         arc_specialties_writer->setHelicalPathHandedness(effective_handedness);
     }
 
@@ -632,29 +627,12 @@ double HelicalSlicer::maxRadiusForMeshes(const QVector<QSharedPointer<MeshBase>>
 
 Polyline HelicalSlicer::createHelix(const Point& center, Distance radius, Distance start_z, Distance top_z,
                                     Distance bead_width, HelicalPathHandedness handedness, Angle start_angle) {
-    Polyline helix;
-    if (top_z <= start_z || bead_width <= 0) { return helix; }
-
-    const double vertical_rise_per_radian = bead_width() / (2.0 * M_PI);
-    const double max_t                    = (top_z() - start_z()) / vertical_rise_per_radian;
-    if (max_t <= 0.0) { return helix; }
-
-    const double length_per_radian = std::hypot(radius(), vertical_rise_per_radian);
-    const Distance target_segment_length =
-        bead_width / 2.0 > kMinHelixSegmentLength ? bead_width / 2.0 : kMinHelixSegmentLength;
-    const int segments =
-        std::clamp(static_cast<int>(std::ceil(max_t * length_per_radian / target_segment_length())), 1, 20000);
-
-    helix.reserve(segments + 1);
-    const double direction = handedness == HelicalPathHandedness::kLeftHanded ? -1.0 : 1.0;
-    for (int i = 0; i <= segments; ++i) {
-        const double t     = max_t * static_cast<double>(i) / static_cast<double>(segments);
-        const double angle = start_angle() + direction * t;
-        helix.push_back(Point(center.x() + radius() * std::cos(angle), center.y() + radius() * std::sin(angle),
-                              start_z() + vertical_rise_per_radian * t));
+    if (top_z <= start_z || bead_width <= 0) {
+        return {};
     }
 
-    return helix;
+    return HelicalPathRounding::createHelixForRevolutions(center, radius, start_z, bead_width, handedness, start_angle,
+                                                          (top_z() - start_z()) / bead_width());
 }
 
 QSharedPointer<SettingsBase> HelicalSlicer::createSegmentSettings(const QSharedPointer<SettingsBase>& layer_settings,

--- a/src/threading/slicers/helical_slicer.cpp
+++ b/src/threading/slicers/helical_slicer.cpp
@@ -70,7 +70,7 @@ struct HelicalCrossSection {
 struct HelixClipResult {
     QVector<Polyline> fragments;
     QVector<HelicalPathBoundaryIntersection> intersections;
-    bool has_inside_points = false;
+    bool has_inside_points  = false;
     bool has_outside_points = false;
 };
 
@@ -309,7 +309,7 @@ void HelicalSlicer::doSlice() {
 void HelicalSlicer::preProcess(nlohmann::json opt_data) {
     m_helical_layers.clear();
     m_has_generated_path_max_z = false;
-    m_generated_path_max_z = 0;
+    m_generated_path_max_z     = 0;
     this->setMaxSteps(0);
 
     QSharedPointer<SettingsBase> global_sb = QSharedPointer<SettingsBase>::create(*GSM->getGlobal());
@@ -494,7 +494,7 @@ void HelicalSlicer::preProcess(nlohmann::json opt_data) {
                         for (const Point& point : path_line) {
                             const Distance point_z(point.z());
                             if (!m_has_generated_path_max_z || point_z > m_generated_path_max_z) {
-                                m_generated_path_max_z = point_z;
+                                m_generated_path_max_z     = point_z;
                                 m_has_generated_path_max_z = true;
                             }
                         }
@@ -627,9 +627,7 @@ double HelicalSlicer::maxRadiusForMeshes(const QVector<QSharedPointer<MeshBase>>
 
 Polyline HelicalSlicer::createHelix(const Point& center, Distance radius, Distance start_z, Distance top_z,
                                     Distance bead_width, HelicalPathHandedness handedness, Angle start_angle) {
-    if (top_z <= start_z || bead_width <= 0) {
-        return {};
-    }
+    if (top_z <= start_z || bead_width <= 0) { return {}; }
 
     return HelicalPathRounding::createHelixForRevolutions(center, radius, start_z, bead_width, handedness, start_angle,
                                                           (top_z() - start_z()) / bead_width());

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -760,10 +760,8 @@ const QString Constants::ProfileSettings::Optimizations::kLayerOrdering         
 const QString Constants::ProfileSettings::Optimizations::kLayerGroupingTolerance = "layer_grouping_tolerance";
 const QString Constants::ProfileSettings::Optimizations::kIslandOrder = "island_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kPathOrder = "path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kCylindricalPathOrder =
-    "cylindrical_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder =
-    "perimeter_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kCylindricalPathOrder = "cylindrical_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder = "perimeter_path_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder = "inset_path_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder = "skin_path_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kCustomIslandXLocation = "custom_island_order_x_location";
@@ -851,12 +849,13 @@ const QString Constants::ProfileSettings::Slicing::kCylinderAxisY             = 
 const QString Constants::ProfileSettings::Slicing::kRadialPathBoundaryPolicy  = "radial_path_boundary_policy";
 const QString Constants::ProfileSettings::Slicing::kRadialPathStartAngle      = "radial_path_start_angle";
 const QString Constants::ProfileSettings::Slicing::kHelicalPathBoundaryPolicy = "helical_path_boundary_policy";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathHandedness     = "helical_path_handedness";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathStartAngle     = "helical_path_start_angle";
-const QString Constants::ProfileSettings::Slicing::kMaxHelicalPathLength      = "max_helical_path_length";
-const QString Constants::ProfileSettings::Slicing::kArcsPerRevolution         = "arcs_per_revolution";
-const QString Constants::ProfileSettings::Slicing::kImagePixelSizeX           = "image_pixel_size_x";
-const QString Constants::ProfileSettings::Slicing::kImagePixelSizeY           = "image_pixel_size_y";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathZClipRounding = "helical_path_z_clip_rounding";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathHandedness = "helical_path_handedness";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathStartAngle = "helical_path_start_angle";
+const QString Constants::ProfileSettings::Slicing::kMaxHelicalPathLength = "max_helical_path_length";
+const QString Constants::ProfileSettings::Slicing::kArcsPerRevolution = "arcs_per_revolution";
+const QString Constants::ProfileSettings::Slicing::kImagePixelSizeX = "image_pixel_size_x";
+const QString Constants::ProfileSettings::Slicing::kImagePixelSizeY = "image_pixel_size_y";
 
 //================================================================================
 // Experimental Settings

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -758,19 +758,19 @@ const QString Constants::ProfileSettings::SpecialModes::kArcFittingMinimumSegmen
 // Optimizations
 const QString Constants::ProfileSettings::Optimizations::kLayerOrdering          = "layer_ordering";
 const QString Constants::ProfileSettings::Optimizations::kLayerGroupingTolerance = "layer_grouping_tolerance";
-const QString Constants::ProfileSettings::Optimizations::kIslandOrder = "island_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPathOrder = "path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kCylindricalPathOrder = "cylindrical_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder = "perimeter_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder = "inset_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder = "skin_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kIslandOrder            = "island_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPathOrder              = "path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kCylindricalPathOrder  = "cylindrical_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder    = "perimeter_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder        = "inset_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder         = "skin_path_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kCustomIslandXLocation = "custom_island_order_x_location";
 const QString Constants::ProfileSettings::Optimizations::kCustomIslandYLocation = "custom_island_order_y_location";
 const QString Constants::ProfileSettings::Optimizations::kCustomIslandZLocation = "custom_island_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathXLocation = "custom_path_order_x_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathYLocation = "custom_path_order_y_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathZLocation = "custom_path_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kPointOrder = "point_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathXLocation   = "custom_path_order_x_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathYLocation   = "custom_path_order_y_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathZLocation   = "custom_path_order_z_location";
+const QString Constants::ProfileSettings::Optimizations::kPointOrder            = "point_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kEnablePointOrderSegmentBreaking =
     "enable_point_order_segment_breaking";
 const QString Constants::ProfileSettings::Optimizations::kLocalRandomnessEnable = "local_randomness_enable";
@@ -849,13 +849,13 @@ const QString Constants::ProfileSettings::Slicing::kCylinderAxisY             = 
 const QString Constants::ProfileSettings::Slicing::kRadialPathBoundaryPolicy  = "radial_path_boundary_policy";
 const QString Constants::ProfileSettings::Slicing::kRadialPathStartAngle      = "radial_path_start_angle";
 const QString Constants::ProfileSettings::Slicing::kHelicalPathBoundaryPolicy = "helical_path_boundary_policy";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathZClipRounding = "helical_path_z_clip_rounding";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathHandedness = "helical_path_handedness";
-const QString Constants::ProfileSettings::Slicing::kHelicalPathStartAngle = "helical_path_start_angle";
-const QString Constants::ProfileSettings::Slicing::kMaxHelicalPathLength = "max_helical_path_length";
-const QString Constants::ProfileSettings::Slicing::kArcsPerRevolution = "arcs_per_revolution";
-const QString Constants::ProfileSettings::Slicing::kImagePixelSizeX = "image_pixel_size_x";
-const QString Constants::ProfileSettings::Slicing::kImagePixelSizeY = "image_pixel_size_y";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathZClipRounding  = "helical_path_z_clip_rounding";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathHandedness     = "helical_path_handedness";
+const QString Constants::ProfileSettings::Slicing::kHelicalPathStartAngle     = "helical_path_start_angle";
+const QString Constants::ProfileSettings::Slicing::kMaxHelicalPathLength      = "max_helical_path_length";
+const QString Constants::ProfileSettings::Slicing::kArcsPerRevolution         = "arcs_per_revolution";
+const QString Constants::ProfileSettings::Slicing::kImagePixelSizeX           = "image_pixel_size_x";
+const QString Constants::ProfileSettings::Slicing::kImagePixelSizeY           = "image_pixel_size_y";
 
 //================================================================================
 // Experimental Settings

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -758,18 +758,21 @@ const QString Constants::ProfileSettings::SpecialModes::kArcFittingMinimumSegmen
 // Optimizations
 const QString Constants::ProfileSettings::Optimizations::kLayerOrdering          = "layer_ordering";
 const QString Constants::ProfileSettings::Optimizations::kLayerGroupingTolerance = "layer_grouping_tolerance";
-const QString Constants::ProfileSettings::Optimizations::kIslandOrder            = "island_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPathOrder              = "path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder     = "perimeter_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder         = "inset_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder          = "skin_path_order_optimization";
-const QString Constants::ProfileSettings::Optimizations::kCustomIslandXLocation  = "custom_island_order_x_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomIslandYLocation  = "custom_island_order_y_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomIslandZLocation  = "custom_island_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathXLocation    = "custom_path_order_x_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathYLocation    = "custom_path_order_y_location";
-const QString Constants::ProfileSettings::Optimizations::kCustomPathZLocation    = "custom_path_order_z_location";
-const QString Constants::ProfileSettings::Optimizations::kPointOrder             = "point_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kIslandOrder = "island_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPathOrder = "path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kCylindricalPathOrder =
+    "cylindrical_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kPerimeterPathOrder =
+    "perimeter_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kInsetPathOrder = "inset_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kSkinPathOrder = "skin_path_order_optimization";
+const QString Constants::ProfileSettings::Optimizations::kCustomIslandXLocation = "custom_island_order_x_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomIslandYLocation = "custom_island_order_y_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomIslandZLocation = "custom_island_order_z_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathXLocation = "custom_path_order_x_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathYLocation = "custom_path_order_y_location";
+const QString Constants::ProfileSettings::Optimizations::kCustomPathZLocation = "custom_path_order_z_location";
+const QString Constants::ProfileSettings::Optimizations::kPointOrder = "point_order_optimization";
 const QString Constants::ProfileSettings::Optimizations::kEnablePointOrderSegmentBreaking =
     "enable_point_order_segment_breaking";
 const QString Constants::ProfileSettings::Optimizations::kLocalRandomnessEnable = "local_randomness_enable";

--- a/src/widgets/gcode_widget.cpp
+++ b/src/widgets/gcode_widget.cpp
@@ -92,6 +92,7 @@ void GCodeWidget::handleModifiedSetting(QString key) {
                                                              PS::Optimizations::kCustomIslandYLocation,
                                                              PS::Optimizations::kCustomIslandZLocation,
                                                              PS::Optimizations::kPathOrder,
+                                                             PS::Optimizations::kCylindricalPathOrder,
                                                              PS::Optimizations::kPerimeterPathOrder,
                                                              PS::Optimizations::kInsetPathOrder,
                                                              PS::Optimizations::kSkinPathOrder,

--- a/src/widgets/part_widget/part_widget.cpp
+++ b/src/widgets/part_widget/part_widget.cpp
@@ -178,6 +178,7 @@ void PartWidget::handleModifiedSetting(const QString& setting_key) {
                                                              PS::Optimizations::kCustomIslandYLocation,
                                                              PS::Optimizations::kCustomIslandZLocation,
                                                              PS::Optimizations::kPathOrder,
+                                                             PS::Optimizations::kCylindricalPathOrder,
                                                              PS::Optimizations::kPerimeterPathOrder,
                                                              PS::Optimizations::kInsetPathOrder,
                                                              PS::Optimizations::kSkinPathOrder,

--- a/templates/Concrete_2in.s2c
+++ b/templates/Concrete_2in.s2c
@@ -336,6 +336,7 @@
             "radial_path_boundary_policy": 0,
             "radial_path_start_angle": 0,
             "helical_path_boundary_policy": 0,
+            "helical_path_z_clip_rounding": 0,
             "helical_path_handedness": 0,
             "helical_path_start_angle": 90,
             "max_helical_path_length": 0,

--- a/templates/Desktop_04mm.s2c
+++ b/templates/Desktop_04mm.s2c
@@ -336,6 +336,7 @@
             "radial_path_boundary_policy": 0,
             "radial_path_start_angle": 0,
             "helical_path_boundary_policy": 0,
+            "helical_path_z_clip_rounding": 0,
             "helical_path_handedness": 0,
             "helical_path_start_angle": 90,
             "max_helical_path_length": 0,

--- a/templates/LFAM_03in.s2c
+++ b/templates/LFAM_03in.s2c
@@ -361,6 +361,7 @@
             "radial_path_boundary_policy": 0,
             "radial_path_start_angle": 0,
             "helical_path_boundary_policy": 0,
+            "helical_path_z_clip_rounding": 0,
             "helical_path_handedness": 0,
             "helical_path_start_angle": 2.035402957908809,
             "max_helical_path_length": 0,

--- a/templates/MFAM_6mm.s2c
+++ b/templates/MFAM_6mm.s2c
@@ -336,6 +336,7 @@
             "radial_path_boundary_policy": 0,
             "radial_path_start_angle": 0,
             "helical_path_boundary_policy": 0,
+            "helical_path_z_clip_rounding": 0,
             "helical_path_handedness": 0,
             "helical_path_start_angle": 2.035402957908809,
             "max_helical_path_length": 0,

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -209,6 +209,32 @@ bool writesStartupWorldApproachAbovePartOrCylinderHeight() {
            worldApproachLineForSafeZ(70.0 * ORNL::mm, 50.0 * ORNL::mm).contains("Z=170.0000");
 }
 
+bool writesStartupWorldApproachAboveGeneratedHelicalMaxZ() {
+    return worldApproachLineForSafeZ(62.0 * ORNL::mm, 50.0 * ORNL::mm).contains("Z=162.0000");
+}
+
+bool writesHelicalZClipRoundingHeader() {
+    QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
+    settings->setSetting(ORNL::PS::Slicing::kSlicingMode, static_cast<int>(ORNL::SlicingMode::kCylindrical));
+    settings->setSetting(ORNL::PS::Slicing::kCylindricalPathPattern,
+                         static_cast<int>(ORNL::CylindricalPathPattern::kHelical));
+    settings->setSetting(ORNL::PS::Slicing::kHelicalPathBoundaryPolicy,
+                         static_cast<int>(ORNL::HelicalPathBoundaryPolicy::kClipZ));
+    settings->setSetting(ORNL::PS::Slicing::kHelicalPathZClipRounding,
+                         static_cast<int>(ORNL::HelicalPathZClipRounding::kCompleteRevolution));
+    settings->setSetting(ORNL::PS::Slicing::kHelicalPathHandedness,
+                         static_cast<int>(ORNL::HelicalPathHandedness::kRightHanded));
+    settings->setSetting(ORNL::PS::Slicing::kHelicalPathStartAngle, 90.0 * ORNL::degree);
+    settings->setSetting(ORNL::PS::Layer::kLayerHeight, 1.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Layer::kBeadWidth, 4.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kLiftHeight, 0.0 * ORNL::mm);
+
+    ORNL::ArcSpecialtiesWriter writer(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+    const QString header = writer.writeSettingsHeader(ORNL::GcodeSyntax::kArcSpecialties);
+    return header.contains(";Helical Path Boundary Policy: Clip Z") &&
+           header.contains(";Helical Z Clip Rounding: Complete Revolution");
+}
+
 bool writesCylindricalTravelWithConfiguredArcDensity() {
     QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
     settings->setSetting(ORNL::PS::Slicing::kSlicingMode, static_cast<int>(ORNL::SlicingMode::kCylindrical));
@@ -269,6 +295,10 @@ int main(int argc, char* argv[]) {
     passed &= expect(writesFirstTravelWithWorkObjectToolFrame(), "Arc Specialties first travel did not use ZR=-135.");
     passed &= expect(writesStartupWorldApproachAbovePartOrCylinderHeight(),
                      "Arc Specialties startup world approach did not use part/cylinder safe Z.");
+    passed &= expect(writesStartupWorldApproachAboveGeneratedHelicalMaxZ(),
+                     "Arc Specialties startup world approach did not use generated helical safe Z.");
+    passed &= expect(writesHelicalZClipRoundingHeader(),
+                     "Arc Specialties writer did not emit the helical Z clip rounding header.");
     passed &= expect(writesCylindricalTravelWithConfiguredArcDensity(),
                      "Arc Specialties cylindrical travel did not honor Arcs per Revolution.");
 

--- a/tests/helical_clip_rounding_tests.cpp
+++ b/tests/helical_clip_rounding_tests.cpp
@@ -1,10 +1,9 @@
+#include <QVector>
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <string>
-
-#include <QVector>
 
 #include "geometry/point.h"
 #include "geometry/polyline.h"
@@ -14,9 +13,7 @@
 
 namespace {
 bool expect(bool condition, const std::string& message) {
-    if (condition) {
-        return true;
-    }
+    if (condition) { return true; }
 
     std::cerr << message << '\n';
     return false;
@@ -34,16 +31,14 @@ ORNL::Point pointAtRevolutions(const ORNL::Point& center, ORNL::Distance radius,
                                ORNL::Distance bead_width, ORNL::HelicalPathHandedness handedness,
                                ORNL::Angle start_angle, double revolutions) {
     const double direction = handedness == ORNL::HelicalPathHandedness::kLeftHanded ? -1.0 : 1.0;
-    const double angle = start_angle() + direction * revolutions * 2.0 * M_PI;
+    const double angle     = start_angle() + direction * revolutions * 2.0 * M_PI;
     return ORNL::Point(center.x() + radius() * std::cos(angle), center.y() + radius() * std::sin(angle),
                        start_z() + bead_width() * revolutions);
 }
 
 int segmentEndIndexForZ(const ORNL::Polyline& helix, ORNL::Distance z) {
     for (int i = 1; i < helix.size(); ++i) {
-        if (helix[i].z() >= z()) {
-            return i;
-        }
+        if (helix[i].z() >= z()) { return i; }
     }
 
     return std::max(1, static_cast<int>(helix.size()) - 1);
@@ -51,12 +46,12 @@ int segmentEndIndexForZ(const ORNL::Polyline& helix, ORNL::Distance z) {
 
 QVector<ORNL::Polyline> roundedAt(double intersection_revolutions, ORNL::HelicalPathZClipRounding rounding,
                                   ORNL::HelicalPathHandedness handedness = ORNL::HelicalPathHandedness::kRightHanded,
-                                  ORNL::Angle start_angle = 0.0 * ORNL::degree) {
+                                  ORNL::Angle start_angle                = 0.0 * ORNL::degree) {
     const ORNL::Point center(0.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm);
-    const ORNL::Distance radius = 10.0 * ORNL::mm;
-    const ORNL::Distance start_z = 0.0 * ORNL::mm;
+    const ORNL::Distance radius     = 10.0 * ORNL::mm;
+    const ORNL::Distance start_z    = 0.0 * ORNL::mm;
     const ORNL::Distance bead_width = 4.0 * ORNL::mm;
-    const ORNL::Polyline helix = ORNL::HelicalPathRounding::createHelixForRevolutions(
+    const ORNL::Polyline helix      = ORNL::HelicalPathRounding::createHelixForRevolutions(
         center, radius, start_z, bead_width, handedness, start_angle, intersection_revolutions);
     const ORNL::Point intersection =
         pointAtRevolutions(center, radius, start_z, bead_width, handedness, start_angle, intersection_revolutions);
@@ -70,9 +65,7 @@ QVector<ORNL::Polyline> roundedAt(double intersection_revolutions, ORNL::Helical
 
 bool exactRoundingKeepsIntersection() {
     const QVector<ORNL::Polyline> result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kExactIntersection);
-    if (result.size() != 1 || result.first().isEmpty()) {
-        return false;
-    }
+    if (result.size() != 1 || result.first().isEmpty()) { return false; }
 
     const ORNL::Point end = result.first().last();
     return nearDistance(end.x(), 0.0 * ORNL::mm) && nearDistance(end.y(), 10.0 * ORNL::mm) &&
@@ -81,9 +74,7 @@ bool exactRoundingKeepsIntersection() {
 
 bool lastFullRoundingStopsAtPreviousRevolution() {
     const QVector<ORNL::Polyline> result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kLastFullRevolution);
-    if (result.size() != 1 || result.first().isEmpty()) {
-        return false;
-    }
+    if (result.size() != 1 || result.first().isEmpty()) { return false; }
 
     const ORNL::Point end = result.first().last();
     return nearDistance(end.x(), 10.0 * ORNL::mm) && nearDistance(end.y(), 0.0 * ORNL::mm) &&
@@ -92,9 +83,7 @@ bool lastFullRoundingStopsAtPreviousRevolution() {
 
 bool completeRoundingExtendsPastOriginalTopZ() {
     const QVector<ORNL::Polyline> result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution);
-    if (result.size() != 1 || result.first().isEmpty()) {
-        return false;
-    }
+    if (result.size() != 1 || result.first().isEmpty()) { return false; }
 
     const ORNL::Point end = result.first().last();
     return nearDistance(end.x(), 10.0 * ORNL::mm) && nearDistance(end.y(), 0.0 * ORNL::mm) &&
@@ -106,11 +95,11 @@ bool lastFullBeforeOneRevolutionOmitsPath() {
 }
 
 bool fullRevolutionEndpointPreservesStartAngleForBothHandednesses() {
-    const ORNL::Angle start_angle = 90.0 * ORNL::degree;
+    const ORNL::Angle start_angle              = 90.0 * ORNL::degree;
     const QVector<ORNL::Polyline> right_result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution,
                                                            ORNL::HelicalPathHandedness::kRightHanded, start_angle);
-    const QVector<ORNL::Polyline> left_result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution,
-                                                          ORNL::HelicalPathHandedness::kLeftHanded, start_angle);
+    const QVector<ORNL::Polyline> left_result  = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution,
+                                                           ORNL::HelicalPathHandedness::kLeftHanded, start_angle);
 
     if (right_result.size() != 1 || left_result.size() != 1 || right_result.first().isEmpty() ||
         left_result.first().isEmpty()) {
@@ -118,12 +107,12 @@ bool fullRevolutionEndpointPreservesStartAngleForBothHandednesses() {
     }
 
     const ORNL::Point right_end = right_result.first().last();
-    const ORNL::Point left_end = left_result.first().last();
+    const ORNL::Point left_end  = left_result.first().last();
     return nearDistance(right_end.x(), 0.0 * ORNL::mm) && nearDistance(right_end.y(), 10.0 * ORNL::mm) &&
            nearDistance(left_end.x(), 0.0 * ORNL::mm) && nearDistance(left_end.y(), 10.0 * ORNL::mm) &&
            nearDistance(right_end.z(), 12.0 * ORNL::mm) && nearDistance(left_end.z(), 12.0 * ORNL::mm);
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;

--- a/tests/helical_clip_rounding_tests.cpp
+++ b/tests/helical_clip_rounding_tests.cpp
@@ -1,0 +1,142 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <QVector>
+
+#include "geometry/point.h"
+#include "geometry/polyline.h"
+#include "slicing/helical_path_rounding.h"
+#include "units/unit.h"
+#include "utilities/enums.h"
+
+namespace {
+bool expect(bool condition, const std::string& message) {
+    if (condition) {
+        return true;
+    }
+
+    std::cerr << message << '\n';
+    return false;
+}
+
+bool near(double actual, double expected, double tolerance = 1.0e-5) {
+    return std::abs(actual - expected) <= tolerance;
+}
+
+bool nearDistance(float actual, ORNL::Distance expected, double tolerance_mm = 1.0e-5) {
+    return near(ORNL::Distance(actual).to(ORNL::mm), expected.to(ORNL::mm), tolerance_mm);
+}
+
+ORNL::Point pointAtRevolutions(const ORNL::Point& center, ORNL::Distance radius, ORNL::Distance start_z,
+                               ORNL::Distance bead_width, ORNL::HelicalPathHandedness handedness,
+                               ORNL::Angle start_angle, double revolutions) {
+    const double direction = handedness == ORNL::HelicalPathHandedness::kLeftHanded ? -1.0 : 1.0;
+    const double angle = start_angle() + direction * revolutions * 2.0 * M_PI;
+    return ORNL::Point(center.x() + radius() * std::cos(angle), center.y() + radius() * std::sin(angle),
+                       start_z() + bead_width() * revolutions);
+}
+
+int segmentEndIndexForZ(const ORNL::Polyline& helix, ORNL::Distance z) {
+    for (int i = 1; i < helix.size(); ++i) {
+        if (helix[i].z() >= z()) {
+            return i;
+        }
+    }
+
+    return std::max(1, static_cast<int>(helix.size()) - 1);
+}
+
+QVector<ORNL::Polyline> roundedAt(double intersection_revolutions, ORNL::HelicalPathZClipRounding rounding,
+                                  ORNL::HelicalPathHandedness handedness = ORNL::HelicalPathHandedness::kRightHanded,
+                                  ORNL::Angle start_angle = 0.0 * ORNL::degree) {
+    const ORNL::Point center(0.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm);
+    const ORNL::Distance radius = 10.0 * ORNL::mm;
+    const ORNL::Distance start_z = 0.0 * ORNL::mm;
+    const ORNL::Distance bead_width = 4.0 * ORNL::mm;
+    const ORNL::Polyline helix = ORNL::HelicalPathRounding::createHelixForRevolutions(
+        center, radius, start_z, bead_width, handedness, start_angle, intersection_revolutions);
+    const ORNL::Point intersection =
+        pointAtRevolutions(center, radius, start_z, bead_width, handedness, start_angle, intersection_revolutions);
+
+    return ORNL::HelicalPathRounding::clipAtHighestIntersection(
+        helix,
+        QVector<ORNL::HelicalPathBoundaryIntersection> {ORNL::HelicalPathBoundaryIntersection {
+            intersection, segmentEndIndexForZ(helix, ORNL::Distance(intersection.z()))}},
+        true, true, center, radius, start_z, bead_width, handedness, start_angle, rounding, 10.0 * ORNL::micron);
+}
+
+bool exactRoundingKeepsIntersection() {
+    const QVector<ORNL::Polyline> result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kExactIntersection);
+    if (result.size() != 1 || result.first().isEmpty()) {
+        return false;
+    }
+
+    const ORNL::Point end = result.first().last();
+    return nearDistance(end.x(), 0.0 * ORNL::mm) && nearDistance(end.y(), 10.0 * ORNL::mm) &&
+           nearDistance(end.z(), 9.0 * ORNL::mm);
+}
+
+bool lastFullRoundingStopsAtPreviousRevolution() {
+    const QVector<ORNL::Polyline> result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kLastFullRevolution);
+    if (result.size() != 1 || result.first().isEmpty()) {
+        return false;
+    }
+
+    const ORNL::Point end = result.first().last();
+    return nearDistance(end.x(), 10.0 * ORNL::mm) && nearDistance(end.y(), 0.0 * ORNL::mm) &&
+           nearDistance(end.z(), 8.0 * ORNL::mm);
+}
+
+bool completeRoundingExtendsPastOriginalTopZ() {
+    const QVector<ORNL::Polyline> result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution);
+    if (result.size() != 1 || result.first().isEmpty()) {
+        return false;
+    }
+
+    const ORNL::Point end = result.first().last();
+    return nearDistance(end.x(), 10.0 * ORNL::mm) && nearDistance(end.y(), 0.0 * ORNL::mm) &&
+           nearDistance(end.z(), 12.0 * ORNL::mm);
+}
+
+bool lastFullBeforeOneRevolutionOmitsPath() {
+    return roundedAt(0.75, ORNL::HelicalPathZClipRounding::kLastFullRevolution).isEmpty();
+}
+
+bool fullRevolutionEndpointPreservesStartAngleForBothHandednesses() {
+    const ORNL::Angle start_angle = 90.0 * ORNL::degree;
+    const QVector<ORNL::Polyline> right_result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution,
+                                                           ORNL::HelicalPathHandedness::kRightHanded, start_angle);
+    const QVector<ORNL::Polyline> left_result = roundedAt(2.25, ORNL::HelicalPathZClipRounding::kCompleteRevolution,
+                                                          ORNL::HelicalPathHandedness::kLeftHanded, start_angle);
+
+    if (right_result.size() != 1 || left_result.size() != 1 || right_result.first().isEmpty() ||
+        left_result.first().isEmpty()) {
+        return false;
+    }
+
+    const ORNL::Point right_end = right_result.first().last();
+    const ORNL::Point left_end = left_result.first().last();
+    return nearDistance(right_end.x(), 0.0 * ORNL::mm) && nearDistance(right_end.y(), 10.0 * ORNL::mm) &&
+           nearDistance(left_end.x(), 0.0 * ORNL::mm) && nearDistance(left_end.y(), 10.0 * ORNL::mm) &&
+           nearDistance(right_end.z(), 12.0 * ORNL::mm) && nearDistance(left_end.z(), 12.0 * ORNL::mm);
+}
+} // namespace
+
+int main() {
+    bool passed = true;
+
+    passed &= expect(exactRoundingKeepsIntersection(), "Expected exact rounding to keep the intersection endpoint.");
+    passed &= expect(lastFullRoundingStopsAtPreviousRevolution(),
+                     "Expected last-full rounding to stop at the previous complete revolution.");
+    passed &= expect(completeRoundingExtendsPastOriginalTopZ(),
+                     "Expected complete rounding to extend to the next full revolution.");
+    passed &= expect(lastFullBeforeOneRevolutionOmitsPath(),
+                     "Expected last-full rounding before one revolution to omit the path.");
+    passed &= expect(fullRevolutionEndpointPreservesStartAngleForBothHandednesses(),
+                     "Expected full-revolution endpoints to preserve start angle for both handednesses.");
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/optimizer_empty_input_tests.cpp
+++ b/tests/optimizer_empty_input_tests.cpp
@@ -14,8 +14,8 @@
 #include "optimizers/island_order_optimizer.h"
 #include "optimizers/path_order_optimizer.h"
 #include "optimizers/polyline_order_optimizer.h"
-#include "step/layer/radial_layer.h"
 #include "step/layer/island/island_base.h"
+#include "step/layer/radial_layer.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
 
@@ -41,9 +41,7 @@ ORNL::Path linePath(float start_x, float end_x) {
 
 ORNL::Path pathFromPoints(const QVector<ORNL::Point>& points) {
     ORNL::Path path;
-    for (int i = 0, end = points.size() - 1; i < end; ++i) {
-        path.append(lineSegment(points[i], points[i + 1]));
-    }
+    for (int i = 0, end = points.size() - 1; i < end; ++i) { path.append(lineSegment(points[i], points[i + 1])); }
 
     return path;
 }
@@ -59,7 +57,7 @@ QSharedPointer<ORNL::SettingsBase> cylindricalSettings(ORNL::PathOrderOptimizati
     settings->setSetting(ORNL::PS::Optimizations::kLocalRandomnessEnable, false);
     return settings;
 }
-} // namespace
+}  // namespace
 
 int main() {
     bool passed = true;
@@ -169,9 +167,8 @@ int main() {
                      "Expected radial linking to honor cylindrical next farthest path order.");
 
     ORNL::Path closed_radial_path =
-        pathFromPoints({ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
-                        ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f),
-                        ORNL::Point(0.0f, 0.0f, 0.0f)});
+        pathFromPoints({ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 10.0f, 0.0f),
+                        ORNL::Point(0.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 0.0f, 0.0f)});
 
     ORNL::Point closed_radial_closest_start(9.8f, 10.0f, 0.0f);
     ORNL::PathOrderOptimizer closed_radial_closest_optimizer(
@@ -196,17 +193,15 @@ int main() {
                          closed_radial_farthest_result[1]->start() == ORNL::Point(10.0f, 10.0f, 0.0f),
                      "Expected closed radial farthest linking to rotate to the farthest segment start.");
 
-    ORNL::Path open_radial_path =
-        pathFromPoints({ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
-                        ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f)});
+    ORNL::Path open_radial_path = pathFromPoints({ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
+                                                  ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f)});
     ORNL::Point open_radial_start(9.8f, 0.0f, 0.0f);
     ORNL::PathOrderOptimizer open_radial_optimizer(
         open_radial_start, 0,
         cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
     open_radial_optimizer.setPathsToEvaluate({open_radial_path});
     ORNL::Path open_radial_result = open_radial_optimizer.linkNextRadialPath();
-    passed &= expect(open_radial_result.size() > 1 &&
-                         open_radial_result[1]->start() == ORNL::Point(0.0f, 0.0f, 0.0f),
+    passed &= expect(open_radial_result.size() > 1 && open_radial_result[1]->start() == ORNL::Point(0.0f, 0.0f, 0.0f),
                      "Expected open radial closest linking to remain endpoint-only.");
 
     QSharedPointer<ORNL::SettingsBase> radial_layer_settings =
@@ -215,9 +210,9 @@ int main() {
     radial_layer.addPath(pathFromPoints({ORNL::Point(100.0f, 0.0f, 0.0f), ORNL::Point(110.0f, 0.0f, 0.0f),
                                          ORNL::Point(110.0f, 10.0f, 0.0f), ORNL::Point(100.0f, 10.0f, 0.0f),
                                          ORNL::Point(100.0f, 0.0f, 0.0f)}));
-    radial_layer.addPath(pathFromPoints({ORNL::Point(0.0f, 0.0f, 1.0f), ORNL::Point(10.0f, 0.0f, 1.0f),
-                                         ORNL::Point(10.0f, 10.0f, 1.0f), ORNL::Point(0.0f, 10.0f, 1.0f),
-                                         ORNL::Point(0.0f, 0.0f, 1.0f)}));
+    radial_layer.addPath(
+        pathFromPoints({ORNL::Point(0.0f, 0.0f, 1.0f), ORNL::Point(10.0f, 0.0f, 1.0f), ORNL::Point(10.0f, 10.0f, 1.0f),
+                        ORNL::Point(0.0f, 10.0f, 1.0f), ORNL::Point(0.0f, 0.0f, 1.0f)}));
     ORNL::Point radial_layer_current_location(9.8f, 10.0f, 0.0f);
     radial_layer.calculateModifiers(radial_layer_current_location);
     passed &= expect(radial_layer_current_location == ORNL::Point(100.0f, 10.0f, 0.0f),
@@ -240,12 +235,12 @@ int main() {
         cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
     helical_closest_reverse_optimizer.setPathsToEvaluate({linePath(10.0f, 1.0f), linePath(20.0f, 21.0f)});
     ORNL::Path helical_closest_reverse_result = helical_closest_reverse_optimizer.linkNextHelicalPath();
-    passed &= expect(helical_closest_reverse_result.size() > 1 &&
-                         helical_closest_reverse_result[1]->start().x() == 1.0f,
-                     "Expected helical closest linking to enter from the nearest end endpoint.");
-    passed &= expect(helical_closest_reverse_result.size() > 1 &&
-                         helical_closest_reverse_result.back()->end().x() == 10.0f,
-                     "Expected helical closest linking to reverse the fragment when entering from the end endpoint.");
+    passed &=
+        expect(helical_closest_reverse_result.size() > 1 && helical_closest_reverse_result[1]->start().x() == 1.0f,
+               "Expected helical closest linking to enter from the nearest end endpoint.");
+    passed &=
+        expect(helical_closest_reverse_result.size() > 1 && helical_closest_reverse_result.back()->end().x() == 10.0f,
+               "Expected helical closest linking to reverse the fragment when entering from the end endpoint.");
 
     ORNL::Point helical_farthest_start(0.0f, 0.0f, 0.0f);
     ORNL::PathOrderOptimizer helical_farthest_optimizer(

--- a/tests/optimizer_empty_input_tests.cpp
+++ b/tests/optimizer_empty_input_tests.cpp
@@ -14,6 +14,7 @@
 #include "optimizers/island_order_optimizer.h"
 #include "optimizers/path_order_optimizer.h"
 #include "optimizers/polyline_order_optimizer.h"
+#include "step/layer/radial_layer.h"
 #include "step/layer/island/island_base.h"
 #include "utilities/constants.h"
 #include "utilities/enums.h"
@@ -25,7 +26,40 @@ bool expect(bool condition, const std::string& message) {
     std::cerr << message << '\n';
     return false;
 }
-}  // namespace
+
+QSharedPointer<ORNL::LineSegment> lineSegment(const ORNL::Point& start, const ORNL::Point& end) {
+    QSharedPointer<ORNL::LineSegment> segment = QSharedPointer<ORNL::LineSegment>::create(start, end);
+    segment->getSb()->setSetting(ORNL::SS::kRegionType, ORNL::RegionType::kPerimeter);
+    return segment;
+}
+
+ORNL::Path linePath(float start_x, float end_x) {
+    ORNL::Path path;
+    path.append(lineSegment(ORNL::Point(start_x, 0.0f, 0.0f), ORNL::Point(end_x, 0.0f, 0.0f)));
+    return path;
+}
+
+ORNL::Path pathFromPoints(const QVector<ORNL::Point>& points) {
+    ORNL::Path path;
+    for (int i = 0, end = points.size() - 1; i < end; ++i) {
+        path.append(lineSegment(points[i], points[i + 1]));
+    }
+
+    return path;
+}
+
+QSharedPointer<ORNL::SettingsBase> cylindricalSettings(ORNL::PathOrderOptimization cylindrical_order,
+                                                       ORNL::PathOrderOptimization planar_order) {
+    QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
+    settings->setSetting(ORNL::PS::Optimizations::kCylindricalPathOrder, static_cast<int>(cylindrical_order));
+    settings->setSetting(ORNL::PS::Optimizations::kPathOrder, static_cast<int>(planar_order));
+    settings->setSetting(ORNL::PS::Optimizations::kPointOrder,
+                         static_cast<int>(ORNL::PointOrderOptimization::kNextClosest));
+    settings->setSetting(ORNL::PS::Optimizations::kMinDistanceEnabled, false);
+    settings->setSetting(ORNL::PS::Optimizations::kLocalRandomnessEnable, false);
+    return settings;
+}
+} // namespace
 
 int main() {
     bool passed = true;
@@ -115,6 +149,114 @@ int main() {
     ORNL::Polyline ordered_result = ordered_open_polyline_optimizer.linkNextPolyline();
     passed &= expect(!ordered_result.isEmpty() && ordered_result.front().x() == 10.0f,
                      "Expected ordered line linking to honor next farthest path order.");
+
+    ORNL::Point radial_closest_start(0.0f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer radial_closest_optimizer(
+        radial_closest_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
+    radial_closest_optimizer.setPathsToEvaluate({linePath(1.0f, 2.0f), linePath(10.0f, 11.0f)});
+    ORNL::Path radial_closest_result = radial_closest_optimizer.linkNextRadialPath();
+    passed &= expect(radial_closest_result.size() > 1 && radial_closest_result[1]->start().x() == 1.0f,
+                     "Expected radial linking to honor cylindrical next closest path order.");
+
+    ORNL::Point radial_farthest_start(0.0f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer radial_farthest_optimizer(
+        radial_farthest_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextFarthest, ORNL::PathOrderOptimization::kNextClosest));
+    radial_farthest_optimizer.setPathsToEvaluate({linePath(1.0f, 2.0f), linePath(10.0f, 11.0f)});
+    ORNL::Path radial_farthest_result = radial_farthest_optimizer.linkNextRadialPath();
+    passed &= expect(radial_farthest_result.size() > 1 && radial_farthest_result[1]->start().x() == 10.0f,
+                     "Expected radial linking to honor cylindrical next farthest path order.");
+
+    ORNL::Path closed_radial_path =
+        pathFromPoints({ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
+                        ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f),
+                        ORNL::Point(0.0f, 0.0f, 0.0f)});
+
+    ORNL::Point closed_radial_closest_start(9.8f, 10.0f, 0.0f);
+    ORNL::PathOrderOptimizer closed_radial_closest_optimizer(
+        closed_radial_closest_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
+    closed_radial_closest_optimizer.setPathsToEvaluate({closed_radial_path});
+    ORNL::Path closed_radial_closest_result = closed_radial_closest_optimizer.linkNextRadialPath();
+    passed &= expect(closed_radial_closest_result.size() > 1 &&
+                         closed_radial_closest_result[1]->start() == ORNL::Point(10.0f, 10.0f, 0.0f),
+                     "Expected closed radial closest linking to rotate to the nearest segment start.");
+    passed &= expect(closed_radial_closest_result.size() > 1 &&
+                         closed_radial_closest_result[1]->end() == ORNL::Point(0.0f, 10.0f, 0.0f),
+                     "Expected closed radial closest linking to preserve segment direction after rotation.");
+
+    ORNL::Point closed_radial_farthest_start(0.0f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer closed_radial_farthest_optimizer(
+        closed_radial_farthest_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextFarthest, ORNL::PathOrderOptimization::kNextClosest));
+    closed_radial_farthest_optimizer.setPathsToEvaluate({closed_radial_path});
+    ORNL::Path closed_radial_farthest_result = closed_radial_farthest_optimizer.linkNextRadialPath();
+    passed &= expect(closed_radial_farthest_result.size() > 1 &&
+                         closed_radial_farthest_result[1]->start() == ORNL::Point(10.0f, 10.0f, 0.0f),
+                     "Expected closed radial farthest linking to rotate to the farthest segment start.");
+
+    ORNL::Path open_radial_path =
+        pathFromPoints({ORNL::Point(0.0f, 0.0f, 0.0f), ORNL::Point(10.0f, 0.0f, 0.0f),
+                        ORNL::Point(10.0f, 10.0f, 0.0f), ORNL::Point(0.0f, 10.0f, 0.0f)});
+    ORNL::Point open_radial_start(9.8f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer open_radial_optimizer(
+        open_radial_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
+    open_radial_optimizer.setPathsToEvaluate({open_radial_path});
+    ORNL::Path open_radial_result = open_radial_optimizer.linkNextRadialPath();
+    passed &= expect(open_radial_result.size() > 1 &&
+                         open_radial_result[1]->start() == ORNL::Point(0.0f, 0.0f, 0.0f),
+                     "Expected open radial closest linking to remain endpoint-only.");
+
+    QSharedPointer<ORNL::SettingsBase> radial_layer_settings =
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest);
+    ORNL::RadialLayer radial_layer(0, radial_layer_settings);
+    radial_layer.addPath(pathFromPoints({ORNL::Point(100.0f, 0.0f, 0.0f), ORNL::Point(110.0f, 0.0f, 0.0f),
+                                         ORNL::Point(110.0f, 10.0f, 0.0f), ORNL::Point(100.0f, 10.0f, 0.0f),
+                                         ORNL::Point(100.0f, 0.0f, 0.0f)}));
+    radial_layer.addPath(pathFromPoints({ORNL::Point(0.0f, 0.0f, 1.0f), ORNL::Point(10.0f, 0.0f, 1.0f),
+                                         ORNL::Point(10.0f, 10.0f, 1.0f), ORNL::Point(0.0f, 10.0f, 1.0f),
+                                         ORNL::Point(0.0f, 0.0f, 1.0f)}));
+    ORNL::Point radial_layer_current_location(9.8f, 10.0f, 0.0f);
+    radial_layer.calculateModifiers(radial_layer_current_location);
+    passed &= expect(radial_layer_current_location == ORNL::Point(100.0f, 10.0f, 0.0f),
+                     "Expected radial layer ordering to choose across all paths instead of same-Z groups.");
+
+    ORNL::Point helical_closest_start(0.0f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer helical_closest_optimizer(
+        helical_closest_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
+    helical_closest_optimizer.setPathsToEvaluate({linePath(1.0f, 2.0f), linePath(10.0f, 11.0f)});
+    ORNL::Path helical_closest_result = helical_closest_optimizer.linkNextHelicalPath();
+    passed &= expect(helical_closest_result.size() > 1 && helical_closest_result[1]->start().x() == 1.0f,
+                     "Expected helical linking to honor cylindrical next closest path order.");
+    passed &= expect(helical_closest_result.size() > 1 && helical_closest_result.back()->end().x() == 2.0f,
+                     "Expected helical closest linking to keep forward direction when the start endpoint is selected.");
+
+    ORNL::Point helical_closest_reverse_start(0.0f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer helical_closest_reverse_optimizer(
+        helical_closest_reverse_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextClosest, ORNL::PathOrderOptimization::kNextFarthest));
+    helical_closest_reverse_optimizer.setPathsToEvaluate({linePath(10.0f, 1.0f), linePath(20.0f, 21.0f)});
+    ORNL::Path helical_closest_reverse_result = helical_closest_reverse_optimizer.linkNextHelicalPath();
+    passed &= expect(helical_closest_reverse_result.size() > 1 &&
+                         helical_closest_reverse_result[1]->start().x() == 1.0f,
+                     "Expected helical closest linking to enter from the nearest end endpoint.");
+    passed &= expect(helical_closest_reverse_result.size() > 1 &&
+                         helical_closest_reverse_result.back()->end().x() == 10.0f,
+                     "Expected helical closest linking to reverse the fragment when entering from the end endpoint.");
+
+    ORNL::Point helical_farthest_start(0.0f, 0.0f, 0.0f);
+    ORNL::PathOrderOptimizer helical_farthest_optimizer(
+        helical_farthest_start, 0,
+        cylindricalSettings(ORNL::PathOrderOptimization::kNextFarthest, ORNL::PathOrderOptimization::kNextClosest));
+    helical_farthest_optimizer.setPathsToEvaluate({linePath(1.0f, 2.0f), linePath(10.0f, 11.0f)});
+    ORNL::Path helical_farthest_result = helical_farthest_optimizer.linkNextHelicalPath();
+    passed &= expect(helical_farthest_result.size() > 1 && helical_farthest_result[1]->start().x() == 11.0f,
+                     "Expected helical farthest linking to enter from the farthest end endpoint.");
+    passed &= expect(helical_farthest_result.size() > 1 && helical_farthest_result.back()->end().x() == 10.0f,
+                     "Expected helical farthest linking to reverse the fragment when entering from the end endpoint.");
 
     passed &= expect(ORNL::optionalPathOrderOptimization(0, ORNL::PathOrderOptimization::kNextFarthest) ==
                          ORNL::PathOrderOptimization::kNextFarthest,


### PR DESCRIPTION
## Summary

Adds cylindrical-specific path ordering controls and helical `Clip Z` endpoint rounding for radial/helical cylindrical slicing.

This PR introduces:
- `Cylindrical Path Order Optimization` with `Next Closest` and `Next Farthest` ordering for cylindrical paths.
- Endpoint-aware radial and helical ordering so cylindrical paths are selected from the nearest or farthest usable entry point.
- `Helical Z Clip Rounding` for `Helical` + `Clip Z`, allowing exact intersection clipping, extension to the next complete revolution, or truncation to the last full revolution.
- Arc Specialties header and safe-Z updates so generated cylindrical G-code reports the active settings and accounts for rounded helical paths that extend above the original model/cylinder height.

## Related issues

- No related issues.

## Details

This is a cylindrical slicing feature update. Previously, radial and helical cylindrical paths did not have a dedicated path-order setting. Helical fragments also preserved generated order/direction, which meant travel optimization could not enter a fragment from its closer endpoint. For `Clip Z`, helical paths ended at the highest model intersection only, with no way to round the endpoint to full revolutions for process requirements.

The new `Cylindrical Path Order Optimization` setting lives under `Profile > Optimizations` and is shown only for cylindrical slicing. It intentionally supports only the cylindrical-safe options:
- `Next Closest`
- `Next Farthest`

The runtime optimizer now uses this dedicated cylindrical setting instead of the planar `Path Order Optimization` setting. Radial and helical paths are handled differently according to their geometry:
- Radial closed paths can rotate to the selected segment start.
- Radial open arcs remain endpoint-only so they are not split unexpectedly.
- Radial ordering considers the full retained path set instead of grouping by same-Z circles.
- Helical fragments compare both the generated start and generated end.
- If a helical fragment is selected from its end, its segments are reversed before output so travel enters from the selected endpoint while preserving path connectivity.

This PR also adds `Helical Z Clip Rounding` under `Profile > Slicing`, shown only when:
- `Slicing Mode` is `Cylindrical`
- `Cylindrical Path Pattern` is `Helical`
- `Helical Path Boundary Policy` is `Clip Z`

The rounding modes are:
- `Exact Intersection`: preserve the existing behavior and stop at the highest-Z model intersection.
- `Complete Revolution`: continue to the next complete revolution, which may extend above the original model or configured cylinder height.
- `Last Full Revolution`: stop at the previous complete revolution; if the highest intersection occurs before one full revolution, the path is omitted.

The helical rounding logic was factored into `HelicalPathRounding` so the endpoint calculation is isolated from `HelicalSlicer` and directly testable. `HelicalSlicer` now tracks the maximum generated helical path Z after rounding and forwards that to the writer setup so Arc Specialties startup travel remains above the actual generated toolpath, including `Complete Revolution` extensions.

Arc Specialties output was updated to include:
- `Cylindrical Path Order Optimization` in the cylindrical settings header.
- `Helical Z Clip Rounding` when applicable.
- Part-local helical Clip Z rounding values when multiple parts contribute helical paths.

Settings metadata, generated config, template `.s2c` defaults, docs, and UI refresh hooks were updated so the new settings are available consistently through profiles, part-local settings, G-code preview invalidation, and documented cylindrical slicing workflows.

## Impact

Functionality impact: Medium. This changes cylindrical path sequencing behavior when users select the new cylindrical ordering option, and it adds new helical Clip Z endpoint policies.

User workflow impact: Medium. Cylindrical users now have explicit control over radial/helical travel ordering without relying on planar path-order settings, and helical Clip Z users can choose whether the generated path should stop at the model intersection or align to complete revolutions.

G-code impact: Medium. The generated order of radial/helical paths can change under cylindrical slicing, and `Complete Revolution` may intentionally emit helical moves above the model or configured cylinder height. Arc Specialties startup safe-Z now accounts for that generated maximum.

Compatibility impact: Low. Defaults preserve existing behavior:
- `Cylindrical Path Order Optimization` defaults to `Next Closest`.
- `Helical Z Clip Rounding` defaults to `Exact Intersection`.
- Existing templates receive explicit default values.

Risk level: Medium. The changes affect slicer ordering, segment reversal, generated helical geometry, and Arc Specialties setup/header output. Risk is limited by keeping the new controls cylindrical-specific, preserving default behavior, and adding focused regression coverage for endpoint selection, reversal, Clip Z rounding, and Arc Specialties output.

## Validation

Build:
- `nix develop .#ornlslicerDev -L --command cmake --build build/generic-llvm-ninja --config Debug --target ornlslicer_obj ornlslicer_optimizer_empty_input_tests ornlslicer_helical_clip_rounding_tests ornlslicer_arc_specialties_parser_tests`
- Result: passed; Ninja reported no work to do for the focused targets.

Tests:
- `nix develop .#ornlslicerDev -L --command ctest --test-dir build/generic-llvm-ninja -C Debug -R 'optimizer_empty_input_tests|helical_clip_rounding_tests|arc_specialties_parser_tests' --output-on-failure`
- Result: passed, 3/3 tests.

Covered cases include:
- Cylindrical `Next Closest` and `Next Farthest` ordering.
- Radial closed-path rotation to the selected segment start.
- Radial open-path endpoint-only behavior.
- Radial layer ordering across the full retained path set instead of same-Z groups.
- Helical start/end endpoint selection.
- Helical fragment reversal when entering from the generated end.
- `Exact Intersection`, `Complete Revolution`, and `Last Full Revolution` Clip Z rounding.
- Omission when `Last Full Revolution` would end before one complete revolution.
- Full-revolution endpoint preservation for both helical handedness modes.
- Arc Specialties header output for helical Clip Z rounding.
- Arc Specialties startup safe-Z accounting for generated helical max Z.