### PR TITLE
Add Arc Specialties helical OptStopMode support

### DIFF
--- a/include/gcode/writers/arc_specialties_writer.h
+++ b/include/gcode/writers/arc_specialties_writer.h
@@ -263,6 +263,18 @@ class ArcSpecialtiesWriter : public WriterBase {
     QString writePendingLayerChange();
 
     /*!
+     * @brief Writes layer-local output held until the first ordered helical print motion chooses OptStopMode.
+     * @return Pending pre-print layer output, or an empty string when none is pending.
+     */
+    QString writePendingLayerPrefix();
+
+    /*!
+     * @brief Writes any helical region schedule deferred until the first ordered print motion.
+     * @return Pending G80 schedule block, or an empty string when none is pending.
+     */
+    QString writePendingRegionSchedule();
+
+    /*!
      * @brief Formats X/Y/Z/XR/YR/ZR/AP/CP coordinate fields for a point.
      * @param destination Point being written.
      * @param params Segment settings containing, for cylindrical paths, radial center metadata.
@@ -360,6 +372,40 @@ class ArcSpecialtiesWriter : public WriterBase {
      */
     bool isCylindricalSlicingMode() const;
 
+    /*!
+     * @brief Returns whether the supplied settings describe cylindrical helical output.
+     * @param params Settings to query before falling back to writer settings.
+     * @return True when Slicing Mode is Cylindrical and Cylindrical Path Pattern is Helical.
+     */
+    bool isHelicalPathPattern(const QSharedPointer<SettingsBase>& params) const;
+
+    /*!
+     * @brief Returns whether layer-local output should be held until the helical OptStopMode is known.
+     * @param params Settings used to identify helical output.
+     * @return True when the layer marker is pending and the first helical print motion has not been seen.
+     */
+    bool shouldBufferHelicalLayerPrefix(const QSharedPointer<SettingsBase>& params) const;
+
+    /*!
+     * @brief Formats the Arc Specialties optional stop mode selected by actual helical CP rotation direction.
+     * @param start_point Motion start point after path ordering.
+     * @param end_point Motion end point after path ordering.
+     * @param params Segment settings used to compute CP.
+     * @return OptStopMode assignment for the first helical print move in a layer, or an empty string otherwise.
+     */
+    QString writeHelicalOptStopMode(const Point& start_point, const Point& end_point,
+                                    const QSharedPointer<SettingsBase>& params);
+
+    /*!
+     * @brief Writes the pending layer marker, helical OptStopMode, and held pre-print layer output.
+     * @param start_point Motion start point after path ordering.
+     * @param end_point Motion end point after path ordering.
+     * @param params Segment settings used to compute CP.
+     * @return Pending layer-start output for the first print move.
+     */
+    QString writeHelicalLayerStart(const Point& start_point, const Point& end_point,
+                                   const QSharedPointer<SettingsBase>& params);
+
     //! @brief Tracks whether any travel move has been emitted.
     bool m_first_travel = true;
 
@@ -374,6 +420,9 @@ class ArcSpecialtiesWriter : public WriterBase {
 
     //! @brief Layer marker held until the initial world approach and kinematics block are complete.
     QString m_pending_layer_change;
+
+    //! @brief Layer-local output held until the first helical print move determines OptStopMode.
+    QString m_pending_layer_prefix;
 
     //! @brief Active region type used for planar print-move comments.
     RegionType m_region_type = RegionType::kUnknown;
@@ -392,6 +441,12 @@ class ArcSpecialtiesWriter : public WriterBase {
 
     //! @brief Tracks whether executable lines should currently receive block numbers.
     bool m_layer_block_numbering_active = false;
+
+    //! @brief Tracks whether the helical rotation-direction mode has been emitted for the active layer.
+    bool m_helical_opt_stop_mode_written = false;
+
+    //! @brief Holds helical G80 schedule output until ordered print motion determines C rotation direction.
+    QString m_pending_region_schedule;
 
     //! @brief Effective part-local Z clip rounding values reported in helical G-code headers.
     QVector<QPair<QString, HelicalPathZClipRounding>> m_helical_path_z_clip_rounding;

--- a/src/gcode/writers/arc_specialties_writer.cpp
+++ b/src/gcode/writers/arc_specialties_writer.cpp
@@ -501,7 +501,7 @@ QString ArcSpecialtiesWriter::writeInitialSetup(Distance minimum_x, Distance min
 
 QString ArcSpecialtiesWriter::writeLayerChange(uint layer_number) {
     const QString layer_change = WriterBase::writeLayerChange(layer_number);
-    if (!m_startup_kinematics_written) {
+    if (!m_startup_kinematics_written || isHelicalPathPattern()) {
         m_pending_layer_change += layer_change;
         return QString();
     }
@@ -517,6 +517,9 @@ QString ArcSpecialtiesWriter::writeBeforeLayer(float min_z, QSharedPointer<Setti
     m_next_block_number             = std::max(1, m_current_layer) * 10000;
     m_layer_block_numbering_started = false;
     m_layer_block_numbering_active  = false;
+    m_helical_opt_stop_mode_written = false;
+    m_pending_layer_prefix.clear();
+    m_pending_region_schedule.clear();
     return rv;
 }
 
@@ -533,6 +536,11 @@ QString ArcSpecialtiesWriter::writeBeforeRegion(RegionType type, int pathSize) {
     if (type == RegionType::kPerimeter) { rv += "G80 [1] ;Perimeter Schedule" % m_newline; }
     else if (type == RegionType::kInset) { rv += "G80 [2] ;Inset Schedule" % m_newline; }
     else if (type == RegionType::kInfill) { rv += "G80 [0] ;Infill Schedule" % m_newline; }
+    if (isHelicalPathPattern()) {
+        m_pending_region_schedule += rv;
+        return QString();
+    }
+
     return writeNumberedBlock(rv, true);
 }
 
@@ -544,6 +552,7 @@ QString ArcSpecialtiesWriter::writeBeforePath(RegionType type) {
 QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_location, TravelLiftType lType,
                                           QSharedPointer<SettingsBase> params) {
     QString rv;
+    QString layer_rv;
     Velocity speed = params->setting<Velocity>(PS::Travel::kSpeed);
     if (speed <= 0) { speed = params->setting<Velocity>(PRS::MachineSpeed::kMaxXYSpeed); }
 
@@ -553,10 +562,10 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     // Determine if travel length is short enough to keep welder on
     Distance travel_distance = start_location.distance(target_location);
     if (m_deposition_active && travel_distance > m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
-        rv += writeWelderOff();
+        layer_rv += writeWelderOff();
     }
     else if (!m_first_travel && travel_distance < m_sb->setting<Distance>(PS::Travel::kMinTravelLength)) {
-        rv += writeWelderOn();
+        layer_rv += writeWelderOn();
     }
 
     const Distance lift_height = m_sb->setting<Distance>(PS::Travel::kLiftHeight);
@@ -639,7 +648,7 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
     if (travel_lift_required && !m_first_travel &&
         (lType == TravelLiftType::kBoth || lType == TravelLiftType::kLiftUpOnly)) {
         travel_start = liftPoint(start_location);
-        rv += writeMotion("G00", travel_start, lift_speed, params, "TRAVEL LIFT");
+        layer_rv += writeMotion("G00", travel_start, lift_speed, params, "TRAVEL LIFT");
     }
 
     Point travel_destination = target_location;
@@ -661,30 +670,36 @@ QString ArcSpecialtiesWriter::writeTravel(Point start_location, Point target_loc
         rv += m_newline;
         rv += commentLine("ENABLE WORK-OBJECT KINEMATICS");
         rv += writeStartupKinematics();
-        rv += writePendingLayerChange();
-        rv += writeMotion("G00", first_travel_destination, speed, params, "TRAVEL");
-        rv += writeBeginningBead();
+        if (!shouldBufferHelicalLayerPrefix(params)) { layer_rv += writePendingLayerChange(); }
+        layer_rv += writeMotion("G00", first_travel_destination, speed, params, "TRAVEL");
+        layer_rv += writeBeginningBead();
     }
     else {
-        rv += cylindrical_mode ? writeRadialArcTravel(travel_start, travel_destination, speed)
-                               : writeLinearTravel(travel_destination, speed);
+        layer_rv += cylindrical_mode ? writeRadialArcTravel(travel_start, travel_destination, speed)
+                                     : writeLinearTravel(travel_destination, speed);
     }
 
     if (travel_lower_required) {
-        rv += writeNumberedBlock("G81" % commentSpaceLine("OPTIONAL STOP ROUTINE"));
-        rv += writeMotion("G01", target_location, lift_speed, params, "TRAVEL LOWER");
+        layer_rv += writeNumberedBlock("G81" % commentSpaceLine("OPTIONAL STOP ROUTINE"));
+        layer_rv += writeMotion("G01", target_location, lift_speed, params, "TRAVEL LOWER");
     }
 
     m_first_travel = false;
-    return rv;
+    if (shouldBufferHelicalLayerPrefix(params)) {
+        m_pending_layer_prefix += layer_rv;
+        return rv;
+    }
+
+    return rv + layer_rv;
 }
 
-QString ArcSpecialtiesWriter::writeLine(const Point&, const Point& target_point,
+QString ArcSpecialtiesWriter::writeLine(const Point& start_point, const Point& target_point,
                                         const QSharedPointer<SettingsBase> params) {
     QString rv;
 
     rv += writeStartupKinematics();
-    rv += writePendingLayerChange();
+    rv += writeHelicalLayerStart(start_point, target_point, params);
+    rv += writePendingRegionSchedule();
     startLayerBlockNumbering();
 
     Velocity speed = params->setting<Velocity>(SS::kSpeed);
@@ -705,7 +720,8 @@ QString ArcSpecialtiesWriter::writeArc(const Point& start_point, const Point& en
 
     QString rv;
     rv += writeStartupKinematics();
-    rv += writePendingLayerChange();
+    rv += writeHelicalLayerStart(start_point, end_point, params);
+    rv += writePendingRegionSchedule();
     startLayerBlockNumbering();
 
     if (!m_deposition_active) { rv += writeWelderOn(); }
@@ -778,13 +794,20 @@ QString ArcSpecialtiesWriter::writeAfterPart() {
 QString ArcSpecialtiesWriter::writeAfterLayer() {
     QString layer_code = m_sb->setting<QString>(PRS::GCode::kLayerCodeChange);
     stopLayerBlockNumbering();
-    return layer_code.isEmpty() ? QString() : layer_code % m_newline;
+    QString rv;
+    rv += writePendingLayerChange();
+    rv += writePendingLayerPrefix();
+    m_pending_region_schedule.clear();
+    return layer_code.isEmpty() ? rv : rv % layer_code % m_newline;
 }
 
 QString ArcSpecialtiesWriter::writeShutdown() {
     stopLayerBlockNumbering();
-
     QString rv;
+    rv += writePendingLayerChange();
+    rv += writePendingLayerPrefix();
+    m_pending_region_schedule.clear();
+
     rv += writeWelderOff();
     if (!m_sb->setting<QString>(PRS::GCode::kEndCode).isEmpty()) {
         rv += m_sb->setting<QString>(PRS::GCode::kEndCode) % m_newline;
@@ -897,6 +920,22 @@ QString ArcSpecialtiesWriter::writePendingLayerChange() {
     m_pending_layer_change.prepend(m_newline);
     QString rv = m_pending_layer_change;
     m_pending_layer_change.clear();
+    return rv;
+}
+
+QString ArcSpecialtiesWriter::writePendingLayerPrefix() {
+    if (m_pending_layer_prefix.isEmpty()) { return QString(); }
+
+    const QString rv = m_pending_layer_prefix;
+    m_pending_layer_prefix.clear();
+    return rv;
+}
+
+QString ArcSpecialtiesWriter::writePendingRegionSchedule() {
+    if (m_pending_region_schedule.isEmpty()) { return QString(); }
+
+    const QString rv = writeNumberedBlock(m_pending_region_schedule, true);
+    m_pending_region_schedule.clear();
     return rv;
 }
 
@@ -1085,9 +1124,26 @@ double ArcSpecialtiesWriter::helicalStartAngle(const QSharedPointer<SettingsBase
 }
 
 bool ArcSpecialtiesWriter::isHelicalPathPattern() const {
-    const CylindricalPathPattern path_pattern =
-        static_cast<CylindricalPathPattern>(m_sb->setting<int>(PS::Slicing::kCylindricalPathPattern));
-    return isCylindricalSlicingMode() && path_pattern == CylindricalPathPattern::kHelical;
+    return isHelicalPathPattern(m_sb);
+}
+
+bool ArcSpecialtiesWriter::isHelicalPathPattern(const QSharedPointer<SettingsBase>& params) const {
+    auto settingOrDefault = [this, &params](const QString& key, int fallback) {
+        if (params != nullptr && params->contains(key)) { return params->setting<int>(key); }
+        if (m_sb != nullptr && m_sb->contains(key)) { return m_sb->setting<int>(key); }
+
+        return fallback;
+    };
+
+    const CylindricalPathPattern path_pattern = static_cast<CylindricalPathPattern>(
+        settingOrDefault(PS::Slicing::kCylindricalPathPattern, static_cast<int>(CylindricalPathPattern::kRadial)));
+    const SlicingMode slicing_mode =
+        static_cast<SlicingMode>(settingOrDefault(PS::Slicing::kSlicingMode, static_cast<int>(SlicingMode::kPlanar)));
+    return slicing_mode == SlicingMode::kCylindrical && path_pattern == CylindricalPathPattern::kHelical;
+}
+
+bool ArcSpecialtiesWriter::shouldBufferHelicalLayerPrefix(const QSharedPointer<SettingsBase>& params) const {
+    return !m_helical_opt_stop_mode_written && !m_pending_layer_change.isEmpty() && isHelicalPathPattern(params);
 }
 
 QString ArcSpecialtiesWriter::printMoveComment(const QSharedPointer<SettingsBase>& params) const {
@@ -1110,5 +1166,32 @@ QString ArcSpecialtiesWriter::printMoveComment(const QSharedPointer<SettingsBase
 bool ArcSpecialtiesWriter::isCylindricalSlicingMode() const {
     const SlicingMode slicing_mode = static_cast<SlicingMode>(m_sb->setting<int>(PS::Slicing::kSlicingMode));
     return slicing_mode == SlicingMode::kCylindrical;
+}
+
+QString ArcSpecialtiesWriter::writeHelicalOptStopMode(const Point& start_point, const Point& end_point,
+                                                      const QSharedPointer<SettingsBase>& params) {
+    if (m_helical_opt_stop_mode_written || !isHelicalPathPattern(params)) { return QString(); }
+
+    const double start_cp                  = cpAxisForPoint(start_point, params) * M_PI / 180.0;
+    const double end_cp                    = cpAxisForPoint(end_point, params) * M_PI / 180.0;
+    const bool positive_rotation_direction = shortestAngularDelta(start_cp, end_cp) >= 0.0;
+    const int opt_stop_mode                = positive_rotation_direction ? 1 : 2;
+    m_helical_opt_stop_mode_written        = true;
+    const QString opt_stop_mode_line       = "V.E.OptStopMode = " % QString::number(opt_stop_mode) % m_newline;
+    if (!m_startup_kinematics_written) {
+        m_pending_layer_change += opt_stop_mode_line;
+        return QString();
+    }
+
+    return opt_stop_mode_line;
+}
+
+QString ArcSpecialtiesWriter::writeHelicalLayerStart(const Point& start_point, const Point& end_point,
+                                                     const QSharedPointer<SettingsBase>& params) {
+    QString rv;
+    rv += writePendingLayerChange();
+    rv += writeHelicalOptStopMode(start_point, end_point, params);
+    rv += writePendingLayerPrefix();
+    return rv;
 }
 }  // namespace ORNL

--- a/tests/arc_specialties_parser_tests.cpp
+++ b/tests/arc_specialties_parser_tests.cpp
@@ -93,6 +93,20 @@ bool parsedLineWithScheduleSpeedKeepsCpForVisualization() {
                false);
 }
 
+bool parsesArcSpecialtiesOptStopModeAssignment() {
+    QStringList original_lines {"V.E.OptStopMode = 1"};
+    QStringList upper_lines {original_lines.first().toUpper()};
+    ORNL::ArcSpecialtiesParser parser(ORNL::GcodeMetaList::ArcSpecialtiesMeta, false, original_lines, upper_lines);
+
+    try {
+        parser.parseLines();
+        return true;
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << '\n';
+        return false;
+    }
+}
+
 bool parsesNumberedArcSpecialtiesMotion() {
     return parsedLineKeepsCpForVisualization(
                "N20002 G01 X=0.0000 Y=1.0000 Z=0.0000 XR=180.0000 YR=0.0000 ZR=-135.0000 "
@@ -275,19 +289,94 @@ bool writesLayerScopedBlockNumbersWhenEnabled() {
     second_layer += writer.writeTravel(ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
                                        ORNL::Point(1.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
                                        ORNL::TravelLiftType::kLiftLowerOnly, segment_settings);
+    second_layer += writer.writeLine(ORNL::Point(1.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm),
+                                     ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 2.0 * ORNL::mm), segment_settings);
 
-    return lineContaining(first_layer, ";BEGINNING LAYER: 1").startsWith(";") &&
+    const int first_opt_stop    = first_layer.indexOf("V.E.OptStopMode = 1\n");
+    const int first_schedule    = first_layer.indexOf("G80 [0] ;Infill Schedule\n");
+    const int second_opt_stop   = second_layer.indexOf("V.E.OptStopMode = 1\n");
+    const int second_welder_off = second_layer.indexOf(";WIRE ARC WELDER OFF");
+    const int second_schedule   = second_layer.indexOf("G80 [0] ;Infill Schedule\n");
+
+    return first_layer.contains(";BEGINNING LAYER: 1\nV.E.OptStopMode = 1\n") &&
+           second_layer.contains(";BEGINNING LAYER: 2\nV.E.OptStopMode = 1\n") &&
+           lineContaining(first_layer, ";BEGINNING LAYER: 1").startsWith(";") &&
            !lineContaining(first_layer, ";WORLD APPROACH TRAVEL").startsWith("N") &&
-           lineContaining(first_layer, "G80 [0] ;Infill Schedule").startsWith("N10000 G80") &&
-           lineContaining(first_layer, ";OPTIONAL STOP ROUTINE").startsWith("N10001 G81") &&
-           lineContaining(first_layer, ";TRAVEL LOWER").startsWith("N10002 G01") &&
+           lineContaining(first_layer, ";OPTIONAL STOP ROUTINE").startsWith("N10000 G81") &&
+           lineContaining(first_layer, ";TRAVEL LOWER").startsWith("N10001 G01") && first_opt_stop >= 0 &&
+           first_schedule > first_opt_stop &&
+           lineContaining(first_layer, "G80 [0] ;Infill Schedule").startsWith("N10002 G80") &&
            lineContaining(first_layer, ";WIRE ARC WELDER ON").startsWith("N10003 G82") &&
            lineContaining(first_layer, ";BLENDING ON").startsWith("N10004 G261") &&
            lineContaining(first_layer, ";HELICAL INFILL").startsWith("N10005 G01") &&
            lineContaining(second_layer, ";WIRE ARC WELDER OFF").startsWith("G83 [0]") &&
-           lineContaining(second_layer, "G80 [0] ;Infill Schedule").startsWith("N20000 G80") &&
-           lineContaining(second_layer, ";OPTIONAL STOP ROUTINE").startsWith("N20001 G81") &&
-           lineContaining(second_layer, ";TRAVEL LOWER").startsWith("N20002 G01");
+           second_welder_off > second_opt_stop &&
+           lineContaining(second_layer, ";OPTIONAL STOP ROUTINE").startsWith("N20000 G81") &&
+           lineContaining(second_layer, ";TRAVEL LOWER").startsWith("N20001 G01") && second_opt_stop >= 0 &&
+           second_schedule > second_opt_stop &&
+           lineContaining(second_layer, "G80 [0] ;Infill Schedule").startsWith("N20002 G80") &&
+           lineContaining(second_layer, ";HELICAL INFILL").startsWith("N20005 G01");
+}
+
+bool writesHelicalOptStopModeFromPostOrderingRotationDirection() {
+    QSharedPointer<ORNL::SettingsBase> settings = helicalWriterSettings(false);
+    settings->setSetting(ORNL::PS::Optimizations::kCylindricalPathOrder,
+                         static_cast<int>(ORNL::PathOrderOptimization::kNextClosest));
+    settings->setSetting(ORNL::PS::Travel::kSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PRS::MachineSpeed::kMaxXYSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PRS::MachineSpeed::kZSpeed, 600.0 * ORNL::mm / ORNL::minute);
+    settings->setSetting(ORNL::PS::Travel::kLiftHeight, 0.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kMinTravelLength, 0.0 * ORNL::mm);
+    settings->setSetting(ORNL::PS::Travel::kMinTravelForLift, 0.0 * ORNL::mm);
+
+    QSharedPointer<ORNL::ArcSpecialtiesWriter> writer =
+        QSharedPointer<ORNL::ArcSpecialtiesWriter>::create(ORNL::GcodeMetaList::ArcSpecialtiesMeta, settings);
+
+    auto write_ordered_layer = [&settings, &writer](uint layer_number, const ORNL::Point& current_location) {
+        const ORNL::Point generated_start(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm);
+        const ORNL::Point generated_end(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm);
+
+        QSharedPointer<ORNL::SettingsBase> segment_settings = helicalSegmentSettings(ORNL::RegionType::kPerimeter);
+        segment_settings->populate(settings);
+
+        ORNL::Path path;
+        QSharedPointer<ORNL::LineSegment> segment =
+            QSharedPointer<ORNL::LineSegment>::create(generated_start, generated_end);
+        segment->setSb(segment_settings);
+        path.append(segment);
+
+        ORNL::CylindricalLayer layer(layer_number + 1, settings, ORNL::CylindricalPathPattern::kHelical);
+        layer.addPath(path);
+        ORNL::Point optimized_current_location = current_location;
+        layer.calculateModifiers(optimized_current_location);
+
+        QString block;
+        block += writer->writeLayerChange(layer_number);
+        block += writer->writeBeforeLayer(layer.getMinZ(), layer.getSb());
+        block += layer.writeGCode(writer);
+        block += writer->writeAfterLayer();
+        return block;
+    };
+
+    const QString positive_layer = write_ordered_layer(0, ORNL::Point(1.0 * ORNL::mm, 0.0 * ORNL::mm, 0.0 * ORNL::mm));
+    const QString negative_layer = write_ordered_layer(1, ORNL::Point(0.0 * ORNL::mm, 1.0 * ORNL::mm, 1.0 * ORNL::mm));
+
+    const int positive_layer_marker = positive_layer.indexOf(";BEGINNING LAYER: 1");
+    const int positive_opt_stop     = positive_layer.indexOf("V.E.OptStopMode = 1\n");
+    const int positive_schedule     = positive_layer.indexOf("G80 [1] ;Perimeter Schedule\n");
+    const int positive_print        = positive_layer.indexOf(";HELICAL PERIMETER\n");
+    const int negative_layer_marker = negative_layer.indexOf(";BEGINNING LAYER: 2");
+    const int negative_opt_stop     = negative_layer.indexOf("V.E.OptStopMode = 2\n");
+    const int negative_schedule     = negative_layer.indexOf("G80 [1] ;Perimeter Schedule\n");
+    const int negative_print        = negative_layer.indexOf(";HELICAL PERIMETER\n");
+
+    return positive_layer.contains(";BEGINNING LAYER: 1\nV.E.OptStopMode = 1\n") &&
+           negative_layer.contains(";BEGINNING LAYER: 2\nV.E.OptStopMode = 2\n") && positive_layer_marker >= 0 &&
+           positive_opt_stop > positive_layer_marker && positive_schedule > positive_opt_stop &&
+           positive_print > positive_schedule && negative_layer_marker >= 0 &&
+           negative_opt_stop > negative_layer_marker && negative_schedule > negative_opt_stop &&
+           negative_print > negative_schedule && !positive_layer.contains("V.E.OptStopMode = 2") &&
+           !negative_layer.contains("V.E.OptStopMode = 1");
 }
 
 void setHelicalToolFrameSettings(const QSharedPointer<ORNL::SettingsBase>& settings) {
@@ -667,6 +756,8 @@ int main(int argc, char* argv[]) {
                      "Arc Specialties parser did not retain linear CP for visualization.");
     passed &= expect(parsedLineWithScheduleSpeedKeepsCpForVisualization(),
                      "Arc Specialties parser did not retain linear CP with the G80 schedule speed variable.");
+    passed &= expect(parsesArcSpecialtiesOptStopModeAssignment(),
+                     "Arc Specialties parser did not accept the OptStopMode assignment.");
     passed &=
         expect(parsesNumberedArcSpecialtiesMotion(), "Arc Specialties parser did not accept Beckhoff block numbers.");
     passed &= expect(rejectsDuplicateScheduleSpeedFeedrate(),
@@ -684,6 +775,8 @@ int main(int argc, char* argv[]) {
                      "Arc Specialties writer did not emit the G80 schedule speed variable for print motion.");
     passed &= expect(writesLayerScopedBlockNumbersWhenEnabled(),
                      "Arc Specialties writer did not emit layer-scoped block numbers.");
+    passed &= expect(writesHelicalOptStopModeFromPostOrderingRotationDirection(),
+                     "Arc Specialties writer did not emit helical OptStopMode from rotation direction.");
     passed &= expect(writesCompactCylindricalPrintComments(),
                      "Arc Specialties writer did not emit compact cylindrical comments.");
     passed &=


### PR DESCRIPTION
## Summary

Adds Arc Specialties helical layer-start handling so each helical layer emits `V.E.OptStopMode = <number>` immediately after `;BEGINNING LAYER: ...`.

## Related issues

- No related issues.

## Details

This feature emits Arc Specialties `OptStopMode` from the actual post-ordering C-axis rotation direction:

- `V.E.OptStopMode = 1` for positive CP rotation.
- `V.E.OptStopMode = 2` for negative CP rotation.

The implementation stays scoped to `ArcSpecialtiesWriter`; no Arc Specialties controller behavior is added to `CylindricalLayer`. To support `Next Closest` ordering, the writer defers helical layer-local prefix output until the first ordered print move is known. It then computes the signed CP delta from that actual print move, emits `OptStopMode` immediately after the layer marker, and releases the buffered travel/setup output and deferred `G80` schedule in the correct order.

This also preserves Arc Specialties block-number behavior by keeping `OptStopMode` unnumbered while continuing to number the deferred `G80` schedule and executable setup/print lines.

## Impact

This changes Arc Specialties helical G-code output by adding one layer-scoped controller assignment near the top of each helical layer. The emitted value now reflects the direction of the first post-optimized helical print move, including paths reversed by cylindrical `Next Closest` ordering.

Risk: Low. The change is isolated to the Arc Specialties writer and focused parser/writer tests. Non-Arc Specialties writers and generic cylindrical layer ordering are not changed.

## Validation

Validated with: 
[Donut3.1.rev-10.zip](https://github.com/user-attachments/files/32063918/Donut3.1.rev-10.zip)
