### PR TITLE
Add GitHub Actions workflow that automatically rebases open PRs

### DIFF
--- a/.github/workflows/auto-rebase.yaml
+++ b/.github/workflows/auto-rebase.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - develop
-  pull_request:
+  pull_request_target:
     branches:
       - develop
     types:
@@ -41,8 +41,20 @@ jobs:
         shell: bash
     env:
       BASE_BRANCH: develop
-      GH_TOKEN: ${{ secrets.AUTO_REBASE_TOKEN || github.token }}
+      # Use a real automation credential so rebased pushes trigger push-based CI.
+      GH_TOKEN: ${{ secrets.AUTO_REBASE_TOKEN }}
     steps:
+      - name: Verify auto-rebase token
+        env:
+          AUTO_REBASE_TOKEN: ${{ secrets.AUTO_REBASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$AUTO_REBASE_TOKEN" ]]; then
+            echo "::error title=Missing AUTO_REBASE_TOKEN::Configure a PAT or GitHub App token in the AUTO_REBASE_TOKEN secret. Rebased pushes made with github.token do not trigger this repository's push-based CI."
+            exit 1
+          fi
+
       - name: Checkout develop
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/auto-rebase.yaml
+++ b/.github/workflows/auto-rebase.yaml
@@ -42,8 +42,6 @@ jobs:
     env:
       BASE_BRANCH: develop
       GH_TOKEN: ${{ secrets.AUTO_REBASE_TOKEN || github.token }}
-      TARGETS_FILE: ${{ runner.temp }}/auto-rebase-targets.txt
-      FAILED_FILE: ${{ runner.temp }}/auto-rebase-failed.txt
     steps:
       - name: Checkout develop
         uses: actions/checkout@v5
@@ -72,6 +70,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          TARGETS_FILE="/tmp/auto-rebase-targets.txt"
           : > "$TARGETS_FILE"
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
@@ -122,6 +121,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          TARGETS_FILE="/tmp/auto-rebase-targets.txt"
+          FAILED_FILE="/tmp/auto-rebase-failed.txt"
           git fetch origin "+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH"
           : > "$FAILED_FILE"
 

--- a/.github/workflows/auto-rebase.yaml
+++ b/.github/workflows/auto-rebase.yaml
@@ -1,0 +1,176 @@
+---
+name: Auto Rebase PRs
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to rebase. Leave blank to use branch or all open PRs."
+        required: false
+        type: string
+      branch:
+        description: "Branch to rebase when pr_number is blank. Leave blank to rebase all open PRs."
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-develop
+  cancel-in-progress: false
+
+jobs:
+  rebase:
+    name: Rebase open develop PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      BASE_BRANCH: develop
+      GH_TOKEN: ${{ secrets.AUTO_REBASE_TOKEN || github.token }}
+      TARGETS_FILE: ${{ runner.temp }}/auto-rebase-targets.txt
+      FAILED_FILE: ${{ runner.temp }}/auto-rebase-failed.txt
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.BASE_BRANCH }}
+          fetch-depth: 0
+          token: ${{ env.GH_TOKEN }}
+
+      - name: Configure Git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Collect PR branches
+        id: targets
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft || false }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          INPUT_BRANCH: ${{ inputs.branch || '' }}
+        run: |
+          set -euo pipefail
+
+          : > "$TARGETS_FILE"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$PR_DRAFT" == "true" ]]; then
+              echo "Skipping draft pull request branch $PR_HEAD_REF."
+            elif [[ "$PR_HEAD_REPOSITORY" == "$REPOSITORY" ]]; then
+              printf '%s\n' "$PR_HEAD_REF" > "$TARGETS_FILE"
+            else
+              echo "Skipping forked pull request branch $PR_HEAD_REPOSITORY:$PR_HEAD_REF."
+            fi
+          elif [[ -n "$INPUT_PR_NUMBER" ]]; then
+            gh pr view "$INPUT_PR_NUMBER" \
+              --json baseRefName,headRefName,headRepositoryOwner,headRepository,isDraft \
+              --jq 'select(.baseRefName == env.BASE_BRANCH and .headRepositoryOwner.login == env.REPOSITORY_OWNER and .headRepository.name == env.REPOSITORY_NAME) | .headRefName' \
+              > "$TARGETS_FILE"
+          elif [[ -n "$INPUT_BRANCH" ]]; then
+            gh pr list \
+              --base "$BASE_BRANCH" \
+              --head "$INPUT_BRANCH" \
+              --state open \
+              --limit 100 \
+              --json headRefName,headRepositoryOwner,headRepository,isDraft \
+              --jq '.[] | select(.headRepositoryOwner.login == env.REPOSITORY_OWNER and .headRepository.name == env.REPOSITORY_NAME) | .headRefName' \
+              > "$TARGETS_FILE"
+          else
+            gh pr list \
+              --base "$BASE_BRANCH" \
+              --state open \
+              --limit 100 \
+              --json headRefName,headRepositoryOwner,headRepository,isDraft \
+              --jq '.[] | select(.isDraft == false and .headRepositoryOwner.login == env.REPOSITORY_OWNER and .headRepository.name == env.REPOSITORY_NAME) | .headRefName' \
+              > "$TARGETS_FILE"
+          fi
+
+          sort -u "$TARGETS_FILE" -o "$TARGETS_FILE"
+
+          if [[ ! -s "$TARGETS_FILE" ]]; then
+            echo "No same-repository pull request branches targeting $BASE_BRANCH were found."
+            echo "has_targets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branches queued for rebase:"
+            cat "$TARGETS_FILE"
+            echo "has_targets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Rebase branches onto develop
+        if: steps.targets.outputs.has_targets == 'true'
+        run: |
+          set -euo pipefail
+
+          git fetch origin "+refs/heads/$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH"
+          : > "$FAILED_FILE"
+
+          while IFS= read -r branch; do
+            [[ -n "$branch" ]] || continue
+
+            if [[ "$branch" == "$BASE_BRANCH" ]]; then
+              echo "Skipping $branch because it is the base branch."
+              continue
+            fi
+
+            echo "::group::Rebase $branch"
+            echo "Rebasing $branch onto origin/$BASE_BRANCH"
+            if ! git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch"; then
+              echo "::error title=Fetch failed::Could not fetch $branch from origin."
+              printf '%s\n' "$branch" >> "$FAILED_FILE"
+              echo "::endgroup::"
+              continue
+            fi
+
+            expected_remote="$(git rev-parse "refs/remotes/origin/$branch")"
+            git switch --force-create "$branch" "$expected_remote"
+
+            if ! git rebase "refs/remotes/origin/$BASE_BRANCH"; then
+              echo "::error title=Rebase conflict::Could not rebase $branch onto origin/$BASE_BRANCH."
+              git rebase --abort || true
+              printf '%s\n' "$branch" >> "$FAILED_FILE"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [[ "$(git rev-parse HEAD)" == "$expected_remote" ]]; then
+              echo "$branch is already current; no push needed."
+              echo "::endgroup::"
+              continue
+            fi
+
+            if ! git push --force-with-lease="refs/heads/$branch:$expected_remote" origin "HEAD:refs/heads/$branch"; then
+              echo "::error title=Push failed::Could not update $branch. The branch may have changed during this run."
+              printf '%s\n' "$branch" >> "$FAILED_FILE"
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "::endgroup::"
+          done < "$TARGETS_FILE"
+
+          if [[ -s "$FAILED_FILE" ]]; then
+            echo "Branches that need manual attention:"
+            cat "$FAILED_FILE"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically rebases open same-repository pull request branches onto `develop`.

