### PR TITLE
Fix regional helical z clip rounding

### DIFF
--- a/include/slicing/helical_region_profile.h
+++ b/include/slicing/helical_region_profile.h
@@ -54,4 +54,6 @@ struct HelicalRegionProfileResult {
 HelicalRegionProfileResult buildHelicalRegionProfile(const HelicalRegionProfileParameters& params);
 HelicalRegionProfileResult buildRetainedHelicalRegionProfile(HelicalRegionProfileParameters params, Distance start_z,
                                                              Distance top_z);
+HelicalRegionProfileResult buildRetainedHelicalRegionProfile(HelicalRegionProfileParameters params, Distance start_z,
+                                                             Distance top_z, HelicalPathZClipRounding z_clip_rounding);
 }  // namespace ORNL

--- a/src/slicing/helical_region_profile.cpp
+++ b/src/slicing/helical_region_profile.cpp
@@ -12,6 +12,12 @@ namespace ORNL {
 namespace {
 constexpr double kRevolutionTolerance = 1.0e-9;
 
+struct PendingProfileBand {
+    RegionType region_type    = RegionType::kUnknown;
+    double revolutions        = 0.0;
+    Distance configured_pitch = 0.0 * mm;
+};
+
 Distance resolvedPitch(const QString& label, Distance stepover, Distance bead_width, QString& reason) {
     if (stepover < 0) {
         reason = label % " cannot be negative. Use 0 to fall back to Default Bead Width.";
@@ -47,16 +53,176 @@ double roundedProfileRevolutions(double raw_revolutions, double max_revolutions,
     return std::clamp(revolutions, 0.0, max_revolutions);
 }
 
-void appendBand(HelicalRegionProfile& profile, RegionType region_type, int revolutions, Distance pitch) {
-    if (revolutions <= 0) { return; }
+void appendBand(HelicalRegionProfile& profile, RegionType region_type, double revolutions, Distance pitch) {
+    if (revolutions <= kRevolutionTolerance) { return; }
 
     const HelicalRegionProfileBand previous =
         profile.bands.isEmpty() ? HelicalRegionProfileBand {} : profile.bands.back();
     const double start_revolutions = profile.bands.isEmpty() ? 0.0 : previous.start_revolutions + previous.revolutions;
     const Distance start_z         = profile.bands.isEmpty() ? profile.start_z : previous.endZ();
 
-    profile.bands.push_back(
-        HelicalRegionProfileBand {region_type, start_revolutions, static_cast<double>(revolutions), start_z, pitch});
+    profile.bands.push_back(HelicalRegionProfileBand {region_type, start_revolutions, revolutions, start_z, pitch});
+}
+
+void appendBand(HelicalRegionProfile& profile, RegionType region_type, int revolutions, Distance pitch) {
+    appendBand(profile, region_type, static_cast<double>(revolutions), pitch);
+}
+
+void addBoundary(QVector<double>& boundaries, double boundary, double total_revolutions) {
+    const double clamped_boundary = std::clamp(boundary, 0.0, total_revolutions);
+    const auto existing = std::find_if(boundaries.cbegin(), boundaries.cend(), [clamped_boundary](double value) {
+        return std::abs(value - clamped_boundary) <= kRevolutionTolerance;
+    });
+    if (existing == boundaries.cend()) { boundaries.push_back(clamped_boundary); }
+}
+
+RegionType boundedRegionType(double revolutions, double total_revolutions, int perimeter_revolutions,
+                             int inset_revolutions) {
+    if (perimeter_revolutions > 0 &&
+        revolutions >= total_revolutions - static_cast<double>(perimeter_revolutions) - kRevolutionTolerance) {
+        return RegionType::kPerimeter;
+    }
+
+    if (inset_revolutions > 0 && revolutions >= total_revolutions -
+                                                    static_cast<double>(perimeter_revolutions + inset_revolutions) -
+                                                    kRevolutionTolerance) {
+        return RegionType::kInset;
+    }
+
+    if (perimeter_revolutions > 0 && revolutions < static_cast<double>(perimeter_revolutions) - kRevolutionTolerance) {
+        return RegionType::kPerimeter;
+    }
+
+    if (inset_revolutions > 0 &&
+        revolutions < static_cast<double>(perimeter_revolutions + inset_revolutions) - kRevolutionTolerance) {
+        return RegionType::kInset;
+    }
+
+    return RegionType::kInfill;
+}
+
+Distance configuredPitchForRegion(RegionType region_type, Distance perimeter_pitch, Distance inset_pitch,
+                                  Distance infill_pitch) {
+    switch (region_type) {
+        case RegionType::kPerimeter:
+            return perimeter_pitch;
+        case RegionType::kInset:
+            return inset_pitch;
+        case RegionType::kInfill:
+        default:
+            return infill_pitch;
+    }
+}
+
+void appendPendingBand(QVector<PendingProfileBand>& bands, RegionType region_type, double revolutions,
+                       Distance configured_pitch) {
+    if (revolutions <= kRevolutionTolerance) { return; }
+
+    if (!bands.isEmpty() && bands.back().region_type == region_type &&
+        bands.back().configured_pitch == configured_pitch) {
+        bands.back().revolutions += revolutions;
+        return;
+    }
+
+    bands.push_back(PendingProfileBand {region_type, revolutions, configured_pitch});
+}
+
+HelicalRegionProfileResult buildRetainedProfileForRoundedRevolutions(const HelicalRegionProfileParameters& params,
+                                                                     Distance start_z, Distance top_z,
+                                                                     double total_revolutions) {
+    HelicalRegionProfileResult result;
+    result.profile.start_z         = start_z;
+    result.profile.available_top_z = top_z;
+
+    if (top_z <= start_z) {
+        result.reason = "Helical retained profile top Z must be greater than start Z.";
+        return result;
+    }
+
+    if (total_revolutions <= kRevolutionTolerance) {
+        result.reason = "Helical retained profile contains no positive full revolutions after z clipping.";
+        return result;
+    }
+
+    QString reason;
+    const Distance perimeter_pitch =
+        resolvedPitch("Perimeter Stepover", params.perimeter_stepover, params.bead_width, reason);
+    if (!reason.isEmpty()) {
+        result.reason = reason;
+        return result;
+    }
+
+    const Distance inset_pitch = resolvedPitch("Inset Stepover", params.inset_stepover, params.bead_width, reason);
+    if (!reason.isEmpty()) {
+        result.reason = reason;
+        return result;
+    }
+
+    const Distance infill_pitch = resolvedPitch("Infill Stepover", params.infill_stepover, params.bead_width, reason);
+    if (!reason.isEmpty()) {
+        result.reason = reason;
+        return result;
+    }
+
+    QVector<double> boundaries;
+    addBoundary(boundaries, 0.0, total_revolutions);
+    addBoundary(boundaries, static_cast<double>(params.perimeter_revolutions), total_revolutions);
+    addBoundary(boundaries, static_cast<double>(params.perimeter_revolutions + params.inset_revolutions),
+                total_revolutions);
+    addBoundary(boundaries,
+                total_revolutions - static_cast<double>(params.perimeter_revolutions + params.inset_revolutions),
+                total_revolutions);
+    addBoundary(boundaries, total_revolutions - static_cast<double>(params.perimeter_revolutions), total_revolutions);
+    addBoundary(boundaries, total_revolutions, total_revolutions);
+    std::sort(boundaries.begin(), boundaries.end());
+
+    QVector<PendingProfileBand> pending_bands;
+    for (int i = 1, end = boundaries.size(); i < end; ++i) {
+        const double run_start = boundaries[i - 1];
+        const double run_end   = boundaries[i];
+        if (run_end <= run_start + kRevolutionTolerance) { continue; }
+
+        const double midpoint = (run_start + run_end) / 2.0;
+        const RegionType region_type =
+            boundedRegionType(midpoint, total_revolutions, params.perimeter_revolutions, params.inset_revolutions);
+        const Distance configured_pitch =
+            configuredPitchForRegion(region_type, perimeter_pitch, inset_pitch, infill_pitch);
+        appendPendingBand(pending_bands, region_type, run_end - run_start, configured_pitch);
+    }
+
+    const Distance available_height = top_z - start_z;
+    Distance fixed_region_height;
+    double infill_revolutions = 0.0;
+    for (const PendingProfileBand& band : pending_bands) {
+        if (band.region_type == RegionType::kInfill) { infill_revolutions += band.revolutions; }
+        else { fixed_region_height += band.configured_pitch * band.revolutions; }
+    }
+
+    Distance bounded_infill_pitch = infill_pitch;
+    if (infill_revolutions > kRevolutionTolerance) {
+        // Z clip rounding has already selected a hard full-revolution endpoint.
+        // Keep shell pitches fixed and let only the middle infill span absorb the remaining height.
+        const Distance infill_height = available_height - fixed_region_height;
+        if (infill_height <= 0) {
+            result.reason = "Helical retained profile shell regions exceed the rounded z clip height.";
+            return result;
+        }
+
+        bounded_infill_pitch = infill_height / infill_revolutions;
+    }
+    else if (fixed_region_height > available_height) {
+        result.reason = "Helical retained profile shell regions exceed the rounded z clip height.";
+        return result;
+    }
+
+    for (const PendingProfileBand& band : pending_bands) {
+        const Distance pitch = band.region_type == RegionType::kInfill ? bounded_infill_pitch : band.configured_pitch;
+        appendBand(result.profile, band.region_type, band.revolutions, pitch);
+    }
+
+    if (result.profile.isEmpty()) { result.reason = "Helical region profile contains no positive-revolution bands."; }
+
+    return result;
 }
 
 }  // namespace
@@ -216,6 +382,6 @@ HelicalRegionProfileResult buildRetainedHelicalRegionProfile(HelicalRegionProfil
     }
 
     const Distance rounded_top_z = result.profile.zAtRevolutions(rounded_top_revolutions);
-    return buildRetainedHelicalRegionProfile(params, start_z, rounded_top_z);
+    return buildRetainedProfileForRoundedRevolutions(params, start_z, rounded_top_z, rounded_top_revolutions);
 }
 }  // namespace ORNL

--- a/src/slicing/helical_region_profile.cpp
+++ b/src/slicing/helical_region_profile.cpp
@@ -35,6 +35,18 @@ double roundedInfillRevolutions(double revolutions, HelicalInfillRevolutionsRoun
     }
 }
 
+double roundedProfileRevolutions(double raw_revolutions, double max_revolutions, HelicalPathZClipRounding rounding) {
+    double revolutions = raw_revolutions;
+    if (rounding == HelicalPathZClipRounding::kCompleteRevolution) {
+        revolutions = std::ceil(raw_revolutions - kRevolutionTolerance);
+    }
+    else if (rounding == HelicalPathZClipRounding::kLastFullRevolution) {
+        revolutions = std::floor(raw_revolutions + kRevolutionTolerance);
+    }
+
+    return std::clamp(revolutions, 0.0, max_revolutions);
+}
+
 void appendBand(HelicalRegionProfile& profile, RegionType region_type, int revolutions, Distance pitch) {
     if (revolutions <= 0) { return; }
 
@@ -188,5 +200,22 @@ HelicalRegionProfileResult buildRetainedHelicalRegionProfile(HelicalRegionProfil
     params.start_z = start_z;
     params.top_z   = top_z;
     return buildHelicalRegionProfile(params);
+}
+
+HelicalRegionProfileResult buildRetainedHelicalRegionProfile(HelicalRegionProfileParameters params, Distance start_z,
+                                                             Distance top_z, HelicalPathZClipRounding z_clip_rounding) {
+    HelicalRegionProfileResult result = buildRetainedHelicalRegionProfile(params, start_z, top_z);
+    if (!result.valid() || z_clip_rounding == HelicalPathZClipRounding::kExactIntersection) { return result; }
+
+    const double raw_top_revolutions = result.profile.revolutionsAtZ(top_z);
+    const double rounded_top_revolutions =
+        roundedProfileRevolutions(raw_top_revolutions, result.profile.totalRevolutions(), z_clip_rounding);
+    if (rounded_top_revolutions <= kRevolutionTolerance) {
+        result.reason = "Helical retained profile contains no positive full revolutions after z clipping.";
+        return result;
+    }
+
+    const Distance rounded_top_z = result.profile.zAtRevolutions(rounded_top_revolutions);
+    return buildRetainedHelicalRegionProfile(params, start_z, rounded_top_z);
 }
 }  // namespace ORNL

--- a/src/threading/slicers/cylindrical_slicer.cpp
+++ b/src/threading/slicers/cylindrical_slicer.cpp
@@ -262,20 +262,6 @@ QVector<HelicalRegionPolylineRun> createHelicalRegionRuns(const HelicalRegionPro
     return runs;
 }
 
-double roundedProfileRevolutions(double raw_revolutions, double max_revolutions, HelicalPathZClipRounding rounding) {
-    constexpr double revolution_tolerance = 1.0e-9;
-
-    double revolutions = raw_revolutions;
-    if (rounding == HelicalPathZClipRounding::kCompleteRevolution) {
-        revolutions = std::ceil(raw_revolutions - revolution_tolerance);
-    }
-    else if (rounding == HelicalPathZClipRounding::kLastFullRevolution) {
-        revolutions = std::floor(raw_revolutions + revolution_tolerance);
-    }
-
-    return std::clamp(revolutions, 0.0, max_revolutions);
-}
-
 //! @brief Flattens adjacent region runs into one polyline used only for model-intersection testing.
 Polyline flattenHelicalRegionRuns(const QVector<HelicalRegionPolylineRun>& runs) {
     Polyline polyline;
@@ -817,7 +803,10 @@ bool CylindricalSlicer::generateHelicalLayers(const QSharedPointer<Part>& part,
             const Distance retained_start_z = profile.zAtRevolutions(retained_bounds->start_revolutions);
             const Distance retained_top_z   = profile.zAtRevolutions(retained_bounds->end_revolutions);
             const HelicalRegionProfileResult retained_profile_result =
-                buildRetainedHelicalRegionProfile(profile_params, retained_start_z, retained_top_z);
+                retained_bounds->ends_at_model_exit
+                    ? buildRetainedHelicalRegionProfile(profile_params, retained_start_z, retained_top_z,
+                                                        z_clip_rounding)
+                    : buildRetainedHelicalRegionProfile(profile_params, retained_start_z, retained_top_z);
             if (!retained_profile_result.valid()) {
                 ++helical_layer_number;
                 ++radii_processed;
@@ -828,10 +817,9 @@ bool CylindricalSlicer::generateHelicalLayers(const QSharedPointer<Part>& part,
 
             const HelicalRegionProfile& retained_profile = retained_profile_result.profile;
             double retained_end_revolutions              = retained_profile.totalRevolutions();
-            if (retained_bounds->ends_at_model_exit) {
-                const double raw_exit_revolutions = retained_profile.revolutionsAtZ(retained_top_z);
-                retained_end_revolutions          = roundedProfileRevolutions(
-                    raw_exit_revolutions, retained_profile.totalRevolutions(), z_clip_rounding);
+            if (retained_bounds->ends_at_model_exit &&
+                z_clip_rounding == HelicalPathZClipRounding::kExactIntersection) {
+                retained_end_revolutions = retained_profile.revolutionsAtZ(retained_top_z);
             }
 
             const QVector<HelicalRegionPolylineRun> retained_runs = createHelicalRegionRuns(

--- a/tests/helical_region_profile_tests.cpp
+++ b/tests/helical_region_profile_tests.cpp
@@ -156,6 +156,16 @@ double infillRevolutions(const ORNL::HelicalRegionProfile& profile) {
     return 0.0;
 }
 
+bool matchesRegionSequence(const ORNL::HelicalRegionProfile& profile, const QVector<ORNL::RegionType>& regions) {
+    if (profile.bands.size() != regions.size()) { return false; }
+
+    for (int i = 0, end = regions.size(); i < end; ++i) {
+        if (profile.bands[i].region_type != regions[i]) { return false; }
+    }
+
+    return true;
+}
+
 bool retainedProfileAnchorsBottomShellsToClippedStart() {
     const ORNL::HelicalRegionProfileResult result =
         ORNL::buildRetainedHelicalRegionProfile(defaultParams(), 10.0 * ORNL::mm, 42.0 * ORNL::mm);
@@ -189,6 +199,45 @@ bool retainedProfileRespectsInfillRevolutionsRounding() {
            nearDistance(floor_result.profile.generatedTopZ(), 40.0 * ORNL::mm) &&
            nearDistance(ceil_result.profile.generatedTopZ(), 44.0 * ORNL::mm);
 }
+
+bool retainedLastFullKeepsTopPerimeterWithoutInsets() {
+    ORNL::HelicalRegionProfileParameters params = defaultParams();
+    params.inset_revolutions                    = 0;
+    params.perimeter_stepover                   = 4.0 * ORNL::mm;
+    params.inset_stepover                       = 4.0 * ORNL::mm;
+    params.infill_stepover                      = 4.0 * ORNL::mm;
+
+    const ORNL::HelicalRegionProfileResult result = ORNL::buildRetainedHelicalRegionProfile(
+        params, 0.0 * ORNL::mm, 23.2 * ORNL::mm, ORNL::HelicalPathZClipRounding::kLastFullRevolution);
+    if (!result.valid()) { return false; }
+
+    return matchesRegionSequence(result.profile,
+                                 QVector<ORNL::RegionType> {ORNL::RegionType::kPerimeter, ORNL::RegionType::kInfill,
+                                                            ORNL::RegionType::kPerimeter}) &&
+           near(result.profile.bands.last().start_revolutions, 4.0) &&
+           nearDistance(result.profile.generatedTopZ(), 20.0 * ORNL::mm) &&
+           near(result.profile.totalRevolutions(), 5.0);
+}
+
+bool retainedLastFullKeepsTopInsetAndPerimeter() {
+    ORNL::HelicalRegionProfileParameters params = defaultParams();
+    params.perimeter_stepover                   = 4.0 * ORNL::mm;
+    params.inset_stepover                       = 4.0 * ORNL::mm;
+    params.infill_stepover                      = 4.0 * ORNL::mm;
+
+    const ORNL::HelicalRegionProfileResult result = ORNL::buildRetainedHelicalRegionProfile(
+        params, 0.0 * ORNL::mm, 23.2 * ORNL::mm, ORNL::HelicalPathZClipRounding::kLastFullRevolution);
+    if (!result.valid()) { return false; }
+
+    return matchesRegionSequence(result.profile,
+                                 QVector<ORNL::RegionType> {ORNL::RegionType::kPerimeter, ORNL::RegionType::kInset,
+                                                            ORNL::RegionType::kInfill, ORNL::RegionType::kInset,
+                                                            ORNL::RegionType::kPerimeter}) &&
+           near(result.profile.bands[3].start_revolutions, 3.0) &&
+           near(result.profile.bands[4].start_revolutions, 4.0) &&
+           nearDistance(result.profile.generatedTopZ(), 20.0 * ORNL::mm) &&
+           near(result.profile.totalRevolutions(), 5.0);
+}
 }  // namespace
 
 int main() {
@@ -208,6 +257,10 @@ int main() {
                      "Expected retained clipped starts to rebuild lower shell bands from the retained start.");
     passed &= expect(retainedProfileRespectsInfillRevolutionsRounding(),
                      "Expected retained clipped profiles to respect infill revolutions rounding.");
+    passed &= expect(retainedLastFullKeepsTopPerimeterWithoutInsets(),
+                     "Expected last-full retained clipping to keep the final revolution as perimeter.");
+    passed &= expect(retainedLastFullKeepsTopInsetAndPerimeter(),
+                     "Expected last-full retained clipping to keep the second-last inset and final perimeter.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/helical_region_profile_tests.cpp
+++ b/tests/helical_region_profile_tests.cpp
@@ -238,6 +238,21 @@ bool retainedLastFullKeepsTopInsetAndPerimeter() {
            nearDistance(result.profile.generatedTopZ(), 20.0 * ORNL::mm) &&
            near(result.profile.totalRevolutions(), 5.0);
 }
+
+bool retainedLastFullDoesNotGrowPastNonUniformRoundedTop() {
+    const ORNL::HelicalRegionProfileResult result = ORNL::buildRetainedHelicalRegionProfile(
+        defaultParams(), 0.0 * ORNL::mm, 21.2 * ORNL::mm, ORNL::HelicalPathZClipRounding::kLastFullRevolution);
+    if (!result.valid()) { return false; }
+
+    return matchesRegionSequence(result.profile,
+                                 QVector<ORNL::RegionType> {ORNL::RegionType::kPerimeter, ORNL::RegionType::kInset,
+                                                            ORNL::RegionType::kInfill, ORNL::RegionType::kInset,
+                                                            ORNL::RegionType::kPerimeter}) &&
+           near(result.profile.bands[3].start_revolutions, 4.0) &&
+           near(result.profile.bands[4].start_revolutions, 5.0) &&
+           nearDistance(result.profile.generatedTopZ(), 20.0 * ORNL::mm) &&
+           near(result.profile.totalRevolutions(), 6.0);
+}
 }  // namespace
 
 int main() {
@@ -261,6 +276,8 @@ int main() {
                      "Expected last-full retained clipping to keep the final revolution as perimeter.");
     passed &= expect(retainedLastFullKeepsTopInsetAndPerimeter(),
                      "Expected last-full retained clipping to keep the second-last inset and final perimeter.");
+    passed &= expect(retainedLastFullDoesNotGrowPastNonUniformRoundedTop(),
+                     "Expected last-full retained clipping to keep non-uniform profiles at the rounded top.");
 
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary

Fixes retained helical region labeling when `Helical Z Clip Rounding` is set to `Last Full Revolution`.

## Related issues

- No related issues.

## Details

When retained helical output ended at a model exit, the slicer rebuilt the retained region profile using the raw clipped top and then applied full-revolution rounding afterward. For `Last Full Revolution`, that could trim the rebuilt profile before its upper shell bands were reached, causing the final full revolution to emit as `Infill` or `Inset` instead of `Perimeter`.

This change moves full-revolution rounding into retained profile construction for model-exit clipping. The retained top is rounded first, then the retained profile is rebuilt against that rounded top so the upper inset/perimeter bands are laid out correctly.

`Exact Intersection` still uses the raw retained top, and retained paths that do not end at a model exit continue using the unrounded retained profile path.

## Impact

This restores expected helical region comments and segment metadata for Last Full Revolution clipping:
- final full revolution emits as `Perimeter`
- when inset revolutions are enabled, the second-last retained revolution emits as `Inset`

Risk level: Low. The change is scoped to retained helical profile construction and only changes rounded model-exit clipping behavior. Existing exact-intersection and non-exit retained profile behavior is preserved.

## Validation

Validated with: 
[Donut3.1.rev-10.zip](https://github.com/user-attachments/files/32029167/Donut3.1.rev-10.zip)
