### PR TITLE
Fix flowrate calculator preference units

### DIFF
--- a/include/windows/flowratecalc.h
+++ b/include/windows/flowratecalc.h
@@ -32,6 +32,12 @@ class FlowrateCalcWindow : public QWidget {
     void closeEvent(QCloseEvent* event);
 
    private slots:
+    //! \brief Update distance labels and entered values when distance units change
+    void distanceUnitsChanged(Distance new_value, Distance old_value);
+
+    //! \brief Update velocity labels and calculated values when velocity units change
+    void velocityUnitsChanged(Velocity new_value, Velocity old_value);
+
     //! \brief Check that all inputs are valid and perform necessary calculations
     //! Inputs are checked automatically as a user alters them
     void checkInputAndCalculate();
@@ -47,8 +53,16 @@ class FlowrateCalcWindow : public QWidget {
     //! \brief Setup events for widget components
     void setupEvents();
 
+    //! \brief Update labels that display preference-controlled units
+    void updateUnitLabels();
+
     //! \brief Layout for widget
     QGridLayout* m_layout;
+
+    //! \brief Unit-aware labels
+    QLabel* m_bead_width_label;
+    QLabel* m_layer_height_label;
+    QLabel* m_gantry_speed_label;
 
     //! \brief Individual input components
     QLineEdit* m_speed_rpm;

--- a/src/windows/flowratecalc.cpp
+++ b/src/windows/flowratecalc.cpp
@@ -3,6 +3,7 @@
 #include <math.h>
 
 #include <QApplication>
+#include <QSignalBlocker>
 
 #include <qcombobox.h>
 #include <qcontainerfwd.h>
@@ -16,13 +17,29 @@
 #include <qstringliteral.h>
 #include <qwidget.h>
 
+#include "managers/preferences_manager.h"
 #include "units/unit.h"
 #include "utilities/enums.h"
 
 namespace ORNL {
+namespace {
+void convertDistanceEntry(QLineEdit* entry, Distance old_unit, Distance new_unit) {
+    if (entry->text().isEmpty()) { return; }
+
+    bool text_ok          = false;
+    const double raw_text = entry->text().toDouble(&text_ok);
+    if (!text_ok) { return; }
+
+    Distance value;
+    value.from(raw_text, old_unit);
+
+    const QSignalBlocker blocker(entry);
+    entry->setText(QString::number(value.to(new_unit), 'g', 6));
+}
+}  // namespace
+
 // TODO:
-//  1. Use unit class
-//  2. Provide unit choices: metric or British
+//  1. Provide unit choices for mass flow rate
 FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     m_parent               = parent;
     m_density_metric       = g / (cm * cm * cm);
@@ -58,14 +75,14 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     // divider between two sections
     m_layout->setColumnMinimumWidth(2, 50);
 
-    QLabel* lbl_beadWidth = new QLabel("Bead Width (in):");
-    m_bead_width          = new QLineEdit();
-    m_layout->addWidget(lbl_beadWidth, 1, 3);
+    m_bead_width_label = new QLabel();
+    m_bead_width       = new QLineEdit();
+    m_layout->addWidget(m_bead_width_label, 1, 3);
     m_layout->addWidget(m_bead_width, 1, 4);
 
-    QLabel* lbl_layerHeight = new QLabel("Layer Height (in):");
-    m_layer_height          = new QLineEdit();
-    m_layout->addWidget(lbl_layerHeight, 2, 3);
+    m_layer_height_label = new QLabel();
+    m_layer_height       = new QLineEdit();
+    m_layout->addWidget(m_layer_height_label, 2, 3);
     m_layout->addWidget(m_layer_height, 2, 4);
 
     QLabel* lbl_printRate = new QLabel("Desired Print Rate (lbs/hr):");
@@ -94,10 +111,10 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     line->setFrameShadow(QFrame::Sunken);
     m_layout->addWidget(line, 6, 0, 1, 5);
 
-    QLabel* lbl_gantrySpeed = new QLabel("Gantry Speed (in/sec):");
-    m_gantry_speed          = new QLineEdit();
+    m_gantry_speed_label = new QLabel();
+    m_gantry_speed       = new QLineEdit();
     m_gantry_speed->setReadOnly(true);
-    m_layout->addWidget(lbl_gantrySpeed, 7, 3);
+    m_layout->addWidget(m_gantry_speed_label, 7, 3);
     m_layout->addWidget(m_gantry_speed, 7, 4);
 
     QLabel* lbl_sprindleSpeed = new QLabel("Spindle Speed (RPM):");
@@ -114,6 +131,7 @@ FlowrateCalcWindow::FlowrateCalcWindow(QWidget* parent) : QWidget() {
     this->setLayout(m_layout);
 
     this->setupEvents();
+    this->updateUnitLabels();
     m_saved_other_density = "";
     this->setFixedSize(this->sizeHint());
 }
@@ -133,6 +151,37 @@ void FlowrateCalcWindow::setupEvents() {
             &FlowrateCalcWindow::checkInputAndCalculate);
     connect(m_density, &QLineEdit::textChanged, this, &FlowrateCalcWindow::saveOtherDensity);
     connect(m_density, &QLineEdit::textChanged, this, &FlowrateCalcWindow::checkInputAndCalculate);
+
+    connect(PreferencesManager::getInstance().get(), &PreferencesManager::distanceUnitChanged, this,
+            &FlowrateCalcWindow::distanceUnitsChanged);
+    connect(PreferencesManager::getInstance().get(), &PreferencesManager::velocityUnitChanged, this,
+            &FlowrateCalcWindow::velocityUnitsChanged);
+}
+
+void FlowrateCalcWindow::updateUnitLabels() {
+    QSharedPointer<PreferencesManager> preferences = PreferencesManager::getInstance();
+
+    m_bead_width_label->setText("Bead Width (" + preferences->getDistanceUnitText() + "):");
+    m_layer_height_label->setText("Layer Height (" + preferences->getDistanceUnitText() + "):");
+    m_gantry_speed_label->setText("Gantry Speed (" + preferences->getVelocityUnitText() + "):");
+
+    setFixedSize(sizeHint());
+}
+
+void FlowrateCalcWindow::distanceUnitsChanged(Distance new_value, Distance old_value) {
+    if (new_value == old_value) { return; }
+
+    convertDistanceEntry(m_bead_width, old_value, new_value);
+    convertDistanceEntry(m_layer_height, old_value, new_value);
+    updateUnitLabels();
+    checkInputAndCalculate();
+}
+
+void FlowrateCalcWindow::velocityUnitsChanged(Velocity new_value, Velocity old_value) {
+    if (new_value == old_value) { return; }
+
+    updateUnitLabels();
+    checkInputAndCalculate();
 }
 
 void FlowrateCalcWindow::enableDensity(int index) {
@@ -171,8 +220,8 @@ void FlowrateCalcWindow::checkInputAndCalculate() {
 
     double v_speedRPM;
     double v_lbsHour;
-    double v_beadWidth;
-    double v_layerHeight;
+    double v_beadWidthInput;
+    double v_layerHeightInput;
     double v_printRate;
     double v_density;
 
@@ -194,12 +243,12 @@ void FlowrateCalcWindow::checkInputAndCalculate() {
         return;
     }
 
-    v_beadWidth = m_bead_width->text().toDouble(&textOkay);
+    v_beadWidthInput = m_bead_width->text().toDouble(&textOkay);
     if (!textOkay && !m_bead_width->text().isEmpty()) {
         m_status_label->setText("Please check that you've specified a valid bead width");
         return;
     }
-    v_layerHeight = m_layer_height->text().toDouble(&textOkay);
+    v_layerHeightInput = m_layer_height->text().toDouble(&textOkay);
     if (!textOkay && !m_layer_height->text().isEmpty()) {
         m_status_label->setText("Please check that you've specified a valid layer height");
         return;
@@ -213,18 +262,25 @@ void FlowrateCalcWindow::checkInputAndCalculate() {
 
     m_status_label->clear();
 
-    bool densityOk;
-    v_density = m_density->text().toDouble(&densityOk) * m_density_metric_to_is;
+    Distance bead_width;
+    bead_width.from(v_beadWidthInput, PreferencesManager::getInstance()->getDistanceUnit());
+    Distance layer_height;
+    layer_height.from(v_layerHeightInput, PreferencesManager::getInstance()->getDistanceUnit());
+    v_density = v_density * m_density_metric_to_is;
 
     // calculations
-    double ratio     = v_printRate / v_lbsHour;
-    double volumeSec = (v_printRate / 3600) / v_density;
-    double area      = v_layerHeight * (v_beadWidth - v_layerHeight) + M_PI * (v_layerHeight / 2) * (v_layerHeight / 2);
-    double gantrySpeed  = volumeSec / area;
-    double spindleSpeed = ratio * v_speedRPM;
+    double ratio             = v_printRate / v_lbsHour;
+    double volumeSec         = (v_printRate / 3600) / v_density;
+    double beadWidthInches   = bead_width.to(in);
+    double layerHeightInches = layer_height.to(in);
+    double area              = layerHeightInches * (beadWidthInches - layerHeightInches) +
+                               M_PI * (layerHeightInches / 2) * (layerHeightInches / 2);
+    Velocity gantrySpeed     = (volumeSec / area) * in / s;
+    double spindleSpeed      = ratio * v_speedRPM;
 
     // write to textboxes
-    m_gantry_speed->setText(QString::number(gantrySpeed, 'f', 4));
+    m_gantry_speed->setText(
+        QString::number(gantrySpeed.to(PreferencesManager::getInstance()->getVelocityUnit()), 'f', 4));
     m_spindle_speed->setText(QString::number(spindleSpeed, 'f', 0));
 
     // Warning message in the same window - thus no need for an additional click


### PR DESCRIPTION
## Summary
- Update the flowrate calculator labels for bead width, layer height, and gantry speed from application unit preferences.
- Convert existing bead width and layer height entries when the distance unit preference changes.
- Convert calculated gantry speed into the preferred velocity unit while keeping the existing imperial mass-flow calculation intact.

## Verification
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer`