### PR TITLE
Add recent files menu

### DIFF
--- a/include/managers/session_manager.h
+++ b/include/managers/session_manager.h
@@ -136,8 +136,8 @@ class SessionManager : public QObject {
     //! \brief Add a project file to recent history.
     void addRecentProjectFile(QString path);
 
-    //! \brief Add a model file to recent history.
-    void addRecentModelFile(QString path);
+    //! \brief Add a build model file to recent history.
+    void addRecentModelFile(QString path, MeshType mt = MeshType::kBuild);
 
     //! \brief Remove a file from recent project and model history.
     void removeRecentFile(QString path);

--- a/include/managers/session_manager.h
+++ b/include/managers/session_manager.h
@@ -14,6 +14,7 @@
 #include <qmutex.h>
 #include <qobject.h>
 #include <qsharedpointer.h>
+#include <qstringlist.h>
 #include <qtmetamacros.h>
 #include <qtypes.h>
 
@@ -125,6 +126,24 @@ class SessionManager : public QObject {
 
     //! \brief Accessor to set history for the most recently selected http config
     void setMostRecentHTTPConfig(QString config);
+
+    //! \brief Accessor to get recently used project files.
+    QStringList getRecentProjectFiles() const;
+
+    //! \brief Accessor to get recently used model files.
+    QStringList getRecentModelFiles() const;
+
+    //! \brief Add a project file to recent history.
+    void addRecentProjectFile(QString path);
+
+    //! \brief Add a model file to recent history.
+    void addRecentModelFile(QString path);
+
+    //! \brief Remove a file from recent project and model history.
+    void removeRecentFile(QString path);
+
+    //! \brief Clear recent project and model file history.
+    void clearRecentFiles();
 
     //! \brief Sets the pointer to part to copy
     //! \param new_part: part to copy for later paste
@@ -301,6 +320,8 @@ class SessionManager : public QObject {
     QString m_most_recent_setting_folder_location;
     QString m_most_recent_layer_bar_setting_folder_location;
     QString m_most_recent_http_config;
+    QStringList m_recent_project_files;
+    QStringList m_recent_model_files;
 
     //! \brief boolean to track when history needs written to file on close
     bool m_dirty_history;

--- a/include/windows/main_window.h
+++ b/include/windows/main_window.h
@@ -246,6 +246,15 @@ class MainWindow : public QMainWindow {
     //! \brief Load a template file from a known path.
     void loadTemplateFile(const QString& filename);
 
+    //! \brief Rebuild the recent files submenu from session history.
+    void updateRecentFilesMenu();
+
+    //! \brief Load a project from recent file history.
+    void loadRecentProjectFile(const QString& filename);
+
+    //! \brief Load a model from recent file history.
+    void loadRecentModelFile(const QString& filename);
+
    private:
     //! \brief Struct to retain action information efficiently.
     struct menu_info {
@@ -398,6 +407,7 @@ class MainWindow : public QMainWindow {
 
     //! \brief QMenus
     QMenu* m_menu_file;
+    QMenu* m_menu_recent_files;
     QMenu* m_menu_edit;
     QMenu* m_menu_view;
     QMenu* m_menu_zoom;

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -4,6 +4,7 @@
 #include <QCoreApplication>
 #include <QStandardPaths>
 #include <cstdlib>
+#include <string>
 
 #include <qcontainerfwd.h>
 #include <qdir.h>
@@ -42,8 +43,60 @@
 
 namespace ORNL {
 namespace {
+constexpr int kMaxRecentFiles = 10;
+
 bool supportsCylindricalSlicing(GcodeSyntax syntax) {
     return syntax == GcodeSyntax::kArcSpecialties;
+}
+
+QString absoluteFilePath(const QString& path) {
+    return QFileInfo(path).absoluteFilePath();
+}
+
+bool hasSuffix(const QString& path, const QStringList& suffixes) {
+    return suffixes.contains(QFileInfo(path).suffix().toLower());
+}
+
+QStringList readStringList(const fifojson& j, const char* key) {
+    QStringList values;
+    if (!j.contains(key) || !j[key].is_array()) return values;
+
+    for (const fifojson& value : j[key]) {
+        if (!value.is_string()) continue;
+
+        values.push_back(QString::fromStdString(value.get<std::string>()));
+    }
+
+    return values;
+}
+
+QStringList sanitizedRecentFiles(const QStringList& files, const QStringList& suffixes) {
+    QStringList result;
+    for (const QString& file : files) {
+        const QString path = absoluteFilePath(file);
+        if (path.isEmpty() || !hasSuffix(path, suffixes) || result.contains(path)) continue;
+
+        result.push_back(path);
+        if (result.size() >= kMaxRecentFiles) break;
+    }
+
+    return result;
+}
+
+void addRecentFile(QStringList& files, QString path) {
+    path = absoluteFilePath(path);
+    if (path.isEmpty()) return;
+
+    files.removeAll(path);
+    files.prepend(path);
+
+    while (files.size() > kMaxRecentFiles) { files.removeLast(); }
+}
+
+fifojson stringListToJson(const QStringList& values) {
+    fifojson result = fifojson::array();
+    for (const QString& value : values) { result.push_back(value); }
+    return result;
 }
 }  // namespace
 
@@ -54,7 +107,7 @@ QSharedPointer<SessionManager> SessionManager::getInstance() {
     return m_singleton;
 }
 
-SessionManager::SessionManager() : m_file(QString()), m_sensor_files_generated(false) {
+SessionManager::SessionManager() : m_file(QString()), m_dirty_history(false), m_sensor_files_generated(false) {
     // Create static location for gcode output for session
     QString appPathStr = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     QDir appPath(appPathStr);
@@ -106,6 +159,9 @@ void SessionManager::loadHistory() {
         m_most_recent_setting_folder_location           = j.value("setting_folder_location", defaultLocation);
         m_most_recent_layer_bar_setting_folder_location = j.value("layer_bar_setting_folder_location", defaultLocation);
         m_most_recent_http_config                       = j.value("http_config", QString());
+        m_recent_project_files = sanitizedRecentFiles(readStringList(j, "recent_project_files"), {"s2p"});
+        m_recent_model_files =
+            sanitizedRecentFiles(readStringList(j, "recent_model_files"), {"stl", "3mf", "obj", "amf", "step", "stp"});
 
         file.close();
     }
@@ -119,6 +175,8 @@ void SessionManager::loadHistory() {
             m_most_recent_setting_folder_location = m_most_recent_layer_bar_setting_folder_location =
                 QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
         m_most_recent_http_config = QString();
+        m_recent_project_files.clear();
+        m_recent_model_files.clear();
 
         m_dirty_history = true;
     }
@@ -138,6 +196,8 @@ void SessionManager::saveHistory() {
         j["setting_folder_location"] = m_most_recent_setting_folder_location;
         j["layer_bar_setting_folder_location"] = m_most_recent_layer_bar_setting_folder_location;
         j["http_config"]                       = m_most_recent_http_config;
+        j["recent_project_files"]              = stringListToJson(m_recent_project_files);
+        j["recent_model_files"]                = stringListToJson(m_recent_model_files);
 
         // Causes segfault if QStandardPaths is referenced here?
         // QDir path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
@@ -183,7 +243,10 @@ bool SessionManager::loadModel(QString filename, bool saveLocation, MeshType mt,
         loader->start();
     }
 
-    if (saveLocation) setMostRecentModelLocation(file_info.absoluteFilePath());
+    if (saveLocation) {
+        setMostRecentModelLocation(file_info.absoluteFilePath());
+        addRecentModelFile(filename);
+    }
 
     return true;
 }
@@ -264,6 +327,8 @@ void SessionManager::reloadPart(QSharedPointer<PartMetaItem> pm) {
     }
 
     QFileInfo file_info(filename);
+    setMostRecentModelLocation(file_info.absoluteFilePath());
+    addRecentModelFile(filename);
 
     MeshLoader* loader = new MeshLoader(filename, pm->part()->getMeshType(), QMatrix4x4(),
                                         PreferencesManager::getInstance()->getImportUnit());
@@ -290,6 +355,8 @@ void SessionManager::replacePart(QSharedPointer<PartMetaItem> pm, QString filena
     }
 
     QFileInfo file_info(filename);
+    setMostRecentModelLocation(file_info.absoluteFilePath());
+    addRecentModelFile(filename);
 
     MeshLoader* loader = new MeshLoader(filename, pm->part()->getMeshType(), QMatrix4x4(),
                                         PreferencesManager::getInstance()->getImportUnit());
@@ -631,7 +698,10 @@ SessionLoader* SessionManager::saveSession(QString path, bool shouldTrack, bool 
     loader->start();
     m_file = path;
 
-    if (shouldTrack) setMostRecentProjectLocation(QFileInfo(path).absolutePath());
+    if (shouldTrack) {
+        setMostRecentProjectLocation(QFileInfo(path).absolutePath());
+        addRecentProjectFile(path);
+    }
 
     return loader;
 }
@@ -734,6 +804,44 @@ QString SessionManager::getMostRecentHTTPConfig() {
 
 void SessionManager::setMostRecentHTTPConfig(QString config) {
     m_most_recent_http_config = config;
+}
+
+QStringList SessionManager::getRecentProjectFiles() const {
+    return m_recent_project_files;
+}
+
+QStringList SessionManager::getRecentModelFiles() const {
+    return m_recent_model_files;
+}
+
+void SessionManager::addRecentProjectFile(QString path) {
+    if (!hasSuffix(path, {"s2p"})) return;
+
+    addRecentFile(m_recent_project_files, path);
+    m_dirty_history = true;
+}
+
+void SessionManager::addRecentModelFile(QString path) {
+    if (!hasSuffix(path, {"stl", "3mf", "obj", "amf", "step", "stp"})) return;
+
+    addRecentFile(m_recent_model_files, path);
+    m_dirty_history = true;
+}
+
+void SessionManager::removeRecentFile(QString path) {
+    path = absoluteFilePath(path);
+
+    const bool removed_project = m_recent_project_files.removeAll(path) > 0;
+    const bool removed_model   = m_recent_model_files.removeAll(path) > 0;
+    if (removed_project || removed_model) m_dirty_history = true;
+}
+
+void SessionManager::clearRecentFiles() {
+    if (m_recent_project_files.isEmpty() && m_recent_model_files.isEmpty()) return;
+
+    m_recent_project_files.clear();
+    m_recent_model_files.clear();
+    m_dirty_history = true;
 }
 
 void SessionManager::setDefaultGcodeDir(QString dir) {

--- a/src/managers/session_manager.cpp
+++ b/src/managers/session_manager.cpp
@@ -245,7 +245,7 @@ bool SessionManager::loadModel(QString filename, bool saveLocation, MeshType mt,
 
     if (saveLocation) {
         setMostRecentModelLocation(file_info.absoluteFilePath());
-        addRecentModelFile(filename);
+        addRecentModelFile(filename, mt);
     }
 
     return true;
@@ -327,11 +327,12 @@ void SessionManager::reloadPart(QSharedPointer<PartMetaItem> pm) {
     }
 
     QFileInfo file_info(filename);
+    const MeshType mesh_type = pm->part()->getMeshType();
     setMostRecentModelLocation(file_info.absoluteFilePath());
-    addRecentModelFile(filename);
+    addRecentModelFile(filename, mesh_type);
 
-    MeshLoader* loader = new MeshLoader(filename, pm->part()->getMeshType(), QMatrix4x4(),
-                                        PreferencesManager::getInstance()->getImportUnit());
+    MeshLoader* loader =
+        new MeshLoader(filename, mesh_type, QMatrix4x4(), PreferencesManager::getInstance()->getImportUnit());
 
     connect(loader, &MeshLoader::finished, loader, &MeshLoader::deleteLater);
 
@@ -355,11 +356,12 @@ void SessionManager::replacePart(QSharedPointer<PartMetaItem> pm, QString filena
     }
 
     QFileInfo file_info(filename);
+    const MeshType mesh_type = pm->part()->getMeshType();
     setMostRecentModelLocation(file_info.absoluteFilePath());
-    addRecentModelFile(filename);
+    addRecentModelFile(filename, mesh_type);
 
-    MeshLoader* loader = new MeshLoader(filename, pm->part()->getMeshType(), QMatrix4x4(),
-                                        PreferencesManager::getInstance()->getImportUnit());
+    MeshLoader* loader =
+        new MeshLoader(filename, mesh_type, QMatrix4x4(), PreferencesManager::getInstance()->getImportUnit());
 
     connect(loader, &MeshLoader::finished, loader, &MeshLoader::deleteLater);
 
@@ -821,8 +823,8 @@ void SessionManager::addRecentProjectFile(QString path) {
     m_dirty_history = true;
 }
 
-void SessionManager::addRecentModelFile(QString path) {
-    if (!hasSuffix(path, {"stl", "3mf", "obj", "amf", "step", "stp"})) return;
+void SessionManager::addRecentModelFile(QString path, MeshType mt) {
+    if (mt != MeshType::kBuild || !hasSuffix(path, {"stl", "3mf", "obj", "amf", "step", "stp"})) return;
 
     addRecentFile(m_recent_model_files, path);
     m_dirty_history = true;

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -1,5 +1,6 @@
 #include "windows/main_window.h"
 
+#include <QDir>
 #include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -81,6 +82,14 @@
 namespace ORNL {
 constexpr int kPartTransformUndoCommandId = 1;
 constexpr int kSettingValueUndoCommandId  = 2;
+
+QString recentFileActionText(const QString& path) {
+    QFileInfo file_info(path);
+    const QString directory = QDir::toNativeSeparators(file_info.absolutePath());
+    if (directory.isEmpty()) return file_info.fileName();
+
+    return QString("%1 (%2)").arg(file_info.fileName(), directory);
+}
 
 class PartTransformUndoCommand : public QUndoCommand {
    public:
@@ -456,6 +465,8 @@ void MainWindow::setupBars() {
     m_menubar->setGeometry(QRect(0, 0, Constants::UI::MainWindow::kWindowSize.width(), 19));
     m_menu_file = new QMenu(m_menubar);
     m_menu_file->setObjectName(QStringLiteral("m_menu_file"));
+    m_menu_recent_files = new QMenu(m_menubar);
+    m_menu_recent_files->setObjectName(QStringLiteral("m_menu_recent_files"));
     m_menu_edit = new QMenu(m_menubar);
     m_menu_edit->setObjectName(QStringLiteral("m_menu_edit"));
     m_menu_view = new QMenu(m_menubar);
@@ -613,6 +624,7 @@ void MainWindow::setupActions() {
     m_menu_file->addAction(m_actions["sel_printer"].action);
     m_menu_file->addAction(m_actions["load_model"].action);
     m_menu_file->addAction(m_actions["load_point_cloud"].action);
+    m_menu_file->addMenu(m_menu_recent_files);
     m_menu_file->addAction(m_actions["last_session"].action);
     m_menu_file->addSeparator();
     m_menu_file->addAction(m_actions["slice"].action);
@@ -762,6 +774,7 @@ void MainWindow::setupInsert() {
 
 void MainWindow::setupEvents() {
     // Menu connections.
+    connect(m_menu_recent_files, &QMenu::aboutToShow, this, &MainWindow::updateRecentFilesMenu);
     connect(m_actions["last_session"].action, &QAction::triggered, this, &MainWindow::autoLoad);
     connect(m_actions["screenshot"].action, &QAction::triggered, m_part_widget, &PartWidget::takeScreenshot);
 
@@ -1305,6 +1318,7 @@ void MainWindow::retranslateUi() {
     }
 
     m_menu_file->setTitle(QApplication::translate("MainWindow", "File", nullptr));
+    m_menu_recent_files->setTitle(QApplication::translate("MainWindow", "Recent Files", nullptr));
     m_menu_edit->setTitle(QApplication::translate("MainWindow", "Edit", nullptr));
     m_menu_zoom->setTitle(QApplication::translate("MainWindow", "Zoom", nullptr));
     m_menu_toolbars->setTitle(QApplication::translate("MainWindow", "Toolbars", nullptr));
@@ -1473,6 +1487,98 @@ void MainWindow::updateStatus(QString status) {
     m_statusbar->showMessage(status);
 }
 
+void MainWindow::updateRecentFilesMenu() {
+    m_menu_recent_files->clear();
+
+    const QStringList project_files = CSM->getRecentProjectFiles();
+    const QStringList model_files   = CSM->getRecentModelFiles();
+    bool has_recent_files           = false;
+
+    if (!project_files.isEmpty()) {
+        QAction* heading = m_menu_recent_files->addAction(QApplication::translate("MainWindow", "Projects", nullptr));
+        heading->setEnabled(false);
+
+        for (const QString& filename : project_files) {
+            QAction* action =
+                m_menu_recent_files->addAction(QIcon(":/icons/open_project_black.png"), recentFileActionText(filename));
+            action->setToolTip(QDir::toNativeSeparators(filename));
+            connect(action, &QAction::triggered, this, [this, filename] { loadRecentProjectFile(filename); });
+            has_recent_files = true;
+        }
+    }
+
+    if (!model_files.isEmpty()) {
+        if (has_recent_files) m_menu_recent_files->addSeparator();
+
+        QAction* heading = m_menu_recent_files->addAction(QApplication::translate("MainWindow", "Models", nullptr));
+        heading->setEnabled(false);
+
+        for (const QString& filename : model_files) {
+            QAction* action =
+                m_menu_recent_files->addAction(QIcon(":/icons/file_black.png"), recentFileActionText(filename));
+            action->setToolTip(QDir::toNativeSeparators(filename));
+            connect(action, &QAction::triggered, this, [this, filename] { loadRecentModelFile(filename); });
+            has_recent_files = true;
+        }
+    }
+
+    if (!has_recent_files) {
+        QAction* empty =
+            m_menu_recent_files->addAction(QApplication::translate("MainWindow", "No Recent Files", nullptr));
+        empty->setEnabled(false);
+        return;
+    }
+
+    m_menu_recent_files->addSeparator();
+    QAction* clear_action = m_menu_recent_files->addAction(
+        QIcon(":/icons/delete_black.png"), QApplication::translate("MainWindow", "Clear Recent Files", nullptr));
+    connect(clear_action, &QAction::triggered, this, [this] {
+        CSM->clearRecentFiles();
+        QTimer::singleShot(0, this, &MainWindow::updateRecentFilesMenu);
+    });
+}
+
+void MainWindow::loadRecentProjectFile(const QString& filename) {
+    QFileInfo file_info(filename);
+    if (!file_info.exists() || !file_info.isFile()) {
+        CSM->removeRecentFile(filename);
+        QTimer::singleShot(0, this, &MainWindow::updateRecentFilesMenu);
+        updateStatus("Recent project file not found: " + QDir::toNativeSeparators(filename));
+        return;
+    }
+
+    if (!confirmProjectClose()) return;
+
+    SessionLoader* loader = loadASession(file_info.absoluteFilePath());
+    if (loader == nullptr) {
+        updateStatus("Could not load recent project: " + QDir::toNativeSeparators(filename));
+        return;
+    }
+
+    connect(loader, &SessionLoader::loadSucceeded, this,
+            [this, title = file_info.fileName()] { this->setTitleInfo(title); });
+
+    m_statusbar->showMessage("Session loaded");
+    m_cmdbar->append("Session loaded: " + file_info.absoluteFilePath());
+    CSM->setMostRecentProjectLocation(file_info.absolutePath());
+    CSM->addRecentProjectFile(file_info.absoluteFilePath());
+}
+
+void MainWindow::loadRecentModelFile(const QString& filename) {
+    QFileInfo file_info(filename);
+    if (!file_info.exists() || !file_info.isFile()) {
+        CSM->removeRecentFile(filename);
+        QTimer::singleShot(0, this, &MainWindow::updateRecentFilesMenu);
+        updateStatus("Recent model file not found: " + QDir::toNativeSeparators(filename));
+        return;
+    }
+
+    const QString filepath = file_info.absoluteFilePath();
+    m_cmdbar->append("Loading model: " + filepath);
+    m_statusbar->showMessage("Loading model: " + filepath);
+    CSM->loadModel(filepath, true, MeshType::kBuild);
+}
+
 bool MainWindow::saveSessionToSelectedFile(bool notifyOnSuccess, bool waitForSave, QString* selectedFile) {
     QFileDialog save_dialog;
     save_dialog.setWindowTitle("Save project");
@@ -1575,16 +1681,19 @@ void MainWindow::loadSession() {
 
     QString filename = load_dialog.selectedFiles().first();
     if (filename.isEmpty()) return;
+    if (!confirmProjectClose()) return;
 
     SessionLoader* loader = loadASession(filename);
     if (loader != nullptr) {
         connect(loader, &SessionLoader::loadSucceeded, this,
                 [this, title = QFileInfo(filename).fileName()] { this->setTitleInfo(title); });
-    }
-    m_statusbar->showMessage("Session loaded");
-    m_cmdbar->append("Session loaded: " + filename);
+        CSM->setMostRecentProjectLocation(QFileInfo(filename).absolutePath());
+        CSM->addRecentProjectFile(filename);
+        updateRecentFilesMenu();
 
-    CSM->setMostRecentProjectLocation(QFileInfo(filename).absolutePath());
+        m_statusbar->showMessage("Session loaded");
+        m_cmdbar->append("Session loaded: " + filename);
+    }
 }
 
 SessionLoader* MainWindow::loadASession(const QString& filename) {
@@ -1730,6 +1839,7 @@ void MainWindow::setLock(bool lock) {
     m_actions["load_point_cloud"].action->setDisabled(lock);
     m_actions["last_session"].action->setDisabled(lock);
     m_actions["slice"].action->setDisabled(lock);
+    m_menu_recent_files->setDisabled(lock);
 
     m_menu_edit->setDisabled(lock);
     m_menu_settings->setDisabled(lock);

--- a/tests/session_manager_tests.cpp
+++ b/tests/session_manager_tests.cpp
@@ -1,5 +1,8 @@
 #include <QCoreApplication>
 #include <QEventLoop>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QStringList>
 #include <QTemporaryDir>
 #include <QTimer>
 #include <cstdlib>
@@ -73,14 +76,66 @@ std::optional<fifojson> readGlobalFromProject(const QString& path) {
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);
+    QStandardPaths::setTestModeEnabled(true);
 
     QTemporaryDir temp_dir;
     if (!expect(temp_dir.isValid(), "Could not create temporary directory.")) return EXIT_FAILURE;
 
+    auto session = ORNL::CSM;
+    session->clearRecentFiles();
+
+    const QString project_one     = temp_dir.path() + "/alpha.s2p";
+    const QString project_two     = temp_dir.path() + "/beta.S2P";
+    const QString project_ignored = temp_dir.path() + "/notes.txt";
+
+    session->addRecentProjectFile(project_one);
+    session->addRecentProjectFile(project_two);
+    session->addRecentProjectFile(project_one);
+    session->addRecentProjectFile(project_ignored);
+
+    QStringList recent_projects = session->getRecentProjectFiles();
+    if (!expect(recent_projects.size() == 2, "Recent project history should deduplicate and filter by extension."))
+        return EXIT_FAILURE;
+    if (!expect(recent_projects[0] == QFileInfo(project_one).absoluteFilePath(),
+                "Most recently reopened project should move to the front."))
+        return EXIT_FAILURE;
+    if (!expect(recent_projects[1] == QFileInfo(project_two).absoluteFilePath(),
+                "Previous project should remain after a duplicate is moved."))
+        return EXIT_FAILURE;
+
+    for (int i = 0; i < 12; ++i) { session->addRecentModelFile(temp_dir.path() + QString("/model-%1.stl").arg(i)); }
+    session->addRecentModelFile(temp_dir.path() + "/fixture.s2p");
+
+    QStringList recent_models = session->getRecentModelFiles();
+    if (!expect(recent_models.size() == 10, "Recent model history should be capped at ten files.")) return EXIT_FAILURE;
+    if (!expect(recent_models[0] == QFileInfo(temp_dir.path() + "/model-11.stl").absoluteFilePath(),
+                "Newest model should be first in recent model history."))
+        return EXIT_FAILURE;
+    if (!expect(recent_models.back() == QFileInfo(temp_dir.path() + "/model-2.stl").absoluteFilePath(),
+                "Recent model history should drop entries past the cap."))
+        return EXIT_FAILURE;
+
+    const QString step_model = temp_dir.path() + "/bracket.step";
+    session->addRecentModelFile(step_model);
+    recent_models = session->getRecentModelFiles();
+    if (!expect(recent_models[0] == QFileInfo(step_model).absoluteFilePath(),
+                "STEP model should be accepted in recent model history."))
+        return EXIT_FAILURE;
+
+    session->removeRecentFile(step_model);
+    if (!expect(!session->getRecentModelFiles().contains(QFileInfo(step_model).absoluteFilePath()),
+                "Removed recent model should not remain in history."))
+        return EXIT_FAILURE;
+
+    session->clearRecentFiles();
+    if (!expect(session->getRecentProjectFiles().isEmpty() && session->getRecentModelFiles().isEmpty(),
+                "Clearing recent files should clear both project and model history."))
+        return EXIT_FAILURE;
+
     QString project_path = temp_dir.path() + "/old-settings-project.s2p";
     if (!expect(writeProjectWithOldGlobal(project_path), "Could not write project fixture.")) return EXIT_FAILURE;
 
-    ORNL::SessionLoader* loader = ORNL::CSM->loadSession(false, project_path, false);
+    ORNL::SessionLoader* loader = session->loadSession(false, project_path, false);
     if (!expect(loader != nullptr, "CLI-style session load rejected the old project before auto-updating settings."))
         return EXIT_FAILURE;
 

--- a/tests/session_manager_tests.cpp
+++ b/tests/session_manager_tests.cpp
@@ -132,6 +132,20 @@ int main(int argc, char* argv[]) {
                 "Clearing recent files should clear both project and model history."))
         return EXIT_FAILURE;
 
+    const QString clipping_model = temp_dir.path() + "/clipping.stl";
+    const QString settings_model = temp_dir.path() + "/settings.stl";
+    const QString build_model    = temp_dir.path() + "/build.stl";
+    session->addRecentModelFile(clipping_model, ORNL::MeshType::kClipping);
+    session->addRecentModelFile(settings_model, ORNL::MeshType::kSettings);
+    session->addRecentModelFile(build_model, ORNL::MeshType::kBuild);
+
+    recent_models = session->getRecentModelFiles();
+    if (!expect(recent_models.size() == 1, "Only build models should be added to recent model history."))
+        return EXIT_FAILURE;
+    if (!expect(recent_models[0] == QFileInfo(build_model).absoluteFilePath(),
+                "Build model should be retained after non-build model history entries are ignored."))
+        return EXIT_FAILURE;
+
     QString project_path = temp_dir.path() + "/old-settings-project.s2p";
     if (!expect(writeProjectWithOldGlobal(project_path), "Could not write project fixture.")) return EXIT_FAILURE;
 


### PR DESCRIPTION
## Summary

Adds a `File > Recent Files` submenu that tracks recently used project files and model files.

## Related issues

- No related issues.

## Details

This feature extends session history to persist bounded recent-file lists for ORNLSlicer project files (`.s2p`) and supported model files (`.stl`, `.3mf`, `.obj`, `.amf`, `.step`, `.stp`).

The File menu now exposes a dynamic `Recent Files` submenu with separate Projects and Models sections. Project entries load the selected `.s2p` session, while model entries import the selected file as a build model. Missing files are removed from the history when selected, and the menu includes a clear action.

Recent history is updated by explicit project load/save flows and model load/replace/reload flows. Autosave and Restore Last Session remain separate from the normal recent-project list.

## Impact

Low risk. The change is scoped to menu wiring and session history bookkeeping, with existing load/save/model import paths reused for behavior. The user-facing impact is improved access to recently used project and model files.

## Validation

- `nix develop -c cmake --build build/generic-llvm-ninja --target ornlslicer_session_manager_tests`
- `nix develop -c ctest --test-dir build/generic-llvm-ninja -C Debug -R session_manager_tests --output-on-failure`
- `git diff --check`

The session manager test now covers recent-file ordering, duplicate handling, extension filtering, the 10-file cap, `.step` model support, removal, and clearing both history lists.