### PR TITLE
Add non-negative integer setting type

### DIFF
--- a/docs/wiki/Adding-a-New-User-Setting.md
+++ b/docs/wiki/Adding-a-New-User-Setting.md
@@ -20,6 +20,7 @@ Each setting entry has these fields:
   - enumeration
   - location
   - multiline_text
+  - non_negative_int
   - number
   - numbered_list
   - percentage

--- a/include/widgets/settings/setting_spin_box.h
+++ b/include/widgets/settings/setting_spin_box.h
@@ -19,7 +19,7 @@ class SettingTab;
 
 //! \brief Widget to provide custom spin box.
 //! Based on QSpinBox with overridden wheelEvent functionality.
-//! Supports three setting types: int, positive_int, and power
+//! Supports integer setting types: number, non_negative_int, positive_int, and power
 class SettingSpinBox : public QSpinBox, public SettingRowBase {
     Q_OBJECT
 

--- a/resources/configs/master.conf
+++ b/resources/configs/master.conf
@@ -5435,7 +5435,7 @@
   },
   "helical_perimeter_revolutions": {
       "display":"Perimeter Revolutions",
-      "type":"positive_int",
+      "type":"non_negative_int",
       "tooltip":"Number of revolutions for perimeter region",
       "depends":{"AND":[{"slicing_mode":1},{"cylindrical_path_pattern":1}]},
       "options":"",
@@ -5448,7 +5448,7 @@
   },
   "helical_inset_revolutions": {
       "display":"Inset Revolutions",
-      "type":"positive_int",
+      "type":"non_negative_int",
       "tooltip":"Number of revolutions for inset region",
       "depends":{"AND":[{"slicing_mode":1},{"cylindrical_path_pattern":1}]},
       "options":"",

--- a/resources/settings/029_profile_helical.yaml
+++ b/resources/settings/029_profile_helical.yaml
@@ -44,7 +44,7 @@ settings:
     local: true
   - name: "helical_perimeter_revolutions"
     display: "Perimeter Revolutions"
-    type: "positive_int"
+    type: "non_negative_int"
     tooltip: "Number of revolutions for perimeter region"
     depends: {"AND":[{"slicing_mode":1},{"cylindrical_path_pattern":1}]}
     options: []
@@ -56,7 +56,7 @@ settings:
     local: false
   - name: "helical_inset_revolutions"
     display: "Inset Revolutions"
-    type: "positive_int"
+    type: "non_negative_int"
     tooltip: "Number of revolutions for inset region"
     depends: {"AND":[{"slicing_mode":1},{"cylindrical_path_pattern":1}]}
     options: []

--- a/scripts/generate_master_config.py
+++ b/scripts/generate_master_config.py
@@ -64,6 +64,7 @@ VALID_TYPES = {
     "multiline_text",
     "number",
     "numbered_list",
+    "non_negative_int",
     "percentage",
     "percentage100",
     "positive_int",
@@ -297,6 +298,12 @@ def validate_setting(setting: OrderedDict[str, Any], setting_names: set[str]) ->
 
     if setting["type"] == "boolean" and not isinstance(setting["default"], bool):
         raise ValueError(f"{name}: boolean default must be true or false")
+
+    if setting["type"] == "non_negative_int":
+        if not isinstance(setting["default"], int) or isinstance(setting["default"], bool):
+            raise ValueError(f"{name}: non_negative_int default must be an integer")
+        if setting["default"] < 0:
+            raise ValueError(f"{name}: non_negative_int default must be zero or greater")
 
     validate_dependency(setting["depends"], setting_names, name)
 

--- a/src/gcode/gcode_settings_importer.cpp
+++ b/src/gcode/gcode_settings_importer.cpp
@@ -703,7 +703,7 @@ bool GcodeSettingsImporter::validateValue(const QString& key, const fifojson& ma
         return true;
     }
 
-    if (type == "number" || type == "positive_int" || type == "power") {
+    if (type == "number" || type == "non_negative_int" || type == "positive_int" || type == "power") {
         int result = 0;
         if (!integerValue(value, result)) {
             error = key + " must be an integer value.";
@@ -715,7 +715,7 @@ bool GcodeSettingsImporter::validateValue(const QString& key, const fifojson& ma
             return false;
         }
 
-        if (enforce_ranges && type == "number" && result < 0) {
+        if (enforce_ranges && (type == "number" || type == "non_negative_int") && result < 0) {
             error = key + " must be zero or greater.";
             return false;
         }

--- a/src/widgets/settings/setting_spin_box.cpp
+++ b/src/widgets/settings/setting_spin_box.cpp
@@ -36,7 +36,10 @@ SettingSpinBox::SettingSpinBox(SettingTab* parent, QSharedPointer<SettingsBase> 
     }
 
     QString type = json[Constants::Settings::Master::kType];
-    if (type == "positive_int" || type == "power") this->setMinimum(1);
+    if (type == "positive_int" || type == "power")
+        this->setMinimum(1);
+    else if (type == "non_negative_int")
+        this->setMinimum(0);
 
     this->setMaximum(INT_MAX);
     this->setAlignment(Qt::AlignRight);

--- a/src/widgets/settings/setting_tab.cpp
+++ b/src/widgets/settings/setting_tab.cpp
@@ -73,6 +73,7 @@ SettingTab::SettingTab(QWidget* parent, QString name, QIcon icon, int index, boo
     m_warning_count = 0;
 
     m_creation_mapping = {{"number", &SettingSpinBox::createInstance},
+                          {"non_negative_int", &SettingSpinBox::createInstance},
                           {"positive_int", &SettingSpinBox::createInstance},
                           {"location", &SettingDistanceSpinBox::createInstance},
                           {"distance", &SettingDistanceSpinBox::createInstance},

--- a/tests/gcode_settings_importer_tests.cpp
+++ b/tests/gcode_settings_importer_tests.cpp
@@ -22,10 +22,43 @@ bool expect(bool condition, const char* message) {
     if (!condition) std::cerr << message << '\n';
     return condition;
 }
+
+bool validatesNonNegativeIntegerSettings() {
+    fifojson master_entry                                  = fifojson::object();
+    master_entry[ORNL::Constants::Settings::Master::kType] = "non_negative_int";
+
+    fifojson normalized;
+    QString error;
+    if (!expect(ORNL::GcodeSettingsImporter::validateValue("non_negative", master_entry, 0, normalized, error),
+                qPrintable(error)))
+        return false;
+    if (!expect(normalized.get<int>() == 0, "Non-negative integer settings should accept zero.")) return false;
+
+    normalized = nullptr;
+    error.clear();
+    if (!expect(ORNL::GcodeSettingsImporter::validateValue("non_negative", master_entry, 3, normalized, error),
+                qPrintable(error)))
+        return false;
+    if (!expect(normalized.get<int>() == 3, "Non-negative integer settings should preserve positive integers."))
+        return false;
+
+    normalized = nullptr;
+    error.clear();
+    if (!expect(!ORNL::GcodeSettingsImporter::validateValue("non_negative", master_entry, -1, normalized, error),
+                "Non-negative integer settings should reject negative values."))
+        return false;
+
+    normalized = nullptr;
+    error.clear();
+    return expect(!ORNL::GcodeSettingsImporter::validateValue("non_negative", master_entry, 1.5, normalized, error),
+                  "Non-negative integer settings should reject fractional values.");
+}
 }  // namespace
 
 int main(int argc, char* argv[]) {
     QCoreApplication app(argc, argv);
+
+    if (!validatesNonNegativeIntegerSettings()) return EXIT_FAILURE;
 
     QTemporaryDir temp_dir;
     if (!expect(temp_dir.isValid(), "Could not create temporary directory.")) return EXIT_FAILURE;


### PR DESCRIPTION
## Summary

Adds a `non_negative_int` setting type for integer settings that may be zero, then updates the helical perimeter and inset revolution settings to use it.

## Related issues

- No related issues.

## Details

This change introduces a new settings metadata type for zero-inclusive integer values. The settings generator now accepts `non_negative_int` and validates that its default is an integer greater than or equal to zero.

The settings UI maps `non_negative_int` to the existing spin box widget and sets its minimum value to `0`. G-code settings import validation also recognizes the new type, accepts zero and positive integer values, and rejects negative or fractional values.

The helical perimeter and inset revolution settings now use `non_negative_int` instead of `positive_int`, matching their existing `0` defaults and the current behavior where zero disables those optional helical regions. The generated `master.conf` was regenerated from the canonical settings YAML.

## Impact

This fixes the type metadata for helical revolution counts so zero is represented as valid by the schema, UI, generated config, and G-code settings importer.

Risk level: Low. The change is limited to adding a new integer type and applying it to two helical settings. Existing `positive_int` behavior is preserved for settings that must remain strictly greater than zero.

## Validation

Validated with:
[Non-Negative-Test.zip](https://github.com/user-attachments/files/32027544/Non-Negative-Test.zip)
