### PR TITLE
Add adaptive width info & improve UI preferences

### DIFF
--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -291,9 +291,10 @@ class ArcSpecialtiesWriter : public WriterBase {
 
     /*!
      * @brief Returns the print-move comment for the active slicing mode and path type.
+     * @param params Segment settings used to report parser-facing region metadata.
      * @return Region, radial, or helical comment text.
      */
-    QString printMoveComment() const;
+    QString printMoveComment(const QSharedPointer<SettingsBase>& params) const;
 
     /*!
      * @brief Returns whether the writer is emitting cylindrical radial or helical paths.

--- a/include/gcode/writers/writer_base.h
+++ b/include/gcode/writers/writer_base.h
@@ -159,6 +159,10 @@ class WriterBase {
     //! \brief Writes a comment with a preceding space, then ends the line
     QString commentSpaceLine(const QString& text);
 
+    //! \brief Builds the parser-facing region comment, including adapted bead width when present.
+    QString regionComment(RegionType region_type, PathModifiers path_modifiers,
+                          const QSharedPointer<SettingsBase>& params, bool include_skeleton_width = false) const;
+
     //! \brief gets a vector in the direction normal to the plane and of a length = travel lift height
     QVector3D getTravelLift();
 

--- a/include/geometry/segment_base.h
+++ b/include/geometry/segment_base.h
@@ -160,6 +160,9 @@ class SegmentBase {
         //! \brief Length for segment info display.
         QString length;
 
+        //! \brief Bead/extrusion width for segment info display.
+        QString width;
+
         //! \brief Region type for segment info display.
         QString type;
 

--- a/include/managers/preferences_manager.h
+++ b/include/managers/preferences_manager.h
@@ -127,6 +127,12 @@ class PreferencesManager : public QObject {
     //! \return if true widths should be used
     bool getUseTrueWidthsPreference();
 
+    //! \brief Gets if g-code bead / segment info should be shown by default.
+    bool getGCodeInfoVisibleByDefaultPreference();
+
+    //! \brief Gets if optimization points should be shown by default.
+    bool getOptimizationPointsVisibleByDefaultPreference();
+
     //! \brief Returns the preferred g-code preview rendering mode.
     GCodePreviewMode getGCodePreviewModePreference();
 
@@ -354,6 +360,14 @@ class PreferencesManager : public QObject {
     //! \param use if true widths should be used
     void setUseTrueWidthsPreference(bool use);
 
+    //! \brief Sets if g-code bead / segment info should be shown by default
+    //! \param show if the info panel should be shown by default
+    void setGCodeInfoVisibleByDefaultPreference(bool show);
+
+    //! \brief Sets if optimization points should be shown by default
+    //! \param show if optimization points should be shown by default
+    void setOptimizationPointsVisibleByDefaultPreference(bool show);
+
     //! \brief Sets the preferred g-code preview rendering mode.
     //! \param mode selected preview mode
     void setGCodePreviewModePreference(GCodePreviewMode mode);
@@ -444,6 +458,8 @@ class PreferencesManager : public QObject {
     bool m_hide_travel_preference;
     bool m_hide_support_preference;
     bool m_use_true_widths_preference;
+    bool m_gcode_info_visible_by_default_preference;
+    bool m_optimization_points_visible_by_default_preference;
     GCodePreviewMode m_gcode_preview_mode_preference;
     int m_gcode_preview_vertex_threshold_preference;
     DisabledSettingVisibility m_disabled_setting_visibility_preference;

--- a/include/threading/gcode_loader.h
+++ b/include/threading/gcode_loader.h
@@ -243,5 +243,8 @@ class GCodeLoader : public QThread {
 
     //! \brief Current settings for gcode loader
     QSharedPointer<SettingsBase> m_sb;
+
+    //! \brief Settings parsed from the loaded file footer for visualization fallbacks.
+    QHash<QString, double> m_file_settings;
 };  // class GCodeLoader
 }  // namespace ORNL

--- a/include/widgets/gcode_info_control.h
+++ b/include/widgets/gcode_info_control.h
@@ -125,6 +125,7 @@ class GCodeInfoControl : public QWidget {
     QLabel* m_infolbl_speed;
     QLabel* m_infolbl_extruder_speed;
     QLabel* m_infolbl_length;
+    QLabel* m_infolbl_width;
     QLabel* m_infolbl_center_distance;
     QLabel* m_infolbl_layer_no;
     QLabel* m_infolbl_line_no;

--- a/include/widgets/main_toolbar.h
+++ b/include/widgets/main_toolbar.h
@@ -101,6 +101,9 @@ class MainToolbar : public QToolBar {
     //! \param status if the g-code view is using orthographic projection
     void setOrthoGcodeChecked(bool status);
 
+    //! \brief emits the current optimization point visibility state
+    void syncOptimizationPointVisibility();
+
    private:
     //! \brief sets up the widget
     void setup();
@@ -164,5 +167,8 @@ class MainToolbar : public QToolBar {
 
     //! \brief if selected part has layer-specific settings available for visualization
     bool m_layer_settings_range_available = false;
+
+    //! \brief tracks whether the optimization point toggle has been manually changed this session
+    bool m_optimization_points_user_toggled = false;
 };
 }  // namespace ORNL

--- a/include/windows/preferences_window.h
+++ b/include/windows/preferences_window.h
@@ -96,6 +96,8 @@ class PreferencesWindow : public QMainWindow {
     QComboBox* m_gcode_preview_mode_combobox;
     QComboBox* m_disabled_setting_visibility_combobox;
     QSpinBox* m_gcode_preview_vertex_threshold_spinbox;
+    QCheckBox* m_gcode_info_visible_by_default_checkbox;
+    QCheckBox* m_optimization_points_visible_by_default_checkbox;
     QCheckBox* m_warn_unsaved_project_on_close_checkbox;
 
     //! \brief List of groupboxes that hold radio buttons for various preferences

--- a/src/gcode/writers/aerobasic_writer.cpp
+++ b/src/gcode/writers/aerobasic_writer.cpp
@@ -213,10 +213,7 @@ QString AeroBasicWriter::writeLine(const Point& start_point, const Point& target
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -252,10 +249,7 @@ QString AeroBasicWriter::writeArc(const Point& start_point, const Point& end_poi
     rv += m_r % QString::number(Distance(end_point.y()).to(m_meta.m_distance_unit), 'f', 4);
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/aml3d_writer.cpp
+++ b/src/gcode/writers/aml3d_writer.cpp
@@ -248,10 +248,7 @@ QString AML3DWriter::writeLine(const Point& start_point, const Point& target_poi
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -300,10 +297,7 @@ QString AML3DWriter::writeArc(const Point& start_point, const Point& end_point, 
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -574,7 +574,7 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
 
     if (speed <= 0) { speed = 10.0 * mm / s; }
 
-    rv += writeMotion("G01", target_point, speed, params, printMoveComment());
+    rv += writeMotion("G01", target_point, speed, params, printMoveComment(params));
     return rv;
 }
 
@@ -599,7 +599,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     rv += QString(ccw ? "G03" : "G02") % writeCoordinates(end_point, params, kToolFrameZR) %
           writeArcCenterParameters(start_point, center_point) % m_f %
           QString::number(speed.to(m_meta.m_velocity_unit), 'f', 4) % inline_optional_stop %
-          commentSpaceLine(printMoveComment());
+          commentSpaceLine(printMoveComment(params));
     return rv;
 }
 
@@ -877,12 +877,17 @@ bool ArcSpecialtiesWriter::isHelicalPathPattern() const {
     return isCylindricalSlicingMode() && path_pattern == CylindricalPathPattern::kHelical;
 }
 
-QString ArcSpecialtiesWriter::printMoveComment() const {
+QString ArcSpecialtiesWriter::printMoveComment(const QSharedPointer<SettingsBase>& params) const {
     if (isCylindricalSlicingMode()) {
         return isHelicalPathPattern() ? Constants::RegionTypeStrings::kHelical : Constants::RegionTypeStrings::kRadial;
     }
 
-    return toString(m_region_type);
+    PathModifiers path_modifiers = PathModifiers::kNone;
+    if (params != nullptr && params->contains(SS::kPathModifiers)) {
+        path_modifiers = params->setting<PathModifiers>(SS::kPathModifiers);
+    }
+
+    return regionComment(m_region_type, path_modifiers, params);
 }
 
 bool ArcSpecialtiesWriter::isCylindricalSlicingMode() const {

--- a/src/gcode/writers/cincinnati_writer.cpp
+++ b/src/gcode/writers/cincinnati_writer.cpp
@@ -544,24 +544,8 @@ QString CincinnatiWriter::writeLine(const Point& start_point, const Point& targe
     // writes WXYZ to destination
     rv += writeCoordinates(target_point);
 
-    // Create comment for region type and path modifiers
-    QString comment = toString(region_type);
-
-    // If the bead width has been adapted, include the true width in the comment for reload/visualization.
-    if (params->setting<bool>(SS::kAdapted)) {
-        comment = "AD-" % comment;
-        comment += "-" % QString::number(params->setting<Distance>(SS::kWidth).to(m_meta.m_distance_unit));
-    }
-    // Skeleton comments have historically included width even when not adapted.
-    else if (region_type == RegionType::kSkeleton) {
-        comment += "-" % QString::number(params->setting<Distance>(SS::kWidth).to(m_meta.m_distance_unit));
-    }
-
-    // Add path modifiers to comments
-    if (path_modifiers != PathModifiers::kNone) { comment += m_space % toString(path_modifiers); }
-
-    // Add comment
-    rv += commentSpaceLine(comment);
+    // Add comment for gcode parser.
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params, true));
 
     m_first_print = false;
 
@@ -622,10 +606,7 @@ QString CincinnatiWriter::writeArc(const Point& start_point, const Point& end_po
           QString::number(Distance(end_point.y()).to(m_meta.m_distance_unit), 'f', 4) % getZWValue(end_point);
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone) {
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    }
-    else { rv += commentSpaceLine(toString(region_type)); }
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params, true));
 
     return rv;
 }

--- a/src/gcode/writers/dmg_dmu_writer.cpp
+++ b/src/gcode/writers/dmg_dmu_writer.cpp
@@ -206,10 +206,7 @@ QString DMGDMUWriter::writeLine(const Point& start_point, const Point& target_po
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -258,10 +255,7 @@ QString DMGDMUWriter::writeArc(const Point& start_point, const Point& end_point,
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/gudel_writer.cpp
+++ b/src/gcode/writers/gudel_writer.cpp
@@ -202,10 +202,7 @@ QString GudelWriter::writeLine(const Point& start_point, const Point& target_poi
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -250,10 +247,7 @@ QString GudelWriter::writeArc(const Point& start_point, const Point& end_point, 
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/haas_metric_no_comments_writer.cpp
+++ b/src/gcode/writers/haas_metric_no_comments_writer.cpp
@@ -258,10 +258,7 @@ QString HaasMetricNoCommentsWriter::writeArc(const Point& start_point, const Poi
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/haas_writer.cpp
+++ b/src/gcode/writers/haas_writer.cpp
@@ -219,10 +219,7 @@ QString HaasWriter::writeLine(const Point& start_point, const Point& target_poin
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -271,10 +268,7 @@ QString HaasWriter::writeArc(const Point& start_point, const Point& end_point, c
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/hurco_writer.cpp
+++ b/src/gcode/writers/hurco_writer.cpp
@@ -210,10 +210,7 @@ QString HurcoWriter::writeLine(const Point& start_point, const Point& target_poi
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -262,10 +259,7 @@ QString HurcoWriter::writeArc(const Point& start_point, const Point& end_point, 
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/ingersoll_writer.cpp
+++ b/src/gcode/writers/ingersoll_writer.cpp
@@ -225,10 +225,7 @@ QString IngersollWriter::writeLine(const Point& start_point, const Point& target
     rv += writeCoordinates(target_point);
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -266,10 +263,7 @@ QString IngersollWriter::writeArc(const Point& start_point, const Point& end_poi
           QString::number(Distance(end_point.y()).to(m_meta.m_distance_unit), 'f', 4) % getZWValue(end_point);
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/juggerbot_writer.cpp
+++ b/src/gcode/writers/juggerbot_writer.cpp
@@ -248,10 +248,7 @@ QString JuggerBotWriter::writeLine(const Point& start_point, const Point& target
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -318,10 +315,7 @@ QString JuggerBotWriter::writeArc(const Point& start_point, const Point& end_poi
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/kraussmaffei_writer.cpp
+++ b/src/gcode/writers/kraussmaffei_writer.cpp
@@ -297,10 +297,7 @@ QString KraussMaffeiWriter::writeLine(const Point& start_point, const Point& tar
     }
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -427,10 +424,7 @@ QString KraussMaffeiWriter::writeArc(const Point& start_point, const Point& end_
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/mach4_writer.cpp
+++ b/src/gcode/writers/mach4_writer.cpp
@@ -337,10 +337,7 @@ QString Mach4Writer::writeLine(const Point& start_point, const Point& target_poi
     }
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -478,10 +475,7 @@ QString Mach4Writer::writeArc(const Point& start_point, const Point& end_point, 
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/marlin_writer.cpp
+++ b/src/gcode/writers/marlin_writer.cpp
@@ -416,10 +416,7 @@ QString MarlinWriter::writeLine(const Point& start_point, const Point& target_po
     }
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -563,10 +560,7 @@ QString MarlinWriter::writeArc(const Point& start_point, const Point& end_point,
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/mazak_writer.cpp
+++ b/src/gcode/writers/mazak_writer.cpp
@@ -236,10 +236,7 @@ QString MazakWriter::writeLine(const Point& start_point, const Point& target_poi
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -288,10 +285,7 @@ QString MazakWriter::writeArc(const Point& start_point, const Point& end_point, 
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/meld_writer.cpp
+++ b/src/gcode/writers/meld_writer.cpp
@@ -204,10 +204,7 @@ QString MeldWriter::writeLine(const Point& start_point, const Point& target_poin
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -255,10 +252,7 @@ QString MeldWriter::writeArc(const Point& start_point, const Point& end_point, c
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/meltio_writer.cpp
+++ b/src/gcode/writers/meltio_writer.cpp
@@ -227,10 +227,7 @@ QString MeltioWriter::writeLine(const Point& start_point, const Point& target_po
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -274,10 +271,7 @@ QString MeltioWriter::writeArc(const Point& start_point, const Point& end_point,
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/mvp_writer.cpp
+++ b/src/gcode/writers/mvp_writer.cpp
@@ -207,10 +207,7 @@ QString MVPWriter::writeLine(const Point& start_point, const Point& target_point
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 

--- a/src/gcode/writers/okuma_writer.cpp
+++ b/src/gcode/writers/okuma_writer.cpp
@@ -226,10 +226,7 @@ QString OkumaWriter::writeLine(const Point& start_point, const Point& target_poi
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -274,10 +271,7 @@ QString OkumaWriter::writeArc(const Point& start_point, const Point& end_point, 
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/ornl_writer.cpp
+++ b/src/gcode/writers/ornl_writer.cpp
@@ -267,10 +267,7 @@ QString ORNLWriter::writeLine(const Point& start_point, const Point& target_poin
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -320,10 +317,7 @@ QString ORNLWriter::writeArc(const Point& start_point, const Point& end_point, c
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone) {
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    }
-    else { rv += commentSpaceLine(toString(region_type)); }
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/reprap_writer.cpp
+++ b/src/gcode/writers/reprap_writer.cpp
@@ -348,10 +348,7 @@ QString RepRapWriter::writeLine(const Point& start_point, const Point& target_po
     }
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -426,10 +423,7 @@ QString RepRapWriter::writeArc(const Point& start_point, const Point& end_point,
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/romi_fanuc_writer.cpp
+++ b/src/gcode/writers/romi_fanuc_writer.cpp
@@ -210,10 +210,7 @@ QString RomiFanucWriter::writeLine(const Point& start_point, const Point& target
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -262,10 +259,7 @@ QString RomiFanucWriter::writeArc(const Point& start_point, const Point& end_poi
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/sandia_writer.cpp
+++ b/src/gcode/writers/sandia_writer.cpp
@@ -220,10 +220,7 @@ QString SandiaWriter::writeLine(const Point& start_point, const Point& target_po
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -272,10 +269,7 @@ QString SandiaWriter::writeArc(const Point& start_point, const Point& end_point,
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/siemens_writer.cpp
+++ b/src/gcode/writers/siemens_writer.cpp
@@ -240,10 +240,7 @@ QString SiemensWriter::writeLine(const Point& start_point, const Point& target_p
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -291,10 +288,7 @@ QString SiemensWriter::writeArc(const Point& start_point, const Point& end_point
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/thermwood_writer.cpp
+++ b/src/gcode/writers/thermwood_writer.cpp
@@ -224,10 +224,7 @@ QString ThermwoodWriter::writeLine(const Point& start_point, const Point& target
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 
@@ -276,10 +273,7 @@ QString ThermwoodWriter::writeArc(const Point& start_point, const Point& end_poi
     }
 
     // Add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     return rv;
 }

--- a/src/gcode/writers/tormach_writer.cpp
+++ b/src/gcode/writers/tormach_writer.cpp
@@ -249,10 +249,11 @@ QString TormachWriter::writeLine(const Point& start_point, const Point& target_p
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type) % m_space % "Bead #" % QString::number(m_bead_number));
+    QString parser_comment = regionComment(region_type, path_modifiers, params);
+    if (path_modifiers == PathModifiers::kNone) {
+        parser_comment += m_space % "Bead #" % QString::number(m_bead_number);
+    }
+    rv += commentSpaceLine(parser_comment);
 
     m_first_print = false;
 

--- a/src/gcode/writers/wolf_writer.cpp
+++ b/src/gcode/writers/wolf_writer.cpp
@@ -225,10 +225,7 @@ QString WolfWriter::writeLine(const Point& start_point, const Point& target_poin
     rv += writeCoordinates(target_point);
 
     // add comment for gcode parser
-    if (path_modifiers != PathModifiers::kNone)
-        rv += commentSpaceLine(toString(region_type) % m_space % toString(path_modifiers));
-    else
-        rv += commentSpaceLine(toString(region_type));
+    rv += commentSpaceLine(regionComment(region_type, path_modifiers, params));
 
     m_first_print = false;
 

--- a/src/gcode/writers/writer_base.cpp
+++ b/src/gcode/writers/writer_base.cpp
@@ -7,6 +7,7 @@
 #include <qtypes.h>
 #include <qvectornd.h>
 
+#include "configs/settings_base.h"
 #include "gcode/gcode_meta.h"
 #include "geometry/point.h"
 #include "managers/settings/settings_manager.h"
@@ -66,6 +67,26 @@ QString WriterBase::commentLine(const QString& text) {
 QString WriterBase::commentSpaceLine(const QString& text) {
     return QString(m_space % m_meta.m_comment_starting_delimiter % text % m_meta.m_comment_ending_delimiter %
                    m_newline);
+}
+
+QString WriterBase::regionComment(RegionType region_type, PathModifiers path_modifiers,
+                                  const QSharedPointer<SettingsBase>& params, bool include_skeleton_width) const {
+    QString comment        = toString(region_type);
+    const bool has_width   = params != nullptr && params->contains(SS::kWidth);
+    const bool has_adapted = params != nullptr && params->contains(SS::kAdapted);
+
+    if (has_width && has_adapted && params->setting<bool>(SS::kAdapted)) {
+        comment = QStringLiteral("AD-") % comment % QStringLiteral("-") %
+                  QString::number(params->setting<Distance>(SS::kWidth).to(m_meta.m_distance_unit));
+    }
+    else if (include_skeleton_width && has_width && region_type == RegionType::kSkeleton) {
+        comment +=
+            QStringLiteral("-") % QString::number(params->setting<Distance>(SS::kWidth).to(m_meta.m_distance_unit));
+    }
+
+    if (path_modifiers != PathModifiers::kNone) { comment += m_space % toString(path_modifiers); }
+
+    return comment;
 }
 
 QVector3D WriterBase::getTravelLift() {

--- a/src/graphics/view/gcode_view.cpp
+++ b/src/graphics/view/gcode_view.cpp
@@ -413,6 +413,8 @@ void GCodeView::initView() {
             break;
     }
 
+    m_printer->setSeamsHidden(!m_state.seams_shown);
+
     m_camera->setDefaultZoom(m_printer->getDefaultZoom());
 
     this->addObject(m_printer);
@@ -649,9 +651,9 @@ void GCodeView::updatePrinterSettings(QSharedPointer<SettingsBase> sb) {
 }
 
 void GCodeView::showSeams(bool show) {
-    m_printer->setSeamsHidden(!show);
-
     m_state.seams_shown = show;
+
+    if (!m_printer.isNull()) { m_printer->setSeamsHidden(!show); }
 
     this->update();
 }

--- a/src/graphics/view/part_view.cpp
+++ b/src/graphics/view/part_view.cpp
@@ -148,9 +148,9 @@ void PartView::showOverhang(bool show) {
 }
 
 void PartView::showSeams(bool show) {
-    m_printer->setSeamsHidden(!show);
-
     m_state.seams_shown = show;
+
+    if (!m_printer.isNull()) { m_printer->setSeamsHidden(!show); }
 
     this->update();
 }
@@ -476,6 +476,8 @@ void PartView::initView() {
             m_printer = QSharedPointer<CartesianPrinterObject>::create(this, m_sb, false);
             break;
     }
+
+    m_printer->setSeamsHidden(!m_state.seams_shown);
 
     QVector3D max = m_printer->maximum();
     QVector3D min = m_printer->minimum();

--- a/src/managers/preferences_manager.cpp
+++ b/src/managers/preferences_manager.cpp
@@ -129,6 +129,8 @@ PreferencesManager::PreferencesManager()
       m_hide_travel_preference(false),
       m_hide_support_preference(false),
       m_use_true_widths_preference(true),
+      m_gcode_info_visible_by_default_preference(false),
+      m_optimization_points_visible_by_default_preference(false),
       m_gcode_preview_mode_preference(GCodePreviewMode::kAuto),
       m_gcode_preview_vertex_threshold_preference(5000000),
       m_disabled_setting_visibility_preference(DisabledSettingVisibility::kGrey),
@@ -285,6 +287,12 @@ void PreferencesManager::importPreferences(QString filepath) {
 
         if (j.contains("use_true_widths")) setUseTrueWidthsPreference(j["use_true_widths"]);
 
+        if (j.contains("gcode_info_visible_by_default"))
+            setGCodeInfoVisibleByDefaultPreference(j["gcode_info_visible_by_default"]);
+
+        if (j.contains("optimization_points_visible_by_default"))
+            setOptimizationPointsVisibleByDefaultPreference(j["optimization_points_visible_by_default"]);
+
         if (j.contains("gcode_preview_mode")) setGCodePreviewModePreference(j["gcode_preview_mode"].get<int>());
 
         if (j.contains("gcode_preview_vertex_threshold"))
@@ -326,39 +334,41 @@ void PreferencesManager::exportPreferences(QString filepath) {
 fifojson PreferencesManager::json() {
     fifojson j;
 
-    j["import_unit"]                          = m_import_unit;
-    j["distance"]                             = m_distance_unit;
-    j["velocity"]                             = m_velocity_unit;
-    j["acceleration"]                         = m_acceleration_unit;
-    j["density"]                              = m_density_unit;
-    j["angle"]                                = m_angle_unit;
-    j["time"]                                 = m_time_unit;
-    j["temperature"]                          = m_temperature_unit;
-    j["voltage"]                              = m_voltage_unit;
-    j["mass"]                                 = m_mass_unit;
-    j["shift"]                                = m_project_shift_preference;
-    j["file_shift"]                           = m_file_shift_preference;
-    j["align"]                                = m_align_preference;
-    j["hide_travel"]                          = m_hide_travel_preference;
-    j["hide_support"]                         = m_hide_support_preference;
-    j["use_true_widths"]                      = m_use_true_widths_preference;
-    j["gcode_preview_mode"]                   = static_cast<int>(m_gcode_preview_mode_preference);
-    j["gcode_preview_vertex_threshold"]       = m_gcode_preview_vertex_threshold_preference;
-    j["disabled_setting_visibility"]          = static_cast<int>(m_disabled_setting_visibility_preference);
-    j["warn_unsaved_project_on_close"]        = m_warn_unsaved_project_on_close_preference;
-    j["hidden_settings"]                      = m_hidden_settings;
-    j["rotation"]                             = m_rotation_unit;
-    j["invert_camera"]                        = m_invert_camera;
-    j["theme"]                                = m_themeName;
-    j["is_window_maximized"]                  = m_is_maximized;
-    j["window_size"]                          = {m_window_size.width(), m_window_size.height()};
-    j["window_pos"]                           = {m_window_pos.x(), m_window_pos.y()};
-    j["use_implicit_transforms"]              = m_use_implicit_transforms;
-    j["always_drop_parts"]                    = m_always_drop_parts;
-    j["visualization_colors"]                 = getVisualizationHexColors();
-    j[kVisualizationColorMigrationVersionKey] = m_visualization_color_migration_version;
-    j["layer_lag"]                            = m_layer_lag;
-    j["segment_lag"]                          = m_segment_lag;
+    j["import_unit"]                            = m_import_unit;
+    j["distance"]                               = m_distance_unit;
+    j["velocity"]                               = m_velocity_unit;
+    j["acceleration"]                           = m_acceleration_unit;
+    j["density"]                                = m_density_unit;
+    j["angle"]                                  = m_angle_unit;
+    j["time"]                                   = m_time_unit;
+    j["temperature"]                            = m_temperature_unit;
+    j["voltage"]                                = m_voltage_unit;
+    j["mass"]                                   = m_mass_unit;
+    j["shift"]                                  = m_project_shift_preference;
+    j["file_shift"]                             = m_file_shift_preference;
+    j["align"]                                  = m_align_preference;
+    j["hide_travel"]                            = m_hide_travel_preference;
+    j["hide_support"]                           = m_hide_support_preference;
+    j["use_true_widths"]                        = m_use_true_widths_preference;
+    j["gcode_info_visible_by_default"]          = m_gcode_info_visible_by_default_preference;
+    j["optimization_points_visible_by_default"] = m_optimization_points_visible_by_default_preference;
+    j["gcode_preview_mode"]                     = static_cast<int>(m_gcode_preview_mode_preference);
+    j["gcode_preview_vertex_threshold"]         = m_gcode_preview_vertex_threshold_preference;
+    j["disabled_setting_visibility"]            = static_cast<int>(m_disabled_setting_visibility_preference);
+    j["warn_unsaved_project_on_close"]          = m_warn_unsaved_project_on_close_preference;
+    j["hidden_settings"]                        = m_hidden_settings;
+    j["rotation"]                               = m_rotation_unit;
+    j["invert_camera"]                          = m_invert_camera;
+    j["theme"]                                  = m_themeName;
+    j["is_window_maximized"]                    = m_is_maximized;
+    j["window_size"]                            = {m_window_size.width(), m_window_size.height()};
+    j["window_pos"]                             = {m_window_pos.x(), m_window_pos.y()};
+    j["use_implicit_transforms"]                = m_use_implicit_transforms;
+    j["always_drop_parts"]                      = m_always_drop_parts;
+    j["visualization_colors"]                   = getVisualizationHexColors();
+    j[kVisualizationColorMigrationVersionKey]   = m_visualization_color_migration_version;
+    j["layer_lag"]                              = m_layer_lag;
+    j["segment_lag"]                            = m_segment_lag;
 
     return j;
 }
@@ -469,6 +479,14 @@ bool PreferencesManager::getHideSupportPreference() {
 
 bool PreferencesManager::getUseTrueWidthsPreference() {
     return m_use_true_widths_preference;
+}
+
+bool PreferencesManager::getGCodeInfoVisibleByDefaultPreference() {
+    return m_gcode_info_visible_by_default_preference;
+}
+
+bool PreferencesManager::getOptimizationPointsVisibleByDefaultPreference() {
+    return m_optimization_points_visible_by_default_preference;
 }
 
 GCodePreviewMode PreferencesManager::getGCodePreviewModePreference() {
@@ -724,6 +742,16 @@ void PreferencesManager::setHideSupportPreference(bool hide) {
 void PreferencesManager::setUseTrueWidthsPreference(bool use) {
     m_use_true_widths_preference = use;
     m_dirty                      = true;
+}
+
+void PreferencesManager::setGCodeInfoVisibleByDefaultPreference(bool show) {
+    m_gcode_info_visible_by_default_preference = show;
+    m_dirty                                    = true;
+}
+
+void PreferencesManager::setOptimizationPointsVisibleByDefaultPreference(bool show) {
+    m_optimization_points_visible_by_default_preference = show;
+    m_dirty                                             = true;
 }
 
 void PreferencesManager::setGCodePreviewModePreference(GCodePreviewMode mode) {

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -86,6 +86,36 @@ float beadDisplayWidth(Distance bead_width) {
     return static_cast<float>(bead_width()) * Constants::OpenGL::kObjectToView;
 }
 
+Distance beadWidthForComment(const QString& comment, const QSharedPointer<SettingsBase>& sb,
+                             Distance comment_distance_unit) {
+    if (comment.contains(Constants::RegionTypeStrings::kRadial) ||
+        comment.contains(Constants::RegionTypeStrings::kHelical)) {
+        return sb->setting<Distance>(PS::Layer::kBeadWidth);
+    }
+    if (comment.startsWith(QStringLiteral("AD-") % Constants::RegionTypeStrings::kPerimeter)) {
+        return beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kPerimeter,
+                                          sb->setting<Distance>(PS::Perimeter::kBeadWidth), comment_distance_unit);
+    }
+    if (comment.contains(Constants::RegionTypeStrings::kPerimeter)) {
+        return sb->setting<Distance>(PS::Perimeter::kBeadWidth);
+    }
+    if (comment.startsWith(QStringLiteral("AD-") % Constants::RegionTypeStrings::kInset)) {
+        return beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kInset,
+                                          sb->setting<Distance>(PS::Inset::kBeadWidth), comment_distance_unit);
+    }
+    if (comment.contains(Constants::RegionTypeStrings::kInset)) { return sb->setting<Distance>(PS::Inset::kBeadWidth); }
+    if (comment.contains(Constants::RegionTypeStrings::kSkeleton)) {
+        return beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kSkeleton,
+                                          sb->setting<Distance>(PS::Skeleton::kBeadWidth), comment_distance_unit);
+    }
+    if (comment.contains(Constants::RegionTypeStrings::kSkin)) { return sb->setting<Distance>(PS::Skin::kBeadWidth); }
+    if (comment.contains(Constants::RegionTypeStrings::kInfill)) {
+        return sb->setting<Distance>(PS::Infill::kBeadWidth);
+    }
+
+    return sb->setting<Distance>(PS::Layer::kBeadWidth);
+}
+
 const QString kCylindricalAxisXComment            = "AXIS_X=";
 const QString kCylindricalAxisYComment            = "AXIS_Y=";
 const QString kWorldApproachTravelComment         = "WORLD APPROACH TRAVEL";
@@ -802,40 +832,7 @@ void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, Se
         m_modifier_colors.contains(color) ? 1.1f : 1.0f;  // Scale modifier segments by 1.1 for better visibility
 
     // Set the display width of the segment based on its region type
-    if (comment.contains(Constants::RegionTypeStrings::kRadial) ||
-        comment.contains(Constants::RegionTypeStrings::kHelical)) {
-        display_width = m_sb->setting<float>(PS::Layer::kBeadWidth) * Constants::OpenGL::kObjectToView;
-    }
-    else if (comment.startsWith(QStringLiteral("AD-") % Constants::RegionTypeStrings::kPerimeter)) {
-        display_width = beadDisplayWidth(beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kPerimeter,
-                                                                    m_sb->setting<Distance>(PS::Perimeter::kBeadWidth),
-                                                                    m_selected_meta.m_distance_unit));
-    }
-    else if (comment.contains(Constants::RegionTypeStrings::kPerimeter)) {
-        display_width = m_sb->setting<float>(PS::Perimeter::kBeadWidth) * Constants::OpenGL::kObjectToView;
-    }
-    else if (comment.startsWith(QStringLiteral("AD-") % Constants::RegionTypeStrings::kInset)) {
-        display_width = beadDisplayWidth(beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kInset,
-                                                                    m_sb->setting<Distance>(PS::Inset::kBeadWidth),
-                                                                    m_selected_meta.m_distance_unit));
-    }
-    else if (comment.contains("INSET")) {
-        display_width = m_sb->setting<float>(PS::Inset::kBeadWidth) * Constants::OpenGL::kObjectToView;
-    }
-    else if (comment.contains("SKELETON")) {
-        display_width = beadDisplayWidth(beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kSkeleton,
-                                                                    m_sb->setting<Distance>(PS::Skeleton::kBeadWidth),
-                                                                    m_selected_meta.m_distance_unit));
-    }
-    else if (comment.contains("SKIN")) {
-        display_width = m_sb->setting<float>(PS::Skin::kBeadWidth) * Constants::OpenGL::kObjectToView;
-    }
-    else if (comment.contains("INFILL")) {
-        display_width = m_sb->setting<float>(PS::Infill::kBeadWidth) * Constants::OpenGL::kObjectToView;
-    }
-    else {  // Default to layer bead width
-        display_width = m_sb->setting<float>(PS::Layer::kBeadWidth) * Constants::OpenGL::kObjectToView;
-    }
+    display_width = beadDisplayWidth(beadWidthForComment(comment, m_sb, m_selected_meta.m_distance_unit));
 
     // Set the display info of the segment
     segment->setDisplayInfo(display_width * scale, display_length, display_height * scale, type, color, line_num,
@@ -871,6 +868,14 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
         m_info_start_pos.distanceToPoint(info_end_pos) / PreferencesManager::getInstance()->getDistanceUnit()();
     segment->m_segment_info_meta.length =
         QString().asprintf("%0.2f", length) % " " % PreferencesManager::getInstance()->getDistanceUnitText();
+
+    if (deposition_active) {
+        const Distance width = beadWidthForComment(comment, m_sb, m_selected_meta.m_distance_unit);
+        segment->m_segment_info_meta.width =
+            QString().asprintf("%0.3f", width.to(PreferencesManager::getInstance()->getDistanceUnit())) % " " %
+            PreferencesManager::getInstance()->getDistanceUnitText();
+    }
+    else { segment->m_segment_info_meta.width = ""; }
 }
 
 QVector<QSharedPointer<SegmentBase>> GCodeLoader::generateVisualSegment(

--- a/src/threading/gcode_loader.cpp
+++ b/src/threading/gcode_loader.cpp
@@ -86,34 +86,65 @@ float beadDisplayWidth(Distance bead_width) {
     return static_cast<float>(bead_width()) * Constants::OpenGL::kObjectToView;
 }
 
+Distance beadWidthSetting(const QString& setting_key, const QSharedPointer<SettingsBase>& sb,
+                          const QHash<QString, double>& file_settings) {
+    const QSharedPointer<SettingsBase> global = GSM->getGlobal();
+    if (sb != nullptr && global != nullptr && sb.data() != global.data() && sb->contains(setting_key)) {
+        return sb->setting<Distance>(setting_key);
+    }
+
+    const auto file_setting = file_settings.constFind(setting_key);
+    if (file_setting != file_settings.constEnd()) { return Distance(file_setting.value()); }
+
+    if (sb != nullptr && sb->contains(setting_key)) { return sb->setting<Distance>(setting_key); }
+
+    return Distance();
+}
+
 Distance beadWidthForComment(const QString& comment, const QSharedPointer<SettingsBase>& sb,
-                             Distance comment_distance_unit) {
+                             const QHash<QString, double>& file_settings, Distance comment_distance_unit) {
     if (comment.contains(Constants::RegionTypeStrings::kRadial) ||
         comment.contains(Constants::RegionTypeStrings::kHelical)) {
-        return sb->setting<Distance>(PS::Layer::kBeadWidth);
+        return beadWidthSetting(PS::Layer::kBeadWidth, sb, file_settings);
     }
     if (comment.startsWith(QStringLiteral("AD-") % Constants::RegionTypeStrings::kPerimeter)) {
         return beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kPerimeter,
-                                          sb->setting<Distance>(PS::Perimeter::kBeadWidth), comment_distance_unit);
+                                          beadWidthSetting(PS::Perimeter::kBeadWidth, sb, file_settings),
+                                          comment_distance_unit);
     }
     if (comment.contains(Constants::RegionTypeStrings::kPerimeter)) {
-        return sb->setting<Distance>(PS::Perimeter::kBeadWidth);
+        return beadWidthSetting(PS::Perimeter::kBeadWidth, sb, file_settings);
     }
     if (comment.startsWith(QStringLiteral("AD-") % Constants::RegionTypeStrings::kInset)) {
         return beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kInset,
-                                          sb->setting<Distance>(PS::Inset::kBeadWidth), comment_distance_unit);
+                                          beadWidthSetting(PS::Inset::kBeadWidth, sb, file_settings),
+                                          comment_distance_unit);
     }
-    if (comment.contains(Constants::RegionTypeStrings::kInset)) { return sb->setting<Distance>(PS::Inset::kBeadWidth); }
+    if (comment.contains(Constants::RegionTypeStrings::kInset)) {
+        return beadWidthSetting(PS::Inset::kBeadWidth, sb, file_settings);
+    }
     if (comment.contains(Constants::RegionTypeStrings::kSkeleton)) {
         return beadWidthFromRegionComment(comment, Constants::RegionTypeStrings::kSkeleton,
-                                          sb->setting<Distance>(PS::Skeleton::kBeadWidth), comment_distance_unit);
+                                          beadWidthSetting(PS::Skeleton::kBeadWidth, sb, file_settings),
+                                          comment_distance_unit);
     }
-    if (comment.contains(Constants::RegionTypeStrings::kSkin)) { return sb->setting<Distance>(PS::Skin::kBeadWidth); }
+    if (comment.contains(Constants::RegionTypeStrings::kSkin)) {
+        return beadWidthSetting(PS::Skin::kBeadWidth, sb, file_settings);
+    }
     if (comment.contains(Constants::RegionTypeStrings::kInfill)) {
-        return sb->setting<Distance>(PS::Infill::kBeadWidth);
+        return beadWidthSetting(PS::Infill::kBeadWidth, sb, file_settings);
+    }
+    if (comment.contains(Constants::RegionTypeStrings::kRaft)) {
+        return beadWidthSetting(MS::PlatformAdhesion::kRaftBeadWidth, sb, file_settings);
+    }
+    if (comment.contains(Constants::RegionTypeStrings::kBrim)) {
+        return beadWidthSetting(MS::PlatformAdhesion::kBrimBeadWidth, sb, file_settings);
+    }
+    if (comment.contains(Constants::RegionTypeStrings::kSkirt)) {
+        return beadWidthSetting(MS::PlatformAdhesion::kSkirtBeadWidth, sb, file_settings);
     }
 
-    return sb->setting<Distance>(PS::Layer::kBeadWidth);
+    return beadWidthSetting(PS::Layer::kBeadWidth, sb, file_settings);
 }
 
 const QString kCylindricalAxisXComment            = "AXIS_X=";
@@ -284,6 +315,7 @@ void GCodeLoader::run() {
 
             m_parser->parseHeader();
             QHash<QString, double> visualizationSettings = m_parser->parseFooter();
+            m_file_settings                              = visualizationSettings;
             QList<QList<GcodeCommand>> m_motion_commands = m_parser->parseLines();
 
             if (m_parser->getWasModified()) {
@@ -832,7 +864,8 @@ void GCodeLoader::setSegmentDisplayInfo(QSharedPointer<SegmentBase>& segment, Se
         m_modifier_colors.contains(color) ? 1.1f : 1.0f;  // Scale modifier segments by 1.1 for better visibility
 
     // Set the display width of the segment based on its region type
-    display_width = beadDisplayWidth(beadWidthForComment(comment, m_sb, m_selected_meta.m_distance_unit));
+    display_width =
+        beadDisplayWidth(beadWidthForComment(comment, m_sb, m_file_settings, m_selected_meta.m_distance_unit));
 
     // Set the display info of the segment
     segment->setDisplayInfo(display_width * scale, display_length, display_height * scale, type, color, line_num,
@@ -870,7 +903,7 @@ void GCodeLoader::setSegmentMetaInfo(QSharedPointer<SegmentBase>& segment, const
         QString().asprintf("%0.2f", length) % " " % PreferencesManager::getInstance()->getDistanceUnitText();
 
     if (deposition_active) {
-        const Distance width = beadWidthForComment(comment, m_sb, m_selected_meta.m_distance_unit);
+        const Distance width = beadWidthForComment(comment, m_sb, m_file_settings, m_selected_meta.m_distance_unit);
         segment->m_segment_info_meta.width =
             QString().asprintf("%0.3f", width.to(PreferencesManager::getInstance()->getDistanceUnit())) % " " %
             PreferencesManager::getInstance()->getDistanceUnitText();

--- a/src/widgets/gcode_info_control.cpp
+++ b/src/widgets/gcode_info_control.cpp
@@ -206,6 +206,7 @@ void GCodeInfoControl::fillSegmentInfo(uint lineNo) {
             m_infolbl_speed->setText(seg->m_segment_info_meta.speed);
             m_infolbl_extruder_speed->setText(seg->m_segment_info_meta.extruderSpeed);
             m_infolbl_length->setText(seg->m_segment_info_meta.length);
+            m_infolbl_width->setText(seg->m_segment_info_meta.width);
             m_infolbl_layer_no->setText(QString::number(seg->layerNumber()));
             m_infolbl_line_no->setText(QString::number(lineNo));
             m_current_segment = seg;
@@ -220,6 +221,7 @@ void GCodeInfoControl::fillSegmentInfo(uint lineNo) {
     m_infolbl_speed->setText("");
     m_infolbl_extruder_speed->setText("");
     m_infolbl_length->setText("");
+    m_infolbl_width->setText("");
     m_infolbl_center_distance->setText("");
     m_infolbl_layer_no->setText("");
     m_infolbl_line_no->setText("");
@@ -349,6 +351,7 @@ void GCodeInfoControl::setupWidget() {
     m_infolbl_speed           = new QLabel;
     m_infolbl_extruder_speed  = new QLabel;
     m_infolbl_length          = new QLabel;
+    m_infolbl_width           = new QLabel;
     m_infolbl_center_distance = new QLabel;
     m_infolbl_layer_no        = new QLabel;
     m_infolbl_line_no         = new QLabel;
@@ -382,12 +385,14 @@ void GCodeInfoControl::setupWidget() {
     m_info_grid->addWidget(m_infolbl_extruder_speed, 4, 1);
     m_info_grid->addWidget(new QLabel("Length"), 5, 0);
     m_info_grid->addWidget(m_infolbl_length, 5, 1);
-    m_info_grid->addWidget(new QLabel("Centerline Distance"), 6, 0);
-    m_info_grid->addWidget(m_infolbl_center_distance, 6, 1);
-    m_info_grid->addWidget(new QLabel("Layer #"), 7, 0);
-    m_info_grid->addWidget(m_infolbl_layer_no, 7, 1);
-    m_info_grid->addWidget(new QLabel("G-Code Line #"), 8, 0);
-    m_info_grid->addWidget(m_infolbl_line_no, 8, 1);
+    m_info_grid->addWidget(new QLabel("Bead Width"), 6, 0);
+    m_info_grid->addWidget(m_infolbl_width, 6, 1);
+    m_info_grid->addWidget(new QLabel("Centerline Distance"), 7, 0);
+    m_info_grid->addWidget(m_infolbl_center_distance, 7, 1);
+    m_info_grid->addWidget(new QLabel("Layer #"), 8, 0);
+    m_info_grid->addWidget(m_infolbl_layer_no, 8, 1);
+    m_info_grid->addWidget(new QLabel("G-Code Line #"), 9, 0);
+    m_info_grid->addWidget(m_infolbl_line_no, 9, 1);
 
     fillSegmentInfo(0);
 }

--- a/src/widgets/gcode_widget.cpp
+++ b/src/widgets/gcode_widget.cpp
@@ -146,6 +146,7 @@ void GCodeWidget::setupWidget() {
 void GCodeWidget::setupSubWidgets() {
     // Segment info Control
     m_segment_info_control = QSharedPointer<GCodeInfoControl>(new GCodeInfoControl(this));
+    m_segment_info_control->setVisible(PreferencesManager::getInstance()->getGCodeInfoVisibleByDefaultPreference());
 
     // Set OpenGL Version information
     // Note: This format must be set before show() is called.

--- a/src/widgets/main_toolbar.cpp
+++ b/src/widgets/main_toolbar.cpp
@@ -110,9 +110,12 @@ void MainToolbar::setupSubWidgets() {
 
     // Seam buttons
     m_seam_btn = buildIconButton(":/icons/map_markers_black.png", "Show optimization points", true);
-    handleModifiedSetting("");
     this->addWidget(m_seam_btn);
-    connect(m_seam_btn, &QToolButton::toggled, this, [this](bool checked) { emit showSeams(checked); });
+    connect(m_seam_btn, &QToolButton::toggled, this, [this](bool checked) {
+        m_optimization_points_user_toggled = true;
+        emit showSeams(checked);
+    });
+    handleModifiedSetting("");
 
     // Overhang Button
     m_overhang_button = buildIconButton(":/icons/support_overhang.png", "Show support overhangs", true);
@@ -127,6 +130,7 @@ void MainToolbar::setupSubWidgets() {
 
     // Bead Inspection Tool / Segment Info Button
     m_segment_info_button = buildIconButton(":/icons/info.png", "Show g-code Bead / Segment Info", true);
+    m_segment_info_button->setChecked(PreferencesManager::getInstance()->getGCodeInfoVisibleByDefaultPreference());
     this->addWidget(m_segment_info_button);
     m_segment_info_button->setEnabled(false);
     connect(m_segment_info_button, &QToolButton::toggled, this,
@@ -519,6 +523,10 @@ void MainToolbar::setOrthoGcodeChecked(bool status) {
     m_2d_gcode_btn->setChecked(status);
 }
 
+void MainToolbar::syncOptimizationPointVisibility() {
+    emit showSeams(m_seam_btn->isEnabled() && m_seam_btn->isChecked());
+}
+
 void MainToolbar::handleModifiedSetting(const QString& setting_key) {
     IslandOrderOptimization islandOrder =
         static_cast<IslandOrderOptimization>(GSM->getGlobal()->setting<int>(PS::Optimizations::kIslandOrder));
@@ -530,12 +538,22 @@ void MainToolbar::handleModifiedSetting(const QString& setting_key) {
         !usesCustomPointLocation(pointOrder)) {
         m_seam_btn->setDisabled(true);
         m_seam_btn->setToolTip("Custom optimization points are not set");
-        m_seam_btn->setChecked(false);
-        emit showSeams(false);
+        if (m_seam_btn->isChecked()) {
+            const QSignalBlocker blocker(m_seam_btn);
+            m_seam_btn->setChecked(false);
+            emit showSeams(false);
+        }
     }
     else {
         m_seam_btn->setDisabled(false);
         m_seam_btn->setToolTip("Show optimization points");
+        if (!m_optimization_points_user_toggled &&
+            PreferencesManager::getInstance()->getOptimizationPointsVisibleByDefaultPreference() &&
+            !m_seam_btn->isChecked()) {
+            const QSignalBlocker blocker(m_seam_btn);
+            m_seam_btn->setChecked(true);
+            emit showSeams(true);
+        }
     }
 }
 }  // namespace ORNL

--- a/src/windows/main_window.cpp
+++ b/src/windows/main_window.cpp
@@ -1071,6 +1071,8 @@ void MainWindow::setupEvents() {
         m_export_window->setDefaultName(m_part_widget->getFirstPartName());
     });
 
+    m_main_toolbar->syncOptimizationPointVisibility();
+
     connect(CSM.get(), &SessionManager::requestTransformationUpdate, m_part_widget,
             &PartWidget::updatePartTransformations);
 

--- a/src/windows/preferences_window.cpp
+++ b/src/windows/preferences_window.cpp
@@ -306,7 +306,21 @@ void PreferencesWindow::setupLayout() {
 
     visualization_tab_layout->addWidget(new QLabel("True-width vertex threshold:"), 1, 0, Qt::AlignTop);
     visualization_tab_layout->addWidget(m_gcode_preview_vertex_threshold_spinbox, 1, 1, Qt::AlignTop);
-    visualization_tab_layout->setRowStretch(2, 1);
+
+    m_optimization_points_visible_by_default_checkbox = new QCheckBox("Show optimization points by default");
+    m_optimization_points_visible_by_default_checkbox->setChecked(
+        PreferencesManager::getInstance()->getOptimizationPointsVisibleByDefaultPreference());
+    m_optimization_points_visible_by_default_checkbox->setToolTip("Show custom optimization points automatically");
+
+    visualization_tab_layout->addWidget(m_optimization_points_visible_by_default_checkbox, 2, 0, 1, 2, Qt::AlignTop);
+
+    m_gcode_info_visible_by_default_checkbox = new QCheckBox("Show bead / segment info by default");
+    m_gcode_info_visible_by_default_checkbox->setChecked(
+        PreferencesManager::getInstance()->getGCodeInfoVisibleByDefaultPreference());
+    m_gcode_info_visible_by_default_checkbox->setToolTip("Show the g-code Bead / Segment Info panel automatically");
+
+    visualization_tab_layout->addWidget(m_gcode_info_visible_by_default_checkbox, 3, 0, 1, 2, Qt::AlignTop);
+    visualization_tab_layout->setRowStretch(4, 1);
 
     connect(m_gcode_preview_mode_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this] {
         PreferencesManager::getInstance()->setGCodePreviewModePreference(
@@ -314,6 +328,11 @@ void PreferencesWindow::setupLayout() {
     });
     connect(m_gcode_preview_vertex_threshold_spinbox, QOverload<int>::of(&QSpinBox::valueChanged),
             PreferencesManager::getInstance().get(), &PreferencesManager::setGCodePreviewVertexThresholdPreference);
+    connect(m_optimization_points_visible_by_default_checkbox, &QCheckBox::clicked,
+            PreferencesManager::getInstance().get(),
+            &PreferencesManager::setOptimizationPointsVisibleByDefaultPreference);
+    connect(m_gcode_info_visible_by_default_checkbox, &QCheckBox::clicked, PreferencesManager::getInstance().get(),
+            &PreferencesManager::setGCodeInfoVisibleByDefaultPreference);
 
     // Visualization Colors tab
     QScrollArea* scrollArea = new QScrollArea(m_tab_widget);
@@ -492,6 +511,10 @@ void PreferencesWindow::importPreferences() {
         m_gcode_preview_mode_combobox->setCurrentIndex(std::max(0, previewModeIndex));
         m_gcode_preview_vertex_threshold_spinbox->setValue(
             m_preferences_manager->getGCodePreviewVertexThresholdPreference());
+        m_optimization_points_visible_by_default_checkbox->setChecked(
+            m_preferences_manager->getOptimizationPointsVisibleByDefaultPreference());
+        m_gcode_info_visible_by_default_checkbox->setChecked(
+            m_preferences_manager->getGCodeInfoVisibleByDefaultPreference());
         int disabledSettingVisibilityIndex = m_disabled_setting_visibility_combobox->findData(
             static_cast<int>(m_preferences_manager->getDisabledSettingVisibilityPreference()));
         m_disabled_setting_visibility_combobox->setCurrentIndex(std::max(0, disabledSettingVisibilityIndex));


### PR DESCRIPTION
## Summary
- show bead/extrusion width in the G-code segment information view
- add preferences for showing G-code info and optimization points by default while preserving toolbar toggles
- centralize adaptive width region comments in writer base and apply them across supported writers

## Testing
- `direnv exec . cmake --build build/generic-llvm-ninja --target ornlslicer`
- `direnv exec . cmake --build build/generic-llvm-ninja`
- `direnv exec . ctest --test-dir build/generic-llvm-ninja -C Debug --output-on-failure`
- `direnv exec . timeout 10s build/generic-llvm-ninja/Debug/ornlslicer`