### PR TITLE
Add optional Arc Specialties block numbering

### DIFF
--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -222,6 +222,29 @@ class ArcSpecialtiesWriter : public WriterBase {
                         const QSharedPointer<SettingsBase>& params, const QString& comment, const Point& cp_reference);
 
     /*!
+     * @brief Starts per-layer Beckhoff block numbering for executable bead-body lines.
+     */
+    void startLayerBlockNumbering();
+
+    /*!
+     * @brief Stops per-layer block numbering for layer transition and shutdown lines.
+     */
+    void stopLayerBlockNumbering();
+
+    /*!
+     * @brief Returns whether Arc Specialties block numbers should be emitted.
+     * @return True when the setting is enabled.
+     */
+    bool shouldEmitBlockNumbers() const;
+
+    /*!
+     * @brief Adds the next per-layer block number to each executable line in a block.
+     * @param block G-Code block to format.
+     * @return Block with Beckhoff-style N numbers when enabled and active.
+     */
+    QString writeNumberedBlock(const QString& block);
+
+    /*!
      * @brief Writes the Arc Specialties kinematics and TRAFO setup block once.
      * @return Startup kinematics block, or an empty string after it has already been emitted.
      */
@@ -354,6 +377,15 @@ class ArcSpecialtiesWriter : public WriterBase {
 
     //! @brief Tracks layer number.
     int m_current_layer = 0;
+
+    //! @brief Tracks the next Beckhoff block number for the active layer.
+    int m_next_block_number = 0;
+
+    //! @brief Tracks whether per-layer block numbering has been initialized for this layer.
+    bool m_layer_block_numbering_started = false;
+
+    //! @brief Tracks whether executable lines should currently receive block numbers.
+    bool m_layer_block_numbering_active = false;
 
     //! @brief Effective part-local Z clip rounding values reported in helical G-code headers.
     QVector<QPair<QString, HelicalPathZClipRounding>> m_helical_path_z_clip_rounding;

--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -227,6 +227,11 @@ class ArcSpecialtiesWriter : public WriterBase {
     void startLayerBlockNumbering();
 
     /*!
+     * @brief Initializes the per-layer Beckhoff block number counter without activating numbering.
+     */
+    void initializeLayerBlockNumbering();
+
+    /*!
      * @brief Stops per-layer block numbering for layer transition and shutdown lines.
      */
     void stopLayerBlockNumbering();
@@ -240,9 +245,10 @@ class ArcSpecialtiesWriter : public WriterBase {
     /*!
      * @brief Adds the next per-layer block number to each executable line in a block.
      * @param block G-Code block to format.
-     * @return Block with Beckhoff-style N numbers when enabled and active.
+     * @param force True to number schedule/setup lines before bead-body numbering is active.
+     * @return Block with Beckhoff-style N numbers when enabled and active or forced.
      */
-    QString writeNumberedBlock(const QString& block);
+    QString writeNumberedBlock(const QString& block, bool force = false);
 
     /*!
      * @brief Writes the Arc Specialties kinematics and TRAFO setup block once.

--- a/include/utilities/constants.h
+++ b/include/utilities/constants.h
@@ -254,6 +254,7 @@ class Constants {
             static const QString kLayerTimeComments;
             static const QString kArcSpecialtiesG2G3OptionalStop;
             static const QString kArcSpecialtiesG80WeldScheduleFile;
+            static const QString kArcSpecialtiesEmitBlockNumbers;
             static const QString kStartCode;
             static const QString kLayerCodeChange;
             static const QString kEndCode;

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -909,6 +909,19 @@
       "symbol":"kArcSpecialtiesG80WeldScheduleFile",
       "local":false
   },
+  "arc_specialties_emit_block_numbers": {
+      "display":"Arc Specialties Emit Block Numbers",
+      "type":"boolean",
+      "tooltip":"If enabled, Arc Specialties G-Code lines are prefixed with controller block numbers.",
+      "depends":{"syntax":31},
+      "options":"",
+      "default":false,
+      "minor":"G-Code",
+      "major":"Printer",
+      "namespace":"Printer::GCode",
+      "symbol":"kArcSpecialtiesEmitBlockNumbers",
+      "local":false
+  },
   "start_code": {
       "display":"Start Code",
       "type":"multiline_text",

--- a/resources/settings/006_printer_g_code.yaml
+++ b/resources/settings/006_printer_g_code.yaml
@@ -97,6 +97,18 @@ settings:
     namespace: "Printer::GCode"
     symbol: "kArcSpecialtiesG80WeldScheduleFile"
     local: false
+  - name: "arc_specialties_emit_block_numbers"
+    display: "Arc Specialties Emit Block Numbers"
+    type: "boolean"
+    tooltip: "If enabled, Arc Specialties G-Code lines are prefixed with controller block numbers."
+    depends: {"syntax":31}
+    options: []
+    default: false
+    minor: "G-Code"
+    major: "Printer"
+    namespace: "Printer::GCode"
+    symbol: "kArcSpecialtiesEmitBlockNumbers"
+    local: false
   - name: "start_code"
     display: "Start Code"
     type: "multiline_text"

--- a/src/gcode/parsers/arc_specialties_parser.cpp
+++ b/src/gcode/parsers/arc_specialties_parser.cpp
@@ -18,6 +18,8 @@ const QRegularExpression kG00CommandPattern("(^\\s*)G00(?=\\s|;|\\(|$)");
 const QRegularExpression kG01CommandPattern("(^\\s*)G01(?=\\s|;|\\(|$)");
 const QRegularExpression kG02CommandPattern("(^\\s*)G02(?=\\s|;|\\(|$)");
 const QRegularExpression kG03CommandPattern("(^\\s*)G03(?=\\s|;|\\(|$)");
+const QRegularExpression kLeadingBlockNumberPattern(
+    "^\\s*N(?:\\[[^\\]]+\\]|[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+))(?=\\s|[A-Z#$;/()\"]|$)\\s*");
 const QString kG80ScheduleSpeedVariable = "V.S.SPEED";
 constexpr char kCpOptionalParameter     = 'C';
 
@@ -33,6 +35,7 @@ ArcSpecialtiesParser::ArcSpecialtiesParser(GcodeMeta meta, bool allowLayerAlter,
 }
 
 GcodeCommand ArcSpecialtiesParser::parseCommand(QString command_string, int line_number) {
+    command_string.remove(kLeadingBlockNumberPattern);
     command_string.replace(kG00CommandPattern, "\\1G0");
     command_string.replace(kG01CommandPattern, "\\1G1");
     command_string.replace(kG02CommandPattern, "\\1G2");

--- a/src/gcode/parsers/common_parser.cpp
+++ b/src/gcode/parsers/common_parser.cpp
@@ -637,7 +637,8 @@ void CommonParser::preallocateVisualCommands() {
     QStringMatcher layerDelimiter(m_layer_delimiter);
     int commandsInLayer = 0;
     QRegExp digitExpression("\\d+");
-    QRegularExpression gMotionCommand("^G0|^G1|^G2|^G3|^G5");
+    QRegularExpression gMotionCommand(
+        "^(?:N(?:\\[[^\\]]+\\]|[+-]?(?:\\d+(?:\\.\\d*)?|\\.\\d+))(?=\\s|[A-Z#$;/()\"]|$)\\s*)?G[01235]");
     m_current_layer = 0;
     for (int i = m_current_line; i < m_current_end_line; ++i) {
         // find layer total, only executed once

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -159,11 +159,15 @@ void ArcSpecialtiesWriter::setHelicalPathHandedness(const QVector<QPair<QString,
 void ArcSpecialtiesWriter::startLayerBlockNumbering() {
     if (!shouldEmitBlockNumbers()) { return; }
 
+    initializeLayerBlockNumbering();
+    m_layer_block_numbering_active = true;
+}
+
+void ArcSpecialtiesWriter::initializeLayerBlockNumbering() {
     if (!m_layer_block_numbering_started) {
         m_next_block_number             = std::max(1, m_current_layer) * 10000;
         m_layer_block_numbering_started = true;
     }
-    m_layer_block_numbering_active = true;
 }
 
 void ArcSpecialtiesWriter::stopLayerBlockNumbering() {
@@ -175,8 +179,10 @@ bool ArcSpecialtiesWriter::shouldEmitBlockNumbers() const {
            m_sb->setting<bool>(PRS::GCode::kArcSpecialtiesEmitBlockNumbers);
 }
 
-QString ArcSpecialtiesWriter::writeNumberedBlock(const QString& block) {
-    if (!shouldEmitBlockNumbers() || !m_layer_block_numbering_active || block.isEmpty()) { return block; }
+QString ArcSpecialtiesWriter::writeNumberedBlock(const QString& block, bool force) {
+    if (!shouldEmitBlockNumbers() || (!m_layer_block_numbering_active && !force) || block.isEmpty()) { return block; }
+
+    initializeLayerBlockNumbering();
 
     QString rv;
     int line_start = 0;
@@ -527,7 +533,7 @@ QString ArcSpecialtiesWriter::writeBeforeRegion(RegionType type, int pathSize) {
     if (type == RegionType::kPerimeter) { rv += "G80 [1] ;Perimeter Schedule" % m_newline; }
     else if (type == RegionType::kInset) { rv += "G80 [2] ;Inset Schedule" % m_newline; }
     else if (type == RegionType::kInfill) { rv += "G80 [0] ;Infill Schedule" % m_newline; }
-    return writeNumberedBlock(rv);
+    return writeNumberedBlock(rv, true);
 }
 
 QString ArcSpecialtiesWriter::writeBeforePath(RegionType type) {

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -156,6 +156,54 @@ void ArcSpecialtiesWriter::setHelicalPathHandedness(const QVector<QPair<QString,
     m_helical_path_handedness = handedness;
 }
 
+void ArcSpecialtiesWriter::startLayerBlockNumbering() {
+    if (!shouldEmitBlockNumbers()) { return; }
+
+    if (!m_layer_block_numbering_started) {
+        m_next_block_number             = std::max(1, m_current_layer) * 10000;
+        m_layer_block_numbering_started = true;
+    }
+    m_layer_block_numbering_active = true;
+}
+
+void ArcSpecialtiesWriter::stopLayerBlockNumbering() {
+    m_layer_block_numbering_active = false;
+}
+
+bool ArcSpecialtiesWriter::shouldEmitBlockNumbers() const {
+    return m_sb != nullptr && m_sb->contains(PRS::GCode::kArcSpecialtiesEmitBlockNumbers) &&
+           m_sb->setting<bool>(PRS::GCode::kArcSpecialtiesEmitBlockNumbers);
+}
+
+QString ArcSpecialtiesWriter::writeNumberedBlock(const QString& block) {
+    if (!shouldEmitBlockNumbers() || !m_layer_block_numbering_active || block.isEmpty()) { return block; }
+
+    QString rv;
+    int line_start = 0;
+    while (line_start < block.size()) {
+        const int newline_index = block.indexOf(m_newline, line_start);
+        const bool has_newline  = newline_index >= 0;
+        const QString line = has_newline ? block.mid(line_start, newline_index - line_start) : block.mid(line_start);
+        const QString trimmed_line = line.trimmed();
+
+        if (trimmed_line.isEmpty() || (!m_meta.m_comment_starting_delimiter.isEmpty() &&
+                                       trimmed_line.startsWith(m_meta.m_comment_starting_delimiter))) {
+            rv += line;
+        }
+        else {
+            rv += "N" % QString::number(m_next_block_number) % " " % line;
+            ++m_next_block_number;
+        }
+
+        if (!has_newline) { break; }
+
+        rv += m_newline;
+        line_start = newline_index + 1;
+    }
+
+    return rv;
+}
+
 QString ArcSpecialtiesWriter::writeSettingsHeader(GcodeSyntax) {
     QString text;
     auto formatToolFrameRotation = [](const ToolFrameRotation& rotation) {
@@ -392,6 +440,11 @@ QString ArcSpecialtiesWriter::writeInitialSetup(Distance minimum_x, Distance min
     m_absolute_arc_center_mode_enabled = usesAbsoluteArcCenters();
     m_startup_kinematics_written       = false;
     m_pending_layer_change.clear();
+    m_current_bead                  = 0;
+    m_current_layer                 = 0;
+    m_next_block_number             = 0;
+    m_layer_block_numbering_started = false;
+    m_layer_block_numbering_active  = false;
     setFeedrate(0.0);
 
     QString rv;
@@ -455,6 +508,9 @@ QString ArcSpecialtiesWriter::writeBeforeLayer(float min_z, QSharedPointer<Setti
     m_layer_start  = true;
     m_current_bead = 1;
     m_current_layer++;
+    m_next_block_number             = std::max(1, m_current_layer) * 10000;
+    m_layer_block_numbering_started = false;
+    m_layer_block_numbering_active  = false;
     return rv;
 }
 
@@ -471,7 +527,7 @@ QString ArcSpecialtiesWriter::writeBeforeRegion(RegionType type, int pathSize) {
     if (type == RegionType::kPerimeter) { rv += "G80 [1] ;Perimeter Schedule" % m_newline; }
     else if (type == RegionType::kInset) { rv += "G80 [2] ;Inset Schedule" % m_newline; }
     else if (type == RegionType::kInfill) { rv += "G80 [0] ;Infill Schedule" % m_newline; }
-    return rv;
+    return writeNumberedBlock(rv);
 }
 
 QString ArcSpecialtiesWriter::writeBeforePath(RegionType type) {
@@ -510,6 +566,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
         rv += commentLine(QString("BEGINNING BEAD: ") % QString::number(m_current_layer) % "." %
                           QString::number(m_current_bead));
         m_current_bead++;
+        startLayerBlockNumbering();
         return rv;
     };
 
@@ -608,7 +665,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     }
 
     if (travel_lower_required) {
-        rv += "G81" % commentSpaceLine("OPTIONAL STOP ROUTINE");
+        rv += writeNumberedBlock("G81" % commentSpaceLine("OPTIONAL STOP ROUTINE"));
         rv += writeMotion("G01", target_location, lift_speed, params, "TRAVEL LOWER");
     }
 
@@ -622,6 +679,7 @@ QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
 
     rv += writeStartupKinematics();
     rv += writePendingLayerChange();
+    startLayerBlockNumbering();
 
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
 
@@ -642,6 +700,7 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     QString rv;
     rv += writeStartupKinematics();
     rv += writePendingLayerChange();
+    startLayerBlockNumbering();
 
     if (!m_deposition_active) { rv += writeWelderOn(); }
 
@@ -654,10 +713,10 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
     const QString inline_optional_stop = m_sb->setting<bool>(PRS::GCode::kArcSpecialtiesG2G3OptionalStop) ? " G81" : "";
 
     const QString print_comment = printMoveComment(params);
-    rv += QString(ccw ? "G03" : "G02") %
-          writeCoordinates(end_point, params, toolFrameRotationForMotion(print_comment, params)) %
-          writeArcCenterParameters(start_point, center_point) % writeMotionFeedrate(speed) % inline_optional_stop %
-          commentSpaceLine(print_comment);
+    rv += writeNumberedBlock(QString(ccw ? "G03" : "G02") %
+                             writeCoordinates(end_point, params, toolFrameRotationForMotion(print_comment, params)) %
+                             writeArcCenterParameters(start_point, center_point) % writeMotionFeedrate(speed) %
+                             inline_optional_stop % commentSpaceLine(print_comment));
     return rv;
 }
 
@@ -695,7 +754,7 @@ QString ArcSpecialtiesWriter::writeAfterPath(RegionType type) {
             }
         }
     }
-    return rv;
+    return writeNumberedBlock(rv);
 }
 
 QString ArcSpecialtiesWriter::writeAfterRegion(RegionType type) {
@@ -712,10 +771,13 @@ QString ArcSpecialtiesWriter::writeAfterPart() {
 
 QString ArcSpecialtiesWriter::writeAfterLayer() {
     QString layer_code = m_sb->setting<QString>(PRS::GCode::kLayerCodeChange);
+    stopLayerBlockNumbering();
     return layer_code.isEmpty() ? QString() : layer_code % m_newline;
 }
 
 QString ArcSpecialtiesWriter::writeShutdown() {
+    stopLayerBlockNumbering();
+
     QString rv;
     rv += writeWelderOff();
     if (!m_sb->setting<QString>(PRS::GCode::kEndCode).isEmpty()) {
@@ -730,7 +792,8 @@ QString ArcSpecialtiesWriter::writeShutdown() {
 
 QString ArcSpecialtiesWriter::writeDwell(Time time) {
     if (time > 0) {
-        return m_G4 % m_p % QString::number(time.to(m_meta.m_time_unit), 'f', 4) % commentSpaceLine("DWELL");
+        return writeNumberedBlock(m_G4 % m_p % QString::number(time.to(m_meta.m_time_unit), 'f', 4) %
+                                  commentSpaceLine("DWELL"));
     }
     return QString();
 }
@@ -741,7 +804,7 @@ QString ArcSpecialtiesWriter::writeWelderOn() {
         rv += "G82" % commentSpaceLine("WIRE ARC WELDER ON");
         rv += "G261" % commentSpaceLine("BLENDING ON");
         m_deposition_active = true;
-        return rv;
+        return writeNumberedBlock(rv);
     }
     else { return QString(); }
 }
@@ -753,7 +816,7 @@ QString ArcSpecialtiesWriter::writeWelderOff(int mode) {
         rv += "G260" % commentSpaceLine("BLENDING OFF");
         rv += "G83 [" % QString::number(g83_mode) % "]" % commentSpaceLine("WIRE ARC WELDER OFF");
         m_deposition_active = false;
-        return rv;
+        return writeNumberedBlock(rv);
     }
     else { return QString(); }
 }
@@ -788,12 +851,12 @@ QString ArcSpecialtiesWriter::writeMotion(const QString& command, const Point& d
     setFeedrate(speed);
     const ToolFrameRotation tool_frame_rotation = toolFrameRotationForMotion(comment, params);
     if (command == "G00") {
-        return command % writeCoordinates(destination, params, tool_frame_rotation, cp_reference) %
-               commentSpaceLine(comment);
+        return writeNumberedBlock(command % writeCoordinates(destination, params, tool_frame_rotation, cp_reference) %
+                                  commentSpaceLine(comment));
     }
     else {
-        return command % writeCoordinates(destination, params, tool_frame_rotation, cp_reference) %
-               writeMotionFeedrate(speed) % commentSpaceLine(comment);
+        return writeNumberedBlock(command % writeCoordinates(destination, params, tool_frame_rotation, cp_reference) %
+                                  writeMotionFeedrate(speed) % commentSpaceLine(comment));
     }
 }
 

--- a/src/utilities/constants.cpp
+++ b/src/utilities/constants.cpp
@@ -318,9 +318,10 @@ const QString Constants::PrinterSettings::GCode::kArcSpecialtiesG2G3OptionalStop
     "arc_specialties_g2_g3_optional_stop";
 const QString Constants::PrinterSettings::GCode::kArcSpecialtiesG80WeldScheduleFile =
     "arc_specialties_g80_weld_schedule_file";
-const QString Constants::PrinterSettings::GCode::kStartCode       = "start_code";
-const QString Constants::PrinterSettings::GCode::kLayerCodeChange = "layer_change_code";
-const QString Constants::PrinterSettings::GCode::kEndCode         = "end_code";
+const QString Constants::PrinterSettings::GCode::kArcSpecialtiesEmitBlockNumbers = "arc_specialties_emit_block_numbers";
+const QString Constants::PrinterSettings::GCode::kStartCode                      = "start_code";
+const QString Constants::PrinterSettings::GCode::kLayerCodeChange                = "layer_change_code";
+const QString Constants::PrinterSettings::GCode::kEndCode                        = "end_code";
 
 //================================================================================
 // Material Settings

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -260,10 +260,10 @@ bool writesLayerScopedBlockNumbersWhenEnabled() {
     QString first_layer;
     first_layer += writer.writeLayerChange(0);
     first_layer += writer.writeBeforeLayer(0.0f, settings);
+    first_layer += writer.writeBeforeRegion(ORNL::RegionType::kInfill, 1);
     first_layer += writer.writeTravel(ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
                                       ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
                                       ORNL::TravelLiftType::kLiftLowerOnly, segment_settings);
-    first_layer += writer.writeBeforeRegion(ORNL::RegionType::kInfill, 1);
     first_layer += writer.writeLine(ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
                                     ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm), segment_settings);
     first_layer += writer.writeAfterLayer();
@@ -271,21 +271,23 @@ bool writesLayerScopedBlockNumbersWhenEnabled() {
     QString second_layer;
     second_layer += writer.writeLayerChange(1);
     second_layer += writer.writeBeforeLayer(1.0f, settings);
+    second_layer += writer.writeBeforeRegion(ORNL::RegionType::kInfill, 1);
     second_layer += writer.writeTravel(ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
                                        ORNL::Point(1.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
                                        ORNL::TravelLiftType::kLiftLowerOnly, segment_settings);
 
     return lineContaining(first_layer, ";BEGINNING LAYER: 1").startsWith(";") &&
            !lineContaining(first_layer, ";WORLD APPROACH TRAVEL").startsWith("N") &&
-           lineContaining(first_layer, ";OPTIONAL STOP ROUTINE").startsWith("N10000 G81") &&
-           lineContaining(first_layer, ";TRAVEL LOWER").startsWith("N10001 G01") &&
-           lineContaining(first_layer, "G80 [0] ;Infill Schedule").startsWith("N10002 G80") &&
+           lineContaining(first_layer, "G80 [0] ;Infill Schedule").startsWith("N10000 G80") &&
+           lineContaining(first_layer, ";OPTIONAL STOP ROUTINE").startsWith("N10001 G81") &&
+           lineContaining(first_layer, ";TRAVEL LOWER").startsWith("N10002 G01") &&
            lineContaining(first_layer, ";WIRE ARC WELDER ON").startsWith("N10003 G82") &&
            lineContaining(first_layer, ";BLENDING ON").startsWith("N10004 G261") &&
            lineContaining(first_layer, ";HELICAL INFILL").startsWith("N10005 G01") &&
            lineContaining(second_layer, ";WIRE ARC WELDER OFF").startsWith("G83 [0]") &&
-           lineContaining(second_layer, ";OPTIONAL STOP ROUTINE").startsWith("N20000 G81") &&
-           lineContaining(second_layer, ";TRAVEL LOWER").startsWith("N20001 G01");
+           lineContaining(second_layer, "G80 [0] ;Infill Schedule").startsWith("N20000 G80") &&
+           lineContaining(second_layer, ";OPTIONAL STOP ROUTINE").startsWith("N20001 G81") &&
+           lineContaining(second_layer, ";TRAVEL LOWER").startsWith("N20002 G01");
 }
 
 void setHelicalToolFrameSettings(const QSharedPointer<ORNL::SettingsBase>& settings) {

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -93,6 +93,15 @@ bool parsedLineWithScheduleSpeedKeepsCpForVisualization() {
                false);
 }
 
+bool parsesNumberedArcSpecialtiesMotion() {
+    return parsedLineKeepsCpForVisualization(
+               "N20002 G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 "
+               "AP=0.0000 CP=90.0000 F600.0000 ;RADIAL") &&
+           parsedArcKeepsCpForVisualization(
+               "N10005 G02 X=1.0000 Y=0.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 "
+               "AP=0.0000 CP=0.0000 I=0.5000 J=0.0000 F600.0000 G81 ;PERIMETER");
+}
+
 bool rejectsDuplicateScheduleSpeedFeedrate() {
     QStringList original_lines {
         "G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 AP=0.0000 CP=90.0000 "
@@ -232,6 +241,51 @@ bool writesG80ScheduleSpeedVariableForLineAndArc() {
         "I=-1.0000 J=0.0000 FV.S.SPEED G81 ;HELICAL PERIMETER";
 
     return line.contains(" FV.S.SPEED ;HELICAL PERIMETER") && !line.contains("F600.0000") && arc == expected_arc;
+}
+
+bool writesLayerScopedBlockNumbersWhenEnabled() {
+    QSharedPointer<ORNL::SettingsBase> settings = helicalWriterSettings(false);
+    settings->setSetting(ORNL::PRS::GCode::kArcSpecialtiesEmitBlockNumbers, true);
+    settings->setSetting(ORNL::PS::Travel::kSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PRS::MachineSpeed::kMaxXYSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PRS::MachineSpeed::kZSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PS::Travel::kLiftHeight, 20.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kMinTravelLength, 0.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kMinTravelForLift, 0.0 * ORNL::mm);
+
+    QSharedPointer<ORNL::SettingsBase> segment_settings = helicalSegmentSettings(ORNL::RegionType::kInfill);
+    segment_settings->populate(settings);
+
+    ORNL::ArcSpecialtiesWriter writer(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+    QString first_layer;
+    first_layer += writer.writeLayerChange(0);
+    first_layer += writer.writeBeforeLayer(0.0f, settings);
+    first_layer += writer.writeTravel(ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
+                                      ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
+                                      ORNL::TravelLiftType::kLiftLowerOnly, segment_settings);
+    first_layer += writer.writeBeforeRegion(ORNL::RegionType::kInfill, 1);
+    first_layer += writer.writeLine(ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm),
+                                    ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm), segment_settings);
+    first_layer += writer.writeAfterLayer();
+
+    QString second_layer;
+    second_layer += writer.writeLayerChange(1);
+    second_layer += writer.writeBeforeLayer(1.0f, settings);
+    second_layer += writer.writeTravel(ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
+                                       ORNL::Point(1.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
+                                       ORNL::TravelLiftType::kLiftLowerOnly, segment_settings);
+
+    return lineContaining(first_layer, ";BEGINNING LAYER: 1").startsWith(";") &&
+           !lineContaining(first_layer, ";WORLD APPROACH TRAVEL").startsWith("N") &&
+           lineContaining(first_layer, ";OPTIONAL STOP ROUTINE").startsWith("N10000 G81") &&
+           lineContaining(first_layer, ";TRAVEL LOWER").startsWith("N10001 G01") &&
+           lineContaining(first_layer, "G80 [0] ;Infill Schedule").startsWith("N10002 G80") &&
+           lineContaining(first_layer, ";WIRE ARC WELDER ON").startsWith("N10003 G82") &&
+           lineContaining(first_layer, ";BLENDING ON").startsWith("N10004 G261") &&
+           lineContaining(first_layer, ";HELICAL INFILL").startsWith("N10005 G01") &&
+           lineContaining(second_layer, ";WIRE ARC WELDER OFF").startsWith("G83 [0]") &&
+           lineContaining(second_layer, ";OPTIONAL STOP ROUTINE").startsWith("N20000 G81") &&
+           lineContaining(second_layer, ";TRAVEL LOWER").startsWith("N20001 G01");
 }
 
 void setHelicalToolFrameSettings(const QSharedPointer<ORNL::SettingsBase>& settings) {
@@ -611,6 +665,8 @@ int main(int argc, char* argv[]) {
                      "Arc Specialties parser did not retain linear CP for visualization.");
     passed &= expect(parsedLineWithScheduleSpeedKeepsCpForVisualization(),
                      "Arc Specialties parser did not retain linear CP with the G80 schedule speed variable.");
+    passed &=
+        expect(parsesNumberedArcSpecialtiesMotion(), "Arc Specialties parser did not accept Beckhoff block numbers.");
     passed &= expect(rejectsDuplicateScheduleSpeedFeedrate(),
                      "Arc Specialties parser did not reject duplicate schedule speed feedrates.");
     passed &= expect(infersLeftHandedHelicalAxisFromReversedCpDelta(),
@@ -624,6 +680,8 @@ int main(int argc, char* argv[]) {
                      "Arc Specialties writer did not emit numeric speed without a G80 weld schedule file.");
     passed &= expect(writesG80ScheduleSpeedVariableForLineAndArc(),
                      "Arc Specialties writer did not emit the G80 schedule speed variable for print motion.");
+    passed &= expect(writesLayerScopedBlockNumbersWhenEnabled(),
+                     "Arc Specialties writer did not emit layer-scoped block numbers.");
     passed &= expect(writesCompactCylindricalPrintComments(),
                      "Arc Specialties writer did not emit compact cylindrical comments.");
     passed &=


### PR DESCRIPTION
## Summary

Adds optional Arc Specialties block numbering for emitted G-code and updates parsing so numbered Arc Specialties motion can be loaded for preview.

## Related issues

- Depends on #276 

## Details

This PR adds the `Arc Specialties Emit Block Numbers` printer G-code setting. When enabled, `ArcSpecialtiesWriter` prefixes executable bead-body lines with Beckhoff-style `N` block numbers scoped by layer: layer 1 starts at `N10000`, layer 2 starts at `N20000`, and so on.

Block numbering is active only during layer bead output. Startup/setup lines, layer comments, world-approach travel, layer transitions, shutdown output, and comment-only lines remain unnumbered. Numbered output includes executable travel-lower, weld on/off, blending, dwell, region schedule, line, and arc commands generated inside the active bead body.

The Arc Specialties parser now strips leading `N` block numbers before normal command parsing, and preallocation recognizes numbered motion commands so preview loading continues to work with numbered files.

## Impact

This improves compatibility with Arc Specialties/Beckhoff workflows that require controller block numbers while preserving existing output by default. The behavior is opt-in and limited to Arc Specialties G-code.

Risk level: Low. The new output format is behind a disabled-by-default setting, and parser changes are scoped to accepting an optional leading block number before supported motion commands.

## Validation

Validated with: 
[regional-helical-example.zip](https://github.com/user-attachments/files/32021053/regional-helical-example.zip)
