### PR TITLE
Add travel feedrate scaling exemption

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 *.bmp filter=lfs diff=lfs merge=lfs -text
 *.gif filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text

--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -211,6 +211,9 @@ class CommonParser : public ParserBase {
     //! \return travel time in gcode file
     Time getTravelTime();
 
+    //! \brief Returns the estimated total travel time after feedrate adjustment.
+    Time getAdjustedTravelTime();
+
     //! \brief Returns whether or not any lines were altered to enforce minimum layer times or expand/contract
     bool getWasModified();
 
@@ -531,6 +534,11 @@ class CommonParser : public ParserBase {
 
     //! \brief Reads a numeric F token from a command before its comment.
     bool commandFeedrate(const QString& line, double& feedrate);
+
+    //! \brief Returns the time delta caused by feedrate adjustment for a parsed motion command.
+    Time adjustedFeedrateTimeDeltaForCommand(const GcodeCommand& command,
+                                             QMap<int, double>::const_iterator& explicit_feedrate,
+                                             bool& emitted_feedrate_set, double& emitted_feedrate);
 
     //! \brief Inserts feedrates where scaled and protected modal spans meet.
     void materializeFeedrateTransitions(double modifier);

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -776,6 +776,7 @@ class Constants {
             static const QString kEnableTravelPause;
             static const QString kEnableTravelCentroidMove;
             static const QString kTravelPauseDuration;
+            static const QString kDisableFeedrateScaling;
         };
 
         class GCode {

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5446,6 +5446,19 @@
       "symbol":"kTravelSpeed",
       "local":true
   },
+  "disable_travel_feedrate_scaling": {
+      "display":"Disable Feedrate Scaling for Travel",
+      "type":"boolean",
+      "tooltip":"If selected, minimum layer time feedrate adjustments will not change travel move speeds.",
+      "depends":{"AND":[{"slicing_mode":0},{"AND":[{"force_minimum_layer_time":true},{"minimum_layer_time_method":1}]}]},
+      "options":"",
+      "default":false,
+      "minor":"Travel",
+      "major":"Profile",
+      "namespace":"Profile::Travel",
+      "symbol":"kDisableTravelFeedrateScaling",
+      "local":false
+  },
   "minimum_infill_travel_length": {
       "display":"Minimum Infill Travel Length",
       "type":"distance",

--- a/resources/settings/027_profile_travel.yaml
+++ b/resources/settings/027_profile_travel.yaml
@@ -13,6 +13,18 @@ settings:
     namespace: "Profile::Travel"
     symbol: "kTravelSpeed"
     local: true
+  - name: "disable_travel_feedrate_scaling"
+    display: "Disable Feedrate Scaling for Travel"
+    type: "boolean"
+    tooltip: "If selected, minimum layer time feedrate adjustments will not change travel move speeds."
+    depends: {"AND":[{"slicing_mode":0},{"AND":[{"force_minimum_layer_time":true},{"minimum_layer_time_method":1}]}]}
+    options: []
+    default: false
+    minor: "Travel"
+    major: "Profile"
+    namespace: "Profile::Travel"
+    symbol: "kDisableTravelFeedrateScaling"
+    local: false
   - name: "minimum_infill_travel_length"
     display: "Minimum Infill Travel Length"
     type: "distance"

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -43,7 +43,8 @@ double parseFooterSettingValue(const QString& value) {
 
 bool isDisableFeedrateScalingSetting(const QString& key) {
     return key == MS::Startup::kDisableFeedrateScaling || key == MS::Slowdown::kDisableFeedrateScaling ||
-           key == MS::TipWipe::kDisableFeedrateScaling || key == MS::SpiralLift::kDisableFeedrateScaling;
+           key == MS::TipWipe::kDisableFeedrateScaling || key == MS::SpiralLift::kDisableFeedrateScaling ||
+           key == PS::Travel::kDisableFeedrateScaling;
 }
 
 double positiveSweep(double sweep) {
@@ -350,8 +351,13 @@ bool CommonParser::feedrateScalingDisabledForCommand(const GcodeCommand& command
         return true;
     }
 
-    return fileBoolSetting(MS::SpiralLift::kDisableFeedrateScaling) &&
-           comment.contains(Constants::PathModifierStrings::kSpiralLift);
+    if (fileBoolSetting(MS::SpiralLift::kDisableFeedrateScaling) &&
+        comment.contains(Constants::PathModifierStrings::kSpiralLift)) {
+        return true;
+    }
+
+    return fileBoolSetting(PS::Travel::kDisableFeedrateScaling) &&
+           comment.contains(Constants::RegionTypeStrings::kTravel);
 }
 
 bool CommonParser::currentMotionDepositsMaterial() const {

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -412,6 +412,44 @@ bool CommonParser::commandFeedrate(const QString& line, double& feedrate) {
     return converted;
 }
 
+Time CommonParser::adjustedFeedrateTimeDeltaForCommand(const GcodeCommand& command,
+                                                       QMap<int, double>::const_iterator& explicit_feedrate,
+                                                       bool& emitted_feedrate_set, double& emitted_feedrate) {
+    const int line_number = command.getLineNumber();
+    while (explicit_feedrate != m_explicit_modal_feedrates.cend() && explicit_feedrate.key() < line_number) {
+        emitted_feedrate     = explicit_feedrate.value();
+        emitted_feedrate_set = true;
+        ++explicit_feedrate;
+    }
+
+    const double original_feedrate   = m_command_modal_feedrates.value(line_number, 0.0);
+    double explicit_command_feedrate = 0.0;
+    if (line_number >= 0 && line_number < m_lines.size() &&
+        commandFeedrate(m_lines[line_number], explicit_command_feedrate)) {
+        emitted_feedrate     = explicit_command_feedrate;
+        emitted_feedrate_set = true;
+    }
+    else if (command.getParameters().contains(m_f_parameter.toLatin1()) && original_feedrate > 0) {
+        // Macro feedrates such as F#981 cannot be read back numerically, but their authored value was
+        // resolved while parsing and remains unchanged unless setCommandFeedrate replaced the token.
+        emitted_feedrate     = original_feedrate;
+        emitted_feedrate_set = true;
+    }
+
+    Time delta;
+    const Time command_adjustable_time = m_command_G1F_times.value(line_number);
+    if (command_adjustable_time > 0 && original_feedrate > 0 && emitted_feedrate_set && emitted_feedrate > 0) {
+        const double effective_modifier = emitted_feedrate / original_feedrate;
+        delta                           = command_adjustable_time / effective_modifier - command_adjustable_time;
+    }
+
+    while (explicit_feedrate != m_explicit_modal_feedrates.cend() && explicit_feedrate.key() == line_number) {
+        ++explicit_feedrate;
+    }
+
+    return delta;
+}
+
 void CommonParser::materializeFeedrateTransitions(double modifier) {
     bool emitted_feedrate_set = false;
     double emitted_feedrate   = 0.0;
@@ -955,36 +993,8 @@ QList<Time> CommonParser::getAdjustedLayerTimes() {
 
     for (int layer = 0; layer < m_motion_commands.size() && layer < adjusted_layer_times.size(); ++layer) {
         for (const GcodeCommand& command : m_motion_commands[layer]) {
-            const int line_number = command.getLineNumber();
-            while (explicit_feedrate != m_explicit_modal_feedrates.cend() && explicit_feedrate.key() < line_number) {
-                emitted_feedrate     = explicit_feedrate.value();
-                emitted_feedrate_set = true;
-                ++explicit_feedrate;
-            }
-
-            const double original_feedrate   = m_command_modal_feedrates.value(line_number, 0.0);
-            double explicit_command_feedrate = 0.0;
-            if (line_number >= 0 && line_number < m_lines.size() &&
-                commandFeedrate(m_lines[line_number], explicit_command_feedrate)) {
-                emitted_feedrate     = explicit_command_feedrate;
-                emitted_feedrate_set = true;
-            }
-            else if (command.getParameters().contains(m_f_parameter.toLatin1()) && original_feedrate > 0) {
-                // Macro feedrates such as F#981 cannot be read back numerically, but their authored value was
-                // resolved while parsing and remains unchanged unless setCommandFeedrate replaced the token.
-                emitted_feedrate     = original_feedrate;
-                emitted_feedrate_set = true;
-            }
-
-            const Time command_adjustable_time = m_command_G1F_times.value(line_number);
-            if (command_adjustable_time > 0 && original_feedrate > 0 && emitted_feedrate_set && emitted_feedrate > 0) {
-                const double effective_modifier = emitted_feedrate / original_feedrate;
-                adjusted_layer_times[layer] += command_adjustable_time / effective_modifier - command_adjustable_time;
-            }
-
-            while (explicit_feedrate != m_explicit_modal_feedrates.cend() && explicit_feedrate.key() == line_number) {
-                ++explicit_feedrate;
-            }
+            adjusted_layer_times[layer] +=
+                adjustedFeedrateTimeDeltaForCommand(command, explicit_feedrate, emitted_feedrate_set, emitted_feedrate);
         }
     }
 
@@ -1013,6 +1023,28 @@ Distance CommonParser::getTravelDistance() {
 
 Time CommonParser::getTravelTime() {
     return m_travel_time;
+}
+
+Time CommonParser::getAdjustedTravelTime() {
+    Time adjusted_travel_time = m_travel_time;
+
+    const bool has_adjusted_feedrates = std::any_of(m_layer_FR_modifiers.cbegin(), m_layer_FR_modifiers.cend(),
+                                                    [](double modifier) { return modifier > 0 && modifier != 1.0; });
+    if (!has_adjusted_feedrates) return adjusted_travel_time;
+
+    bool emitted_feedrate_set = false;
+    double emitted_feedrate   = 0.0;
+    auto explicit_feedrate    = m_explicit_modal_feedrates.cbegin();
+
+    for (const QList<GcodeCommand>& layer_commands : m_motion_commands) {
+        for (const GcodeCommand& command : layer_commands) {
+            const Time delta =
+                adjustedFeedrateTimeDeltaForCommand(command, explicit_feedrate, emitted_feedrate_set, emitted_feedrate);
+            if (!command.getDepositionActive()) { adjusted_travel_time += delta; }
+        }
+    }
+
+    return adjusted_travel_time;
 }
 
 bool CommonParser::getWasModified() {

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -5,6 +5,7 @@
 #include <QFileInfo>
 #include <QStringBuilder>
 #include <QTextStream>
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <optional>
@@ -323,6 +324,11 @@ void GCodeLoader::run() {
                 (m_parser->getPrintingDistance() / PreferencesManager::getInstance()->getDistanceUnit())();
             double travelDistanceValue =
                 (m_parser->getTravelDistance() / PreferencesManager::getInstance()->getDistanceUnit())();
+            const bool has_adjusted_feedrates =
+                std::any_of(layer_FR_modifiers.cbegin(), layer_FR_modifiers.cend(),
+                            [](double modifier) { return modifier > 0 && modifier != 1.0; });
+            const Time travel_time_estimate =
+                has_adjusted_feedrates ? m_parser->getAdjustedTravelTime() : m_parser->getTravelTime();
             double massValue = (total_mass / PreferencesManager::getInstance()->getMassUnit())();
             keyInfo = keyInfo % "Volume: " % QString::number(volumeValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "³\n" % "Printing Distance: " %
@@ -330,8 +336,8 @@ void GCodeLoader::run() {
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" % "Travel Distance: " %
                       QString::number(travelDistanceValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" %
-                      "Total Travel Time Estimate: " % MathUtils::formattedTimeSpan(m_parser->getTravelTime()()) %
-                      "\n" % "Total Distance: " % QString::number(distanceValue) % " " %
+                      "Total Travel Time Estimate: " % MathUtils::formattedTimeSpan(travel_time_estimate()) % "\n" %
+                      "Total Distance: " % QString::number(distanceValue) % " " %
                       PreferencesManager::getInstance()->getDistanceUnit().toString() % "\n" % "Approximate Weight (" %
                       toString(m_material) % "): " % QString::number(massValue) % " " %
                       PreferencesManager::getInstance()->getMassUnit().toString() % "\n";

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -718,6 +718,7 @@ const QString Constants::ProfileSettings::Travel::kFinalLiftDistance        = "f
 const QString Constants::ProfileSettings::Travel::kEnableTravelPause        = "enable_travel_pause";
 const QString Constants::ProfileSettings::Travel::kEnableTravelCentroidMove = "travel_centroid_move";
 const QString Constants::ProfileSettings::Travel::kTravelPauseDuration      = "travel_pause_duration";
+const QString Constants::ProfileSettings::Travel::kDisableFeedrateScaling   = "disable_travel_feedrate_scaling";
 
 // G-Code
 const QString Constants::ProfileSettings::GCode::kPerimeterStart = "perimeter_start_code";
@@ -1212,6 +1213,8 @@ const QHash<QString, QString> Constants::GcodeFileVariables::kNecessaryVariables
      Constants::MaterialSettings::TipWipe::kDisableFeedrateScaling},
     {Constants::MaterialSettings::SpiralLift::kDisableFeedrateScaling.toUpper(),
      Constants::MaterialSettings::SpiralLift::kDisableFeedrateScaling},
+    {Constants::ProfileSettings::Travel::kDisableFeedrateScaling.toUpper(),
+     Constants::ProfileSettings::Travel::kDisableFeedrateScaling},
     {Constants::MaterialSettings::Density::kMaterialType.toUpper(),
      Constants::MaterialSettings::Density::kMaterialType},
     {Constants::MaterialSettings::Density::kDensity.toUpper(), Constants::MaterialSettings::Density::kDensity},

--- a/tests/common_parser_tests.cpp
+++ b/tests/common_parser_tests.cpp
@@ -37,6 +37,26 @@ bool lineFeedrate(const QString& line, double& feedrate) {
     return converted;
 }
 
+void configureLayerTimeSettings() {
+    auto global_settings = ORNL::GSM->getGlobal();
+    global_settings->setSetting(ORNL::MS::Cooling::kForceMinLayerTime, true);
+    global_settings->setSetting(ORNL::MS::Cooling::kForceMinLayerTimeMethod,
+                                static_cast<int>(ORNL::ForceMinimumLayerTime::kSlow_Feedrate));
+    global_settings->setSetting(ORNL::MS::Cooling::kMinLayerTime, 5.0);
+    global_settings->setSetting(ORNL::MS::Cooling::kMaxLayerTime, 0.0);
+    global_settings->setSetting(ORNL::MS::Cooling::kExtruderScaleFactor, 1.0);
+    global_settings->setSetting(ORNL::MS::Filament::kFilamentBAxis, false);
+    global_settings->setSetting(ORNL::MS::Startup::kDisableFeedrateScaling, false);
+    global_settings->setSetting(ORNL::MS::Slowdown::kDisableFeedrateScaling, false);
+    global_settings->setSetting(ORNL::MS::TipWipe::kDisableFeedrateScaling, false);
+    global_settings->setSetting(ORNL::MS::SpiralLift::kDisableFeedrateScaling, false);
+    global_settings->setSetting(ORNL::PS::Travel::kDisableFeedrateScaling, false);
+    global_settings->setSetting(ORNL::PRS::MachineSpeed::kMinXYSpeed, 0.0);
+    global_settings->setSetting(ORNL::PRS::MachineSpeed::kMaxXYSpeed, 1000000.0);
+    global_settings->setSetting(ORNL::PS::Layer::kBeadWidth, 0.4);
+    global_settings->setSetting(ORNL::PS::Layer::kLayerHeight, 0.2);
+}
+
 bool accumulatesTravelTimeForNonDepositionMove() {
     QStringList original_lines {"G1 F60 X1 ;TRAVEL"};
     QStringList upper_lines = upperLines(original_lines);
@@ -68,18 +88,7 @@ bool accumulatesTravelTimeForTravelCommentAfterDepositionMove() {
 }
 
 bool keepsTravelFeedrateWhenTravelScalingDisabled() {
-    auto global_settings = ORNL::GSM->getGlobal();
-    global_settings->setSetting(ORNL::MS::Cooling::kForceMinLayerTime, true);
-    global_settings->setSetting(ORNL::MS::Cooling::kForceMinLayerTimeMethod,
-                                static_cast<int>(ORNL::ForceMinimumLayerTime::kSlow_Feedrate));
-    global_settings->setSetting(ORNL::MS::Cooling::kMinLayerTime, 5.0);
-    global_settings->setSetting(ORNL::MS::Cooling::kMaxLayerTime, 0.0);
-    global_settings->setSetting(ORNL::MS::Cooling::kExtruderScaleFactor, 1.0);
-    global_settings->setSetting(ORNL::MS::Filament::kFilamentBAxis, false);
-    global_settings->setSetting(ORNL::PRS::MachineSpeed::kMinXYSpeed, 0.0);
-    global_settings->setSetting(ORNL::PRS::MachineSpeed::kMaxXYSpeed, 1000000.0);
-    global_settings->setSetting(ORNL::PS::Layer::kBeadWidth, 0.4);
-    global_settings->setSetting(ORNL::PS::Layer::kLayerHeight, 0.2);
+    configureLayerTimeSettings();
 
     QStringList original_lines {
         ";BEGINNING LAYER: 1",
@@ -95,13 +104,45 @@ bool keepsTravelFeedrateWhenTravelScalingDisabled() {
         parser.parseFooter();
         parser.parseLines();
 
-        double travel_feedrate        = 0.0;
-        double print_feedrate         = 0.0;
-        const QList<double> modifiers = parser.getLayerFeedRateModifiers();
+        double travel_feedrate            = 0.0;
+        double print_feedrate             = 0.0;
+        const QList<double> modifiers     = parser.getLayerFeedRateModifiers();
+        const double travel_time          = parser.getTravelTime()();
+        const double adjusted_travel_time = parser.getAdjustedTravelTime()();
 
         return parser.getWasModified() && modifiers.size() > 1 && modifiers[1] > 0.0 && modifiers[1] < 1.0 &&
                lineFeedrate(original_lines[1], travel_feedrate) && lineFeedrate(original_lines[2], print_feedrate) &&
-               std::abs(travel_feedrate - 60.0) < 1.0e-6 && print_feedrate > 0.0 && print_feedrate < 60.0;
+               std::abs(travel_feedrate - 60.0) < 1.0e-6 && print_feedrate > 0.0 && print_feedrate < 60.0 &&
+               std::abs(adjusted_travel_time - travel_time) < 1.0e-6;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << '\n';
+        return false;
+    }
+}
+
+bool adjustsTravelTimeWhenTravelFeedrateIsScaled() {
+    configureLayerTimeSettings();
+
+    QStringList original_lines {
+        ";BEGINNING LAYER: 1",
+        "G1 F60 X1 ;TRAVEL",
+        "G1 F60 X2 E1 ;PERIMETER",
+        ";Settings Footer",
+        ";disable_travel_feedrate_scaling false",
+    };
+    QStringList upper_lines = upperLines(original_lines);
+    ORNL::CommonParser parser(ORNL::GcodeMetaList::MarlinMeta, true, original_lines, upper_lines);
+
+    try {
+        parser.parseFooter();
+        parser.parseLines();
+
+        double travel_feedrate        = 0.0;
+        const QList<double> modifiers = parser.getLayerFeedRateModifiers();
+
+        return parser.getWasModified() && modifiers.size() > 1 && modifiers[1] > 0.0 && modifiers[1] < 1.0 &&
+               lineFeedrate(original_lines[1], travel_feedrate) && travel_feedrate > 0.0 && travel_feedrate < 60.0 &&
+               parser.getAdjustedTravelTime()() > parser.getTravelTime()();
     } catch (const std::exception& ex) {
         std::cerr << ex.what() << '\n';
         return false;
@@ -119,6 +160,8 @@ int main(int argc, char* argv[]) {
                      "Common parser did not accumulate travel time for a travel comment after deposition.");
     passed &= expect(keepsTravelFeedrateWhenTravelScalingDisabled(),
                      "Common parser scaled a travel move when travel feedrate scaling was disabled.");
+    passed &= expect(adjustsTravelTimeWhenTravelFeedrateIsScaled(),
+                     "Common parser did not adjust travel time when travel feedrate was scaled.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/common_parser_tests.cpp
+++ b/tests/common_parser_tests.cpp
@@ -1,12 +1,16 @@
 #include <QCoreApplication>
+#include <QRegularExpression>
 #include <QStringList>
+#include <cmath>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
 
 #include "gcode/gcode_meta.h"
 #include "gcode/parsers/common_parser.h"
+#include "managers/settings/settings_manager.h"
 #include "units/unit.h"
+#include "utilities/constants.h"
 
 namespace {
 bool expect(bool condition, const char* message) {
@@ -19,6 +23,18 @@ QStringList upperLines(const QStringList& lines) {
     for (const QString& line : lines) { upper_lines.append(line.toUpper()); }
 
     return upper_lines;
+}
+
+bool lineFeedrate(const QString& line, double& feedrate) {
+    static const QRegularExpression feedrate_token("(^|\\s)F([-+]?\\d*\\.?\\d+(?:[Ee][-+]?\\d+)?)",
+                                                   QRegularExpression::CaseInsensitiveOption);
+
+    const QRegularExpressionMatch match = feedrate_token.match(line);
+    if (!match.hasMatch()) return false;
+
+    bool converted = false;
+    feedrate       = match.captured(2).toDouble(&converted);
+    return converted;
 }
 
 bool accumulatesTravelTimeForNonDepositionMove() {
@@ -50,6 +66,47 @@ bool accumulatesTravelTimeForTravelCommentAfterDepositionMove() {
         return false;
     }
 }
+
+bool keepsTravelFeedrateWhenTravelScalingDisabled() {
+    auto global_settings = ORNL::GSM->getGlobal();
+    global_settings->setSetting(ORNL::MS::Cooling::kForceMinLayerTime, true);
+    global_settings->setSetting(ORNL::MS::Cooling::kForceMinLayerTimeMethod,
+                                static_cast<int>(ORNL::ForceMinimumLayerTime::kSlow_Feedrate));
+    global_settings->setSetting(ORNL::MS::Cooling::kMinLayerTime, 5.0);
+    global_settings->setSetting(ORNL::MS::Cooling::kMaxLayerTime, 0.0);
+    global_settings->setSetting(ORNL::MS::Cooling::kExtruderScaleFactor, 1.0);
+    global_settings->setSetting(ORNL::MS::Filament::kFilamentBAxis, false);
+    global_settings->setSetting(ORNL::PRS::MachineSpeed::kMinXYSpeed, 0.0);
+    global_settings->setSetting(ORNL::PRS::MachineSpeed::kMaxXYSpeed, 1000000.0);
+    global_settings->setSetting(ORNL::PS::Layer::kBeadWidth, 0.4);
+    global_settings->setSetting(ORNL::PS::Layer::kLayerHeight, 0.2);
+
+    QStringList original_lines {
+        ";BEGINNING LAYER: 1",
+        "G1 F60 X1 ;TRAVEL",
+        "G1 F60 X2 E1 ;PERIMETER",
+        ";Settings Footer",
+        ";disable_travel_feedrate_scaling true",
+    };
+    QStringList upper_lines = upperLines(original_lines);
+    ORNL::CommonParser parser(ORNL::GcodeMetaList::MarlinMeta, true, original_lines, upper_lines);
+
+    try {
+        parser.parseFooter();
+        parser.parseLines();
+
+        double travel_feedrate        = 0.0;
+        double print_feedrate         = 0.0;
+        const QList<double> modifiers = parser.getLayerFeedRateModifiers();
+
+        return parser.getWasModified() && modifiers.size() > 1 && modifiers[1] > 0.0 && modifiers[1] < 1.0 &&
+               lineFeedrate(original_lines[1], travel_feedrate) && lineFeedrate(original_lines[2], print_feedrate) &&
+               std::abs(travel_feedrate - 60.0) < 1.0e-6 && print_feedrate > 0.0 && print_feedrate < 60.0;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << '\n';
+        return false;
+    }
+}
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -60,6 +117,8 @@ int main(int argc, char* argv[]) {
                      "Common parser did not accumulate travel time for a travel move.");
     passed &= expect(accumulatesTravelTimeForTravelCommentAfterDepositionMove(),
                      "Common parser did not accumulate travel time for a travel comment after deposition.");
+    passed &= expect(keepsTravelFeedrateWhenTravelScalingDisabled(),
+                     "Common parser scaled a travel move when travel feedrate scaling was disabled.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary
- Add a Profile > Travel checkbox to disable minimum-layer-time feedrate scaling for travel moves.
- Wire the setting into constants, G-code footer parsing, and parser feedrate-scaling skip logic.
- Add a common parser regression test confirming travel feedrate remains unchanged while print motion is scaled.

## Testing
- `nix develop --command ctest --test-dir build/generic-llvm-ninja -C Debug -R common_parser_tests --output-on-failure`