### PR TITLE
Add connected spiral insets option

### DIFF
--- a/include/geometry/spiral_path.h
+++ b/include/geometry/spiral_path.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <limits>
 
 #include <qcontainerfwd.h>
@@ -13,9 +15,28 @@
 namespace ORNL {
 namespace SpiralPath {
 namespace detail {
+struct RayLoopIntersection {
+    Point point;
+    double distance;
+    int segment_index;
+};
+
 inline Point pointAlongSegment(const Point& start, const Point& end, double ratio) {
     return Point(start.x() + ((end.x() - start.x()) * ratio), start.y() + ((end.y() - start.y()) * ratio),
                  start.z() + ((end.z() - start.z()) * ratio));
+}
+
+inline double cross2D(double lhs_x, double lhs_y, double rhs_x, double rhs_y) {
+    return (lhs_x * rhs_y) - (lhs_y * rhs_x);
+}
+
+inline bool normalize2D(double& x, double& y) {
+    const double length = std::sqrt((x * x) + (y * y));
+    if (length <= std::numeric_limits<double>::epsilon()) { return false; }
+
+    x /= length;
+    y /= length;
+    return true;
 }
 
 inline Point stopPointOnClosingSegment(const Polyline& line, Distance distance_before_start) {
@@ -151,6 +172,121 @@ inline void rotateToClosestForwardExistingPoint(Polyline& line, const Point& que
     for (int i = 0; i < rotation_index; ++i) { line.move(0, line.size() - 1); }
 }
 
+inline bool raySegmentIntersection(const Point& ray_start, double ray_direction_x, double ray_direction_y,
+                                   const Point& segment_start, const Point& segment_end, Point& intersection,
+                                   double& ray_distance) {
+    const double segment_x          = segment_end.x() - segment_start.x();
+    const double segment_y          = segment_end.y() - segment_start.y();
+    const double denom              = cross2D(ray_direction_x, ray_direction_y, segment_x, segment_y);
+    const double to_segment_start_x = segment_start.x() - ray_start.x();
+    const double to_segment_start_y = segment_start.y() - ray_start.y();
+    constexpr double epsilon        = 1.0e-6;
+
+    if (std::abs(denom) <= epsilon) {
+        if (std::abs(cross2D(to_segment_start_x, to_segment_start_y, ray_direction_x, ray_direction_y)) > epsilon) {
+            return false;
+        }
+
+        const double segment_start_projection =
+            (to_segment_start_x * ray_direction_x) + (to_segment_start_y * ray_direction_y);
+        const double segment_end_projection = ((segment_end.x() - ray_start.x()) * ray_direction_x) +
+                                              ((segment_end.y() - ray_start.y()) * ray_direction_y);
+
+        if (segment_start_projection < -epsilon && segment_end_projection < -epsilon) { return false; }
+
+        const bool use_segment_start =
+            segment_start_projection >= -epsilon &&
+            (segment_start_projection <= segment_end_projection || segment_end_projection < -epsilon);
+        ray_distance = std::max(0.0, use_segment_start ? segment_start_projection : segment_end_projection);
+        intersection = use_segment_start ? segment_start : segment_end;
+        return true;
+    }
+
+    double t = cross2D(to_segment_start_x, to_segment_start_y, segment_x, segment_y) / denom;
+    double u = cross2D(to_segment_start_x, to_segment_start_y, ray_direction_x, ray_direction_y) / denom;
+
+    if (t < -epsilon || u < -epsilon || u > 1.0 + epsilon) { return false; }
+
+    t = std::max(0.0, t);
+    u = std::clamp(u, 0.0, 1.0);
+
+    ray_distance = t;
+    intersection = pointAlongSegment(segment_start, segment_end, u);
+    return true;
+}
+
+inline bool findRayLoopIntersection(const Polyline& line, const Point& ray_start, double ray_direction_x,
+                                    double ray_direction_y, double max_distance, RayLoopIntersection& intersection) {
+    bool found              = false;
+    double closest_distance = std::numeric_limits<double>::max();
+
+    for (int i = 0, end = line.size(); i < end; ++i) {
+        const int next_index = (i + 1) % line.size();
+        Point candidate_point;
+        double candidate_distance = 0.0;
+        if (!raySegmentIntersection(ray_start, ray_direction_x, ray_direction_y, line[i], line[next_index],
+                                    candidate_point, candidate_distance)) {
+            continue;
+        }
+
+        if (candidate_distance <= max_distance + 1.0e-6 && candidate_distance < closest_distance) {
+            closest_distance = candidate_distance;
+            intersection     = {candidate_point, candidate_distance, i};
+            found            = true;
+        }
+    }
+
+    return found;
+}
+
+inline void rotateToSegmentPoint(Polyline& line, int segment_index, const Point& point) {
+    if (line.size() < 2) { return; }
+
+    const int next_index = (segment_index + 1) % line.size();
+    int rotation_index   = next_index;
+
+    if (point == line[segment_index]) { rotation_index = segment_index; }
+    else if (point == line[next_index]) { rotation_index = next_index; }
+    else { line.insert(next_index, point); }
+
+    for (int i = 0; i < rotation_index; ++i) { line.move(0, line.size() - 1); }
+}
+
+inline bool rotateToFortyFiveDegreeConnector(const Polyline& current_loop, Polyline& next_loop,
+                                             const Point& connector_start, Distance stop_distance) {
+    if (current_loop.size() < 2 || next_loop.size() < 2) { return false; }
+
+    double tangent_x = current_loop.front().x() - current_loop.back().x();
+    double tangent_y = current_loop.front().y() - current_loop.back().y();
+    if (!normalize2D(tangent_x, tangent_y)) { return false; }
+
+    const double normal_x             = -tangent_y;
+    const double normal_y             = tangent_x;
+    constexpr double forty_five_scale = 0.7071067811865476;
+    const double max_connector_length = std::max(stop_distance() * 2.0, 1.0e-6);
+    const std::array<std::array<double, 2>, 2> directions {{
+        {{(tangent_x + normal_x) * forty_five_scale, (tangent_y + normal_y) * forty_five_scale}},
+        {{(tangent_x - normal_x) * forty_five_scale, (tangent_y - normal_y) * forty_five_scale}},
+    }};
+
+    bool found = false;
+    RayLoopIntersection best {Point(), std::numeric_limits<double>::max(), 0};
+    for (const std::array<double, 2>& direction : directions) {
+        RayLoopIntersection candidate {Point(), std::numeric_limits<double>::max(), 0};
+        if (findRayLoopIntersection(next_loop, connector_start, direction[0], direction[1], max_connector_length,
+                                    candidate) &&
+            candidate.distance < best.distance) {
+            best  = candidate;
+            found = true;
+        }
+    }
+
+    if (!found) { return false; }
+
+    rotateToSegmentPoint(next_loop, best.segment_index, best.point);
+    return true;
+}
+
 inline Distance validWidthOrFallback(Distance width, Distance fallback_width) {
     return width > 0 ? width : fallback_width;
 }
@@ -159,18 +295,30 @@ inline Distance transitionDistance(Distance current_width, Distance next_width, 
     return (validWidthOrFallback(current_width, fallback_width) + validWidthOrFallback(next_width, fallback_width)) / 2;
 }
 
-inline Point prepareConnector(const Polyline& current_loop, Polyline& next_loop, Distance stop_distance) {
-    const Point rough_connector_start = stopPointOnClosingSegment(current_loop, stop_distance);
+inline Point transitionPoint(const Polyline& line, Distance distance_before_start, bool complete_before_connecting) {
+    if (complete_before_connecting && !line.isEmpty()) { return line.front(); }
+
+    return stopPointOnClosingSegment(line, distance_before_start);
+}
+
+inline Point prepareConnector(const Polyline& current_loop, Polyline& next_loop, Distance stop_distance,
+                              bool complete_before_connecting) {
+    const Point rough_connector_start = transitionPoint(current_loop, stop_distance, complete_before_connecting);
     const bool smooth_closing_segment = hasSmoothClosingSegment(current_loop);
     if (next_loop.size() >= 3) {
-        if (smooth_closing_segment) {
+        if (complete_before_connecting) {
+            if (!rotateToFortyFiveDegreeConnector(current_loop, next_loop, rough_connector_start, stop_distance)) {
+                rotateToClosestPoint(next_loop, rough_connector_start);
+            }
+        }
+        else if (smooth_closing_segment) {
             rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, current_loop.back(),
                                                 current_loop.front());
         }
         else { rotateToClosestPoint(next_loop, rough_connector_start); }
     }
 
-    if (smooth_closing_segment || next_loop.isEmpty()) { return rough_connector_start; }
+    if (complete_before_connecting || smooth_closing_segment || next_loop.isEmpty()) { return rough_connector_start; }
 
     return MathUtils::nearestPointOnSegment(current_loop.back(), current_loop.front(), next_loop.front()).first;
 }
@@ -218,10 +366,11 @@ inline Distance closedPolylineLength(const Polyline& line) {
 }
 
 /*!
- * \brief Returns the point on a closed loop's closing segment where a spiral transition should begin.
+ * \brief Returns the point where a spiral transition should begin.
  */
-inline Point transitionStartPoint(const Polyline& line, Distance distance_before_start) {
-    return detail::stopPointOnClosingSegment(line, distance_before_start);
+inline Point transitionStartPoint(const Polyline& line, Distance distance_before_start,
+                                  bool complete_before_connecting = false) {
+    return detail::transitionPoint(line, distance_before_start, complete_before_connecting);
 }
 
 /*!
@@ -233,10 +382,12 @@ inline Point transitionStartPoint(const Polyline& line, Distance distance_before
  * \param ordered_loops Closed loops without a repeated final point.
  * \param loop_widths Bead widths for the ordered loops.
  * \param fallback_width Width used when a per-loop width is not supplied.
+ * \param complete_before_connecting Close each loop before adding the connector to the next loop.
  * \return One or more polylines, each representing a connectable spiral group.
  */
 inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& ordered_loops,
-                                                  const QVector<Distance>& loop_widths, Distance fallback_width) {
+                                                  const QVector<Distance>& loop_widths, Distance fallback_width,
+                                                  bool complete_before_connecting = false) {
     QVector<detail::StitchLoop> loops;
     loops.reserve(ordered_loops.size());
     for (int i = 0, end = ordered_loops.size(); i < end; ++i) {
@@ -276,16 +427,17 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
             detail::StitchLoop prepared_next_loop = next_loop;
             const Distance stop_distance =
                 detail::transitionDistance(current_loop.width, next_loop.width, fallback_width);
-            const Point connector_start =
-                detail::prepareConnector(current_loop.loop, prepared_next_loop.loop, stop_distance);
+            const Point connector_start = detail::prepareConnector(current_loop.loop, prepared_next_loop.loop,
+                                                                   stop_distance, complete_before_connecting);
 
             if (detail::canConnectLoops(current_loop, prepared_next_loop, connector_start, stop_distance)) {
                 if (spiral.back() != connector_start) { spiral += connector_start; }
                 current_loop = prepared_next_loop;
             }
             else {
-                const Point final_stop = detail::stopPointOnClosingSegment(
-                    current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
+                const Point final_stop = detail::transitionPoint(
+                    current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width),
+                    complete_before_connecting);
 
                 if (spiral.back() != final_stop) { spiral += final_stop; }
                 spiral_groups.push_back(spiral);
@@ -294,8 +446,9 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
             }
         }
         else {
-            const Point final_stop = detail::stopPointOnClosingSegment(
-                current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
+            const Point final_stop = detail::transitionPoint(
+                current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width),
+                complete_before_connecting);
 
             if (spiral.back() != final_stop) { spiral += final_stop; }
             spiral_groups.push_back(spiral);
@@ -306,13 +459,13 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
     return spiral_groups;
 }
 
-inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& ordered_loops,
-                                                  Distance final_stop_distance) {
+inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& ordered_loops, Distance final_stop_distance,
+                                                  bool complete_before_connecting = false) {
     QVector<Distance> loop_widths;
     loop_widths.reserve(ordered_loops.size());
     for (int i = 0, end = ordered_loops.size(); i < end; ++i) { loop_widths.push_back(final_stop_distance); }
 
-    return linkClosedPolylineGroups(ordered_loops, loop_widths, final_stop_distance);
+    return linkClosedPolylineGroups(ordered_loops, loop_widths, final_stop_distance, complete_before_connecting);
 }
 
 /*!
@@ -321,10 +474,11 @@ inline QVector<Polyline> linkClosedPolylineGroups(const QVector<Polyline>& order
  * \param ordered_loops Closed loops without a repeated final point.
  * \param loop_widths Bead widths for the ordered loops.
  * \param fallback_width Width used when a per-loop width is not supplied.
+ * \param complete_before_connecting Close each loop before adding the connector to the next loop.
  * \return One polyline that walks each loop and transitions to the next loop before fully closing.
  */
 inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, const QVector<Distance>& loop_widths,
-                                    Distance fallback_width) {
+                                    Distance fallback_width, bool complete_before_connecting = false) {
     QVector<detail::StitchLoop> loops;
     loops.reserve(ordered_loops.size());
     for (int i = 0, end = ordered_loops.size(); i < end; ++i) {
@@ -362,15 +516,17 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, cons
             detail::StitchLoop next_loop = loops.takeFirst();
             const Distance stop_distance =
                 detail::transitionDistance(current_loop.width, next_loop.width, fallback_width);
-            const Point connector_start = detail::prepareConnector(current_loop.loop, next_loop.loop, stop_distance);
+            const Point connector_start =
+                detail::prepareConnector(current_loop.loop, next_loop.loop, stop_distance, complete_before_connecting);
 
             if (spiral.back() != connector_start) { spiral += connector_start; }
 
             current_loop = next_loop;
         }
         else {
-            const Point final_stop = detail::stopPointOnClosingSegment(
-                current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width));
+            const Point final_stop = detail::transitionPoint(
+                current_loop.loop, detail::validWidthOrFallback(current_loop.width, fallback_width),
+                complete_before_connecting);
 
             if (spiral.back() != final_stop) { spiral += final_stop; }
             break;
@@ -380,7 +536,8 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, cons
     return spiral;
 }
 
-inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Distance final_stop_distance) {
+inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Distance final_stop_distance,
+                                    bool complete_before_connecting = false) {
     QVector<Polyline> loops = ordered_loops;
     Polyline spiral;
 
@@ -391,25 +548,16 @@ inline Polyline linkClosedPolylines(const QVector<Polyline>& ordered_loops, Dist
         spiral += loop;
 
         if (loop_index + 1 < end) {
-            Polyline next_loop                = loops[loop_index + 1];
-            Point rough_connector_start       = detail::stopPointOnClosingSegment(loop, final_stop_distance);
-            const bool smooth_closing_segment = detail::hasSmoothClosingSegment(loop);
-            if (smooth_closing_segment) {
-                detail::rotateToClosestForwardExistingPoint(next_loop, rough_connector_start, loop.back(),
-                                                            loop.front());
-            }
-            else { detail::rotateToClosestPoint(next_loop, rough_connector_start); }
-            const Point next_start = next_loop.front();
-            Point connector_start;
-            if (smooth_closing_segment) { connector_start = rough_connector_start; }
-            else { connector_start = MathUtils::nearestPointOnSegment(loop.back(), loop.front(), next_start).first; }
+            Polyline next_loop = loops[loop_index + 1];
+            const Point connector_start =
+                detail::prepareConnector(loop, next_loop, final_stop_distance, complete_before_connecting);
 
             if (spiral.back() != connector_start) { spiral += connector_start; }
 
             loops[loop_index + 1] = next_loop;
         }
         else {
-            const Point final_stop = detail::stopPointOnClosingSegment(loop, final_stop_distance);
+            const Point final_stop = detail::transitionPoint(loop, final_stop_distance, complete_before_connecting);
 
             if (spiral.back() != final_stop) { spiral += final_stop; }
         }

--- a/include/step/layer/regions/inset.h
+++ b/include/step/layer/regions/inset.h
@@ -44,6 +44,10 @@ class Inset : public RegionBase {
     //! \return the computed geometry
     QVector<Polyline> getComputedGeometry();
 
+    //! \brief gets the bead widths associated with computed geometry
+    //! \return the computed bead widths
+    QVector<Distance> getComputedWidths();
+
    private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to

--- a/include/step/layer/regions/perimeter.h
+++ b/include/step/layer/regions/perimeter.h
@@ -47,6 +47,11 @@ class Perimeter : public RegionBase {
     //! \return the computed geometry
     QVector<Polyline> getComputedGeometry();
 
+    //! \brief Sets inset geometry that should be connected onto spiral perimeter output.
+    //! \param geometry: computed inset closed-loop paths
+    //! \param widths: bead widths associated with the inset paths
+    void setConnectedInsetGeometry(const QVector<Polyline>& geometry, const QVector<Distance>& widths);
+
    private:
     //! \brief Creates modifiers
     //! \param path Current path to add modifiers to
@@ -92,11 +97,26 @@ class Perimeter : public RegionBase {
      */
     static bool isAdaptedWidth(const Distance& width, const QSharedPointer<SettingsBase>& parent_sb);
 
+    //! \brief Applies inset segment settings after the connected perimeter-to-inset bridge.
+    //! \param path Path containing perimeter paths followed by connected inset paths.
+    void applyConnectedInsetSettings(Path& path) const;
+
+    //! \brief Returns the inset bead width for a connected inset segment.
+    //! \param start Segment start point.
+    //! \param end Segment end point.
+    Distance connectedInsetWidthForSegment(const Point& start, const Point& end) const;
+
     //! \brief Holds the computed geometry before it is converted into paths
     QVector<Polyline> m_computed_geometry;
 
     //! \brief Holds the bead width associated with each computed contour in m_computed_geometry
     QVector<Distance> m_computed_widths;
+
+    //! \brief Holds computed inset geometry to connect after spiral perimeters.
+    QVector<Polyline> m_connected_inset_geometry;
+
+    //! \brief Holds the bead width associated with each connected inset contour.
+    QVector<Distance> m_connected_inset_widths;
 
     //! \brief Holds the layer number that we are currently on
     uint m_layer_num;

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -632,6 +632,8 @@ class Constants {
             static const QString kFlyingStartDistance;
             static const QString kFlyingStartSpeed;
             static const QString kEnableSpiralPerimeter;
+            static const QString kCompletePathBeforeConnecting;
+            static const QString kConnectToInsets;
         };
 
         class Inset {
@@ -650,6 +652,7 @@ class Constants {
             static const QString kMinSegmentLength;
             static const QString kOverlap;
             static const QString kEnableSpiralInset;
+            static const QString kCompletePathBeforeConnecting;
         };
 
         class Skeleton {

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -4094,6 +4094,32 @@
       "symbol":"kEnableSpiralPerimeter",
       "local":true
   },
+  "spiral_perimeter_complete_path_before_connecting": {
+      "display":"Complete path before connecting",
+      "type":"boolean",
+      "tooltip":"If selected, spiral perimeters will complete the current path before connecting to the next path.",
+      "depends":{"AND":[{"slicing_mode":0},{"AND":[{"perimeter":true},{"spiral_perimeter":true}]}]},
+      "options":"",
+      "default":false,
+      "minor":"Perimeter",
+      "major":"Profile",
+      "namespace":"Profile::Perimeter",
+      "symbol":"kCompletePathBeforeConnecting",
+      "local":true
+  },
+  "spiral_perimeter_connect_to_insets": {
+      "display":"Connect to spiral insets",
+      "type":"boolean",
+      "tooltip":"If selected, spiral perimeters will connect directly to spiral insets.",
+      "depends":{"AND":[{"slicing_mode":0},{"AND":[{"perimeter":true},{"AND":[{"inset":true},{"AND":[{"spiral_perimeter":true},{"spiral_inset":true}]}]}]}]},
+      "options":"",
+      "default":false,
+      "minor":"Perimeter",
+      "major":"Profile",
+      "namespace":"Profile::Perimeter",
+      "symbol":"kConnectToInsets",
+      "local":true
+  },
   "inset": {
       "display":"Enable Inset",
       "type":"boolean",
@@ -4261,6 +4287,19 @@
       "major":"Profile",
       "namespace":"Profile::Inset",
       "symbol":"kEnableSpiralInset",
+      "local":true
+  },
+  "spiral_inset_complete_path_before_connecting": {
+      "display":"Complete path before connecting",
+      "type":"boolean",
+      "tooltip":"If selected, spiral insets will complete the current path before connecting to the next path.",
+      "depends":{"AND":[{"slicing_mode":0},{"AND":[{"inset":true},{"spiral_inset":true}]}]},
+      "options":"",
+      "default":false,
+      "minor":"Inset",
+      "major":"Profile",
+      "namespace":"Profile::Inset",
+      "symbol":"kCompletePathBeforeConnecting",
       "local":true
   },
   "skeleton": {

--- a/resources/settings/021_profile_perimeter.yaml
+++ b/resources/settings/021_profile_perimeter.yaml
@@ -244,3 +244,27 @@ settings:
     namespace: "Profile::Perimeter"
     symbol: "kEnableSpiralPerimeter"
     local: true
+  - name: "spiral_perimeter_complete_path_before_connecting"
+    display: "Complete path before connecting"
+    type: "boolean"
+    tooltip: "If selected, spiral perimeters will complete the current path before connecting to the next path."
+    depends: {"AND":[{"slicing_mode":0},{"AND":[{"perimeter":true},{"spiral_perimeter":true}]}]}
+    options: []
+    default: false
+    minor: "Perimeter"
+    major: "Profile"
+    namespace: "Profile::Perimeter"
+    symbol: "kCompletePathBeforeConnecting"
+    local: true
+  - name: "spiral_perimeter_connect_to_insets"
+    display: "Connect to spiral insets"
+    type: "boolean"
+    tooltip: "If selected, spiral perimeters will connect directly to spiral insets."
+    depends: {"AND":[{"slicing_mode":0},{"AND":[{"perimeter":true},{"AND":[{"inset":true},{"AND":[{"spiral_perimeter":true},{"spiral_inset":true}]}]}]}]}
+    options: []
+    default: false
+    minor: "Perimeter"
+    major: "Profile"
+    namespace: "Profile::Perimeter"
+    symbol: "kConnectToInsets"
+    local: true

--- a/resources/settings/022_profile_inset.yaml
+++ b/resources/settings/022_profile_inset.yaml
@@ -157,3 +157,15 @@ settings:
     namespace: "Profile::Inset"
     symbol: "kEnableSpiralInset"
     local: true
+  - name: "spiral_inset_complete_path_before_connecting"
+    display: "Complete path before connecting"
+    type: "boolean"
+    tooltip: "If selected, spiral insets will complete the current path before connecting to the next path."
+    depends: {"AND":[{"slicing_mode":0},{"AND":[{"inset":true},{"spiral_inset":true}]}]}
+    options: []
+    default: false
+    minor: "Inset"
+    major: "Profile"
+    namespace: "Profile::Inset"
+    symbol: "kCompletePathBeforeConnecting"
+    local: true

--- a/src/step/layer/island/polymer_island.cpp
+++ b/src/step/layer/island/polymer_island.cpp
@@ -9,6 +9,7 @@
 #include "geometry/path.h"
 #include "geometry/point.h"
 #include "geometry/polygon_list.h"
+#include "geometry/polyline.h"
 #include "geometry/settings_polygon.h"
 #include "managers/settings/settings_manager.h"
 #include "step/layer/island/island_base.h"
@@ -70,7 +71,32 @@ void PolymerIsland::optimize(int layerNumber, Point& currentLocation,
 
     bool wasLastSpiral = false;
 
+    QSharedPointer<Perimeter> connected_perimeter = getRegion(RegionType::kPerimeter).dynamicCast<Perimeter>();
+    QSharedPointer<Inset> connected_inset         = getRegion(RegionType::kInset).dynamicCast<Inset>();
+    QVector<Polyline> connected_inset_geometry;
+    QVector<Distance> connected_inset_widths;
+
+    if (!connected_perimeter.isNull() && !connected_inset.isNull()) {
+        connected_inset_geometry = connected_inset->getComputedGeometry();
+        connected_inset_widths   = connected_inset->getComputedWidths();
+    }
+
+    const bool connect_spiral_perimeter_to_inset =
+        !connected_perimeter.isNull() && !connected_inset.isNull() && !connected_inset_geometry.isEmpty() &&
+        connected_perimeter->getIndex() < connected_inset->getIndex() &&
+        m_sb->setting<bool>(PS::Perimeter::kEnableSpiralPerimeter) &&
+        m_sb->setting<bool>(PS::Perimeter::kConnectToInsets) && m_sb->setting<bool>(PS::Inset::kEnableSpiralInset);
+
+    if (connect_spiral_perimeter_to_inset) {
+        connected_perimeter->setConnectedInsetGeometry(connected_inset_geometry, connected_inset_widths);
+    }
+
     for (QSharedPointer<RegionBase> r : m_regions) {
+        if (connect_spiral_perimeter_to_inset && r.data() == connected_inset.data()) {
+            connected_inset->getPaths().clear();
+            continue;
+        }
+
         if (previousRegions.size() > 0)
             wasLastSpiral = previousRegions.last()->getSb()->setting<bool>(PS::SpecialModes::kEnableSpiralize);
 

--- a/src/step/layer/regions/inset.cpp
+++ b/src/step/layer/regions/inset.cpp
@@ -427,6 +427,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
     };
 
     if (m_sb->setting<bool>(PS::Inset::kEnableSpiralInset)) {
+        const bool complete_path_before_connecting = m_sb->setting<bool>(PS::Inset::kCompletePathBeforeConnecting);
+
         if (!m_sb->setting<bool>(PS::Inset::kAdaptive)) {
             Point spiral_query_location = current_location;
             PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
@@ -446,7 +448,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
 
                 if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) { continue; }
 
-                spiral_query_location = SpiralPath::transitionStartPoint(result, bead_width);
+                spiral_query_location =
+                    SpiralPath::transitionStartPoint(result, bead_width, complete_path_before_connecting);
                 ordered_insets.push_back(result);
             }
 
@@ -472,8 +475,9 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
                 return;
             }
 
-            appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_insets, bead_width),
-                              ordered_insets.front().orientation(), min_path_length);
+            appendSpiralPaths(
+                SpiralPath::linkClosedPolylineGroups(ordered_insets, bead_width, complete_path_before_connecting),
+                ordered_insets.front().orientation(), min_path_length);
 
             return;
         }
@@ -510,7 +514,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
             const Distance result_width = beadWidthForSegment(result.front(), result[1], m_sb);
             ordered_inset_widths.push_back(result_width);
             ordered_insets.push_back(result);
-            spiral_query_location = SpiralPath::transitionStartPoint(result, result_width);
+            spiral_query_location =
+                SpiralPath::transitionStartPoint(result, result_width, complete_path_before_connecting);
         }
 
         if (ordered_insets.isEmpty()) { return; }
@@ -541,7 +546,8 @@ void Inset::optimize(int layerNumber, Point& current_location, bool& shouldNextP
         }
 
         const Distance nominal_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
-        appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_insets, ordered_inset_widths, nominal_width),
+        appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_insets, ordered_inset_widths, nominal_width,
+                                                               complete_path_before_connecting),
                           ordered_insets.front().orientation(), min_path_length);
 
         return;
@@ -598,6 +604,10 @@ Path Inset::createPath(Polyline line) {
 
 QVector<Polyline> Inset::getComputedGeometry() {
     return m_computed_geometry;
+}
+
+QVector<Distance> Inset::getComputedWidths() {
+    return m_computed_widths;
 }
 
 void Inset::calculateModifiers(Path& path, bool supportsG3) {

--- a/src/step/layer/regions/perimeter.cpp
+++ b/src/step/layer/regions/perimeter.cpp
@@ -303,6 +303,70 @@ bool pointOnClosedPolylineXY(const Point& point, const Polyline& line, double to
     return false;
 }
 
+bool pointOnAnyClosedPolylineXY(const Point& point, const QVector<Polyline>& lines, double tolerance) {
+    for (const Polyline& line : lines) {
+        if (pointOnClosedPolylineXY(point, line, tolerance)) { return true; }
+    }
+
+    return false;
+}
+
+Distance widthForSegmentOnGeometry(const Point& start, const Point& end, const QVector<Polyline>& geometry,
+                                   const QVector<Distance>& widths, Distance fallback_width) {
+    Point midpoint = (start + end) * 0.5;
+    const Distance tolerance(std::max(fallback_width() * 1.0e-3, 1.0e-6));
+
+    for (int i = 0; i < geometry.size() && i < widths.size(); ++i) {
+        if (pointOnClosedPolylineXY(midpoint, geometry[i], tolerance())) { return widths[i]; }
+    }
+
+    if (!widths.isEmpty()) {
+        const Distance first_width = widths.first();
+        const bool uniform_width =
+            std::all_of(widths.begin(), widths.end(), [first_width, tolerance](const Distance& width) {
+                return std::fabs(width() - first_width()) <= tolerance();
+            });
+        if (uniform_width) { return first_width; }
+    }
+
+    return fallback_width;
+}
+
+Distance widthForLineOnGeometry(const Polyline& line, const QVector<Polyline>& geometry,
+                                const QVector<Distance>& widths, Distance fallback_width) {
+    if (line.size() < 2) { return fallback_width; }
+
+    return widthForSegmentOnGeometry(line.front(), line[1], geometry, widths, fallback_width);
+}
+
+bool isInsetAdaptedWidth(const Distance& width, const QSharedPointer<SettingsBase>& parent_sb) {
+    const Distance nominal_width = parent_sb->setting<Distance>(PS::Inset::kBeadWidth);
+    return std::fabs(width() - nominal_width()) > std::max(nominal_width() * 1.0e-3, 1.0e-6);
+}
+
+void populateInsetSegmentSettings(QSharedPointer<SettingsBase> segment_sb,
+                                  const QSharedPointer<SettingsBase>& parent_sb, const Distance& bead_width,
+                                  bool adapted) {
+    segment_sb->populate(parent_sb);
+
+    Velocity speed = parent_sb->setting<Velocity>(PS::Inset::kSpeed);
+    if (adapted && bead_width > 0) {
+        const Distance ref_width = parent_sb->setting<Distance>(PS::Inset::kBeadWidth);
+        const Velocity ref_speed = parent_sb->setting<Velocity>(PS::Inset::kSpeed);
+        const double min_speed   = ref_speed() * 0.01;
+        speed                    = Velocity(std::max((ref_speed() * ref_width()) / bead_width(), min_speed));
+    }
+
+    segment_sb->setSetting(SS::kWidth, bead_width);
+    segment_sb->setSetting(SS::kHeight, parent_sb->setting<Distance>(PS::Layer::kLayerHeight));
+    segment_sb->setSetting(SS::kSpeed, speed);
+    segment_sb->setSetting(SS::kAccel, parent_sb->setting<Acceleration>(PRS::Acceleration::kInset));
+    segment_sb->setSetting(SS::kExtruderSpeed, parent_sb->setting<AngularVelocity>(PS::Inset::kExtruderSpeed));
+    segment_sb->setSetting(SS::kMaterialNumber, parent_sb->setting<int>(MS::MultiMaterial::kInsetNum));
+    segment_sb->setSetting(SS::kRegionType, RegionType::kInset);
+    segment_sb->setSetting(SS::kAdapted, adapted);
+}
+
 }  // namespace
 
 Perimeter::Perimeter(const QSharedPointer<SettingsBase>& sb, const int index,
@@ -325,6 +389,8 @@ void Perimeter::compute(uint layer_num) {
     m_paths.clear();
     m_computed_geometry.clear();
     m_computed_widths.clear();
+    m_connected_inset_geometry.clear();
+    m_connected_inset_widths.clear();
 
     setMaterialNumber(m_sb->setting<int>(MS::MultiMaterial::kPerimeterNum));
     Distance beadWidth                = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
@@ -500,6 +566,10 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             PrintDirection::kReverse_off)
             for (Polyline& line : m_computed_geometry) { line = line.reverse(); }
 
+        const bool connect_to_spiral_insets =
+            m_sb->setting<bool>(PS::Perimeter::kConnectToInsets) && m_sb->setting<bool>(PS::Inset::kEnable) &&
+            m_sb->setting<bool>(PS::Inset::kEnableSpiralInset) && !m_connected_inset_geometry.isEmpty();
+
         auto appendSpiralPaths = [&](const QVector<Polyline>& spiral_groups, bool ccw, Distance min_path_length) {
             for (const Polyline& spiral_group : spiral_groups) {
                 if (spiral_group.size() < 3) { continue; }
@@ -512,6 +582,8 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 if (newPath.calculateLength() < min_path_length) { continue; }
 
                 if (newPath.size() > 0) {
+                    if (connect_to_spiral_insets) { applyConnectedInsetSettings(newPath); }
+
                     calculateModifiers(newPath, m_sb->setting<bool>(PRS::MachineSetup::kSupportG3), true);
                     PathModifierGenerator::GenerateTravel(newPath, current_location,
                                                           m_sb->setting<Velocity>(PS::Travel::kSpeed));
@@ -523,6 +595,56 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
         };
 
         if (m_sb->setting<bool>(PS::Perimeter::kEnableSpiralPerimeter)) {
+            const bool complete_path_before_connecting =
+                m_sb->setting<bool>(PS::Perimeter::kCompletePathBeforeConnecting);
+
+            auto appendConnectedInsetLoops = [&](QVector<Polyline>& ordered_loops, QVector<Distance>& ordered_widths,
+                                                 Point& spiral_query_location, bool normalize_orientation,
+                                                 bool& has_spiral_orientation, bool& spiral_orientation) {
+                if (!connect_to_spiral_insets) { return; }
+
+                PolylineOrderOptimizer inset_poo(spiral_query_location, layerNumber);
+                configureOptimizer(inset_poo, PointOrderOptimization::kNextClosest);
+                QVector<Polyline> inset_geometry = m_connected_inset_geometry;
+                if (static_cast<PrintDirection>(m_sb->setting<int>(PS::Ordering::kInsetReverseDirection)) !=
+                    PrintDirection::kReverse_off) {
+                    for (Polyline& line : inset_geometry) { line = line.reverse(); }
+                }
+                inset_poo.setGeometryToEvaluate(inset_geometry, RegionType::kInset,
+                                                PathOrderOptimization::kNextClosest);
+
+                const Distance inset_min_path_length = m_sb->setting<Distance>(PS::Inset::kMinPathLength);
+                const Distance inset_nominal_width   = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
+
+                while (inset_poo.getCurrentPolylineCount() > 0) {
+                    inset_poo.setPointParameters(PointOrderOptimization::kNextClosest, false, 0, 0, false, 0, false);
+
+                    Polyline result = inset_poo.linkNextPolyline();
+
+                    if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < inset_min_path_length) {
+                        continue;
+                    }
+
+                    if (normalize_orientation) {
+                        if (!has_spiral_orientation) {
+                            spiral_orientation     = result.orientation();
+                            has_spiral_orientation = true;
+                        }
+                        else if (result.orientation() != spiral_orientation) {
+                            result = result.reverse();
+                            result.move(result.size() - 1, 0);
+                        }
+                    }
+
+                    const Distance result_width = widthForLineOnGeometry(result, m_connected_inset_geometry,
+                                                                         m_connected_inset_widths, inset_nominal_width);
+                    ordered_widths.push_back(result_width);
+                    ordered_loops.push_back(result);
+                    spiral_query_location =
+                        SpiralPath::transitionStartPoint(result, result_width, complete_path_before_connecting);
+                }
+            };
+
             if (!m_sb->setting<bool>(PS::Perimeter::kAdaptive)) {
                 Point spiral_query_location = current_location;
                 PolylineOrderOptimizer spiral_poo(spiral_query_location, layerNumber);
@@ -530,6 +652,7 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 spiral_poo.setGeometryToEvaluate(m_computed_geometry, RegionType::kPerimeter, pathOrderOptimization);
 
                 QVector<Polyline> ordered_perimeters;
+                QVector<Distance> ordered_widths;
                 const Distance min_path_length = m_sb->setting<Distance>(PS::Perimeter::kMinPathLength);
                 const Distance bead_width      = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
 
@@ -543,11 +666,18 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
 
                     if (result.size() < 3 || SpiralPath::closedPolylineLength(result) < min_path_length) { continue; }
 
-                    spiral_query_location = SpiralPath::transitionStartPoint(result, bead_width);
+                    spiral_query_location =
+                        SpiralPath::transitionStartPoint(result, bead_width, complete_path_before_connecting);
                     ordered_perimeters.push_back(result);
+                    ordered_widths.push_back(bead_width);
                 }
 
                 if (ordered_perimeters.isEmpty()) { return; }
+
+                bool has_spiral_orientation = false;
+                bool spiral_orientation     = false;
+                appendConnectedInsetLoops(ordered_perimeters, ordered_widths, spiral_query_location, false,
+                                          has_spiral_orientation, spiral_orientation);
 
                 if (ordered_perimeters.size() == 1) {
                     Polyline result = ordered_perimeters.first();
@@ -569,7 +699,8 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                     return;
                 }
 
-                appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_perimeters, bead_width),
+                appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_perimeters, ordered_widths, bead_width,
+                                                                       complete_path_before_connecting),
                                   ordered_perimeters.front().orientation(), min_path_length);
 
                 return;
@@ -607,10 +738,14 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
                 const Distance result_width = beadWidthForSegment(result.front(), result[1], m_sb);
                 ordered_perimeter_widths.push_back(result_width);
                 ordered_perimeters.push_back(result);
-                spiral_query_location = SpiralPath::transitionStartPoint(result, result_width);
+                spiral_query_location =
+                    SpiralPath::transitionStartPoint(result, result_width, complete_path_before_connecting);
             }
 
             if (ordered_perimeters.isEmpty()) { return; }
+
+            appendConnectedInsetLoops(ordered_perimeters, ordered_perimeter_widths, spiral_query_location, true,
+                                      has_spiral_orientation, spiral_orientation);
 
             if (ordered_perimeters.size() == 1) {
                 PolylineOrderOptimizer first_loop_poo(current_location, layerNumber);
@@ -638,9 +773,9 @@ void Perimeter::optimize(int layerNumber, Point& current_location, bool& shouldN
             }
 
             const Distance nominal_width = m_sb->setting<Distance>(PS::Perimeter::kBeadWidth);
-            appendSpiralPaths(
-                SpiralPath::linkClosedPolylineGroups(ordered_perimeters, ordered_perimeter_widths, nominal_width),
-                ordered_perimeters.front().orientation(), min_path_length);
+            appendSpiralPaths(SpiralPath::linkClosedPolylineGroups(ordered_perimeters, ordered_perimeter_widths,
+                                                                   nominal_width, complete_path_before_connecting),
+                              ordered_perimeters.front().orientation(), min_path_length);
 
             return;
         }
@@ -699,6 +834,11 @@ Path Perimeter::createPath(Polyline line) {
 
 QVector<Polyline> Perimeter::getComputedGeometry() {
     return m_computed_geometry;
+}
+
+void Perimeter::setConnectedInsetGeometry(const QVector<Polyline>& geometry, const QVector<Distance>& widths) {
+    m_connected_inset_geometry = geometry;
+    m_connected_inset_widths   = widths;
 }
 
 void Perimeter::calculateModifiers(Path& path, bool supportsG3) {
@@ -884,6 +1024,44 @@ Distance Perimeter::beadWidthForSegment(const Point& start, const Point& end,
     }
 
     return fallback_width;
+}
+
+void Perimeter::applyConnectedInsetSettings(Path& path) const {
+    if (m_connected_inset_geometry.isEmpty()) { return; }
+
+    const Distance fallback_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
+    const Distance tolerance(std::max(fallback_width() * 1.0e-3, 1.0e-6));
+    bool using_inset_settings = false;
+
+    for (const QSharedPointer<SegmentBase>& segment : path.getSegments()) {
+        if (segment == nullptr) { continue; }
+
+        const bool midpoint_on_inset =
+            pointOnAnyClosedPolylineXY(segment->midpoint(), m_connected_inset_geometry, tolerance());
+        const bool end_on_inset = pointOnAnyClosedPolylineXY(segment->end(), m_connected_inset_geometry, tolerance());
+        if (midpoint_on_inset || end_on_inset) { using_inset_settings = true; }
+
+        if (!using_inset_settings) { continue; }
+
+        QSharedPointer<SettingsBase> parent_sb = QSharedPointer<SettingsBase>::create(*m_sb);
+        for (const SettingsPolygon& polygon : m_settings_polygons) {
+            if (polygon.inside(segment->midpoint())) {
+                parent_sb->populate(polygon.getSettings());
+                break;
+            }
+        }
+
+        const Distance bead_width = connectedInsetWidthForSegment(segment->start(), segment->end());
+        populateInsetSegmentSettings(segment->getSb(), parent_sb, bead_width,
+                                     isInsetAdaptedWidth(bead_width, parent_sb));
+    }
+}
+
+Distance Perimeter::connectedInsetWidthForSegment(const Point& start, const Point& end) const {
+    const Distance fallback_width = m_sb->setting<Distance>(PS::Inset::kBeadWidth);
+    if (!m_sb->setting<bool>(PS::Inset::kAdaptive)) { return fallback_width; }
+
+    return widthForSegmentOnGeometry(start, end, m_connected_inset_geometry, m_connected_inset_widths, fallback_width);
 }
 
 bool Perimeter::isAdaptedWidth(const Distance& width, const QSharedPointer<SettingsBase>& parent_sb) {

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -586,6 +586,9 @@ const QString Constants::ProfileSettings::Perimeter::kEnableFlyingStart     = "p
 const QString Constants::ProfileSettings::Perimeter::kFlyingStartDistance   = "perimeter_flying_start_distance";
 const QString Constants::ProfileSettings::Perimeter::kFlyingStartSpeed      = "perimeter_flying_start_speed";
 const QString Constants::ProfileSettings::Perimeter::kEnableSpiralPerimeter = "spiral_perimeter";
+const QString Constants::ProfileSettings::Perimeter::kCompletePathBeforeConnecting =
+    "spiral_perimeter_complete_path_before_connecting";
+const QString Constants::ProfileSettings::Perimeter::kConnectToInsets = "spiral_perimeter_connect_to_insets";
 
 // Inset
 const QString Constants::ProfileSettings::Inset::kEnable              = "inset";
@@ -601,6 +604,8 @@ const QString Constants::ProfileSettings::Inset::kMinPathLength       = "inset_m
 const QString Constants::ProfileSettings::Inset::kMinSegmentLength    = "inset_minimum_segment_length";
 const QString Constants::ProfileSettings::Inset::kOverlap             = "inset_overlap_distance";
 const QString Constants::ProfileSettings::Inset::kEnableSpiralInset   = "spiral_inset";
+const QString Constants::ProfileSettings::Inset::kCompletePathBeforeConnecting =
+    "spiral_inset_complete_path_before_connecting";
 
 // Skeleton
 const QString Constants::ProfileSettings::Skeleton::kEnable                        = "skeleton";

--- a/tests/spiral_path_tests.cpp
+++ b/tests/spiral_path_tests.cpp
@@ -25,6 +25,22 @@ bool expectPoint(const ORNL::Point& point, double x, double y, const std::string
     return expect(closeTo(point.x(), x) && closeTo(point.y(), y), message);
 }
 
+bool expectForwardFortyFiveConnector(const ORNL::Polyline& loop, const ORNL::Point& connector_start,
+                                     const ORNL::Point& connector_end, const std::string& message) {
+    const double tangent_x           = loop.front().x() - loop.back().x();
+    const double tangent_y           = loop.front().y() - loop.back().y();
+    const double connector_x         = connector_end.x() - connector_start.x();
+    const double connector_y         = connector_end.y() - connector_start.y();
+    const double tangent_length_sq   = (tangent_x * tangent_x) + (tangent_y * tangent_y);
+    const double connector_length_sq = (connector_x * connector_x) + (connector_y * connector_y);
+
+    if (tangent_length_sq <= 0.0 || connector_length_sq <= 0.0) { return expect(false, message); }
+
+    const double normalized_dot =
+        ((tangent_x * connector_x) + (tangent_y * connector_y)) / std::sqrt(tangent_length_sq * connector_length_sq);
+    return expect(closeTo(normalized_dot, std::sqrt(0.5)), message);
+}
+
 ORNL::Polyline square(double min_x, double min_y, double max_x, double max_y) {
     ORNL::Polyline line;
     line.push_back(ORNL::Point(min_x, min_y, 0.0f));
@@ -43,6 +59,49 @@ ORNL::Polyline rectangleStartingOnLeftEdge(double min_x, double min_y, double ma
     line.push_back(ORNL::Point(min_x, max_y, 0.0f));
     return line;
 }
+
+ORNL::Polyline smoothClosingOuterLoop() {
+    ORNL::Polyline line;
+    line.push_back(ORNL::Point(0.0, 0.0, 0.0f));
+    line.push_back(ORNL::Point(100.0, 0.0, 0.0f));
+    line.push_back(ORNL::Point(100.0, 100.0, 0.0f));
+    line.push_back(ORNL::Point(-70.0, 80.0, 0.0f));
+    line.push_back(ORNL::Point(-10.0, 10.0, 0.0f));
+    return line;
+}
+
+ORNL::Polyline smoothClosingInnerLoop() {
+    ORNL::Polyline line;
+    line.push_back(ORNL::Point(-5.0, 5.0, 0.0f));
+    line.push_back(ORNL::Point(10.0, 20.0, 0.0f));
+    line.push_back(ORNL::Point(85.0, 25.0, 0.0f));
+    line.push_back(ORNL::Point(85.0, 85.0, 0.0f));
+    line.push_back(ORNL::Point(-35.0, 55.0, 0.0f));
+    line.push_back(ORNL::Point(-15.0, 16.0, 0.0f));
+    return line;
+}
+
+ORNL::Polyline forwardPreferenceOuterLoop() {
+    ORNL::Polyline line;
+    line.push_back(ORNL::Point(0.0, 0.0, 0.0f));
+    line.push_back(ORNL::Point(100.0, 0.0, 0.0f));
+    line.push_back(ORNL::Point(100.0, 100.0, 0.0f));
+    line.push_back(ORNL::Point(-100.0, 100.0, 0.0f));
+    line.push_back(ORNL::Point(-100.0, 0.0, 0.0f));
+    line.push_back(ORNL::Point(-10.0, 0.0, 0.0f));
+    return line;
+}
+
+ORNL::Polyline forwardPreferenceInnerLoop() {
+    ORNL::Polyline line;
+    line.push_back(ORNL::Point(-2.0, 2.0, 0.0f));
+    line.push_back(ORNL::Point(5.0, 5.0, 0.0f));
+    line.push_back(ORNL::Point(80.0, 10.0, 0.0f));
+    line.push_back(ORNL::Point(80.0, 80.0, 0.0f));
+    line.push_back(ORNL::Point(-80.0, 80.0, 0.0f));
+    line.push_back(ORNL::Point(-10.0, 10.0, 0.0f));
+    return line;
+}
 }  // namespace
 
 int main() {
@@ -57,6 +116,71 @@ int main() {
 
     passed &= expect(adjacent_groups.size() == 1, "Expected adjacent nested loops to remain in one spiral group.");
 
+    QVector<ORNL::Polyline> complete_adjacent_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(adjacent_loops, bead_width, true);
+
+    passed &= expect(complete_adjacent_groups.size() == 1,
+                     "Expected complete-before-connecting nested loops to remain in one spiral group.");
+    if (complete_adjacent_groups.size() == 1) {
+        const ORNL::Polyline& complete_group = complete_adjacent_groups.front();
+        passed &= expect(complete_group.size() >= 6,
+                         "Expected complete-before-connecting spiral group to include both loops and connector.");
+        if (complete_group.size() >= 6) {
+            passed &= expectPoint(complete_group[4], 0.0, 0.0,
+                                  "Expected first loop to close before connecting to the next loop.");
+            passed &= expectPoint(complete_group[5], 1.0, 1.0,
+                                  "Expected completed loop to connect to the next loop at its nearest corner.");
+            passed &= expect(closeTo(std::abs(complete_group[5].x() - complete_group[4].x()),
+                                     std::abs(complete_group[5].y() - complete_group[4].y())),
+                             "Expected completed-loop connector to move at a 45-degree angle.");
+        }
+        passed &= expectPoint(complete_group.back(), 1.0, 1.0,
+                              "Expected final loop to close when complete-before-connecting is enabled.");
+    }
+
+    QVector<ORNL::Polyline> smooth_completed_loops;
+    smooth_completed_loops.push_back(smoothClosingOuterLoop());
+    smooth_completed_loops.push_back(smoothClosingInnerLoop());
+    QVector<ORNL::Polyline> smooth_completed_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(smooth_completed_loops, ORNL::Distance(5.0), true);
+
+    passed &= expect(smooth_completed_groups.size() == 1,
+                     "Expected completed smooth-closing loops to connect to the nearest next loop point.");
+    if (smooth_completed_groups.size() == 1) {
+        const ORNL::Polyline& complete_group = smooth_completed_groups.front();
+        passed &= expect(complete_group.size() >= 7,
+                         "Expected completed smooth-closing loop to include a printed connector.");
+        if (complete_group.size() >= 7) {
+            passed &=
+                expectPoint(complete_group[5], 0.0, 0.0, "Expected smooth-closing loop to complete before connecting.");
+            passed &= expectPoint(complete_group[6], -5.0, 5.0,
+                                  "Expected smooth-closing loop to fall back to the nearest connectable point.");
+        }
+    }
+
+    QVector<ORNL::Polyline> forward_preference_loops;
+    forward_preference_loops.push_back(forwardPreferenceOuterLoop());
+    forward_preference_loops.push_back(forwardPreferenceInnerLoop());
+    QVector<ORNL::Polyline> forward_preference_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(forward_preference_loops, ORNL::Distance(5.0), true);
+
+    passed &= expect(forward_preference_groups.size() == 1,
+                     "Expected completed loops with forward and backward diagonals to remain connected.");
+    if (forward_preference_groups.size() == 1) {
+        const ORNL::Polyline& complete_group = forward_preference_groups.front();
+        passed &=
+            expect(complete_group.size() >= 8, "Expected forward-preference loop to include a printed connector.");
+        if (complete_group.size() >= 8) {
+            passed &= expectPoint(complete_group[6], 0.0, 0.0,
+                                  "Expected forward-preference loop to complete before connecting.");
+            passed &= expectPoint(complete_group[7], 5.0, 5.0,
+                                  "Expected forward-preference loop to skip the shorter backward diagonal.");
+            passed &= expectForwardFortyFiveConnector(
+                forward_preference_loops.front(), complete_group[6], complete_group[7],
+                "Expected completed-loop connector to move forward at a 45-degree angle.");
+        }
+    }
+
     QVector<ORNL::Polyline> disjoint_loops;
     disjoint_loops.push_back(square(0.0, 0.0, 10.0, 10.0));
     disjoint_loops.push_back(square(30.0, 0.0, 40.0, 10.0));
@@ -70,6 +194,16 @@ int main() {
                               "Expected next disjoint group to keep its existing start vertex.");
         passed &= expect(disjoint_groups.front().back().distance(disjoint_groups.back().front()) > bead_width * 2.0,
                          "Expected rejected connector to exceed the spiral adjacency threshold.");
+    }
+
+    QVector<ORNL::Polyline> complete_disjoint_groups =
+        ORNL::SpiralPath::linkClosedPolylineGroups(disjoint_loops, bead_width, true);
+
+    passed &= expect(complete_disjoint_groups.size() == 2,
+                     "Expected complete-before-connecting disjoint loops to remain split.");
+    if (complete_disjoint_groups.size() == 2) {
+        passed &= expectPoint(complete_disjoint_groups.front().back(), 0.0, 0.0,
+                              "Expected rejected complete-before-connecting group to close before travel.");
     }
 
     QVector<ORNL::Polyline> nested_gap_loops;


### PR DESCRIPTION
## Summary
- Add a perimeter checkbox, `Connect to spiral insets`, shown when spiral perimeters and spiral insets are enabled.
- Allow spiral perimeter optimization to append computed spiral inset loops and skip the separate inset optimization pass when the option is enabled.
- Preserve the 45-degree forward connector behavior and apply inset segment settings after the perimeter-to-inset bridge.

## Validation
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer_spiral_path_tests`
- `nix develop --command ctest --test-dir build/generic-llvm-ninja -C Debug -R spiral_path_tests --output-on-failure`
- `nix develop --command cmake --build build/generic-llvm-ninja --target ornlslicer`
- Sliced a temporary copy of `ConnectedInsetsTest.s2p` with `inset`, `spiral_inset`, and `spiral_perimeter_connect_to_insets` enabled; verified the first perimeter-to-inset handoff had no travel/extruder-off between moves and measured 45.002 degrees relative to the incoming tangent.
- `git diff --check`