The workflow runs when `develop` is updated, when a PR targeting `develop` is opened/reopened/synchronized/marked ready for review, and through manual `workflow_dispatch` for targeted rebases by PR number or branch name.

## Related issues

- No related issues.

## Details

This adds `.github/workflows/auto-rebase.yaml`, a new CI workflow for keeping active `develop` PR branches current after base branch movement.

The workflow supports three operating modes:

- Automatic all-PR rebase after pushes to `develop`.
- Automatic single-PR rebase when a same-repository PR targeting `develop` is opened, reopened, synchronized, or marked ready for review.
- Manual dispatch using either a `pr_number`, a `branch`, or neither input to rebase all eligible open PR branches.

Target collection is handled through the GitHub CLI. The workflow filters PRs to same-repository branches owned by this repository, avoiding forked PR branches that the workflow should not attempt to rewrite. Draft PRs are skipped during automatic collection so in-progress work is not rebased unexpectedly.

Each selected branch is fetched from `origin`, checked out from the expected remote SHA, rebased onto `origin/develop`, and pushed back with an explicit `--force-with-lease`. The lease is tied to the SHA fetched immediately before the rebase, so if a branch changes during the workflow run, the push fails instead of overwriting newer remote work.

Conflict and failure handling is branch-scoped. If a fetch, rebase, or push fails for one branch, the workflow records that branch, aborts any failed rebase, and continues processing the remaining queue. At the end of the run, any failed branches are printed together and the job exits with failure so maintainers know which PRs need manual attention.

The workflow also uses runner temp files for target and failure tracking, groups per-branch logs in GitHub Actions output, avoids no-op pushes when a branch is already current, and supports an optional `AUTO_REBASE_TOKEN` secret while falling back to `github.token`.

## Impact

This reduces manual maintenance for open PR branches after `develop` advances. Contributors should see fewer stale PR branches and fewer CI runs blocked only because a branch has fallen behind the base branch.

Risk level: Medium.

The workflow intentionally rewrites same-repository PR branches by force-pushing rebased history. The use of same-repository filtering, draft PR skipping, conflict aborts, and explicit `--force-with-lease` reduces the risk, but the feature still changes remote branch history by design. Forked PRs are not rebased by this workflow.

The workflow affects GitHub Actions behavior only. It does not change application code, build output, slicer behavior, or runtime functionality.