### PR TITLE
Add arc-specialties g80 weld schedule support and feedrate handling

### DIFF
--- a/include/gcode/parsers/arc_specialties_parser.h
+++ b/include/gcode/parsers/arc_specialties_parser.h
@@ -13,7 +13,8 @@ namespace ORNL {
  *
  * The visualization path only models XYZ. This parser accepts Arc Specialties `KEY=value` motion fields, validates and
  * strips the orientation-only fields, normalizes X/Y/Z/I/J/K/R/F into the shared parser's single-letter parameter
- * format, and delegates motion estimation and visualization command creation to CommonParser.
+ * format, accepts known schedule-speed feedrate macros, and delegates motion estimation and visualization command
+ * creation to CommonParser.
  */
 class ArcSpecialtiesParser : public CommonParser {
    public:
@@ -98,7 +99,7 @@ class ArcSpecialtiesParser : public CommonParser {
     /*!
      * @brief Checks whether a parameter key is a preview-relevant linear or feedrate field.
      * @param key Parameter key.
-     * @return True for X, Y, Z, or F.
+     * @return True for X, Y, Z, I, J, K, R, or F.
      */
     bool isCommonMotionKey(const QString& key) const;
 

--- a/include/gcode/parsers/common_parser.h
+++ b/include/gcode/parsers/common_parser.h
@@ -294,6 +294,9 @@ class CommonParser : public ParserBase {
     //! \note This value will be set using the defined unit type.
     void setSpeed(NT value);
 
+    //! \brief Clears the active modal feedrate when a syntax-specific feedrate macro has no numeric preview value.
+    void clearModalFeedrate();
+
     //! \brief Sets the spindle speed of the extruder.
     //! \param value Value to set the spindle speed to.
     //! \note This value will be set using the defined unit type.

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -178,6 +178,25 @@ class ArcSpecialtiesWriter : public WriterBase {
     QString writeWelderOff(int mode = 0);
 
     /*!
+     * @brief Returns the quote-stripped G80 weld schedule file configured for output.
+     * @return Sanitized schedule file path, or an empty string when unset.
+     */
+    QString g80WeldScheduleFile() const;
+
+    /*!
+     * @brief Returns whether print motion feedrates should reference the G80 schedule speed variable.
+     * @return True when a sanitized G80 weld schedule file is configured.
+     */
+    bool usesG80ScheduleSpeedVariable() const;
+
+    /*!
+     * @brief Formats the Arc Specialties motion feedrate field.
+     * @param speed Numeric feedrate used when schedule speed output is inactive.
+     * @return Either a numeric F field or the G80 schedule speed variable field.
+     */
+    QString writeMotionFeedrate(Velocity speed) const;
+
+    /*!
      * @brief Writes a single Arc Specialties motion command.
      * @param command G-code command string.
      * @param destination Endpoint being written.

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -253,6 +253,7 @@ class Constants {
             static const QString kEnableSettingsFooter;
             static const QString kLayerTimeComments;
             static const QString kArcSpecialtiesG2G3OptionalStop;
+            static const QString kArcSpecialtiesG80WeldScheduleFile;
             static const QString kStartCode;
             static const QString kLayerCodeChange;
             static const QString kEndCode;

--- a/include/widgets/settings/setting_file_path.h
+++ b/include/widgets/settings/setting_file_path.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <QLineEdit>
+#include <QScopedPointer>
+#include <QToolButton>
+#include <QWidget>
+
+#include <qgridlayout.h>
+#include <qobject.h>
+#include <qsharedpointer.h>
+#include <qtmetamacros.h>
+#include <qvariant.h>
+
+#include "configs/settings_base.h"
+#include "utilities/qt_json_conversion.h"
+#include "widgets/settings/setting_row_base.h"
+#include "widgets/settings/setting_tab.h"
+
+namespace ORNL {
+class SettingTab;
+
+//! \brief Widget for selecting a file path setting.
+//! Supports the file_path setting type.
+class SettingFilePath : public QWidget, public SettingRowBase {
+    Q_OBJECT
+
+   public:
+    //! \brief Default Constructor
+    //! \param parent: parent settingtab to setup events
+    //! \param sb: global setting base
+    //! \param key: key of current row
+    //! \param json: master json of current row
+    //! \param layout: layout to add current row to
+    //! \param index: index to insert the row into the layout
+    SettingFilePath(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key, fifojson json,
+                    QGridLayout* layout, int index);
+
+    //! \brief Static construction helper with the same parameters as default constructor
+    static SettingRowBase* createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
+                                          fifojson json, QGridLayout* layout, int index);
+
+    //! \brief Hides current row
+    virtual void hide() override;
+
+    //! \brief Shows current row
+    virtual void show() override;
+
+    //! \brief Enable/disable row
+    //! \param enabled: enable/disable state
+    void setEnabled(bool enabled) override;
+
+   signals:
+    //! \brief Signal emitted when setting is modified by user
+    //! \param key: key of setting modified
+    void modified(QString key);
+
+    //! \brief Signal emitted to pass a warning, such as mismatched settings in the settings base, up to the next level
+    //! \param count: Integer representing warning status, should be either 1, -1 or 0; 1 adds a warning, -1 removes a
+    //! warning, 0 does nothing.
+    void warnParent(int count);
+
+   public slots:
+    //! \brief Slot to handle when user manually changes value
+    //! \param val: value cast to appropriate type within each class
+    virtual void valueChanged(QVariant val) override;
+
+    //! \brief Slot to handle setting reload when user changes units or
+    //! selects new setting profile
+    virtual void reloadValue() override;
+
+   protected:
+    //! \brief Sets error notification when dynamic dependency check fails
+    //! \param msg: Message to display
+    virtual void setNotification(QString msg) override;
+
+    //! \brief Clears notifications when dynamic dependency check passes
+    virtual void clearNotification() override;
+
+   private:
+    //! \brief Opens a file selection dialog and stores the selected path.
+    void selectFile();
+
+    //! \brief Keeps track of if a warning has been emitted or not.
+    bool m_warn;
+
+    QScopedPointer<QLineEdit> m_line_edit;
+    QScopedPointer<QToolButton> m_browse_button;
+};
+}  // namespace ORNL

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -896,6 +896,19 @@
       "symbol":"kArcSpecialtiesG2G3OptionalStop",
       "local":false
   },
+  "arc_specialties_g80_weld_schedule_file": {
+      "display":"Arc Specialties G80 Weld Schedule File",
+      "type":"file_path",
+      "tooltip":"File path used by Arc Specialties G-Code for G80 weld schedules.",
+      "depends":{"syntax":31},
+      "options":"",
+      "default":"",
+      "minor":"G-Code",
+      "major":"Printer",
+      "namespace":"Printer::GCode",
+      "symbol":"kArcSpecialtiesG80WeldScheduleFile",
+      "local":false
+  },
   "start_code": {
       "display":"Start Code",
       "type":"multiline_text",

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -6503,7 +6503,7 @@
       "display":"Enable Sharp Corner Extension",
       "type":"boolean",
       "tooltip":"If selected, sharp toolpath junctions are extended outward to compensate for corner rounding during printing.",
-      "depends":"",
+      "depends":{"slicing_mode":0},
       "options":"",
       "default":false,
       "minor":"Special Modes",

--- a/resources/settings/006_printer_g_code.yaml
+++ b/resources/settings/006_printer_g_code.yaml
@@ -85,6 +85,18 @@ settings:
     namespace: "Printer::GCode"
     symbol: "kArcSpecialtiesG2G3OptionalStop"
     local: false
+  - name: "arc_specialties_g80_weld_schedule_file"
+    display: "Arc Specialties G80 Weld Schedule File"
+    type: "file_path"
+    tooltip: "File path used by Arc Specialties G-Code for G80 weld schedules."
+    depends: {"syntax":31}
+    options: []
+    default: ""
+    minor: "G-Code"
+    major: "Printer"
+    namespace: "Printer::GCode"
+    symbol: "kArcSpecialtiesG80WeldScheduleFile"
+    local: false
   - name: "start_code"
     display: "Start Code"
     type: "multiline_text"

--- a/resources/settings/034_profile_special_modes.yaml
+++ b/resources/settings/034_profile_special_modes.yaml
@@ -81,7 +81,7 @@ settings:
     display: "Enable Sharp Corner Extension"
     type: "boolean"
     tooltip: "If selected, sharp toolpath junctions are extended outward to compensate for corner rounding during printing."
-    depends: {}
+    depends: {"slicing_mode":0}
     options: []
     default: false
     minor: "Special Modes"

--- a/scripts/generate_master_config.py
+++ b/scripts/generate_master_config.py
@@ -59,6 +59,7 @@ VALID_TYPES = {
     "density",
     "distance",
     "enumeration",
+    "file_path",
     "location",
     "multiline_text",
     "number",

--- a/src/gcode/gcode_settings_importer.cpp
+++ b/src/gcode/gcode_settings_importer.cpp
@@ -176,7 +176,7 @@ bool parseRawValue(const QString& key, const fifojson& master_entry, const QStri
         return true;
     } catch (const std::exception& e) {
         const QString type = settingType(master_entry);
-        if (type == "string" || type == "multiline_text") {
+        if (type == "string" || type == "multiline_text" || type == "file_path") {
             parsed_value = raw_value.toStdString();
             return true;
         }
@@ -737,7 +737,7 @@ bool GcodeSettingsImporter::validateValue(const QString& key, const fifojson& ma
         return true;
     }
 
-    if (type == "string" || type == "multiline_text") {
+    if (type == "string" || type == "multiline_text" || type == "file_path") {
         if (!value.is_string()) {
             error = key + " must be a string value.";
             return false;

--- a/src/gcode/parsers/arc_specialties_parser.cpp
+++ b/src/gcode/parsers/arc_specialties_parser.cpp
@@ -18,7 +18,12 @@ const QRegularExpression kG00CommandPattern("(^\\s*)G00(?=\\s|;|\\(|$)");
 const QRegularExpression kG01CommandPattern("(^\\s*)G01(?=\\s|;|\\(|$)");
 const QRegularExpression kG02CommandPattern("(^\\s*)G02(?=\\s|;|\\(|$)");
 const QRegularExpression kG03CommandPattern("(^\\s*)G03(?=\\s|;|\\(|$)");
-constexpr char kCpOptionalParameter = 'C';
+const QString kG80ScheduleSpeedVariable = "V.S.SPEED";
+constexpr char kCpOptionalParameter     = 'C';
+
+bool isG80ScheduleSpeedVariable(const QString& value) {
+    return value.trimmed().compare(kG80ScheduleSpeedVariable, Qt::CaseInsensitive) == 0;
+}
 }  // namespace
 
 ArcSpecialtiesParser::ArcSpecialtiesParser(GcodeMeta meta, bool allowLayerAlter, QStringList& lines,
@@ -112,6 +117,11 @@ QVector<QString> ArcSpecialtiesParser::normalizeAndStripOrientationAxes(QVector<
 
         if (isCommonMotionKey(key)) {
             validateUniqueKey(key, used_keys);
+            if (key == "F" && isG80ScheduleSpeedVariable(value)) {
+                clearModalFeedrate();
+                continue;
+            }
+
             validateNumericValue(value);
             filtered_params.push_back(key % value);
             continue;

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -369,6 +369,13 @@ void CommonParser::recordModalFeedrateForCommand(const GcodeCommand& command) {
     if (m_has_modal_feedrate) m_command_modal_feedrates.insert(command.getLineNumber(), m_modal_feedrate);
 }
 
+void CommonParser::clearModalFeedrate() {
+    m_modal_feedrate     = 0.0;
+    m_has_modal_feedrate = false;
+    m_with_F_value       = false;
+    setSpeed(0.0);
+}
+
 void CommonParser::setCommandFeedrate(QString& line, double feedrate) {
     static const QRegularExpression feedrate_token(
         "(^|[\\s,/*()])(F(?:[-+]?\\d*\\.?\\d+(?:[Ee][-+]?\\d+)?|#[A-Za-z0-9_]+))",

--- a/src/gcode/parsers/parser_base.cpp
+++ b/src/gcode/parsers/parser_base.cpp
@@ -129,7 +129,7 @@ void ParserBase::extractComments(QString& command) {
         m_current_gcode_command.setComment(comment.trimmed());
 
         if (start_index > 0)
-            command = command.left(start_index - 1);
+            command = command.left(start_index).trimmed();
         else
             command = QString();
     }

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -32,6 +32,9 @@ const QString kRadialCenterY = "radial_center_y";
 //! @brief First TRAFO-off move comment used to keep the approach orientation distinct from work-object motion.
 const QString kWorldApproachTravelComment = "WORLD APPROACH TRAVEL";
 
+//! @brief Default Arc Specialties G80 weld schedule file path.
+const QString kDefaultG80WeldScheduleFile = "";
+
 //! @brief Fixed tool-frame XR.
 constexpr double kToolFrameXR = 180.0;
 
@@ -390,27 +393,33 @@ QString ArcSpecialtiesWriter::writeInitialSetup(Distance minimum_x, Distance min
 
     QString rv;
 
-    rv += "V.E.Sch.Preflow = 3  ;Preflow Time in Seconds" % m_newline;
-    rv += "V.E.Sch.TravelDelay = 0  ;Travel Start Delay in Seconds" % m_newline;
-    rv += "V.E.Sch.Postflow = 10   ;Stationary Postflow Time" % m_newline;
-    rv += "V.E.Sch.PostPurge = 0   ;Postflow Time after moving away (can reduce preflow delay)" % m_newline;
-    rv += "V.E.Sch.Weld.Program = 4   ;Program/Mode in Main Weld" % m_newline;
-    rv += "V.E.Sch.Weld.WFS = 250   ;IPM Wire Feed Speed in Main Weld" % m_newline;
-    rv += "V.E.Sch.Weld.Volts = 65   ;Trim or Volts in Main Weld" % m_newline;
-    rv += "V.E.Sch.Weld.Control = 25   ;Arc Control in Main Weld" % m_newline;
-    rv += "V.E.Sch.Crater.Program = 4   ;Program/Mode in Crater Fill" % m_newline;
-    rv += "V.E.Sch.Crater.WFS = 250   ;IPM Wire Feed Speed in Crater Fill" % m_newline;
-    rv += "V.E.Sch.Crater.Volts = 70   ;Trim or Volts in Crater Fill" % m_newline;
-    rv += "V.E.Sch.Crater.Control = 25   ;Arc Control in Crater Fill" % m_newline;
-    rv += "V.E.Sch.Crater.Time = .5   ;Crater Fill Time in Seconds" % m_newline;
+    QString g80_schedule_file = m_sb->setting<QString>(PRS::GCode::kArcSpecialtiesG80WeldScheduleFile);
+    if (g80_schedule_file.isEmpty()) { g80_schedule_file = kDefaultG80WeldScheduleFile; }
+    g80_schedule_file.remove('"');
+
+    rv += commentLine("DEFINE G80 WELD SCHEDULES");
+    rv += "#FILE NAME[ G80=\"" % g80_schedule_file % "\" ]" % m_newline;
+    rv += "#DELETE V.S.LASTBLOCK" % m_newline;
+    rv += "$IF EXIST[V.S.SPEED]==FALSE" % m_newline;
+    rv += "M00" % m_newline;
+    rv += "#DELETE V.S.SPEED" % m_newline;
+    rv += "#VAR" % m_newline;
+    rv += "V.S.SPEED" % m_newline;
+    rv += "#ENDVAR" % m_newline;
+    rv += "M00" % m_newline;
+    rv += "$ENDIF" % m_newline;
+    rv += m_newline;
+
+    rv += "G80 [0] ;Default Schedule (Infill)" % m_newline;
     rv += "#CONTOUR MODE [DEV PATH_DEV=2 CONST_VEL=1]" % m_newline;
     /// TODO: M06 command does not work as of 2026-08-07 and is disabled for now. Must be re-enabled when the M06
     /// command is fixed in the Arc Specialties controller or be replaced with a different command that achieves the
     /// same effect.
-    rv += ";M06 T1   ;Select Tool 1" % m_newline;
+    rv += ";M06 T1 ;Select Tool 1" % m_newline;
     rv += "M49 ;Send Robot Home" % m_newline;
     rv += "#CHANNEL INIT [CMDPOS]" % m_newline;
-    rv += "" % m_newline;
+    rv += m_newline;
+
     rv += "G90" % m_newline;
     rv += "#TRAFO OFF" % m_newline;
     rv += "#FLUSH WAIT" % m_newline;
@@ -457,7 +466,11 @@ QString ArcSpecialtiesWriter::writeBeforeIsland() {
 }
 
 QString ArcSpecialtiesWriter::writeBeforeRegion(RegionType type, int pathSize) {
-    return QString();
+    QString rv;
+    if (type == RegionType::kPerimeter) { rv += "G80 [1] ;Perimeter Schedule" % m_newline; }
+    else if (type == RegionType::kInset) { rv += "G80 [2] ;Inset Schedule" % m_newline; }
+    else if (type == RegionType::kInfill) { rv += "G80 [0] ;Infill Schedule" % m_newline; }
+    return rv;
 }
 
 QString ArcSpecialtiesWriter::writeBeforePath(RegionType type) {

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -35,6 +35,9 @@ const QString kWorldApproachTravelComment = "WORLD APPROACH TRAVEL";
 //! @brief Default Arc Specialties G80 weld schedule file path.
 const QString kDefaultG80WeldScheduleFile = "";
 
+//! @brief Arc Specialties schedule-selected speed variable.
+const QString kG80ScheduleSpeedVariable = "V.S.SPEED";
+
 //! @brief Fixed tool-frame XR.
 constexpr double kToolFrameXR = 180.0;
 
@@ -393,9 +396,7 @@ QString ArcSpecialtiesWriter::writeInitialSetup(Distance minimum_x, Distance min
 
     QString rv;
 
-    QString g80_schedule_file = m_sb->setting<QString>(PRS::GCode::kArcSpecialtiesG80WeldScheduleFile);
-    if (g80_schedule_file.isEmpty()) { g80_schedule_file = kDefaultG80WeldScheduleFile; }
-    g80_schedule_file.remove('"');
+    const QString g80_schedule_file = g80WeldScheduleFile();
 
     rv += commentLine("DEFINE G80 WELD SCHEDULES");
     rv += "#FILE NAME[ G80=\"" % g80_schedule_file % "\" ]" % m_newline;
@@ -655,8 +656,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     const QString print_comment = printMoveComment(params);
     rv += QString(ccw ? "G03" : "G02") %
           writeCoordinates(end_point, params, toolFrameRotationForMotion(print_comment, params)) %
-          writeArcCenterParameters(start_point, center_point) % m_f %
-          QString::number(speed.to(m_meta.m_velocity_unit), 'f', 4) % inline_optional_stop %
+          writeArcCenterParameters(start_point, center_point) % writeMotionFeedrate(speed) % inline_optional_stop %
           commentSpaceLine(print_comment);
     return rv;
 }
@@ -758,6 +758,25 @@ QString ArcSpecialtiesWriter::writeWelderOff(int mode) {
     else { return QString(); }
 }
 
+QString ArcSpecialtiesWriter::g80WeldScheduleFile() const {
+    QString g80_schedule_file = m_sb->contains(PRS::GCode::kArcSpecialtiesG80WeldScheduleFile)
+                                    ? m_sb->setting<QString>(PRS::GCode::kArcSpecialtiesG80WeldScheduleFile)
+                                    : kDefaultG80WeldScheduleFile;
+    if (g80_schedule_file.isEmpty()) { g80_schedule_file = kDefaultG80WeldScheduleFile; }
+    g80_schedule_file.remove('"');
+    return g80_schedule_file;
+}
+
+bool ArcSpecialtiesWriter::usesG80ScheduleSpeedVariable() const {
+    return !g80WeldScheduleFile().isEmpty();
+}
+
+QString ArcSpecialtiesWriter::writeMotionFeedrate(Velocity speed) const {
+    if (usesG80ScheduleSpeedVariable()) { return m_f % kG80ScheduleSpeedVariable; }
+
+    return m_f % QString::number(speed.to(m_meta.m_velocity_unit), 'f', 4);
+}
+
 QString ArcSpecialtiesWriter::writeMotion(const QString& command, const Point& destination, Velocity speed,
                                           const QSharedPointer<SettingsBase>& params, const QString& comment) {
     return writeMotion(command, destination, speed, params, comment, destination);
@@ -773,8 +792,8 @@ QString ArcSpecialtiesWriter::writeMotion(const QString& command, const Point& d
                commentSpaceLine(comment);
     }
     else {
-        return command % writeCoordinates(destination, params, tool_frame_rotation, cp_reference) % m_f %
-               QString::number(speed.to(m_meta.m_velocity_unit), 'f', 4) % commentSpaceLine(comment);
+        return command % writeCoordinates(destination, params, tool_frame_rotation, cp_reference) %
+               writeMotionFeedrate(speed) % commentSpaceLine(comment);
     }
 }
 

--- a/src/step/layer/cylindrical_layer.cpp
+++ b/src/step/layer/cylindrical_layer.cpp
@@ -50,15 +50,6 @@ QSharedPointer<SettingsBase> firstPrintSettings(const Path& path, const QSharedP
     return fallback;
 }
 
-//! @brief Returns the first print region at or after a path index.
-RegionType nextPrintRegionType(const Path& path, int start_index) {
-    for (int i = start_index, end = path.size(); i < end; ++i) {
-        if (!isTravelSegment(path[i])) { return segmentRegionType(path[i]); }
-    }
-
-    return RegionType::kUnknown;
-}
-
 //! @brief Recomputes region-start flags after optimizer ordering or reversal.
 void recomputeRegionStartFlags(Path& path) {
     bool has_previous_print_region = false;
@@ -100,34 +91,39 @@ void restoreCylindricalPathSettings(Path& path, const QSharedPointer<SettingsBas
 QString writeHelicalPathByRegionRuns(Path& path, const QSharedPointer<WriterBase>& writer) {
     QString gcode;
     bool path_open           = false;
+    bool region_open         = false;
     RegionType active_region = RegionType::kUnknown;
+
+    auto openRegion = [&gcode, &region_open, &active_region, &writer](RegionType region_type) {
+        active_region = region_type;
+        gcode += writer->writeBeforeRegion(active_region, 1);
+        region_open = true;
+    };
 
     for (int i = 0, end = path.size(); i < end; ++i) {
         const QSharedPointer<SegmentBase>& segment = path[i];
 
         if (isTravelSegment(segment)) {
-            if (!path_open) {
-                active_region = nextPrintRegionType(path, i + 1);
-                gcode += writer->writeBeforePath(active_region);
-                path_open = true;
-            }
-
             gcode += segment->writeGCode(writer);
             continue;
         }
 
         const RegionType segment_region = segmentRegionType(segment);
         if (!path_open) {
-            active_region = segment_region;
+            openRegion(segment_region);
             gcode += writer->writeBeforePath(active_region);
             path_open = true;
         }
-        else if (segment_region != active_region) { active_region = segment_region; }
+        else if (segment_region != active_region) {
+            if (region_open) { gcode += writer->writeAfterRegion(active_region); }
+            openRegion(segment_region);
+        }
 
         gcode += segment->writeGCode(writer);
     }
 
     if (path_open) { gcode += writer->writeAfterPath(active_region); }
+    if (region_open) { gcode += writer->writeAfterRegion(active_region); }
 
     return gcode;
 }
@@ -145,7 +141,9 @@ QString CylindricalLayer::writeGCode(QSharedPointer<WriterBase> writer) {
     if (m_paths.isEmpty()) { return writer->writeEmptyStep(); }
 
     QString gcode;
-    gcode += writer->writeBeforeRegion(RegionType::kPerimeter, m_paths.size());
+    if (m_path_pattern != CylindricalPathPattern::kHelical) {
+        gcode += writer->writeBeforeRegion(RegionType::kPerimeter, m_paths.size());
+    }
     for (Path& path : m_paths) {
         if (path.size() == 0) { continue; }
 
@@ -156,7 +154,9 @@ QString CylindricalLayer::writeGCode(QSharedPointer<WriterBase> writer) {
             gcode += writer->writeAfterPath(RegionType::kPerimeter);
         }
     }
-    gcode += writer->writeAfterRegion(RegionType::kPerimeter);
+    if (m_path_pattern != CylindricalPathPattern::kHelical) {
+        gcode += writer->writeAfterRegion(RegionType::kPerimeter);
+    }
 
     return gcode;
 }

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -316,6 +316,8 @@ const QString Constants::PrinterSettings::GCode::kEnableSettingsFooter = "enable
 const QString Constants::PrinterSettings::GCode::kLayerTimeComments    = "enable_layer_time_comments";
 const QString Constants::PrinterSettings::GCode::kArcSpecialtiesG2G3OptionalStop =
     "arc_specialties_g2_g3_optional_stop";
+const QString Constants::PrinterSettings::GCode::kArcSpecialtiesG80WeldScheduleFile =
+    "arc_specialties_g80_weld_schedule_file";
 const QString Constants::PrinterSettings::GCode::kStartCode       = "start_code";
 const QString Constants::PrinterSettings::GCode::kLayerCodeChange = "layer_change_code";
 const QString Constants::PrinterSettings::GCode::kEndCode         = "end_code";

--- a/src/widgets/settings/setting_file_path.cpp
+++ b/src/widgets/settings/setting_file_path.cpp
@@ -1,0 +1,121 @@
+#include "widgets/settings/setting_file_path.h"
+
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QToolTip>
+
+#include <qgridlayout.h>
+#include <qlabel.h>
+#include <qlineedit.h>
+#include <qnamespace.h>
+#include <qobject.h>
+#include <qsharedpointer.h>
+#include <qtoolbutton.h>
+#include <qvariant.h>
+
+#include "configs/settings_base.h"
+#include "utilities/constants.h"
+#include "utilities/qt_json_conversion.h"
+#include "widgets/settings/setting_row_base.h"
+
+namespace ORNL {
+
+SettingFilePath::SettingFilePath(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key, fifojson json,
+                                 QGridLayout* layout, int index)
+    : QWidget(parent), SettingRowBase(parent, sb, key, json, layout, index) {
+    QString cur;
+    m_warn = false;
+    if (m_sb->contains(m_key))
+        cur = m_sb->setting<QString>(m_key);
+    else {
+        cur = json.operator[](Constants::Settings::Master::kDefault).get<QString>();
+        m_sb->setSetting(m_key, cur);
+    }
+
+    m_line_edit.reset(new QLineEdit(this));
+    m_line_edit->setAlignment(Qt::AlignRight);
+    m_line_edit->setText(cur);
+
+    m_browse_button.reset(new QToolButton(this));
+    m_browse_button->setText("...");
+    m_browse_button->setToolTip("Select file");
+    m_browse_button->setFixedWidth(28);
+
+    QHBoxLayout* row_layout = new QHBoxLayout(this);
+    row_layout->setContentsMargins(0, 0, 0, 0);
+    row_layout->setSpacing(4);
+    row_layout->addWidget(m_line_edit.get());
+    row_layout->addWidget(m_browse_button.get());
+
+    connect(m_line_edit.get(), &QLineEdit::textChanged, this, &SettingFilePath::valueChanged);
+    connect(m_browse_button.get(), &QToolButton::clicked, this, &SettingFilePath::selectFile);
+    connect(this, &SettingFilePath::modified, parent, &SettingTab::keyModified);
+    connect(this, &SettingFilePath::warnParent, parent, &SettingTab::headerWarning);
+
+    layout->addWidget(this, index, 1, Qt::AlignRight);
+
+    m_unit_label.reset(new QLabel(""));
+    layout->addWidget(m_unit_label.get(), index, 2, Qt::AlignLeft);
+    registerRowWidget(this);
+}
+
+SettingRowBase* SettingFilePath::createInstance(SettingTab* parent, QSharedPointer<SettingsBase> sb, QString key,
+                                                fifojson json, QGridLayout* layout, int index) {
+    return new SettingFilePath(parent, sb, key, json, layout, index);
+}
+
+void SettingFilePath::setEnabled(bool enabled) {
+    SettingRowBase::setEnabled(enabled);
+    applyWidgetState(this);
+}
+
+void SettingFilePath::setNotification(QString msg) {
+    this->setStyleFromFile(m_line_edit.get(), m_theme_path + "setting_rows_warning.qss");
+    QToolTip::showText(this->mapToGlobal(QPoint(0, 0)), msg, nullptr, QRect(), 30000);
+}
+
+void SettingFilePath::clearNotification() {
+    this->setStyleFromFile(m_line_edit.get(), m_theme_path + "setting_rows_normal.qss");
+    m_line_edit->setToolTip("");
+}
+
+void SettingFilePath::hide() {
+    SettingRowBase::hide();
+    applyWidgetState(this);
+}
+
+void SettingFilePath::show() {
+    SettingRowBase::show();
+    applyWidgetState(this);
+}
+
+void SettingFilePath::valueChanged(QVariant val) {
+    if (m_warn)
+        emit warnParent(-1);  // if a value is changed, it changes for all selected settings bases, so remove a warning.
+    m_warn = false;
+    valueChangedHelper<QString>(val.toString());
+    emit modified(m_key);
+}
+
+void SettingFilePath::reloadValue() {
+    m_line_edit->blockSignals(true);
+    bool consistent = true;
+    QString cur     = reloadValueHelper<QString>(consistent);
+    if (consistent) m_line_edit->setText(cur);
+
+    m_line_edit->blockSignals(false);
+    emit modified(m_key);
+    emit warnParent(warningCountDelta(!consistent, m_warn));
+}
+
+void SettingFilePath::selectFile() {
+    const QFileInfo current_file(m_line_edit->text());
+    const QString start_directory = current_file.dir().exists() ? current_file.absolutePath() : QDir::homePath();
+    const QString file_path =
+        QFileDialog::getOpenFileName(this, tr("Select File"), start_directory, tr("NC Files (*.nc);;All Files (*)"));
+
+    if (!file_path.isEmpty()) { m_line_edit->setText(QDir::toNativeSeparators(file_path)); }
+}
+}  // Namespace ORNL

--- a/src/widgets/settings/setting_tab.cpp
+++ b/src/widgets/settings/setting_tab.cpp
@@ -28,6 +28,7 @@
 #include "widgets/settings/setting_check_box.h"
 #include "widgets/settings/setting_combo_box.h"
 #include "widgets/settings/setting_double_spin_box.h"
+#include "widgets/settings/setting_file_path.h"
 #include "widgets/settings/setting_header.h"
 #include "widgets/settings/setting_line_edit.h"
 #include "widgets/settings/setting_numbered_list.h"
@@ -82,6 +83,7 @@ SettingTab::SettingTab(QWidget* parent, QString name, QIcon icon, int index, boo
                           {"speed", &SettingSpeedSpinBox::createInstance},
                           {"rpm", &SettingDoubleSpinBox::createInstance},
                           {"accel", &SettingAccelSpinBox::createInstance},
+                          {"file_path", &SettingFilePath::createInstance},
                           {"string", &SettingLineEdit::createInstance},
                           {"multiline_text", &SettingPlainTextEdit::createInstance},
                           {"density", &SettingDoubleSpinBox::createInstance},

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -16,6 +16,7 @@
 #include "geometry/path.h"
 #include "geometry/point.h"
 #include "geometry/segments/line.h"
+#include "geometry/segments/travel.h"
 #include "step/layer/cylindrical_layer.h"
 #include "units/unit.h"
 #include "utilities/constants.h"
@@ -96,6 +97,17 @@ bool writesInlineArcOptionalStop() {
 
     return first_arc.contains("F600.0000 G81 ;") && second_arc.contains("F600.0000 G81 ;") &&
            !first_arc.contains("G81 ;OPTIONAL STOP ROUTINE") && !second_arc.contains("G81 ;OPTIONAL STOP ROUTINE");
+}
+
+bool writesConfiguredG80WeldScheduleFile() {
+    QSharedPointer<ORNL::SettingsBase> settings = QSharedPointer<ORNL::SettingsBase>::create();
+    settings->setSetting(ORNL::PRS::GCode::kArcSpecialtiesG80WeldScheduleFile, QString("D:\\Schedules\\custom_sch.nc"));
+
+    ORNL::ArcSpecialtiesWriter writer(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+    const QString setup = writer.writeInitialSetup(0.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm, 1);
+
+    return setup.contains("#FILE NAME[ G80=\"D:\\Schedules\\custom_sch.nc\" ]\n") &&
+           !setup.contains("#FILE NAME[ G80=\"\" ]\n");
 }
 
 bool writesCompactCylindricalPrintComments() {
@@ -219,8 +231,22 @@ bool helicalLayerFinalizesOnlyAtPhysicalPathEnd() {
     settings->setSetting(ORNL::PS::GCode::kPerimeterEnd, QStringLiteral("PERIMETER_END_SENTINEL"));
     settings->setSetting(ORNL::PS::GCode::kInsetEnd, QStringLiteral("INSET_END_SENTINEL"));
     settings->setSetting(ORNL::PS::GCode::kInfillEnd, QStringLiteral("INFILL_END_SENTINEL"));
+    settings->setSetting(ORNL::PS::Travel::kSpeed, 482.6 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PRS::MachineSpeed::kMaxXYSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PRS::MachineSpeed::kZSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PS::Travel::kLiftHeight, 0.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kMinTravelLength, 0.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kMinTravelForLift, 0.0 * ORNL::mm);
 
     ORNL::Path path;
+    QSharedPointer<ORNL::TravelSegment> travel = QSharedPointer<ORNL::TravelSegment>::create(
+        ORNL::Point(1.0 * ORNL::mm, -1.0 * ORNL::mm, 0.0 * ORNL::mm),
+        ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm), ORNL::TravelLiftType::kNoLift);
+    QSharedPointer<ORNL::SettingsBase> travel_settings = helicalSegmentSettings(ORNL::RegionType::kPerimeter);
+    travel_settings->populate(settings);
+    travel->setSb(travel_settings);
+    path.append(travel);
+
     const auto append_segment = [&path](const ORNL::Point& start, const ORNL::Point& end,
                                         ORNL::RegionType region_type) {
         QSharedPointer<ORNL::LineSegment> segment = QSharedPointer<ORNL::LineSegment>::create(start, end);
@@ -240,11 +266,20 @@ bool helicalLayerFinalizesOnlyAtPhysicalPathEnd() {
 
     QSharedPointer<ORNL::ArcSpecialtiesWriter> writer =
         QSharedPointer<ORNL::ArcSpecialtiesWriter>::create(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
-    const QString block = layer.writeGCode(writer);
+    const QString block          = layer.writeGCode(writer);
+    const int perimeter_schedule = block.indexOf("G80 [1] ;Perimeter Schedule\n");
+    const int inset_schedule     = block.indexOf("G80 [2] ;Inset Schedule\n");
+    const int infill_schedule    = block.indexOf("G80 [0] ;Infill Schedule\n");
+    const int beginning_bead     = block.indexOf(";BEGINNING BEAD:");
+    const int first_print        = block.indexOf(";HELICAL PERIMETER\n");
 
     return block.contains(";HELICAL PERIMETER\n") && block.contains(";HELICAL INSET\n") &&
-           block.contains(";HELICAL INFILL\n") && !block.contains("PERIMETER_END_SENTINEL") &&
-           !block.contains("INSET_END_SENTINEL") && block.count("INFILL_END_SENTINEL") == 1;
+           block.contains(";HELICAL INFILL\n") && beginning_bead >= 0 && perimeter_schedule > beginning_bead &&
+           first_print > perimeter_schedule && inset_schedule > perimeter_schedule &&
+           infill_schedule > inset_schedule && block.count("G80 [1] ;Perimeter Schedule\n") == 1 &&
+           block.count("G80 [2] ;Inset Schedule\n") == 1 && block.count("G80 [0] ;Infill Schedule\n") == 1 &&
+           !block.contains("PERIMETER_END_SENTINEL") && !block.contains("INSET_END_SENTINEL") &&
+           block.count("INFILL_END_SENTINEL") == 1;
 }
 
 bool writesHelicalRegionToolFrameRotations() {
@@ -498,6 +533,8 @@ int main(int argc, char* argv[]) {
     passed &= expect(rightHandedCpDeltaDoesNotMirrorAxis(),
                      "Arc Specialties loader unexpectedly reversed right-handed CP delta.");
     passed &= expect(writesInlineArcOptionalStop(), "Arc Specialties writer did not emit inline G81 on G02/G03.");
+    passed &= expect(writesConfiguredG80WeldScheduleFile(),
+                     "Arc Specialties writer did not emit the configured G80 weld schedule file.");
     passed &= expect(writesCompactCylindricalPrintComments(),
                      "Arc Specialties writer did not emit compact cylindrical comments.");
     passed &=

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -42,7 +42,7 @@ bool parsesArcLine(const QString& line) {
     }
 }
 
-bool parsedArcKeepsCpForVisualization(const QString& line) {
+bool parsedArcKeepsCpForVisualization(const QString& line, bool expect_feedrate_parameter = true) {
     QStringList original_lines {line};
     QStringList upper_lines {line.toUpper()};
     ORNL::ArcSpecialtiesParser parser(ORNL::GcodeMetaList::ArcSpecialtiesMeta, false, original_lines, upper_lines);
@@ -51,7 +51,25 @@ bool parsedArcKeepsCpForVisualization(const QString& line) {
         const QList<QList<ORNL::GcodeCommand>> commands = parser.parseLines();
         return commands.size() == 1 && commands.first().size() == 1 &&
                commands.first().first().getOptionalParameters().contains('C') &&
-               commands.first().first().getOptionalParameters().value('C') == 0.0;
+               commands.first().first().getOptionalParameters().value('C') == 0.0 &&
+               commands.first().first().getParameters().contains('F') == expect_feedrate_parameter;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << '\n';
+        return false;
+    }
+}
+
+bool parsedLineKeepsCpForVisualization(const QString& line, bool expect_feedrate_parameter = true) {
+    QStringList original_lines {line};
+    QStringList upper_lines {line.toUpper()};
+    ORNL::ArcSpecialtiesParser parser(ORNL::GcodeMetaList::ArcSpecialtiesMeta, false, original_lines, upper_lines);
+
+    try {
+        const QList<QList<ORNL::GcodeCommand>> commands = parser.parseLines();
+        return commands.size() == 1 && commands.first().size() == 1 &&
+               commands.first().first().getOptionalParameters().contains('C') &&
+               commands.first().first().getOptionalParameters().value('C') == 90.0 &&
+               commands.first().first().getParameters().contains('F') == expect_feedrate_parameter;
     } catch (const std::exception& ex) {
         std::cerr << ex.what() << '\n';
         return false;
@@ -59,21 +77,34 @@ bool parsedArcKeepsCpForVisualization(const QString& line) {
 }
 
 bool parsedLineKeepsCpForVisualization() {
+    return parsedLineKeepsCpForVisualization(
+        "G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=90.0000 "
+        "F600.0000 ;RADIAL");
+}
+
+bool parsedLineWithScheduleSpeedKeepsCpForVisualization() {
+    return parsedLineKeepsCpForVisualization(
+               "G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 "
+               "CP=90.0000 FV.S.SPEED ;RADIAL",
+               false) &&
+           parsedLineKeepsCpForVisualization(
+               "G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 "
+               "CP=90.0000 F=V.S.SPEED ;RADIAL",
+               false);
+}
+
+bool rejectsDuplicateScheduleSpeedFeedrate() {
     QStringList original_lines {
         "G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=90.0000 "
-        "F600.0000 ;RADIAL"};
+        "F600.0000 FV.S.SPEED ;RADIAL"};
     QStringList upper_lines {original_lines.first().toUpper()};
     ORNL::ArcSpecialtiesParser parser(ORNL::GcodeMetaList::ArcSpecialtiesMeta, false, original_lines, upper_lines);
 
     try {
-        const QList<QList<ORNL::GcodeCommand>> commands = parser.parseLines();
-        return commands.size() == 1 && commands.first().size() == 1 &&
-               commands.first().first().getOptionalParameters().contains('C') &&
-               commands.first().first().getOptionalParameters().value('C') == 90.0;
-    } catch (const std::exception& ex) {
-        std::cerr << ex.what() << '\n';
-        return false;
-    }
+        parser.parseLines();
+    } catch (const std::exception&) { return true; }
+
+    return false;
 }
 
 QString lineContaining(const QString& block, const QString& marker);
@@ -163,6 +194,44 @@ QSharedPointer<ORNL::SettingsBase> helicalSegmentSettings(std::optional<ORNL::Re
     segment_settings->setSetting(ORNL::PS::Helical::kHelicalPathStartAngle, 0.0 * ORNL::degree);
     if (region_type.has_value()) { segment_settings->setSetting(ORNL::SS::kRegionType, region_type.value()); }
     return segment_settings;
+}
+
+bool writesNumericSpeedWhenG80ScheduleFileIsEmpty() {
+    QSharedPointer<ORNL::SettingsBase> settings = helicalWriterSettings(false);
+    settings->setSetting(ORNL::PRS::GCode::kArcSpecialtiesG80WeldScheduleFile, QString());
+
+    ORNL::ArcSpecialtiesWriter writer(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+    const QString block = writer.writeLine(ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
+                                           ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
+                                           helicalSegmentSettings(ORNL::RegionType::kPerimeter));
+    const QString line  = lineContaining(block, ";HELICAL PERIMETER");
+
+    return line.contains(" F600.0000 ;HELICAL PERIMETER") && !line.contains("FV.S.SPEED");
+}
+
+bool writesG80ScheduleSpeedVariableForLineAndArc() {
+    QSharedPointer<ORNL::SettingsBase> settings = helicalWriterSettings(true);
+    settings->setSetting(ORNL::PRS::GCode::kArcSpecialtiesG80WeldScheduleFile, QString("D:\\Schedules\\custom_sch.nc"));
+    settings->setSetting(ORNL::PRS::GCode::kArcSpecialtiesG2G3OptionalStop, true);
+
+    const ORNL::Point start(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm);
+    const ORNL::Point end(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm);
+    const ORNL::Point center(0.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm);
+    QSharedPointer<ORNL::SettingsBase> segment_settings = helicalSegmentSettings(ORNL::RegionType::kPerimeter);
+
+    ORNL::ArcSpecialtiesWriter line_writer(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+    const QString line_block = line_writer.writeLine(start, end, segment_settings);
+    const QString line       = lineContaining(line_block, ";HELICAL PERIMETER");
+
+    ORNL::ArcSpecialtiesWriter arc_writer(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+    const QString arc_block = arc_writer.writeArc(start, end, center, 90.0 * ORNL::degree, false, segment_settings);
+    const QString arc       = lineContaining(arc_block, ";HELICAL PERIMETER");
+
+    const QString expected_arc =
+        "G02 X=0.0000 Y=1.0000 Z=1.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=90.0000 "
+        "I=-1.0000 J=0.0000 FV.S.SPEED G81 ;HELICAL PERIMETER";
+
+    return line.contains(" FV.S.SPEED ;HELICAL PERIMETER") && !line.contains("F600.0000") && arc == expected_arc;
 }
 
 void setHelicalToolFrameSettings(const QSharedPointer<ORNL::SettingsBase>& settings) {
@@ -520,14 +589,30 @@ int main(int argc, char* argv[]) {
     const QString counter_clockwise_arc =
         "G03 X=1.0000 Y=0.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=0.0000 "
         "I=0.5000 J=0.0000 F600.0000 G81 ;PERIMETER";
+    const QString clockwise_schedule_speed_arc =
+        "G02 X=1.0000 Y=0.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=0.0000 "
+        "I=0.5000 J=0.0000 FV.S.SPEED G81 ;PERIMETER";
+    const QString counter_clockwise_schedule_speed_arc =
+        "G03 X=1.0000 Y=0.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=0.0000 "
+        "I=0.5000 J=0.0000 FV.S.SPEED G81 ;PERIMETER";
 
     bool passed = true;
     passed &= expect(parsesArcLine(clockwise_arc), "Arc Specialties G02 did not ignore inline G81.");
     passed &= expect(parsesArcLine(counter_clockwise_arc), "Arc Specialties G03 did not ignore inline G81.");
+    passed &= expect(parsesArcLine(clockwise_schedule_speed_arc),
+                     "Arc Specialties G02 did not accept the G80 schedule speed variable.");
+    passed &= expect(parsesArcLine(counter_clockwise_schedule_speed_arc),
+                     "Arc Specialties G03 did not accept the G80 schedule speed variable.");
     passed &= expect(parsedArcKeepsCpForVisualization(clockwise_arc),
                      "Arc Specialties parser did not retain CP for visualization.");
+    passed &= expect(parsedArcKeepsCpForVisualization(clockwise_schedule_speed_arc, false),
+                     "Arc Specialties parser did not retain CP with the G80 schedule speed variable.");
     passed &= expect(parsedLineKeepsCpForVisualization(),
                      "Arc Specialties parser did not retain linear CP for visualization.");
+    passed &= expect(parsedLineWithScheduleSpeedKeepsCpForVisualization(),
+                     "Arc Specialties parser did not retain linear CP with the G80 schedule speed variable.");
+    passed &= expect(rejectsDuplicateScheduleSpeedFeedrate(),
+                     "Arc Specialties parser did not reject duplicate schedule speed feedrates.");
     passed &= expect(infersLeftHandedHelicalAxisFromReversedCpDelta(),
                      "Arc Specialties loader did not reverse left-handed helical CP delta.");
     passed &= expect(rightHandedCpDeltaDoesNotMirrorAxis(),
@@ -535,6 +620,10 @@ int main(int argc, char* argv[]) {
     passed &= expect(writesInlineArcOptionalStop(), "Arc Specialties writer did not emit inline G81 on G02/G03.");
     passed &= expect(writesConfiguredG80WeldScheduleFile(),
                      "Arc Specialties writer did not emit the configured G80 weld schedule file.");
+    passed &= expect(writesNumericSpeedWhenG80ScheduleFileIsEmpty(),
+                     "Arc Specialties writer did not emit numeric speed without a G80 weld schedule file.");
+    passed &= expect(writesG80ScheduleSpeedVariableForLineAndArc(),
+                     "Arc Specialties writer did not emit the G80 schedule speed variable for print motion.");
     passed &= expect(writesCompactCylindricalPrintComments(),
                      "Arc Specialties writer did not emit compact cylindrical comments.");
     passed &=


### PR DESCRIPTION
## Summary

Adds configurable Arc Specialties G80 weld schedule support end to end. This includes a new settings UI control for selecting a weld schedule file, generated settings/config support for the new `file_path` setting type, Arc Specialties writer output for loading and selecting G80 schedules, and parser support for reading the resulting schedule-speed feedrate macro back into preview.

## Related issues

- No related issues.

## Details

This PR adds a new `Arc Specialties G80 Weld Schedule File` printer setting under Printer > G-Code for Arc Specialties syntax. The setting uses a new `file_path` settings type, which is backed by a dedicated `SettingFilePath` widget. The widget provides both manual path entry and a browse button using `QFileDialog::getOpenFileName`, then stores selected paths with platform-native separators. The settings importer now treats `file_path` values like other string-backed settings, and the master config generator recognizes the new type so `master.conf` is regenerated from the canonical YAML.

Arc Specialties initial setup now emits a G80 schedule definition block instead of hard-coded weld schedule variable assignments. The configured schedule file is written into:

```gcode
#FILE NAME[ G80="..." ]
```

The writer strips embedded double quotes from the configured value before output so the generated controller directive remains syntactically valid. If the setting is empty, the emitted file name remains empty and motion feedrates continue to use numeric values.

When a G80 schedule file is configured, Arc Specialties print motion feedrates now emit the controller schedule speed variable:

```gcode
FV.S.SPEED
```

This applies consistently to linear and arc print moves. When no schedule file is configured, the writer preserves the previous numeric feedrate behavior, such as `F600.0000`.

The writer also emits region-specific G80 schedule selection commands:

```gcode
G80 [1] ;Perimeter Schedule
G80 [2] ;Inset Schedule
G80 [0] ;Infill Schedule
```

Helical cylindrical path output was adjusted so these schedule selections are emitted at real region transitions inside a continuous helical path. The path still finalizes only at the physical path end, avoiding premature path closure while allowing perimeter, inset, and infill regions to select their intended weld schedules.

The Arc Specialties parser now accepts `V.S.SPEED` as a known schedule-speed feedrate macro. Because this macro does not provide a numeric preview feedrate, the parser clears the active modal feedrate for that command instead of trying to coerce it into a number. Duplicate feedrate handling is still enforced, so a motion command cannot contain both a numeric feedrate and the schedule-speed macro.

This PR also fixes parser comment extraction so command text is trimmed correctly after removing inline comments. That prevents stale spacing from affecting later command parsing.

Finally, the sharp corner extension setting now depends on planar slicing mode. That keeps the setting scoped to the slicing mode where the feature applies.

## Impact

Arc Specialties users can now select an external G80 weld schedule file directly from settings and generate controller-ready schedule setup output without manually editing the G-code header.

For configured schedules, generated print motion delegates feedrate selection to the G80 schedule through `V.S.SPEED`. This better matches schedule-driven Arc Specialties workflows and keeps perimeter, inset, and infill toolpaths tied to their region-specific weld schedule selections.

For users who leave the new schedule file setting empty, motion feedrate output remains numeric, preserving existing behavior.

The new parser behavior allows generated Arc Specialties G-code containing `FV.S.SPEED` or `F=V.S.SPEED` to load back into ORNLSlicer for preview without rejecting the schedule-speed macro as non-numeric input.

Risk level: Medium. The PR touches settings generation/import, settings UI registration, Arc Specialties writer setup and motion formatting, parser normalization, and helical cylindrical region output. The behavior is syntax-specific and covered by focused parser/writer tests, but it changes emitted controller setup for Arc Specialties output.

## Validation

Validated using: 
[regional-helical-example.zip](https://github.com/user-attachments/files/32017852/regional-helical-example.zip)
